### PR TITLE
feat(flow-window): integrate hummingbird 4D-viewer / flow-window workstream into main

### DIFF
--- a/app/Http/Controllers/Api/Mobile/FlowController.php
+++ b/app/Http/Controllers/Api/Mobile/FlowController.php
@@ -8,11 +8,13 @@ use App\Models\Bed;
 use App\Models\CensusSnapshot;
 use App\Models\Evs\EvsRequest;
 use App\Models\Transport\TransportRequest;
+use App\Services\Flow\DutyProjectionService;
 use App\Services\Flow\FloorPlateAssetService;
 use App\Services\Flow\FloorRollupService;
 use App\Services\Flow\FlowLensService;
 use App\Services\Flow\ForwardProjectionService;
 use App\Services\Flow\OperationalTimelineService;
+use App\Services\Flow\Spaces3dAssetService;
 use App\Services\Mobile\MobilePersonaCatalog;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -51,11 +53,37 @@ class FlowController extends Controller
         private readonly FloorRollupService $floors,
         private readonly OperationalTimelineService $timeline,
         private readonly ForwardProjectionService $projections,
+        private readonly DutyProjectionService $dutyProjections,
+        private readonly Spaces3dAssetService $spaces3dAsset,
     ) {}
 
     public function floors(Request $request): JsonResponse
     {
         $document = $this->plates->load();
+        $etag = '"'.$document['version'].'"';
+
+        if (trim((string) $request->headers->get('If-None-Match')) === $etag) {
+            return response()->json(null, 304)->withHeaders(['ETag' => $etag]);
+        }
+
+        return $this->envelope(
+            $document,
+            meta: ['version' => $document['version']],
+            links: ['web' => url('/rtdc/patient-flow-navigator')],
+        )->withHeaders([
+            'ETag' => $etag,
+            'Cache-Control' => 'private, max-age=86400',
+        ]);
+    }
+
+    /**
+     * The 3D space-anchor asset (centroids + unit/bed bridges) the native
+     * SceneKit/Filament viewers use to place tokens + duty markers over the
+     * GLB shell. Geometry only, no live state — ETagged + aggressively cached.
+     */
+    public function spaces3d(Request $request): JsonResponse
+    {
+        $document = $this->spaces3dAsset->load();
         $etag = '"'.$document['version'].'"';
 
         if (trim((string) $request->headers->get('If-None-Match')) === $etag) {
@@ -159,6 +187,17 @@ class FlowController extends Controller
             $payload['projections'] = array_map(
                 fn (array $item): array => $this->lens->redactRow($item, $depth, $scope, $taskRefs),
                 $this->projections->projections($from->max($now), $to, $scope, $lens['projection_kinds']),
+            );
+        }
+
+        // Duties — the persona's actionable worklist, spatially anchored and
+        // due-dated (NATIVE-4D-VIEWER-PLAN §4 W1). Like projections: clamped to
+        // the lens `duty_kinds`, redacted per patient_dots, and served IN FULL
+        // even on a `?since=` delta (it is current worklist, not append-only).
+        if (in_array('duties', $layers, true)) {
+            $payload['duties'] = array_map(
+                fn (array $item): array => $this->lens->redactRow($item, $depth, $scope, $taskRefs),
+                $this->dutyProjections->duties($now, $lens['duty_kinds'] ?? [], $this->scopeUnitIds($scope)),
             );
         }
 
@@ -286,6 +325,19 @@ class FlowController extends Controller
                 'status' => (string) $bed->status,
             ])
             ->all();
+    }
+
+    /** @return list<int>|null  null = house/patient scope (no spatial duty filter) */
+    private function scopeUnitIds(array $scope): ?array
+    {
+        return match ($scope['type']) {
+            'unit' => $scope['unit_id'] !== null ? [(int) $scope['unit_id']] : [],
+            'floor' => array_values(array_filter(array_column(
+                collect($this->floorRollup())->firstWhere('floor', $scope['floor'])['units'] ?? [],
+                'unit_id',
+            ))),
+            default => null,
+        };
     }
 
     /** @return list<array<string, mixed>> */

--- a/app/Http/Controllers/Api/Mobile/FlowController.php
+++ b/app/Http/Controllers/Api/Mobile/FlowController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Mobile;
 
 use App\Http\Concerns\RendersMobileEnvelope;
 use App\Http\Controllers\Controller;
+use App\Models\Bed;
 use App\Models\CensusSnapshot;
 use App\Models\Evs\EvsRequest;
 use App\Models\Transport\TransportRequest;
@@ -25,7 +26,8 @@ use Illuminate\Http\Request;
  *       strong ETag; geometry only, no live state, aggressively cacheable.
  *   GET /api/mobile/v1/flow/window   (mobile:read) — snapshots + events +
  *       projections for one persona-lensed scope, clipped to ≤48h centered
- *       on now.
+ *       on now. `?since=` (Phase 5 delta refresh) narrows events/snapshots
+ *       to t > since; projections/spaces/bed_statuses always come in full.
  *
  * Everything is clamped server-side by FlowLensService (config/hummingbird/
  * flow_lens.php). Unauthorized scopes are an explicit 403 state, and
@@ -82,6 +84,21 @@ class FlowController extends Controller
 
         $now = CarbonImmutable::now();
         [$from, $to] = $this->clampWindow($request, $now);
+
+        // Delta refresh (Phase 5): `since` filters the append-only halves
+        // (events, snapshots) to t > since; projections/spaces/bed_statuses
+        // are recomputed and served in full on every request. Unlike from/to
+        // (which clamp silently), an unparseable or out-of-range `since` is a
+        // hard 422 — a delta against the wrong window must never look like a
+        // quiet full refresh.
+        $since = null;
+        if (($sinceRaw = $request->query('since')) !== null && trim((string) $sinceRaw) !== '') {
+            $since = $this->parseTime((string) $sinceRaw);
+            if ($since === null || $since->lt($from) || $since->gte($to)) {
+                return $this->invalidSince($from, $to);
+            }
+        }
+
         $layers = $this->lens->clampLayers($lens, $request->query('layers'));
         $depth = $this->lens->effectivePatientDepth($lens, $scope, $request->user());
         $taskRefs = $depth === 'task' ? $this->taskPatientRefs($roleId) : [];
@@ -91,6 +108,7 @@ class FlowController extends Controller
                 'from' => $from->toIso8601String(),
                 'to' => $to->toIso8601String(),
                 'now' => $now->toIso8601String(),
+                'since' => $since?->toIso8601String(),
             ],
             'lens' => [
                 'role_id' => $roleId,
@@ -120,13 +138,20 @@ class FlowController extends Controller
         }
 
         if (in_array('snapshots', $layers, true)) {
-            $payload['snapshots'] = $this->snapshots($from, $to, $scope);
+            $payload['snapshots'] = $this->snapshots($from, $to, $scope, $since);
         }
 
         if (in_array('events', $layers, true)) {
+            $events = $this->timeline->events($from, $to->min($now), $scope, $lens['event_kinds']);
+            if ($since !== null) {
+                $events = array_values(array_filter(
+                    $events,
+                    fn (array $event): bool => CarbonImmutable::parse($event['t'])->gt($since),
+                ));
+            }
             $payload['events'] = array_map(
                 fn (array $event): array => $this->lens->redactRow($event, $depth, $scope, $taskRefs),
-                $this->timeline->events($from, $to->min($now), $scope, $lens['event_kinds']),
+                $events,
             );
         }
 
@@ -135,6 +160,14 @@ class FlowController extends Controller
                 fn (array $item): array => $this->lens->redactRow($item, $depth, $scope, $taskRefs),
                 $this->projections->projections($from->max($now), $to, $scope, $lens['projection_kinds']),
             );
+        }
+
+        // Bed-level "now" for the turn map: only floor/unit scopes, and only
+        // for lenses whose event_kinds already include bed_status — the same
+        // vocabulary gate, so transport/executive/etc. never receive the key.
+        if (in_array($scope['type'], ['floor', 'unit'], true)
+            && in_array('bed_status', $lens['event_kinds'], true)) {
+            $payload['bed_statuses'] = $this->bedStatuses($scope);
         }
 
         return $this->envelope(
@@ -180,11 +213,12 @@ class FlowController extends Controller
         }
     }
 
-    /** @return list<array<string, mixed>> census checkpoints in scope */
-    private function snapshots(CarbonImmutable $from, CarbonImmutable $to, array $scope): array
+    /** @return list<array<string, mixed>> census checkpoints in scope (t > since on a delta) */
+    private function snapshots(CarbonImmutable $from, CarbonImmutable $to, array $scope, ?CarbonImmutable $since = null): array
     {
         $query = CensusSnapshot::query()
             ->whereBetween('captured_at', [$from, $to])
+            ->when($since, fn ($query) => $query->where('captured_at', '>', $since))
             ->orderBy('captured_at');
 
         if ($scope['type'] === 'unit' || $scope['type'] === 'patient') {
@@ -216,6 +250,44 @@ class FlowController extends Controller
             ->all();
     }
 
+    /**
+     * Current bed state for the scoped floor/unit — strictly "now", never
+     * historical or projected (the review/prediction halves stay in events/
+     * projections). Floor membership comes from the same manifest-driven
+     * rollup the snapshots/spaces layers use.
+     *
+     * @param  array{type: string, floor: ?int, unit_id: ?int}  $scope
+     * @return list<array{bed_id: int, unit_id: int, label: ?string, status: string}>
+     */
+    private function bedStatuses(array $scope): array
+    {
+        $unitIds = $scope['type'] === 'unit'
+            ? [(int) $scope['unit_id']]
+            : array_values(array_filter(array_column(
+                collect($this->floorRollup())->firstWhere('floor', $scope['floor'])['units'] ?? [],
+                'unit_id',
+            )));
+
+        if ($unitIds === []) {
+            return [];
+        }
+
+        return Bed::query()
+            ->where('is_deleted', false)
+            ->whereIn('unit_id', $unitIds)
+            ->orderBy('unit_id')
+            ->orderBy('label')
+            ->limit(5000)
+            ->get(['bed_id', 'unit_id', 'label', 'status'])
+            ->map(fn (Bed $bed): array => [
+                'bed_id' => (int) $bed->bed_id,
+                'unit_id' => (int) $bed->unit_id,
+                'label' => $bed->label,
+                'status' => (string) $bed->status,
+            ])
+            ->all();
+    }
+
     /** @return list<array<string, mixed>> */
     private function floorRollup(): array
     {
@@ -234,6 +306,20 @@ class FlowController extends Controller
                 ->distinct()->pluck('patient_ref')->all(),
             default => [],
         };
+    }
+
+    private function invalidSince(CarbonImmutable $from, CarbonImmutable $to): JsonResponse
+    {
+        return response()->json([
+            'error' => [
+                'code' => 'invalid_since',
+                'message' => sprintf(
+                    'since must be an ISO8601 timestamp within [%s, %s).',
+                    $from->toIso8601String(),
+                    $to->toIso8601String(),
+                ),
+            ],
+        ], 422);
     }
 
     private function forbidden(string $reason): JsonResponse

--- a/app/Http/Controllers/Concerns/ResolvesFlowLens.php
+++ b/app/Http/Controllers/Concerns/ResolvesFlowLens.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use App\Models\Unit;
+use App\Services\Flow\FlowLensService;
+use App\Services\Mobile\MobilePersonaCatalog;
+use App\Support\Hospital\HospitalManifest;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Inertia props for the web 4D Navigator's persona lens — FLOW-WINDOW-PLAN
+ * §7.3 ("Persona lens prop: page reads the user's role → same lens config →
+ * layer defaults + inspector redaction — closes G7 on web").
+ *
+ * Mirrors EnforceFlowLens' resolution (?persona= → X-Hummingbird-Role →
+ * user default) but degrades instead of 403ing: a page render is not an API
+ * read. When no lens resolves (plain web user with no Hummingbird persona)
+ * the prop is null and the component falls back to the full house view —
+ * patient-level API reads stay guarded server-side by EnforceFlowLens.
+ */
+trait ResolvesFlowLens
+{
+    /** @return array<string, mixed>|null */
+    protected function resolveFlowLens(Request $request): ?array
+    {
+        $personas = app(MobilePersonaCatalog::class);
+        $lensService = app(FlowLensService::class);
+
+        try {
+            return $lensService->lensFor($personas->fromRequest($request));
+        } catch (AuthorizationException) {
+            // Requested persona unavailable to this user (or no persona at
+            // all) — fall back to the user's own default persona, if any.
+        }
+
+        try {
+            $allowed = $personas->allowedForUser($request->user());
+
+            return $allowed === [] ? null : $lensService->lensFor($allowed[0]);
+        } catch (AuthorizationException) {
+            return null;
+        }
+    }
+
+    /**
+     * unit_id ↔ unit_code ↔ floor bridge so the client can join projection
+     * items (unit_id / bed_id) against the /locations payload's unit_code.
+     *
+     * @return list<array{unit_id: int, unit_code: ?string, name: ?string, floor: ?int}>
+     */
+    protected function flowUnits(): array
+    {
+        if (! Schema::hasTable('prod.units')) {
+            return [];
+        }
+
+        $manifest = app(HospitalManifest::class);
+
+        return Unit::query()
+            ->where('is_deleted', false)
+            ->orderBy('unit_id')
+            ->get(['unit_id', 'abbreviation', 'name'])
+            ->map(function (Unit $unit) use ($manifest): array {
+                $entry = $unit->abbreviation ? $manifest->unit($unit->abbreviation) : null;
+
+                return [
+                    'unit_id' => (int) $unit->unit_id,
+                    'unit_code' => $unit->abbreviation,
+                    'name' => $unit->name,
+                    'floor' => isset($entry['floor']) ? (int) $entry['floor'] : null,
+                ];
+            })
+            ->values()
+            ->all();
+    }
+}

--- a/app/Http/Controllers/EDDashboardController.php
+++ b/app/Http/Controllers/EDDashboardController.php
@@ -7,6 +7,8 @@ use Inertia\Inertia;
 
 class EDDashboardController extends Controller
 {
+    use \App\Http\Controllers\Concerns\ResolvesFlowLens;
+
     /**
      * Display the ED dashboard.
      *
@@ -36,9 +38,12 @@ class EDDashboardController extends Controller
      *
      * @return \Inertia\Response
      */
-    public function flow()
+    public function flow(Request $request)
     {
-        return Inertia::render('ED/Analytics/Flow');
+        return Inertia::render('ED/Analytics/Flow', [
+            'flowLens' => $this->resolveFlowLens($request),
+            'flowUnits' => $this->flowUnits(),
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/RTDCDashboardController.php
+++ b/app/Http/Controllers/RTDCDashboardController.php
@@ -9,6 +9,8 @@ use Inertia\Response as InertiaResponse;
 
 class RTDCDashboardController extends Controller
 {
+    use \App\Http\Controllers\Concerns\ResolvesFlowLens;
+
     public function __construct(
         private readonly RtdcService $rtdcService,
     ) {}
@@ -49,6 +51,8 @@ class RTDCDashboardController extends Controller
         return Inertia::render('RTDC/PatientFlowNavigator', [
             'workflow' => 'rtdc',
             'facilityCode' => config('facility_models.zep_500.facility_code', 'ZEPHYRUS-500'),
+            'flowLens' => $this->resolveFlowLens($request),
+            'flowUnits' => $this->flowUnits(),
         ]);
     }
 

--- a/app/Services/Flow/DutyProjectionService.php
+++ b/app/Services/Flow/DutyProjectionService.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace App\Services\Flow;
+
+use App\Models\Barrier;
+use App\Models\Bed;
+use App\Models\BedRequest;
+use App\Models\Encounter;
+use App\Models\Evs\EvsRequest;
+use App\Models\Facility\FacilitySpace;
+use App\Models\Ops\Approval;
+use App\Models\Staffing\StaffingRequest;
+use App\Models\Transport\TransportRequest;
+use App\Models\Unit;
+use App\Services\Mobile\MobilePatientContextService;
+use Carbon\CarbonImmutable;
+
+/**
+ * The per-persona DUTIES layer of the 48h Flow Window (NATIVE-4D-VIEWER-PLAN §4 W1).
+ *
+ * Turns each persona's live worklist (transport / EVS / placement / barrier /
+ * staffing / approval / discharge-leverage) into ONE spatially-anchored,
+ * due-dated stream the native 3D viewer can place: every duty carries a 3D
+ * centroid (from hosp_space.facility_spaces, feet→metres), a due_at, a
+ * window_status (overdue|due|upcoming), and the governed BFF endpoint that
+ * actions it.
+ *
+ * The stream is clamped to the caller's lens `duty_kinds`; patient identity is
+ * carried ONLY as the internal `_patient_ref` (for FlowLensService::redactRow
+ * to gate) plus an opaque ptok — the controller redacts before serialization,
+ * exactly as it does for events and projections, so patient_dots:none personas
+ * never receive a patient ref.
+ */
+class DutyProjectionService
+{
+    private const FEET_TO_M = 0.3048;
+
+    private const DUE_SOON_MINUTES = 120;
+
+    /** Governed BFF action per duty kind. {id}/{uuid} are substituted per row. */
+    private const ACTIONS = [
+        'transport_run' => ['endpoint' => '/api/mobile/v1/transport/requests/{id}/status', 'method' => 'POST', 'label' => 'Update run'],
+        'bed_turn' => ['endpoint' => '/api/mobile/v1/evs/requests/{id}/status', 'method' => 'POST', 'label' => 'Update turn'],
+        'placement' => ['endpoint' => '/api/mobile/v1/rtdc/bed-requests/{id}/decision', 'method' => 'POST', 'label' => 'Place'],
+        'barrier_resolve' => ['endpoint' => '/api/mobile/v1/rtdc/barriers/{id}/resolve', 'method' => 'POST', 'label' => 'Resolve'],
+        'staffing_fill' => ['endpoint' => '/api/mobile/v1/staffing/requests/{id}/fill', 'method' => 'POST', 'label' => 'Fill'],
+        'approval' => ['endpoint' => '/api/mobile/v1/ops/approvals/{uuid}/decision', 'method' => 'POST', 'label' => 'Decide'],
+        // discharge_leverage / or_case_milestone have no write endpoint yet.
+    ];
+
+    /** @var array{unit: array<int, array>, bed: array<int, array>, label: array<string, array>}|null */
+    private ?array $anchors = null;
+
+    public function __construct(private readonly MobilePatientContextService $patients) {}
+
+    /**
+     * @param  list<string>  $dutyKinds  the caller's lens-granted kinds
+     * @param  list<int>|null  $scopeUnitIds  null = house (no spatial filter); else keep duties in these units
+     * @return list<array<string, mixed>>
+     */
+    public function duties(CarbonImmutable $now, array $dutyKinds, ?array $scopeUnitIds = null): array
+    {
+        $want = fn (string $kind): bool => in_array($kind, $dutyKinds, true);
+        $out = [];
+
+        if ($want('transport_run')) {
+            foreach (TransportRequest::query()->where('is_deleted', false)->whereNotIn('status', ['completed', 'cancelled', 'handoff_complete'])->get() as $r) {
+                $anchor = $this->anchorForLabel($r->destination) ?? $this->anchorForLabel($r->origin);
+                $due = $r->needed_at ? CarbonImmutable::parse($r->needed_at) : null;
+                $tier = $r->priority === 'stat' ? 'critical' : 'warning';
+                $out[] = $this->duty('transport_run', 'transport-'.$r->transport_request_id, (string) $r->transport_request_id,
+                    trim(($r->origin ?: '—').' → '.($r->destination ?: '—')), $anchor, $due, $tier, $now, $r->patient_ref);
+            }
+        }
+
+        if ($want('bed_turn')) {
+            foreach (EvsRequest::query()->where('is_deleted', false)->whereNotIn('status', ['completed', 'cancelled'])->get() as $r) {
+                $anchor = $this->anchorForBed($r->bed_id) ?? $this->anchorForUnit($r->unit_id) ?? $this->anchorForLabel($r->location_label);
+                $due = $r->needed_at ? CarbonImmutable::parse($r->needed_at) : null;
+                $tier = $r->isolation_required ? 'warning' : 'info';
+                $label = ($r->location_label ?: 'Bed turn').($r->isolation_required ? ' · isolation' : '');
+                $out[] = $this->duty('bed_turn', 'evs-'.$r->evs_request_id, (string) $r->evs_request_id,
+                    $label, $anchor, $due, $tier, $now, $r->patient_ref);
+            }
+        }
+
+        if ($want('placement')) {
+            foreach (BedRequest::pending()->orderBy('created_at')->get() as $r) {
+                $due = $r->created_at ? CarbonImmutable::parse($r->created_at) : null; // age-based; no hard due
+                $tier = ($r->acuity_tier !== null && $r->acuity_tier <= 1) ? 'critical' : (($r->acuity_tier !== null && $r->acuity_tier <= 2) ? 'warning' : 'info');
+                $label = ($r->service ?: 'Unassigned').' · needs '.($r->required_unit_type ?: 'any');
+                // A pending request has no assigned bed → unanchored (a house-level tray item) until placed.
+                $out[] = $this->duty('placement', 'bedreq-'.$r->bed_request_id, (string) $r->bed_request_id,
+                    $label, null, $due, $tier, $now, $r->patient_ref, dueless: true);
+            }
+        }
+
+        if ($want('barrier_resolve')) {
+            foreach (Barrier::open()->orderBy('opened_at')->get() as $b) {
+                $anchor = $this->anchorForUnit($b->unit_id);
+                $due = $b->opened_at ? CarbonImmutable::parse($b->opened_at) : null;
+                $tier = in_array($b->category, ['placement', 'medical'], true) ? 'warning' : 'info';
+                // Barrier free text is never surfaced — category only, no patient identity.
+                $out[] = $this->duty('barrier_resolve', 'barrier-'.$b->barrier_id, (string) $b->barrier_id,
+                    ucfirst($b->category ?: 'Discharge').' barrier', $anchor, $due, $tier, $now, null, dueless: true);
+            }
+        }
+
+        if ($want('staffing_fill')) {
+            foreach (StaffingRequest::query()->whereNotIn('status', ['filled', 'cancelled', 'closed'])->get() as $r) {
+                $anchor = $this->anchorForUnit($r->unit_id);
+                $due = $r->needed_by ? CarbonImmutable::parse($r->needed_by) : null;
+                $tier = $r->priority === 'stat' ? 'critical' : ($r->priority === 'urgent' ? 'warning' : 'info');
+                $label = ($r->unit_label ?: 'Unit').' · '.($r->role ?: 'staff').' fill';
+                $out[] = $this->duty('staffing_fill', 'staffing-'.$r->staffing_request_id, (string) $r->staffing_request_id,
+                    $label, $anchor, $due, $tier, $now, null);
+            }
+        }
+
+        if ($want('approval')) {
+            foreach (Approval::query()->where('status', 'pending')->with('action.recommendation')->get() as $a) {
+                $rec = $a->action?->recommendation;
+                $due = $a->requested_at ? CarbonImmutable::parse($a->requested_at) : null;
+                $tier = match ($rec?->risk_level) {
+                    'critical' => 'critical', 'high' => 'warning', default => 'info'
+                };
+                $out[] = $this->duty('approval', 'ops-approval-'.$a->approval_uuid, (string) $a->approval_uuid,
+                    $rec?->title ?? 'Operational approval', null, $due, $tier, $now, null, dueless: true);
+            }
+        }
+
+        if ($want('discharge_leverage')) {
+            foreach (Encounter::query()->where('status', 'active')->whereNotNull('expected_discharge_date')
+                ->whereDate('expected_discharge_date', '<=', $now->toDateString())->get() as $e) {
+                $anchor = $this->anchorForBed($e->bed_id) ?? $this->anchorForUnit($e->unit_id);
+                $due = CarbonImmutable::parse($e->expected_discharge_date);
+                $out[] = $this->duty('discharge_leverage', 'edd-'.$e->encounter_id, (string) $e->encounter_id,
+                    'Expected discharge', $anchor, $due, 'info', $now, $e->patient_ref);
+            }
+        }
+
+        // Scope filter: house (null) keeps everything; floor/unit keeps only duties
+        // anchored in the scoped units (unanchored house-level items drop out).
+        if ($scopeUnitIds !== null) {
+            $set = array_flip($scopeUnitIds);
+            $out = array_values(array_filter($out, fn (array $d): bool => $d['unit_id'] !== null && isset($set[$d['unit_id']])));
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array{space_ref: ?string, unit_id: ?int, bed_id: ?int, centroid_m: ?array}|null  $anchor
+     * @return array<string, mixed>
+     */
+    private function duty(string $kind, string $id, string $recordId, string $label, ?array $anchor,
+        ?CarbonImmutable $due, string $tier, CarbonImmutable $now, ?string $patientRef, bool $dueless = false): array
+    {
+        $action = self::ACTIONS[$kind] ?? null;
+        if ($action !== null) {
+            $action['endpoint'] = str_replace(['{id}', '{uuid}'], $recordId, $action['endpoint']);
+        }
+
+        return [
+            'id' => $id,
+            'kind' => $kind,
+            'label' => $label,
+            'space_ref' => $anchor['space_ref'] ?? null,
+            'unit_id' => $anchor['unit_id'] ?? null,
+            'bed_id' => $anchor['bed_id'] ?? null,
+            'centroid_m' => $anchor['centroid_m'] ?? null,
+            'due_at' => $due?->toIso8601String(),
+            'window_status' => $this->windowStatus($due, $tier, $now, $dueless),
+            'tier' => $tier,
+            '_patient_ref' => $patientRef,
+            'patient_context_ref' => $patientRef ? $this->patients->contextRefFor($patientRef) : null,
+            'provenance' => ['service' => 'duty_projection'],
+            'action' => $action,
+        ];
+    }
+
+    /** overdue = past due; due = within the next 2h (or dueless + urgent); else upcoming. */
+    private function windowStatus(?CarbonImmutable $due, string $tier, CarbonImmutable $now, bool $dueless): ?string
+    {
+        if ($due === null) {
+            return null;
+        }
+        if ($dueless) {
+            // Age/urgency-based rather than a hard deadline (barriers, pending placements).
+            return $tier === 'info' ? 'upcoming' : 'due';
+        }
+
+        return match (true) {
+            $due->lt($now) => 'overdue',
+            $due->lte($now->addMinutes(self::DUE_SOON_MINUTES)) => 'due',
+            default => 'upcoming',
+        };
+    }
+
+    // -----------------------------------------------------------------
+    // Spatial anchoring — unit_id / bed_id / free-text → facility_space centroid
+    // -----------------------------------------------------------------
+
+    /** @return array{space_ref: string, unit_id: int, bed_id: null, centroid_m: array}|null */
+    private function anchorForUnit(?int $unitId): ?array
+    {
+        return $unitId !== null ? ($this->anchors()['unit'][$unitId] ?? null) : null;
+    }
+
+    /** @return array{space_ref: string, unit_id: int, bed_id: int, centroid_m: array}|null */
+    private function anchorForBed(?int $bedId): ?array
+    {
+        return $bedId !== null ? ($this->anchors()['bed'][$bedId] ?? null) : null;
+    }
+
+    private function anchorForLabel(?string $text): ?array
+    {
+        if ($text === null || trim($text) === '') {
+            return null;
+        }
+
+        return $this->anchors()['label'][mb_strtolower(trim($text))] ?? null;
+    }
+
+    /** @return array{unit: array<int, array>, bed: array<int, array>, label: array<string, array>} */
+    private function anchors(): array
+    {
+        if ($this->anchors !== null) {
+            return $this->anchors;
+        }
+
+        $unit = [];
+        $label = [];
+        foreach (Unit::query()->whereNotNull('facility_space_id')->with('facilitySpace')->get() as $u) {
+            $centroid = $this->centroid($u->facilitySpace);
+            if ($centroid === null) {
+                continue;
+            }
+            $anchor = ['space_ref' => $u->facilitySpace->space_code, 'unit_id' => (int) $u->unit_id, 'bed_id' => null, 'centroid_m' => $centroid];
+            $unit[(int) $u->unit_id] = $anchor;
+            foreach ([$u->name, $u->abbreviation] as $name) {
+                if ($name) {
+                    $label[mb_strtolower(trim($name))] = $anchor;
+                }
+            }
+        }
+
+        $bed = [];
+        foreach (Bed::query()->where('is_deleted', false)->whereNotNull('facility_space_id')->with('facilitySpace')->get() as $b) {
+            $centroid = $this->centroid($b->facilitySpace);
+            if ($centroid === null) {
+                continue;
+            }
+            $anchor = ['space_ref' => $b->facilitySpace->space_code, 'unit_id' => (int) $b->unit_id, 'bed_id' => (int) $b->bed_id, 'centroid_m' => $centroid];
+            $bed[(int) $b->bed_id] = $anchor;
+            if ($b->label) {
+                $label[mb_strtolower(trim($b->label))] = $anchor;
+            }
+        }
+
+        return $this->anchors = ['unit' => $unit, 'bed' => $bed, 'label' => $label];
+    }
+
+    /**
+     * Center-origin CAD geometry (feet) → 3D centroid in metres {x, y, z}.
+     * position_ft carries {x, level, z}; `level` is the vertical (floor) axis.
+     *
+     * @return array{x: float, y: float, z: float}|null
+     */
+    private function centroid(?FacilitySpace $space): ?array
+    {
+        $position = $space?->geometry['position_ft'] ?? null;
+        if (! is_array($position) || ! isset($position['x'], $position['z'])) {
+            return null;
+        }
+
+        return [
+            'x' => round(((float) $position['x']) * self::FEET_TO_M, 3),
+            'y' => round(((float) ($position['level'] ?? 0)) * self::FEET_TO_M, 3),
+            'z' => round(((float) $position['z']) * self::FEET_TO_M, 3),
+        ];
+    }
+}

--- a/app/Services/Flow/ForwardProjectionService.php
+++ b/app/Services/Flow/ForwardProjectionService.php
@@ -394,6 +394,7 @@ class ForwardProjectionService
                 service: 'or_schedule',
                 reliability: null,
                 endsAt: $ends,
+                room: $case->room?->name,
             );
         })->filter()->values();
     }
@@ -574,6 +575,7 @@ class ForwardProjectionService
         ?array $band = null,
         ?CarbonImmutable $endsAt = null,
         bool $derived = false,
+        ?string $room = null,
     ): array {
         $ptok = $patientRef !== null ? $this->patientContext->contextRefFor($patientRef) : null;
 
@@ -583,6 +585,7 @@ class ForwardProjectionService
             'confidence' => $confidence,
             'unit_id' => $unitId,
             'bed_id' => $bedId,
+            'room' => $room, // OR room name on scheduled_or_case; null elsewhere
             'entity' => $entity,
             'patient_context_ref' => $ptok,
             '_patient_ref' => $patientRef, // internal; stripped by the controller

--- a/app/Services/Flow/OperationalTimelineService.php
+++ b/app/Services/Flow/OperationalTimelineService.php
@@ -405,8 +405,8 @@ class OperationalTimelineService
     /** @return Collection<int, array<string, mixed>> */
     private function orEvents(CarbonImmutable $from, CarbonImmutable $to, array $kinds): Collection
     {
-        if (! in_array('or_milestone', $kinds, true)
-            || ! \Illuminate\Support\Facades\Schema::hasTable('prod.orlog')) {
+        $table = $this->orlogTable();
+        if (! in_array('or_milestone', $kinds, true) || $table === null) {
             return collect(); // periop import is optional; degrade to an empty lane
         }
 
@@ -421,12 +421,15 @@ class OperationalTimelineService
 
         $events = collect();
         $logs = \App\Models\ORLog::query()
+            ->from($table)
+            ->with('case.room') // ORLog→case→room: OR-side milestones land in a named room
             ->where('is_deleted', false)
             ->whereBetween('tracking_date', [$from->toDateString(), $to->toDateString()])
             ->limit(5000)
             ->get();
 
         foreach ($logs as $log) {
+            $room = $log->case?->room?->name;
             foreach ($milestones as $column => $label) {
                 $at = $this->orMilestoneAt($log, $column);
                 if ($at === null || ! $at->betweenIncluded($from, $to)) {
@@ -438,16 +441,32 @@ class OperationalTimelineService
                     entity: ['type' => 'or_case', 'ref' => (string) $log->case_id],
                     patientRef: null,
                     fromSpace: null,
-                    toSpace: str_starts_with($column, 'pacu') ? 'PACU' : 'OR',
+                    toSpace: str_starts_with($column, 'pacu') ? 'PACU' : ($room ?? 'OR'),
                     unitId: null,
                     label: $label.($log->primary_procedure ? ' · '.$log->primary_procedure : ''),
                     tier: 'info',
-                    source: 'prod.orlog',
+                    source: $table,
                 ));
             }
         }
 
         return $events;
+    }
+
+    /**
+     * Legacy ETL deployments carry the milestone log as prod.orlog; the
+     * migration path (and CommandCenterDemoSeeder + every periop SQL surface)
+     * uses prod.or_logs. Read whichever exists so or_milestone works on both.
+     */
+    private function orlogTable(): ?string
+    {
+        foreach (['prod.orlog', 'prod.or_logs'] as $table) {
+            if (\Illuminate\Support\Facades\Schema::hasTable($table)) {
+                return $table;
+            }
+        }
+
+        return null;
     }
 
     // -------------------------------------------------------------------

--- a/app/Services/Flow/Spaces3dAssetService.php
+++ b/app/Services/Flow/Spaces3dAssetService.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services\Flow;
+
+use App\Models\Bed;
+use App\Models\Facility\FacilitySpace;
+use App\Models\Unit;
+use App\Support\Hospital\HospitalManifest;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * 3D space-anchor asset for the NATIVE viewer (NATIVE-4D-VIEWER-PLAN §4 W3, D4).
+ *
+ * Ships the per-space 3D centroid (metres) + unit/bed bridges so the SceneKit /
+ * Filament renderers can place patient tokens and duty markers by centroid over
+ * the GLB shell — no fragile GLB-node mapping. Same source geometry as the 2D
+ * plates (hosp_space.facility_spaces.geometry.position_ft {x, level, z}), just
+ * projected to 3D metres. PHI-free, versioned by content hash, ETag-served at
+ * GET /api/mobile/v1/flow/spaces3d.
+ */
+class Spaces3dAssetService
+{
+    public const ASSET_PATH = 'flow/spaces3d.json';
+
+    private const FEET_TO_M = 0.3048;
+
+    private const CATEGORIES = [
+        'floor', 'zone', 'unit', 'room', 'bay', 'bed', 'corridor',
+        'vertical_transport', 'procedure_room', 'imaging',
+    ];
+
+    public function __construct(private readonly HospitalManifest $manifest) {}
+
+    /** @return array<string, mixed> */
+    public function build(): array
+    {
+        $spaces = FacilitySpace::query()
+            ->whereIn('space_category', self::CATEGORIES)
+            ->whereNotNull('floor_number')
+            ->orderBy('floor_number')
+            ->orderBy('space_code')
+            ->get(['facility_space_id', 'space_code', 'space_category', 'floor_number', 'geometry']);
+
+        $unitBySpace = Unit::query()->where('is_deleted', false)->whereNotNull('facility_space_id')
+            ->pluck('unit_id', 'facility_space_id');
+        $bedBySpace = Bed::query()->where('is_deleted', false)->whereNotNull('facility_space_id')
+            ->get(['bed_id', 'unit_id', 'facility_space_id'])->keyBy('facility_space_id');
+
+        $out = [];
+        foreach ($spaces as $space) {
+            $centroid = $this->centroid($space->geometry ?? []);
+            if ($centroid === null) {
+                continue;
+            }
+
+            $row = [
+                'space_ref' => $space->space_code,
+                'floor' => (int) $space->floor_number,
+                'category' => $space->space_category,
+                'unit_id' => ($u = $unitBySpace[$space->facility_space_id] ?? null) !== null ? (int) $u : null,
+                'bed_id' => null,
+                'centroid_m' => $centroid,
+            ];
+            if (($bed = $bedBySpace[$space->facility_space_id] ?? null) !== null) {
+                $row['bed_id'] = (int) $bed->bed_id;
+                $row['unit_id'] = (int) $bed->unit_id;
+            }
+            $out[] = $row;
+        }
+
+        $document = [
+            'facility' => [
+                'code' => $this->manifest->facilityCode(),
+                'cad_code' => $this->manifest->cadFacilityCode(),
+                'name' => $this->manifest->facilityName(),
+            ],
+            'units' => 'centroid_m {x, y, z} in metres; y is the vertical (floor) axis',
+            'spaces' => $out,
+        ];
+        $document['version'] = 'v1-'.substr(sha1(json_encode($document['spaces'])), 0, 12);
+
+        return $document;
+    }
+
+    /** @return array<string, mixed> */
+    public function write(): array
+    {
+        $document = $this->build();
+        Storage::disk('local')->put(self::ASSET_PATH, json_encode($document, JSON_UNESCAPED_SLASHES));
+        Cache::forget('flow:spaces3d:doc');
+
+        return $document;
+    }
+
+    /** @return array<string, mixed> */
+    public function load(): array
+    {
+        return Cache::remember('flow:spaces3d:doc', 300, function (): array {
+            $disk = Storage::disk('local');
+            if ($disk->exists(self::ASSET_PATH)) {
+                $decoded = json_decode((string) $disk->get(self::ASSET_PATH), true);
+                if (is_array($decoded) && isset($decoded['version'])) {
+                    return $decoded;
+                }
+            }
+
+            return $this->write();
+        });
+    }
+
+    /**
+     * Center-origin CAD geometry (feet) → 3D centroid metres {x, y, z}.
+     *
+     * @param  array<string, mixed>  $geometry
+     * @return array{x: float, y: float, z: float}|null
+     */
+    private function centroid(array $geometry): ?array
+    {
+        $position = $geometry['position_ft'] ?? null;
+        if (! is_array($position) || ! isset($position['x'], $position['z'])) {
+            return null;
+        }
+
+        return [
+            'x' => round(((float) $position['x']) * self::FEET_TO_M, 3),
+            'y' => round(((float) ($position['level'] ?? 0)) * self::FEET_TO_M, 3),
+            'z' => round(((float) $position['z']) * self::FEET_TO_M, 3),
+        ];
+    }
+}

--- a/config/hummingbird/flow_lens.php
+++ b/config/hummingbird/flow_lens.php
@@ -11,9 +11,12 @@
 |   scope_default    where the window opens (house | floor | unit | patient)
 |   scopes_allowed   scopes the role may request; anything else ⇒ 403
 |   layers           payload layers the role may request (snapshots, events,
-|                    projections, spaces)
+|                    projections, spaces, duties)
 |   event_kinds      normalized OperationalTimelineService kinds served
 |   projection_kinds ForwardProjectionService kinds served
+|   duty_kinds       DutyProjectionService kinds served — the persona's
+|                    actionable worklist, spatially anchored + due-dated (the
+|                    "what's due for me" layer the native 3D viewer renders)
 |   patient_dots     patient-entity depth in payloads — maps 1:1 onto the
 |                    MobilePatientContextService access matrix:
 |                      full  any operational patient        (bed_manager,
@@ -39,6 +42,10 @@
 |   expected_discharge, predicted_census, predicted_arrivals,
 |   scheduled_or_case, transport_due, evs_due, staffing_shift_gap,
 |   surge_probability
+|
+| Full duty-kind vocabulary (DutyProjectionService):
+|   transport_run, bed_turn, placement, barrier_resolve, staffing_fill,
+|   approval, discharge_leverage
 */
 
 return [
@@ -47,13 +54,14 @@ return [
     'charge_nurse' => [
         'scope_default' => 'unit',
         'scopes_allowed' => ['unit', 'floor', 'patient'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => [
             'admit', 'transfer', 'discharge', 'bed_status', 'acuity_changed',
             'bed_request', 'placement', 'transport_status', 'evs_status',
             'barrier_opened', 'barrier_resolved',
         ],
         'projection_kinds' => ['expected_discharge', 'predicted_census', 'evs_due', 'transport_due', 'staffing_shift_gap'],
+        'duty_kinds' => ['barrier_resolve', 'discharge_leverage'],
         'patient_dots' => 'unit',
         'actions' => ['resolve_barrier', 'acknowledge_inbound', 'open_patient'],
         'default_zoom_hours' => 12, // opens at the last shift boundary
@@ -62,12 +70,13 @@ return [
     'bedside_nurse' => [
         'scope_default' => 'unit',
         'scopes_allowed' => ['unit', 'patient'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => [
             'admit', 'transfer', 'discharge', 'bed_status', 'acuity_changed',
             'transport_status', 'evs_status', 'barrier_opened', 'barrier_resolved',
         ],
         'projection_kinds' => ['expected_discharge', 'evs_due', 'transport_due'],
+        'duty_kinds' => ['barrier_resolve', 'discharge_leverage'],
         'patient_dots' => 'unit',
         'actions' => ['open_patient'],
         'default_zoom_hours' => 8,
@@ -77,7 +86,7 @@ return [
     'bed_manager' => [
         'scope_default' => 'house',
         'scopes_allowed' => ['house', 'floor', 'unit', 'patient'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => [
             'admit', 'transfer', 'discharge', 'bed_status', 'acuity_changed',
             'ed_arrival', 'ed_admit_decision', 'bed_request', 'placement',
@@ -87,6 +96,7 @@ return [
             'expected_discharge', 'predicted_census', 'predicted_arrivals',
             'scheduled_or_case', 'transport_due', 'evs_due', 'surge_probability',
         ],
+        'duty_kinds' => ['placement', 'barrier_resolve'],
         'patient_dots' => 'full',
         'actions' => ['place_bed', 'open_patient'],
         'default_zoom_hours' => 48,
@@ -95,7 +105,7 @@ return [
     'house_supervisor' => [
         'scope_default' => 'house',
         'scopes_allowed' => ['house', 'floor', 'unit', 'patient'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => [
             'admit', 'transfer', 'discharge', 'bed_status', 'acuity_changed',
             'ed_arrival', 'ed_admit_decision', 'bed_request', 'placement',
@@ -107,6 +117,7 @@ return [
             'scheduled_or_case', 'transport_due', 'evs_due', 'staffing_shift_gap',
             'surge_probability',
         ],
+        'duty_kinds' => ['placement', 'barrier_resolve', 'staffing_fill'],
         'patient_dots' => 'full',
         'actions' => ['place_bed', 'resolve_barrier', 'open_patient'],
         'default_zoom_hours' => 48,
@@ -116,9 +127,10 @@ return [
     'hospitalist' => [
         'scope_default' => 'house',
         'scopes_allowed' => ['house', 'floor', 'unit', 'patient'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => ['admit', 'transfer', 'discharge', 'acuity_changed', 'barrier_opened', 'barrier_resolved'],
         'projection_kinds' => ['expected_discharge', 'predicted_census'],
+        'duty_kinds' => ['discharge_leverage'],
         'patient_dots' => 'unit',
         'actions' => ['open_patient'],
         'default_zoom_hours' => 24,
@@ -127,9 +139,10 @@ return [
     'intensivist' => [
         'scope_default' => 'house',
         'scopes_allowed' => ['house', 'floor', 'unit', 'patient'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => ['admit', 'transfer', 'discharge', 'acuity_changed', 'barrier_opened', 'barrier_resolved'],
         'projection_kinds' => ['expected_discharge', 'predicted_census'],
+        'duty_kinds' => ['discharge_leverage'],
         'patient_dots' => 'unit',
         'actions' => ['open_patient'],
         'default_zoom_hours' => 24,
@@ -139,9 +152,10 @@ return [
     'transport' => [
         'scope_default' => 'house',
         'scopes_allowed' => ['house', 'floor', 'patient'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => ['transport_status', 'discharge'],
         'projection_kinds' => ['transport_due', 'expected_discharge'],
+        'duty_kinds' => ['transport_run'],
         'patient_dots' => 'task',
         'actions' => ['claim_trip', 'open_patient'],
         'default_zoom_hours' => 8, // ±4h default zoom
@@ -151,9 +165,10 @@ return [
     'evs' => [
         'scope_default' => 'house',
         'scopes_allowed' => ['house', 'floor', 'patient'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => ['evs_status', 'bed_status', 'discharge'],
         'projection_kinds' => ['evs_due', 'expected_discharge'],
+        'duty_kinds' => ['bed_turn'],
         'patient_dots' => 'task',
         'actions' => ['claim_turn', 'start_turn', 'complete_turn'],
         'default_zoom_hours' => 8,
@@ -163,9 +178,10 @@ return [
     'or_nurse' => [
         'scope_default' => 'floor',
         'scopes_allowed' => ['floor'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => ['or_milestone'],
         'projection_kinds' => ['scheduled_or_case'],
+        'duty_kinds' => [], // OR milestones ride the event timeline; no patient-identified duties
         'patient_dots' => 'none',
         'actions' => [],
         'default_zoom_hours' => 16, // today's schedule span
@@ -175,9 +191,10 @@ return [
     'periop_manager' => [
         'scope_default' => 'floor',
         'scopes_allowed' => ['floor', 'house'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => ['or_milestone'],
         'projection_kinds' => ['scheduled_or_case', 'predicted_census'],
+        'duty_kinds' => [],
         'patient_dots' => 'none',
         'actions' => [],
         'default_zoom_hours' => 16,
@@ -187,7 +204,7 @@ return [
     'capacity_lead' => [
         'scope_default' => 'house',
         'scopes_allowed' => ['house', 'floor', 'unit', 'patient'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => [
             'admit', 'transfer', 'discharge', 'ed_arrival', 'ed_admit_decision',
             'bed_request', 'placement', 'barrier_opened', 'barrier_resolved',
@@ -196,6 +213,7 @@ return [
             'expected_discharge', 'predicted_census', 'predicted_arrivals',
             'staffing_shift_gap', 'surge_probability',
         ],
+        'duty_kinds' => ['approval', 'placement', 'barrier_resolve'],
         'patient_dots' => 'full',
         'actions' => ['decide_approval', 'open_patient'],
         'default_zoom_hours' => 48,
@@ -205,9 +223,10 @@ return [
     'executive' => [
         'scope_default' => 'house',
         'scopes_allowed' => ['house'],
-        'layers' => ['snapshots', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'projections', 'spaces', 'duties'],
         'event_kinds' => [],
         'projection_kinds' => ['predicted_census', 'predicted_arrivals', 'surge_probability'],
+        'duty_kinds' => [], // aggregate posture only — no patient-identified worklist
         'patient_dots' => 'none',
         'actions' => [],
         'default_zoom_hours' => 48,
@@ -217,9 +236,10 @@ return [
     'staffing_coordinator' => [
         'scope_default' => 'house',
         'scopes_allowed' => ['house', 'floor', 'unit'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => ['staffing_fill', 'admit', 'discharge'],
         'projection_kinds' => ['predicted_census', 'predicted_arrivals', 'staffing_shift_gap'],
+        'duty_kinds' => ['staffing_fill'],
         'patient_dots' => 'none',
         'actions' => ['fill_request'],
         'default_zoom_hours' => 24,
@@ -229,13 +249,14 @@ return [
     'pi_lead' => [
         'scope_default' => 'house',
         'scopes_allowed' => ['house', 'floor', 'unit'],
-        'layers' => ['snapshots', 'events', 'projections', 'spaces'],
+        'layers' => ['snapshots', 'events', 'projections', 'spaces', 'duties'],
         'event_kinds' => [
             'admit', 'transfer', 'discharge', 'bed_status', 'ed_arrival',
             'ed_admit_decision', 'transport_status', 'evs_status',
             'barrier_opened', 'barrier_resolved',
         ],
         'projection_kinds' => ['predicted_census', 'predicted_arrivals'],
+        'duty_kinds' => [], // de-identified pattern work, not individual duties
         'patient_dots' => 'none',
         'actions' => ['clip_window'],
         'default_zoom_hours' => 48,

--- a/docs/DEVLOG-native-4d-viewer-2026-07-05.md
+++ b/docs/DEVLOG-native-4d-viewer-2026-07-05.md
@@ -1,0 +1,127 @@
+# DEVLOG — Native 4D Viewer + Flow Window (2026-07-05)
+
+Handoff for the next session. This subproject turns the Hummingbird mobile
+**Flow Window** (48h persona-lensed map: 24h review + 24h prediction) into a
+**native 3D per-persona "duties" viewer** and eliminates the old 2.5D renderer.
+Governing plan: **`docs/hummingbird/NATIVE-4D-VIEWER-PLAN.md`** (read it first).
+Prior context: `docs/hummingbird/FLOW-WINDOW-PLAN.md`, memory
+`hummingbird-flow-window`, `canonical-backend-db`, `env-local-shadowing-trap`.
+
+---
+
+## 0. TL;DR — where we are
+
+- **Flow Window Phases 0–5: DONE, committed, pushed** (branch `codex/hummingbird-login`, `155d7e1..14f98ae`). Web 3D Navigator + mobile 2.5D map + backend, all green.
+- **NATIVE-4D-VIEWER — the active track:**
+  - **Phase A (backend duties layer + 3D substrate): DONE + verified, UNCOMMITTED.**
+  - **Phase B (native SceneKit 3D on iOS): FOUNDATION rendering on-device, UNCOMMITTED.** Reaches geometry+camera; patient tokens / time / picking / Android still open.
+  - **Phases C–E: OPEN.**
+- **The 3D twin renders on iPhone 17 Pro** (1,450 exploded floor-segment anchors, bed_manager lens) — see the reproduce recipe in §6.
+- **Everything runs against `pgsql.acumenus.net`** (the canonical DB). `.env` is pointed there.
+
+---
+
+## 1. Flow Window Phases 0–5 — DONE (committed + pushed)
+
+Baseline the native viewer builds on. All shipped, tested, and on the branch:
+- Backend data plane, `FlowLensService` + `config/hummingbird/flow_lens.php` (14 roles), `GET /api/mobile/v1/flow/{floors,window}`, `?since=` deltas, web RBAC (`EnforceFlowLens`).
+- Web 3D Navigator decomposed (`NavigatorScene.ts`, three.js lazy chunk), 48h Chronobar, projection ghosts, persona lens, `?persona=&scope=&t=` handoff.
+- Mobile **2.5D** map (iOS `Features/Flow/`, Android `ui/flow/`) for all 14 personas: floor plates + HouseStack + Chronobar + timeline lanes + per-persona lenses (transport arcs, EVS turn map, OR RoomLanes, aggregate curves), delta merge, offline cache, Live Activities/widgets.
+- **This 2.5D spatial renderer is what the native 3D replaces (see §4 Phase D).**
+
+---
+
+## 2. NATIVE-4D-VIEWER Phase A — DONE + verified (UNCOMMITTED)
+
+Backend "duties" layer + 3D substrate. Built inline (crash-resilient). All files on disk, **not committed**.
+
+**Shipped:**
+- `app/Services/Flow/DutyProjectionService.php` — per-persona, spatially-anchored, due-dated duties from the live domains (transport/EVS/placement/barrier/staffing/approval/discharge-leverage). Each duty: `{id, kind, label, space_ref, unit_id, bed_id, centroid_m{x,y,z}|null, due_at, window_status: overdue|due|upcoming, tier, patient_context_ref, provenance, action{endpoint,method,label}}`. Anchors via `facility_spaces.geometry.position_ft × 0.3048`. Carries `_patient_ref` for `FlowLensService::redactRow` (unset before serialize).
+- `app/Services/Flow/Spaces3dAssetService.php` + `GET /api/mobile/v1/flow/spaces3d` (`FlowController::spaces3d`) — versioned, ETagged 3D centroid anchors (`{version, spaces:[{space_ref, floor, category, unit_id, bed_id, centroid_m}]}`). Same load/write/version pattern as `FloorPlateAssetService`.
+- `config/hummingbird/flow_lens.php` — `duty_kinds` added to all 14 roles + `duties` in each `layers`.
+- `app/Http/Controllers/Api/Mobile/FlowController.php` — `duties[]` in the window payload (lens-clamped, redacted, **full on `?since=`**), `scopeUnitIds()` helper, `spaces3d()` endpoint.
+- `routes/api.php` — `/flow/spaces3d` route.
+- OpenAPI `hummingbird-bff.v1.yaml` — `FlowDuty`, `FlowSpace3d`, `FlowSpaces3dEnvelope`, `duties` on window, `/flow/spaces3d` path.
+- Tests: `tests/Feature/Mobile/FlowWindowTest.php` (duty clamp per persona, **14-role duty redaction matrix**, since-full, spaces3d 304); `SeedsFlowStory` already seeds transport/EVS/barrier/EDD duties; `MobileBffTest` drift map entry.
+
+**Verified:** `php artisan test tests/Feature/Mobile tests/Feature/MobileSharedDtoFixtureTest.php tests/Feature/PatientFlow` → **62 passed** (+drift/PatientFlow), Pint clean, fixtures regenerated with `duties`. Over HTTP against `pgsql.acumenus.net`: `spaces3d`=1450, `window?persona=bed_manager`=12 duties.
+**Caveat baked into tests:** the bare `zephyrus_test` DB has no CAD catalog → duty `centroid_m` resolves `null` there (anchoring only exercised against a catalog-loaded DB).
+
+---
+
+## 3. NATIVE-4D-VIEWER Phase B — iOS foundation rendering (UNCOMMITTED)
+
+Native SceneKit 3D twin. **Renders on iPhone 17 Pro** (verified visually).
+
+**Shipped (iOS only):**
+- `hummingbird/iosApp/Hummingbird/Features/Flow/Flow3DView.swift` — SceneKit `UIViewRepresentable`. Exploded floor plates (segments = `SCNBox` per space, Y = floor rank × gap), bed-status colors, **free orbit/pinch** via `allowsCameraControl` + explicit `pointOfView`. **Frames on the clinical core** (bed/room categories) so campus/floor-slab CAD outliers don't blow up the camera distance.
+- `FlowModels.swift` — `FlowDuty`, `FlowSpace3d`, `FlowSpaces3dDocument`, `FlowCentroid3d`, `FlowDutyAction`; `duties` added to `FlowWindowData` (decode + memberwise init + `merged(delta:)` + CodingKeys).
+- `APIClient.swift` — `flowSpaces3d(bearer:)`.
+- `FlowWindowStore.swift` — `@Published spaces3d`, fetched in `load()`.
+- `FlowMapView.swift` — `is3DLens` (bed_manager/house_supervisor) → `flow3DLayer` renders `Flow3DView` instead of the 2.5D `houseLayer`.
+
+**Verified:** `xcodebuild` green; on-device shows "1,450 anchors" exploded hospital twin, bed_manager lens, inside the Flow Window (Chronobar + timeline lanes intact).
+
+**What's LEFT in Phase B (to reach web-viewer parity):**
+1. **Patient tokens** — spheres at bed centroids from window snapshots/events, hidden for `patient_dots:none`.
+2. **Chronobar-driven time** — the scrubber `t` should drive the scene (past replay, future ghosts). Right now the scene is static "now"; it does not yet react to `store.t`.
+3. **Tap-pick → inspector** — raycast the `SCNBox` (nodes are named by `space_ref`) → selection sheet.
+4. **Census / forecast heat** — per-unit pillars; forecast ghosts ahead of now.
+5. **Legibility** — house scope is currently monochrome (bed colors only show at floor/unit scope where `bed_statuses` is served). Add census heat + a "focus my duties" camera. Segment sizes/scale tuning.
+6. **Gesture conflict** — the 3D canvas sits in a scrolling layout; `allowsCameraControl` fights the scroll. Phase E may want a full-screen 3D mode.
+7. **Android Filament/SceneView** — the SECOND renderer, not started. `ui/flow/` on Android needs the same: DTOs (duty + spaces3d), a `Flow3DView` equivalent (SceneView), wiring in `FlowMapScreen`.
+
+---
+
+## 4. Phases C–E — OPEN (from the plan)
+
+- **Phase C — duties overlay + one-tap actions (frontline first):** render the `duties[]` (already flowing to the client — 12 for bed_manager) as 3D markers at their `centroid_m`, colored by `window_status` (overdue coral / due amber / upcoming ghost), with a synced duties bottom-sheet and one-tap `action.endpoint` calls. Start with transport/evs/charge_nurse.
+- **Phase D — all 14 personas in 3D + DELETE the 2.5D:** wire every lens' framing into the 3D scene, then remove iOS `FloorPlateView.swift`/`HouseStackView.swift`, Android `FloorPlateCanvas.kt`/`HouseStack.kt`, and the 2.5D branches in FlowMapView/FlowMapScreen. **Parity-before-delete** — do not delete until every persona renders in 3D.
+- **Phase E — perf/legibility/battery + offline + screenshot matrix + the two cache fixes (§5).**
+
+---
+
+## 5. CRITICAL environment notes & gotchas (read before touching anything)
+
+1. **Canonical DB = `pgsql.acumenus.net`** (user `smudoshi`, pass `Acumenus321$%`, db `zephyrus`). `.env` is pointed there. Do NOT use the wiped `192.168.1.58` or local `hb_pg`. Memory: `canonical-backend-db`.
+2. **`.env.local` shadowing trap:** `APP_ENV=local` + a tracked `.env.local` makes Laravel load `.env.local` INSTEAD of `.env` (drops APP_KEY → 500). `.env.local` is currently **moved aside** to `.env.local.shadow-disabled` so the full `.env` loads. Keep it aside. Memory: `env-local-shadowing-trap`.
+3. **Backend serves via Docker:** containers `hb_pg` (owns ports), `hb_serve` (mounts the repo at `/var/www/html`, runs `php artisan serve --port=8001`), `hb_reverb`. After any crash/restart: `docker start hb_pg hb_serve hb_reverb`, then `docker exec hb_serve php artisan config:clear`. The iOS sim build targets `localhost:8001`.
+4. **Post-restart DB race:** right after `docker start`, `pgsql.acumenus.net` connections can TIME OUT for a few seconds, then recover. Retry before concluding the DB is broken.
+5. **TWO caching bugs that hid the 3D render (Phase E must fix):**
+   - **Server:** `Spaces3dAssetService.load()` (and FloorPlateAssetService) cache the built asset in the 300s **file cache**. Under the post-restart DB race, an **empty** build got cached and served as `spaces=[]`. Fix: don't cache empty builds; invalidate on empty. Workaround: `docker exec hb_serve php artisan tinker --execute="Cache::forget('flow:spaces3d:doc'); Cache::forget('flow:plates:doc');"` + delete `storage/app/flow/*.json`.
+   - **Client:** the endpoint sends `Cache-Control: private, max-age=86400`, so iOS `URLCache` cached the transient empty response for **24h across relaunches**. Only an app **uninstall** cleared it. Fix: APIClient should revalidate versioned assets via `If-None-Match` (ETag) rather than blind-serve for 24h.
+6. **No `demo` user on the canonical DB.** To run the mobile app, auto-login as the **admin**: `HB_USER=smudoshi HB_PASS='Acumenus321$%'` (broad access → any persona). Creating a `demo` account on prod was intentionally NOT done (safety: weak-cred backdoor on a production hospital DB). Goal (a) was retired; (b) — show the map via the existing admin — is done.
+7. **Temp test affordance in the tree:** `HB_HOME_MODE=map` hook in `hummingbird/iosApp/Hummingbird/Features/RTDC/HouseCapacityView.swift` (`viewMode` initial value reads the env). Launch-gated, inert in production; used to screenshot the Map without tapping. Revert or keep as a sanctioned hook.
+8. **Tests run against `zephyrus_test`** (phpunit.xml). NEVER `migrate:fresh` anything but the test DB; NEVER touch `pgsql.acumenus.net` data.
+9. **Working tree is heavily dirty and UNCOMMITTED.** It contains (a) this native-viewer work (Phase A backend + Phase B iOS + plan/devlog), (b) the earlier toggle fix, AND (c) a large **unrelated** service-line/deployment + staffing-wizard body of work from other sessions (`app/Services/Deployment/`, `app/Models/Org/`, `database/migrations/2026_07_04_*`, etc.). **Do not commit the unrelated work.** Stage the native-viewer files explicitly (see §7). The Flow Window Phases 2–5 are already committed/pushed.
+
+---
+
+## 6. How to build / verify / reproduce the 3D render
+
+**Backend tests:** `php artisan test tests/Feature/Mobile` (host; uses `zephyrus_test`). Must stay green.
+
+**iOS build:** `cd hummingbird/iosApp && xcodegen generate && xcodebuild -project Hummingbird.xcodeproj -scheme Hummingbird -destination 'generic/platform=iOS Simulator' build`.
+
+**Reproduce the on-device 3D twin (the exact dance that works):**
+1. `docker start hb_pg hb_serve hb_reverb && docker exec hb_serve php artisan config:clear`
+2. Warm the server cache correctly: `docker exec hb_serve php artisan tinker --execute="\Illuminate\Support\Facades\Cache::forget('flow:spaces3d:doc'); echo count(app(\App\Services\Flow\Spaces3dAssetService::class)->load()['spaces']);"` → must print **1450**, not 0.
+3. Build for the booted sim (`-destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath build/DD`).
+4. **Uninstall first** to clear the client URLCache: `xcrun simctl uninstall booted net.acumenus.hummingbird`, then `install`.
+5. Launch: `SIMCTL_CHILD_HB_AUTOLOGIN=1 SIMCTL_CHILD_HB_USER=smudoshi SIMCTL_CHILD_HB_PASS='Acumenus321$%' SIMCTL_CHILD_HB_ROLE=bed_manager SIMCTL_CHILD_HB_TAB=home SIMCTL_CHILD_HB_HOME_MODE=map xcrun simctl launch booted net.acumenus.hummingbird`
+6. Screenshot: `xcrun simctl io booted screenshot out.png`. Expect the exploded 3D hospital (1,450 anchors).
+
+**Web 4D Navigator (three.js, live movement):** log in at `http://localhost:8001/login` as `smudoshi` / `Acumenus321$%`, go to `/rtdc/patient-flow-navigator`. Requires the Vite dev server (`npm run dev`, :5176) because `app.blade.php` hardcodes a `.jsx` per-page entry and this page is `.tsx` — **pre-existing bug worth fixing** (make the blade resolve `.tsx`). Run `patient-flow:rebase-synthetic --anchor=now` so the synthetic movements fall in the 48h window.
+
+---
+
+## 7. Suggested next steps (in order)
+
+1. **Commit the native-viewer work** (explicit pathspec — do NOT sweep the unrelated deployment work): `app/Services/Flow/DutyProjectionService.php`, `Spaces3dAssetService.php`, `app/Http/Controllers/Api/Mobile/FlowController.php`, `config/hummingbird/flow_lens.php`, `routes/api.php`, OpenAPI + fixtures, `tests/Feature/Mobile/FlowWindowTest.php`, `tests/Feature/MobileBffTest.php`, `hummingbird/iosApp/Hummingbird/Features/Flow/*`, `Networking/APIClient.swift`, `docs/hummingbird/NATIVE-4D-VIEWER-PLAN.md`, this devlog. (Also the earlier toggle fix in `resources/js/Components/PatientFlowNavigator/`.)
+2. **Finish Phase B iOS parity:** patient tokens → Chronobar-driven time → tap-pick inspector → census heat.
+3. **Android Filament renderer** (the second engine).
+4. **Phase C duties overlay + actions** (duties already reach the client).
+5. **Phase E:** fix the two caching bugs (§5.5), then perf + the persona screenshot matrix.
+6. **Phase D:** delete the 2.5D renderers once all personas render in 3D.
+
+Open product questions (plan §11): service-scope patient access for hospitalist/intensivist; EDD write-back as a first-class duty action; whether to reuse the 753 KB GLB shell or keep the procedural box scene.

--- a/docs/hummingbird/FLOW-WINDOW-PLAN.md
+++ b/docs/hummingbird/FLOW-WINDOW-PLAN.md
@@ -1,5 +1,70 @@
 # The 48-Hour Flow Window — 4D for Every Persona
 
+**Status update 2026-07-04 (later) — Phases 3–4 IMPLEMENTED.**
+Phase 3 (aggregate lenses, both platforms): shared FlowCurve (48h census
+curve: solid past from snapshots, dashed predicted_census + band ribbon,
+staffed-capacity line, shift detents); executive 15s auto-replay time-lapse
+(Reduce Motion honored) settling into the forecast strip; capacity_lead
+curve-first with client-side floor/unit focus; staffing coverage-vs-curve
+with per-floor worst-gap tints (never color alone); hospitalist/intensivist
+discharge-leverage lane (ranked expected_discharge → A2P when ref present;
+iOS census-home map had to be enabled for them, Android already had it);
+pi_lead 4h/s replay + clip-to-share (plain-text summary + links.web
+?from=&to= — v1, no PDSA write). No backend changes needed.
+Phase 4 (web Navigator parity): monolith decomposed (NavigatorScene.ts is
+React-free and the only three.js importer — lazy chunk 642 kB, navigator UI
+chunk 21.7 kB); trails/heat rebuild now bucketed instead of per-frame;
+48h Chronobar (past coverage band, dashed future, detents, graceful sparse
+data); projection ghost layer from /api/patient-flow/projections (entity
+ghosts at unit/room anchors, aggregate forecast pillars + HUD, provenance
+in inspector); persona lens via shared ResolvesFlowLens trait (patient_dots
+none/unit/task redaction in scene + inspector; lens-less web users keep the
+full house view); ?persona=&scope=&t= handoff. Verified: vite build green,
+vitest 180 passed, tsc no new errors, full backend suite 376 passed / 1
+pre-existing env failure (EddyKnowledgeRagTest needs pgvector, absent from
+the local hb_pg postgres image — fails identically on HEAD).
+**Status update 2026-07-04 (final) — Phase 5 IMPLEMENTED. Phases 0–5 all
+shipped.** Backend: `?since=` delta on GET /flow/window — events/snapshots
+filtered to t > since, projections/spaces/bed_statuses always full,
+`window.since` echo, 422 `invalid_since` on out-of-range/malformed;
+OpenAPI + 4 delta tests (FlowWindowTest 20 green, MobileBff drift green).
+iOS: delta merge + per-user offline FlowCache (LRU 20, staleness caption,
+cleared on logout) + Reverb/foreground delta refresh; the widget extension,
+Live Activities, and App-Group house-glance widget were already shipped in
+commit 9ac1b6a, so Phase 5 EXTENDED them — added SLA countdowns
+(Text(timerInterval:) on lock screen + Dynamic Island, calm not coral) and
+the enriched glance widget (occupancy %, net bed need, For You count,
+next-4h ghost count, updated-at); clean xcodebuild green, 0 warnings,
+.appex embedded — no fallback rung taken. Android: same delta merge +
+per-user filesDir/flow-cache (atomic, LRU 20) + Glance house widget
+(app-driven updateAll, no background networking) + T1–T4 urgency
+notification channels registered at start (FCM send still blocked on
+server credentials); 17 new pure-logic unit tests + assembleDebug green.
+Whole feature verified: backend mobile/flow suites green, both mobile
+builds green. REMAINING (tracked, not blocking): persona screenshot matrix
+(14 roles × surfaces × 2 platforms), plate-LOD/dot-batching perf pass,
+real APNs/FCM push credentials, EDD write-back + service-scope patient
+access (§11 open questions), and the pre-existing pgvector env gap in
+EddyKnowledgeRagTest (unrelated to this feature).
+
+**Status update 2026-07-04 — Phase 2 IMPLEMENTED.** Frontline task lenses +
+periop shipped on both platforms: transport (house/floor trip arcs with
+unit-abbr → unit-name → bed-label endpoint resolution, off-map gutter for
+free-text destinations, derived-ghost trips with provenance chips), EVS (turn
+map: bed-level `bed_statuses` tints at floor/unit scope — now-only, fading on
+scrub — plus past turn ticks and dashed `evs_due` bed ghosts with time/ISO
+chips), OR (RoomLanes: per-room case bars t→ends_at with cascade drift "+Xm"
+chips, milestone ticks, or_nurse room picker, periop floor auto-resolved via
+procedure_room plates). Contract additions (additive): projection `room`
+field, window `bed_statuses` (floor/unit scope × bed_status-lens gate),
+or_milestone `to_space` = real room name; new fixture
+`mobile-flow-window-evs.json`; story seeds now cover transport/EVS/OR.
+Bug fixed en route: or_milestone read the legacy `prod.orlog` table that no
+migration creates — now resolves `prod.orlog` → `prod.or_logs` at query time.
+Verified: backend 64 passed (redaction matrix green), Android
+`assembleDebug` + unit tests green, iOS `xcodebuild` green + 7 fixtures
+decoded. Phases 3–5 remain open.
+
 **Status:** Phases 0–1 IMPLEMENTED (2026-07-03) — data plane + contract + lens
 RBAC shipped and verified (`FlowWindowTest`, `PatientFlowApiTest`,
 `MobileBffTest` green; live-verified against the seeded local `hb_pg` demo);

--- a/docs/hummingbird/NATIVE-4D-VIEWER-PLAN.md
+++ b/docs/hummingbird/NATIVE-4D-VIEWER-PLAN.md
@@ -1,0 +1,172 @@
+# Native 4D Viewer — Per-Persona Duties in Space & Time
+
+**Status:** Proposed (not started) — supersedes the mobile 2.5D Flow Window renderer.
+**Date:** 2026-07-04
+**Decisions locked (user):** (1) **Native 3D on both platforms** — SceneKit (iOS) + Filament/SceneView (Android), not WebView, not 2.5D. (2) **The 2.5D floor‑plate / axonometric‑stack view is eliminated** — the native 3D twin replaces it (built to full‑persona parity *before* deletion; see §9). (3) Write this plan before code.
+**Mandate:** the 4D viewer is a **critically important frontline surface for every persona** — its job is to show *what assignments and duties are due for their actions*, in the real building, across the 48‑hour window.
+**Builds on:** `FLOW-WINDOW-PLAN.md` (Phases 0–5, shipped), `ALTITUDE-PERSONA-OPERATING-PLAN.md`, `ADR-2026-07-01-altitude-patient-lens.md`.
+
+---
+
+## 1. The reframe: the 4D viewer is a **duties** instrument
+
+The current viewers answer *"where are patients moving?"* The mandate is different and sharper:
+
+> For **this persona**, show **the duties due to me** — what, **where** in the building, **when** on the timeline (overdue / due / upcoming), and let me **act** — rendered in a real 3D twin I can read and trust at a glance.
+
+So the 3D twin is not the point; it is the **canvas**. The point is the persona's **duties, in space and time**. Every design decision serves legibility of "my work, where and when." A 3D building that doesn't make a transporter's next three runs obvious in two seconds is a failure regardless of how good it looks.
+
+Design non‑negotiables (PRODUCT.md / DESIGN.md):
+- **Duties‑first, twin‑second.** The 3D exists to place and time the duties. A persona must be able to answer "what's due for me next, and where?" in ~2s.
+- **Earned urgency.** Overdue = coral; due‑soon = amber; upcoming = calm/ghost. Never an alarm field.
+- **Defensible.** Every projected/predicted duty cites its source + reliability (reuse the Flow Window provenance model).
+- **One‑handed glance‑and‑act.** Frontline devices, gloves, motion. Big tap targets, a duties bottom‑sheet synced to the scene, Reduce‑Motion honored.
+
+---
+
+## 2. What exists today (build on it — do not restart)
+
+### 2.1 Mobile 2.5D Flow Window (to be replaced)
+- iOS `Features/Flow/`, Android `ui/flow/`. Per‑persona, live `prod.*`, 48h Chronobar, entry via List⇄Map on all 14 persona homes.
+- **2.5D spatial renderers (RETIRE):** iOS `FloorPlateView.swift`, `HouseStackView.swift`; Android `FloorPlateCanvas.kt`, `HouseStack.kt`.
+- **Reusable, keep:** `Chronobar(View)`, `FlowModels`, `FlowWindowStore` / `FlowViewModel`, `FlowWindowCache`, `TimelineLanes`, `FlowCurve(View)`, `FlowLensPanels` / `FlowAggregateLenses`, `RoomLanes(View)`, `TransportRoutesLayer`, `EvsTurnLayer` (their *data/logic*; the drawing moves into the 3D scene where spatial).
+
+### 2.2 Web 3D viewer (reference implementation for the scene)
+- three.js `NavigatorScene.ts` + the GLB shell (`public/vendor/zephyrus-facility-models/zep-500/hospital_model.glb`, **753 KB**). Persona lens (Phase 4), projection ghosts, Chronobar, patient tokens/trails/census/forecast. Runs on synthetic `flow_core` (no live tasks, no duties overlay). This is the **scene spec reference** the native renderers mirror.
+
+### 2.3 Backend & data (the substrate the duties layer plugs into)
+- `GET /api/mobile/v1/flow/{window,floors}`, `FlowLensService`, `flow_lens.php` (14 roles with **scope / event_kinds / projection_kinds / patient_dots / actions**), `ForwardProjectionService` (due‑dated projections: `transport_due`, `evs_due`, `staffing_shift_gap`, `expected_discharge`, …), `OperationalTimelineService`, `bed_statuses`, `since`‑deltas.
+- **Task/duty domains already live:** `TransportOperationsService`, `EvsOperationsService`, `BedPlacementService`, `BarrierService`, `StaffingOperationsService`, `RoomStatusService`, `OperationalActivityLedger`, `MobileForYouService` (already ranks each persona's duties!).
+- **3D geometry substrate exists:** `hosp_space.facility_spaces` carries `floor_number`, `position_ft`, and **`centroid_x_ft / centroid_y_ft / centroid_z_ft`** per space (room/bed/unit) — exact 3D anchors for tokens and duty markers. Bridged to `prod.units`/`prod.beds` (Phase 0 `facility:link-operational`).
+
+**Key insight:** ~70% of "duties due per persona" already exists as data (For‑You + projections + domain queues + actions). The missing pieces are (a) a **unified, spatially‑anchored, due‑dated duties stream**, and (b) a **native 3D renderer** that places it. We are not starting from zero.
+
+---
+
+## 3. Architecture decisions
+
+- **D1 — Native 3D, two engines.** iOS **SceneKit** (OS‑native, SwiftUI `UIViewRepresentable`, node picking, instancing; GLB→USDZ via Model I/O/`GLTFKit` at build time). Android **Filament via SceneView (`io.github.sceneview:sceneview`)** (Compose‑friendly, glTF/PBR, hit‑testing). Rejected: WebView embed (battery/offline/feel), RealityKit (overhead), raw OpenGL (cost).
+- **D2 — Eliminate the 2.5D, but parity‑before‑delete.** The 3D twin is the *only* spatial view at the end. The 2.5D renderers are deleted in **Phase D**, *after* the 3D reaches all‑14‑persona parity — never leave a persona without a spatial view mid‑flight.
+- **D3 — Duties are a first‑class layer, not a footnote.** New `duties[]` in the window payload: `{id, kind, persona_action, label, space_ref, unit_id, bed_id, centroid_3d, due_at, window_status: overdue|due|upcoming, tier, provenance, action{endpoint,method}}`. Sourced from the domain services above, per‑persona via the lens.
+- **D4 — Reuse the GLB shell; anchor by centroid, not mesh nodes.** The GLB is the building *shell*. Tokens/duty‑markers are placed by `facility_spaces` **3D centroids** (ft→m), exactly as the web viewer maps `position_ft`. No fragile GLB‑internal node mapping required. Ship the GLB + a compact **space‑anchor asset** (`GET /flow/spaces3d`: `{space_ref, floor, unit_id, bed_id, centroid_m, category}`), versioned + ETagged like the 2D plates.
+- **D5 — One scene *spec*, three renderers.** Layout math (exploded‑floor offsets, token sizing, color/urgency mapping, ghost grammar, camera framings) is defined **once** in shared design tokens + the API contract + shared fixtures, and implemented per renderer (three.js / SceneKit / Filament). Prevents divergence across the three viewers.
+- **D6 — Keep the temporal + lens spine.** Chronobar (48h), TimelineLanes, `FlowWindowStore`/`FlowViewModel`, lens RBAC, `since`‑deltas, offline cache — all reused. The 3D scene is a new *render target* for the same store.
+
+---
+
+## 4. Data plane (backend workstreams)
+
+### W1 — Duties service (the core new capability)
+`app/Services/Flow/DutyProjectionService.php`: assemble each persona's due duties into one spatially‑anchored, due‑dated stream, composing the existing domain services + `MobileForYouService` + `ForwardProjectionService`. Each duty carries a `space_ref` + `centroid_3d` (via `facility_spaces`), a `due_at`, a `window_status`, and its governed `action`. Kinds by persona (see §8): trips, turns, placements, barriers, discharges‑to‑confirm, staffing fills, OR milestones, approvals, PDSA steps.
+
+### W2 — Per‑persona duty lens
+Extend `config/hummingbird/flow_lens.php`: add `duty_kinds` + confirm `actions` per role. Enforce server‑side in `FlowLensService` (duties clamped to the role, patient identity still ptok‑gated by `patient_dots`).
+
+### W3 — 3D space‑anchor asset
+`FloorPlateAssetService` → add `spaces3d` export (`facility:export-spaces3d`): per‑space 3D centroid (m), floor, category, unit/bed bridges; versioned JSON, ETag, `GET /api/mobile/v1/flow/spaces3d`. Ship alongside the GLB (or a mobile‑decimated glTF if profiling demands).
+
+### W4 — Window payload + contract
+Add `duties[]` to `GET /flow/window` (lens‑clamped, `since`‑aware — duties are "always full" like projections). OpenAPI + shared fixtures (`mobile-flow-window*.json`) + drift test + the 14‑role **redaction matrix extended to duties** (zero raw refs; zero patient identity for `patient_dots:none`; each persona sees only *their* duty kinds).
+
+### W5 — Live per‑space state for the twin
+Ensure room/segment‑level occupancy/status (extend `bed_statuses` → `space_states` at floor/unit scope) so segments light by real state at time `t` (occupied/available/blocked/dirty/in‑use). Reuse the checkpoint+replay model for the past half.
+
+---
+
+## 5. The native 3D scene (per platform — mirror the web scene spec)
+
+Shared scene graph (both engines):
+1. **Building shell** — GLB, semi‑transparent, floors separable.
+2. **Exploded‑floor layout** — floors lifted apart on Y by a shared offset (the axonometric idea, now true 3D), so interior segments are visible; collapse‑to‑solid‑tower toggle.
+3. **Segment layer** — room/bed segments colored by live state at `t` (from W5), placed by centroid.
+4. **Patient tokens** *(lens `patient_dots` ≠ none)* — instanced markers at bed centroids; hidden entirely for aggregate personas.
+5. **Trails** — polylines through a patient's visited centroids up to `t` (past half only).
+6. **Census / Forecast heat** — per‑unit pillars; forecast pillars as translucent ghosts ahead of `now`.
+7. **Duties layer (the headline)** — per‑persona duty markers at their `space_ref` centroid: shape by kind, color by `window_status` (coral/amber/calm), badge with `due_at` countdown, ghost styling when future. Routes (transport) as arcs between origin/destination centroids across floors.
+8. **Camera** — orbit/pinch; **per‑persona default framing** (§8); "Focus my duties" fit‑to‑bounds; Reset.
+9. **Picking** — tap → raycast → segment/patient/duty → inspector bottom‑sheet with the governed action.
+10. **Time** — the Chronobar drives `t`; scrubbing/playback updates layers (past = replay, future = ghosts), symmetric with today's Flow Window.
+
+Engine specifics: SceneKit `SCNView` in a `UIViewRepresentable` bridged to `FlowWindowStore`; Filament `SceneView` composable bridged to `FlowViewModel`. Instanced token geometry, LOD, frustum culling, `preferredFramesPerSecond`/`renderCallback` gating, pause on background.
+
+---
+
+## 6. Duties overlay & actionability (per persona)
+
+- **Duty markers** placed by centroid, sized for touch, badged with countdown; overdue floats/pulses (subtle), upcoming is ghosted on the future half of the Chronobar.
+- **Synced duties sheet** — a bottom sheet listing the persona's duties (ranked overdue→due→upcoming), each row selectable → highlights/frames its marker in 3D; the reverse also holds (tap marker → scroll sheet). This is the "what's due for me" answer.
+- **One‑tap actions** — each duty's governed endpoint (already on the BFF): `claim/advance/handoff` trip, `claim/start/complete` turn, `resolve` barrier, `place/reject` bed, `fill` request, `decide` approval, `confirm EDD`. Optimistic UI + `since`‑delta refresh + 409 conflict handling (reuse Phase 5).
+- **"Focus my duties"** camera preset frames only the spaces with the persona's open duties.
+
+---
+
+## 7. Per‑persona 3D lens specs (all 14 — duties‑first)
+
+Format — **Default framing** · **Duties shown** · **Patient depth** · **Signature "what's due" moment**.
+
+- **Transporter** — camera follows own trips across floors (route arcs) · trips (claim/advance/handoff) + derived discharge‑runs · task · *"3 runs due next hour; the STAT from 4W is overdue — here's the route."*
+- **EVS** — floors colored by dirty/turn state · turns (claim/start/complete), isolation‑flagged · task · *"Floor 4 lights up amber — 5 turns due, 1 isolation, ordered by due‑time."*
+- **Charge / Bedside Nurse** — own unit exploded, bed grid in 3D · discharges‑to‑confirm, barriers‑to‑resolve, inbound placements, EVS/transport touching my beds · unit · *"My unit at shift‑start: 3 probable discharges, 2 barriers due, 2 boarders inbound."*
+- **Hospitalist / Intensivist** — their patients lit across floors · discharge‑leverage duties (confirm EDD), downgrades · unit(service‑scope = §12 open Q) · *"Rounding order by what my discharge unblocks."*
+- **Bed Manager / House Supervisor** — whole house, exploded · placements (place/reject with scored beds as arcs), barriers, surge · full · *"Scrub +6h: MICU saturates unless 2 step‑downs move — place them here."*
+- **OR Nurse / Periop Manager** — periop floor, rooms in 3D · case milestones, turnovers, PACU handoffs (delay cascade) · none · *"OR‑4 turnover drag threatens the 13:00 slot."*
+- **Capacity Lead** — house, curve‑primary + 3D heat · approvals plotted at projected impact time · full · *"This approval moves the 18:00 peak −2.1 beds."*
+- **Executive** — house heat only, **no tokens/duties markers** (aggregate; `patient_dots:none`) · none · *15s time‑lapse settling into tomorrow's forecast band.*
+- **Staffing Coordinator** — floors tinted by gap vs predicted census · fills due at shift boundaries · none · *"TEL7A below‑safe at 19:00 if 4 admits land — fill here."*
+- **PI / Quality Lead** — de‑identified house replay · pattern clips (no patient markers) · none · *"Boarding builds 15:00–19:00 every day — clip it."*
+
+(Executive/PI/Staffing/OR remain aggregate/no‑patient per the A2P matrix; their "duties" are approvals/fills/clips, not patient‑identified.)
+
+---
+
+## 8. Retiring the 2.5D (§ "eliminate it")
+
+- **Delete (Phase D, after 3D parity):** iOS `FloorPlateView.swift`, `HouseStackView.swift`; Android `FloorPlateCanvas.kt`, `HouseStack.kt`; and the 2.5D branches inside `FlowMapView`/`FlowMapScreen`.
+- **Absorb into 3D:** `RoomLanes` (OR) and `TransportRoutesLayer`/`EvsTurnLayer` spatial drawing become 3D layers; their *logic* is retained.
+- **Keep as supporting 2D chrome (not the retired "2.5D map"):** Chronobar, TimelineLanes, `FlowCurve` (census curve panel), the duties bottom‑sheet, `FlowLensPanels`.
+- **Entry point:** the home "Map" segment becomes the 3D viewer (relabel "3D" / "Twin"); the "List" worklist stays.
+
+---
+
+## 9. Phasing
+
+- **Phase A — Backend duties + 3D substrate:** W1 DutyProjectionService · W2 duty lens · W3 `spaces3d` asset · W4 `duties[]` contract + fixtures + 14‑role redaction matrix · W5 space_states. Ship behind the existing lens; verify with tests before any UI.
+- **Phase B — Native 3D foundation (both platforms), one persona:** SceneKit + SceneView scenes to **parity with the web viewer** (shell, exploded floors, segments, patients, trails, census, forecast, camera, picking, Chronobar‑driven time) for **bed_manager/house_supervisor** (house scope). Flagged; 2.5D still present.
+- **Phase C — Duties overlay + actions (frontline first):** the duties layer + synced sheet + one‑tap actions for **transport, evs, charge_nurse** end‑to‑end.
+- **Phase D — All personas + eliminate 2.5D:** wire all 14 lens framings into the 3D scene; **delete the 2.5D renderers** (§8); 3D becomes the sole spatial view.
+- **Phase E — Perf, legibility, stickiness:** LOD/instancing/battery pass, per‑persona camera tuning, offline model+asset cache, Live Activity/widget ties to due‑duties, the full **persona × surface × platform screenshot matrix** as the regression gate.
+
+Each phase ends demo‑able against the canonical DB (`pgsql.acumenus.net`); test writes only against `zephyrus_test`.
+
+---
+
+## 10. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Three renderers of one scene** (three.js + SceneKit + Filament) diverge | D5: one scene *spec* in tokens + contract + shared fixtures; parity checklist per phase |
+| Native 3D is a large, two‑engine lift | Phase to parity on one persona first; reuse GLB + centroid anchoring (no node mapping); keep the whole temporal/lens/store spine |
+| **Deleting the only spatial view before 3D is ready** | D2 parity‑before‑delete: 2.5D removed only in Phase D |
+| 3D on a phone becomes an unreadable gimmick | Duties‑first framing, per‑persona default cameras, "Focus my duties", bottom‑sheet sync, 2s‑glance success criterion |
+| Battery/thermal on frontline devices | LOD, instancing, culling, fps gating, pause‑on‑background, decimated model if needed |
+| GLB→USDZ / SceneView maturity | Build‑time conversion validated in Phase B spike; SceneView is production‑used; fall back to a decimated glTF |
+| PHI via a richer surface | Duties + tokens are ptok‑gated; `patient_dots:none` personas get no markers; redaction matrix extended to duties as a Phase‑A gate |
+
+---
+
+## 11. Open questions
+
+1. **Service‑scope patient access** for hospitalist/intensivist (unit‑based today) — needed for their "my patients across the house" duties. (Same P5.4‑class change flagged in FLOW‑WINDOW‑PLAN §11.)
+2. **EDD write‑back** (confirm/adjust discharge) as a first‑class duty+action — new endpoint + ledger event.
+3. **Model fidelity** — is the 753 KB shell enough per‑floor detail, or do we need a higher‑detail per‑floor model for unit/bed legibility when zoomed?
+4. **Offline** — cache the model + `spaces3d` + last window per (persona, scope); how much history to keep for the replay half.
+
+---
+
+## 12. Success criteria
+
+- Every one of the 14 personas opens a **native 3D** twin and, within ~2 seconds, can see **what is due to them, where, and when** — verified by the screenshot matrix + task‑time checks.
+- A frontline duty can be **acted on** from the 3D scene (claim/start/complete/place/resolve/fill) end‑to‑end.
+- Zero raw patient refs in any payload; zero patient markers for `patient_dots:none` personas (automated).
+- The **2.5D renderers are deleted**; the 3D twin is the sole spatial view, at parity with the web viewer plus the duties layer.
+- Web (three.js) and mobile (SceneKit/Filament) render the same state for the same `t` and persona.

--- a/docs/hummingbird/api-contract/fixtures/mobile-flow-floors.json
+++ b/docs/hummingbird/api-contract/fixtures/mobile-flow-floors.json
@@ -19,7 +19,7 @@
                 "shape_count": 4,
                 "spaces": [
                     {
-                        "id": 204,
+                        "id": 615,
                         "code": "ZEPHYRUS-500:L3-icu_patient-01",
                         "category": "corridor",
                         "label": "L3 ICU patient corridor segment 01",
@@ -31,7 +31,7 @@
                         ]
                     },
                     {
-                        "id": 203,
+                        "id": 614,
                         "code": "ZEPHYRUS-500:TICU-B001",
                         "category": "bed",
                         "label": "Test Surgical Trauma ICU bed 001",
@@ -45,7 +45,7 @@
                         "unit_id": 26
                     },
                     {
-                        "id": 202,
+                        "id": 613,
                         "code": "ZEPHYRUS-500:TICU-R001",
                         "category": "room",
                         "label": "Test Surgical Trauma ICU patient room 001",
@@ -57,7 +57,7 @@
                         ]
                     },
                     {
-                        "id": 201,
+                        "id": 612,
                         "code": "ZEPHYRUS-500:UNIT-TICU",
                         "category": "unit",
                         "label": "Test Surgical Trauma ICU",
@@ -83,7 +83,7 @@
                 "shape_count": 1,
                 "spaces": [
                     {
-                        "id": 205,
+                        "id": 616,
                         "code": "ZEPHYRUS-500:TRM-01",
                         "category": "vertical_transport",
                         "label": "Trauma priority elevator 01",
@@ -97,12 +97,12 @@
                 ]
             }
         ],
-        "version": "v1-2b3e9f90ad5d"
+        "version": "v1-a8f91dc9a9e4"
     },
     "meta": {
-        "as_of": "2026-07-04T19:36:22.656383Z",
+        "as_of": "2026-07-05T03:05:15.385660Z",
         "stale": false,
-        "version": "v1-2b3e9f90ad5d"
+        "version": "v1-a8f91dc9a9e4"
     },
     "links": {
         "web": "http://localhost/rtdc/patient-flow-navigator"

--- a/docs/hummingbird/api-contract/fixtures/mobile-flow-floors.json
+++ b/docs/hummingbird/api-contract/fixtures/mobile-flow-floors.json
@@ -19,7 +19,7 @@
                 "shape_count": 4,
                 "spaces": [
                     {
-                        "id": 36,
+                        "id": 204,
                         "code": "ZEPHYRUS-500:L3-icu_patient-01",
                         "category": "corridor",
                         "label": "L3 ICU patient corridor segment 01",
@@ -31,7 +31,7 @@
                         ]
                     },
                     {
-                        "id": 35,
+                        "id": 203,
                         "code": "ZEPHYRUS-500:TICU-B001",
                         "category": "bed",
                         "label": "Test Surgical Trauma ICU bed 001",
@@ -45,7 +45,7 @@
                         "unit_id": 26
                     },
                     {
-                        "id": 34,
+                        "id": 202,
                         "code": "ZEPHYRUS-500:TICU-R001",
                         "category": "room",
                         "label": "Test Surgical Trauma ICU patient room 001",
@@ -57,7 +57,7 @@
                         ]
                     },
                     {
-                        "id": 33,
+                        "id": 201,
                         "code": "ZEPHYRUS-500:UNIT-TICU",
                         "category": "unit",
                         "label": "Test Surgical Trauma ICU",
@@ -83,7 +83,7 @@
                 "shape_count": 1,
                 "spaces": [
                     {
-                        "id": 37,
+                        "id": 205,
                         "code": "ZEPHYRUS-500:TRM-01",
                         "category": "vertical_transport",
                         "label": "Trauma priority elevator 01",
@@ -97,12 +97,12 @@
                 ]
             }
         ],
-        "version": "v1-346c77a48494"
+        "version": "v1-2b3e9f90ad5d"
     },
     "meta": {
-        "as_of": "2026-07-04T01:27:05.400748Z",
+        "as_of": "2026-07-04T19:36:22.656383Z",
         "stale": false,
-        "version": "v1-346c77a48494"
+        "version": "v1-2b3e9f90ad5d"
     },
     "links": {
         "web": "http://localhost/rtdc/patient-flow-navigator"

--- a/docs/hummingbird/api-contract/fixtures/mobile-flow-window-evs.json
+++ b/docs/hummingbird/api-contract/fixtures/mobile-flow-window-evs.json
@@ -1,9 +1,10 @@
 {
     "data": {
         "window": {
-            "from": "2026-07-03T19:36:22+00:00",
-            "to": "2026-07-05T19:36:22+00:00",
-            "now": "2026-07-04T19:36:22+00:00"
+            "from": "2026-07-04T03:05:15+00:00",
+            "to": "2026-07-06T03:05:15+00:00",
+            "now": "2026-07-05T03:05:15+00:00",
+            "since": null
         },
         "lens": {
             "role_id": "evs",
@@ -17,7 +18,8 @@
                 "snapshots",
                 "events",
                 "projections",
-                "spaces"
+                "spaces",
+                "duties"
             ],
             "event_kinds": [
                 "evs_status",
@@ -44,7 +46,7 @@
             "label": "Floor 3"
         },
         "spaces": {
-            "plates_version": "v1-2b3e9f90ad5d",
+            "plates_version": "v1-a8f91dc9a9e4",
             "floors": [
                 {
                     "floor": 1,
@@ -680,7 +682,7 @@
         "snapshots": [],
         "events": [
             {
-                "t": "2026-07-04T18:51:22+00:00",
+                "t": "2026-07-05T02:20:14+00:00",
                 "kind": "evs_status",
                 "entity": {
                     "type": "evs",
@@ -699,7 +701,29 @@
         ],
         "projections": [
             {
-                "t": "2026-07-04T20:06:22+00:00",
+                "t": "2026-07-05T04:05:14+00:00",
+                "kind": "evs_due",
+                "confidence": "definite",
+                "unit_id": 1,
+                "bed_id": 1,
+                "room": null,
+                "entity": {
+                    "type": "evs",
+                    "ref": "1"
+                },
+                "patient_context_ref": "ptok_dcf6bf35b952bc96d48730ad",
+                "label": "Turn due \u00b7 MICU-01",
+                "value": null,
+                "band": null,
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "evs_requests",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-05T11:00:00+00:00",
                 "kind": "expected_discharge",
                 "confidence": "definite",
                 "unit_id": 1,
@@ -721,7 +745,7 @@
                 }
             },
             {
-                "t": "2026-07-04T20:26:22+00:00",
+                "t": "2026-07-05T11:20:00+00:00",
                 "kind": "evs_due",
                 "confidence": "probable",
                 "unit_id": 1,
@@ -741,30 +765,9 @@
                     "service": "derived \u00b7 expected_discharge",
                     "reliability": null
                 }
-            },
-            {
-                "t": "2026-07-04T20:36:22+00:00",
-                "kind": "evs_due",
-                "confidence": "definite",
-                "unit_id": 1,
-                "bed_id": 1,
-                "room": null,
-                "entity": {
-                    "type": "evs",
-                    "ref": "1"
-                },
-                "patient_context_ref": "ptok_dcf6bf35b952bc96d48730ad",
-                "label": "Turn due \u00b7 MICU-01",
-                "value": null,
-                "band": null,
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "evs_requests",
-                    "reliability": null
-                }
             }
         ],
+        "duties": [],
         "bed_statuses": [
             {
                 "bed_id": 1,
@@ -1345,12 +1348,12 @@
         ]
     },
     "meta": {
-        "as_of": "2026-07-04T19:36:22.669267Z",
+        "as_of": "2026-07-05T03:05:15.400626Z",
         "stale": false,
         "version": null,
         "count": 4
     },
     "links": {
-        "web": "http://localhost/rtdc/patient-flow-navigator?persona=evs&scope=floor%3A3&t=2026-07-04T19%3A36%3A22%2B00%3A00"
+        "web": "http://localhost/rtdc/patient-flow-navigator?persona=evs&scope=floor%3A3&t=2026-07-05T03%3A05%3A15%2B00%3A00"
     }
 }

--- a/docs/hummingbird/api-contract/fixtures/mobile-flow-window-evs.json
+++ b/docs/hummingbird/api-contract/fixtures/mobile-flow-window-evs.json
@@ -6,12 +6,11 @@
             "now": "2026-07-04T19:36:22+00:00"
         },
         "lens": {
-            "role_id": "bed_manager",
+            "role_id": "evs",
             "scope_default": "house",
             "scopes_allowed": [
                 "house",
                 "floor",
-                "unit",
                 "patient"
             ],
             "layers": [
@@ -21,42 +20,28 @@
                 "spaces"
             ],
             "event_kinds": [
-                "admit",
-                "transfer",
-                "discharge",
-                "bed_status",
-                "acuity_changed",
-                "ed_arrival",
-                "ed_admit_decision",
-                "bed_request",
-                "placement",
-                "transport_status",
                 "evs_status",
-                "barrier_opened",
-                "barrier_resolved"
+                "bed_status",
+                "discharge"
             ],
             "projection_kinds": [
-                "expected_discharge",
-                "predicted_census",
-                "predicted_arrivals",
-                "scheduled_or_case",
-                "transport_due",
                 "evs_due",
-                "surge_probability"
+                "expected_discharge"
             ],
-            "patient_dots": "full",
+            "patient_dots": "task",
             "actions": [
-                "place_bed",
-                "open_patient"
+                "claim_turn",
+                "start_turn",
+                "complete_turn"
             ],
-            "default_zoom_hours": 48
+            "default_zoom_hours": 8
         },
         "scope": {
-            "type": "house",
-            "floor": null,
+            "type": "floor",
+            "floor": 3,
             "unit_id": null,
             "patient_context_ref": null,
-            "label": "House"
+            "label": "Floor 3"
         },
         "spaces": {
             "plates_version": "v1-2b3e9f90ad5d",
@@ -695,74 +680,6 @@
         "snapshots": [],
         "events": [
             {
-                "t": "2026-07-04T13:36:22+00:00",
-                "kind": "admit",
-                "entity": {
-                    "type": "patient",
-                    "ref": "ptok_8d4a9ae0c199bcb8aa2dba8e"
-                },
-                "patient_context_ref": "ptok_8d4a9ae0c199bcb8aa2dba8e",
-                "from_space": null,
-                "to_space": "MICU",
-                "unit_id": 1,
-                "label": "Admitted to MICU",
-                "tier": "info",
-                "provenance": {
-                    "source": "prod.operational_events"
-                }
-            },
-            {
-                "t": "2026-07-04T15:36:22+00:00",
-                "kind": "barrier_opened",
-                "entity": {
-                    "type": "barrier",
-                    "ref": "1"
-                },
-                "patient_context_ref": null,
-                "from_space": null,
-                "to_space": "MICU",
-                "unit_id": 1,
-                "label": "Barrier \u00b7 Awaiting ride",
-                "tier": "warning",
-                "provenance": {
-                    "source": "prod.barriers"
-                }
-            },
-            {
-                "t": "2026-07-04T17:36:22+00:00",
-                "kind": "transport_status",
-                "entity": {
-                    "type": "transport",
-                    "ref": "1"
-                },
-                "patient_context_ref": "ptok_d28278b3880c212d359d8919",
-                "from_space": "ED",
-                "to_space": "MICU-01",
-                "unit_id": null,
-                "label": "Transport requested",
-                "tier": "info",
-                "provenance": {
-                    "source": "prod.transport_events"
-                }
-            },
-            {
-                "t": "2026-07-04T18:36:22+00:00",
-                "kind": "transport_status",
-                "entity": {
-                    "type": "transport",
-                    "ref": "1"
-                },
-                "patient_context_ref": "ptok_d28278b3880c212d359d8919",
-                "from_space": "ED",
-                "to_space": "MICU-01",
-                "unit_id": null,
-                "label": "Transport queued",
-                "tier": "info",
-                "provenance": {
-                    "source": "prod.transport_events"
-                }
-            },
-            {
                 "t": "2026-07-04T18:51:22+00:00",
                 "kind": "evs_status",
                 "entity": {
@@ -782,91 +699,6 @@
         ],
         "projections": [
             {
-                "t": "2026-07-04T18:36:22+00:00",
-                "kind": "scheduled_or_case",
-                "confidence": "definite",
-                "unit_id": null,
-                "bed_id": null,
-                "room": "OR 3",
-                "entity": {
-                    "type": "or_case",
-                    "ref": "1"
-                },
-                "patient_context_ref": null,
-                "label": "OR 3 \u00b7 General Surgery",
-                "value": null,
-                "band": null,
-                "ends_at": "2026-07-04T22:36:22+00:00",
-                "derived": false,
-                "provenance": {
-                    "service": "or_schedule",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-04T19:36:22+00:00",
-                "kind": "surge_probability",
-                "confidence": "probable",
-                "unit_id": null,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Surge probability \u00b7 next 24h",
-                "value": 4,
-                "band": null,
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "command_center_surge_heuristic",
-                    "reliability": 0.8
-                }
-            },
-            {
-                "t": "2026-07-04T20:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "probable",
-                "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-04T20:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "probable",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 5
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
                 "t": "2026-07-04T20:06:22+00:00",
                 "kind": "expected_discharge",
                 "confidence": "definite",
@@ -877,7 +709,7 @@
                     "type": "encounter",
                     "ref": "1"
                 },
-                "patient_context_ref": "ptok_8d4a9ae0c199bcb8aa2dba8e",
+                "patient_context_ref": null,
                 "label": "Expected discharge",
                 "value": null,
                 "band": null,
@@ -885,28 +717,6 @@
                 "derived": false,
                 "provenance": {
                     "service": "rtdc_predictions \u00d7 encounter EDD",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-04T20:06:22+00:00",
-                "kind": "transport_due",
-                "confidence": "probable",
-                "unit_id": 1,
-                "bed_id": 1,
-                "room": null,
-                "entity": {
-                    "type": "encounter",
-                    "ref": "1"
-                },
-                "patient_context_ref": "ptok_8d4a9ae0c199bcb8aa2dba8e",
-                "label": "Likely discharge transport",
-                "value": null,
-                "band": null,
-                "ends_at": null,
-                "derived": true,
-                "provenance": {
-                    "service": "derived \u00b7 expected_discharge",
                     "reliability": null
                 }
             },
@@ -953,786 +763,594 @@
                     "service": "evs_requests",
                     "reliability": null
                 }
-            },
+            }
+        ],
+        "bed_statuses": [
             {
-                "t": "2026-07-04T21:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "probable",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 4
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-04T21:36:22+00:00",
-                "kind": "transport_due",
-                "confidence": "definite",
-                "unit_id": null,
-                "bed_id": null,
-                "room": null,
-                "entity": {
-                    "type": "transport",
-                    "ref": "1"
-                },
-                "patient_context_ref": "ptok_d28278b3880c212d359d8919",
-                "label": "Transport due \u00b7 ED \u2192 MICU-01",
-                "value": null,
-                "band": null,
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "transport_requests",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-04T22:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "probable",
+                "bed_id": 1,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast",
-                    "reliability": null
-                }
+                "label": "MICU-01",
+                "status": "occupied"
             },
             {
-                "t": "2026-07-04T22:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "probable",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 4
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-04T23:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "probable",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 4
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T00:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
+                "bed_id": 2,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
+                "label": "MICU-02",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T00:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "probable",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T01:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "probable",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T02:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
+                "bed_id": 3,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
+                "label": "MICU-03",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T02:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T03:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T04:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
+                "bed_id": 4,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
+                "label": "MICU-04",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T04:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T05:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T06:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
+                "bed_id": 5,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
+                "label": "MICU-05",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T06:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 4
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T07:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 5
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T08:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
+                "bed_id": 6,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
+                "label": "MICU-06",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T08:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 5
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T09:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 6
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T10:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
+                "bed_id": 7,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
+                "label": "MICU-07",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T10:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 6
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T11:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 7
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T12:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
+                "bed_id": 8,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 0,
-                "band": {
-                    "lower": 0,
-                    "upper": 1
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
+                "label": "MICU-08",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T12:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 6
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T13:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 6
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T14:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
+                "bed_id": 9,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 0,
-                "band": {
-                    "lower": 0,
-                    "upper": 1
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
+                "label": "MICU-09",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T14:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 6
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T15:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 6
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T16:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
+                "bed_id": 10,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 0,
-                "band": {
-                    "lower": 0,
-                    "upper": 1
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
+                "label": "MICU-10",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T16:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 6
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T17:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 7
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T18:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
+                "bed_id": 11,
                 "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 0,
-                "band": {
-                    "lower": 0,
-                    "upper": 1
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
+                "label": "MICU-11",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T18:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 7
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
+                "bed_id": 12,
+                "unit_id": 1,
+                "label": "MICU-12",
+                "status": "available"
             },
             {
-                "t": "2026-07-05T19:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 2,
-                "band": {
-                    "lower": 0,
-                    "upper": 7
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
+                "bed_id": 13,
+                "unit_id": 1,
+                "label": "MICU-13",
+                "status": "available"
+            },
+            {
+                "bed_id": 14,
+                "unit_id": 1,
+                "label": "MICU-14",
+                "status": "available"
+            },
+            {
+                "bed_id": 15,
+                "unit_id": 1,
+                "label": "MICU-15",
+                "status": "available"
+            },
+            {
+                "bed_id": 16,
+                "unit_id": 1,
+                "label": "MICU-16",
+                "status": "available"
+            },
+            {
+                "bed_id": 17,
+                "unit_id": 1,
+                "label": "MICU-17",
+                "status": "available"
+            },
+            {
+                "bed_id": 18,
+                "unit_id": 1,
+                "label": "MICU-18",
+                "status": "available"
+            },
+            {
+                "bed_id": 19,
+                "unit_id": 1,
+                "label": "MICU-19",
+                "status": "available"
+            },
+            {
+                "bed_id": 20,
+                "unit_id": 1,
+                "label": "MICU-20",
+                "status": "available"
+            },
+            {
+                "bed_id": 21,
+                "unit_id": 1,
+                "label": "MICU-21",
+                "status": "available"
+            },
+            {
+                "bed_id": 22,
+                "unit_id": 1,
+                "label": "MICU-22",
+                "status": "available"
+            },
+            {
+                "bed_id": 23,
+                "unit_id": 1,
+                "label": "MICU-23",
+                "status": "available"
+            },
+            {
+                "bed_id": 24,
+                "unit_id": 1,
+                "label": "MICU-24",
+                "status": "available"
+            },
+            {
+                "bed_id": 25,
+                "unit_id": 2,
+                "label": "SICU-01",
+                "status": "available"
+            },
+            {
+                "bed_id": 26,
+                "unit_id": 2,
+                "label": "SICU-02",
+                "status": "available"
+            },
+            {
+                "bed_id": 27,
+                "unit_id": 2,
+                "label": "SICU-03",
+                "status": "available"
+            },
+            {
+                "bed_id": 28,
+                "unit_id": 2,
+                "label": "SICU-04",
+                "status": "available"
+            },
+            {
+                "bed_id": 29,
+                "unit_id": 2,
+                "label": "SICU-05",
+                "status": "available"
+            },
+            {
+                "bed_id": 30,
+                "unit_id": 2,
+                "label": "SICU-06",
+                "status": "available"
+            },
+            {
+                "bed_id": 31,
+                "unit_id": 2,
+                "label": "SICU-07",
+                "status": "available"
+            },
+            {
+                "bed_id": 32,
+                "unit_id": 2,
+                "label": "SICU-08",
+                "status": "available"
+            },
+            {
+                "bed_id": 33,
+                "unit_id": 2,
+                "label": "SICU-09",
+                "status": "available"
+            },
+            {
+                "bed_id": 34,
+                "unit_id": 2,
+                "label": "SICU-10",
+                "status": "available"
+            },
+            {
+                "bed_id": 35,
+                "unit_id": 2,
+                "label": "SICU-11",
+                "status": "available"
+            },
+            {
+                "bed_id": 36,
+                "unit_id": 2,
+                "label": "SICU-12",
+                "status": "available"
+            },
+            {
+                "bed_id": 37,
+                "unit_id": 2,
+                "label": "SICU-13",
+                "status": "available"
+            },
+            {
+                "bed_id": 38,
+                "unit_id": 2,
+                "label": "SICU-14",
+                "status": "available"
+            },
+            {
+                "bed_id": 39,
+                "unit_id": 2,
+                "label": "SICU-15",
+                "status": "available"
+            },
+            {
+                "bed_id": 40,
+                "unit_id": 2,
+                "label": "SICU-16",
+                "status": "available"
+            },
+            {
+                "bed_id": 41,
+                "unit_id": 2,
+                "label": "SICU-17",
+                "status": "available"
+            },
+            {
+                "bed_id": 42,
+                "unit_id": 2,
+                "label": "SICU-18",
+                "status": "available"
+            },
+            {
+                "bed_id": 43,
+                "unit_id": 2,
+                "label": "SICU-19",
+                "status": "available"
+            },
+            {
+                "bed_id": 44,
+                "unit_id": 2,
+                "label": "SICU-20",
+                "status": "available"
+            },
+            {
+                "bed_id": 45,
+                "unit_id": 2,
+                "label": "SICU-21",
+                "status": "available"
+            },
+            {
+                "bed_id": 46,
+                "unit_id": 2,
+                "label": "SICU-22",
+                "status": "available"
+            },
+            {
+                "bed_id": 47,
+                "unit_id": 2,
+                "label": "SICU-23",
+                "status": "available"
+            },
+            {
+                "bed_id": 48,
+                "unit_id": 2,
+                "label": "SICU-24",
+                "status": "available"
+            },
+            {
+                "bed_id": 49,
+                "unit_id": 3,
+                "label": "NSICU-01",
+                "status": "available"
+            },
+            {
+                "bed_id": 50,
+                "unit_id": 3,
+                "label": "NSICU-02",
+                "status": "available"
+            },
+            {
+                "bed_id": 51,
+                "unit_id": 3,
+                "label": "NSICU-03",
+                "status": "available"
+            },
+            {
+                "bed_id": 52,
+                "unit_id": 3,
+                "label": "NSICU-04",
+                "status": "available"
+            },
+            {
+                "bed_id": 53,
+                "unit_id": 3,
+                "label": "NSICU-05",
+                "status": "available"
+            },
+            {
+                "bed_id": 54,
+                "unit_id": 3,
+                "label": "NSICU-06",
+                "status": "available"
+            },
+            {
+                "bed_id": 55,
+                "unit_id": 3,
+                "label": "NSICU-07",
+                "status": "available"
+            },
+            {
+                "bed_id": 56,
+                "unit_id": 3,
+                "label": "NSICU-08",
+                "status": "available"
+            },
+            {
+                "bed_id": 57,
+                "unit_id": 3,
+                "label": "NSICU-09",
+                "status": "available"
+            },
+            {
+                "bed_id": 58,
+                "unit_id": 3,
+                "label": "NSICU-10",
+                "status": "available"
+            },
+            {
+                "bed_id": 59,
+                "unit_id": 3,
+                "label": "NSICU-11",
+                "status": "available"
+            },
+            {
+                "bed_id": 60,
+                "unit_id": 3,
+                "label": "NSICU-12",
+                "status": "available"
+            },
+            {
+                "bed_id": 61,
+                "unit_id": 3,
+                "label": "NSICU-13",
+                "status": "available"
+            },
+            {
+                "bed_id": 62,
+                "unit_id": 3,
+                "label": "NSICU-14",
+                "status": "available"
+            },
+            {
+                "bed_id": 63,
+                "unit_id": 3,
+                "label": "NSICU-15",
+                "status": "available"
+            },
+            {
+                "bed_id": 64,
+                "unit_id": 3,
+                "label": "NSICU-16",
+                "status": "available"
+            },
+            {
+                "bed_id": 65,
+                "unit_id": 3,
+                "label": "NSICU-17",
+                "status": "available"
+            },
+            {
+                "bed_id": 66,
+                "unit_id": 3,
+                "label": "NSICU-18",
+                "status": "available"
+            },
+            {
+                "bed_id": 67,
+                "unit_id": 3,
+                "label": "NSICU-19",
+                "status": "available"
+            },
+            {
+                "bed_id": 68,
+                "unit_id": 3,
+                "label": "NSICU-20",
+                "status": "available"
+            },
+            {
+                "bed_id": 69,
+                "unit_id": 4,
+                "label": "CVICU-01",
+                "status": "available"
+            },
+            {
+                "bed_id": 70,
+                "unit_id": 4,
+                "label": "CVICU-02",
+                "status": "available"
+            },
+            {
+                "bed_id": 71,
+                "unit_id": 4,
+                "label": "CVICU-03",
+                "status": "available"
+            },
+            {
+                "bed_id": 72,
+                "unit_id": 4,
+                "label": "CVICU-04",
+                "status": "available"
+            },
+            {
+                "bed_id": 73,
+                "unit_id": 4,
+                "label": "CVICU-05",
+                "status": "available"
+            },
+            {
+                "bed_id": 74,
+                "unit_id": 4,
+                "label": "CVICU-06",
+                "status": "available"
+            },
+            {
+                "bed_id": 75,
+                "unit_id": 4,
+                "label": "CVICU-07",
+                "status": "available"
+            },
+            {
+                "bed_id": 76,
+                "unit_id": 4,
+                "label": "CVICU-08",
+                "status": "available"
+            },
+            {
+                "bed_id": 77,
+                "unit_id": 4,
+                "label": "CVICU-09",
+                "status": "available"
+            },
+            {
+                "bed_id": 78,
+                "unit_id": 4,
+                "label": "CVICU-10",
+                "status": "available"
+            },
+            {
+                "bed_id": 79,
+                "unit_id": 4,
+                "label": "CVICU-11",
+                "status": "available"
+            },
+            {
+                "bed_id": 80,
+                "unit_id": 4,
+                "label": "CVICU-12",
+                "status": "available"
+            },
+            {
+                "bed_id": 81,
+                "unit_id": 4,
+                "label": "CVICU-13",
+                "status": "available"
+            },
+            {
+                "bed_id": 82,
+                "unit_id": 4,
+                "label": "CVICU-14",
+                "status": "available"
+            },
+            {
+                "bed_id": 83,
+                "unit_id": 4,
+                "label": "CVICU-15",
+                "status": "available"
+            },
+            {
+                "bed_id": 84,
+                "unit_id": 4,
+                "label": "CVICU-16",
+                "status": "available"
+            },
+            {
+                "bed_id": 85,
+                "unit_id": 4,
+                "label": "CVICU-17",
+                "status": "available"
+            },
+            {
+                "bed_id": 86,
+                "unit_id": 4,
+                "label": "CVICU-18",
+                "status": "available"
+            },
+            {
+                "bed_id": 87,
+                "unit_id": 4,
+                "label": "CVICU-19",
+                "status": "available"
+            },
+            {
+                "bed_id": 88,
+                "unit_id": 4,
+                "label": "CVICU-20",
+                "status": "available"
+            },
+            {
+                "bed_id": 89,
+                "unit_id": 5,
+                "label": "BURN-01",
+                "status": "available"
+            },
+            {
+                "bed_id": 90,
+                "unit_id": 5,
+                "label": "BURN-02",
+                "status": "available"
+            },
+            {
+                "bed_id": 91,
+                "unit_id": 5,
+                "label": "BURN-03",
+                "status": "available"
+            },
+            {
+                "bed_id": 92,
+                "unit_id": 5,
+                "label": "BURN-04",
+                "status": "available"
+            },
+            {
+                "bed_id": 93,
+                "unit_id": 5,
+                "label": "BURN-05",
+                "status": "available"
+            },
+            {
+                "bed_id": 94,
+                "unit_id": 5,
+                "label": "BURN-06",
+                "status": "available"
+            },
+            {
+                "bed_id": 95,
+                "unit_id": 5,
+                "label": "BURN-07",
+                "status": "available"
+            },
+            {
+                "bed_id": 96,
+                "unit_id": 5,
+                "label": "BURN-08",
+                "status": "available"
             }
         ]
     },
     "meta": {
-        "as_of": "2026-07-04T19:36:22.652282Z",
+        "as_of": "2026-07-04T19:36:22.669267Z",
         "stale": false,
         "version": null,
-        "count": 48
+        "count": 4
     },
     "links": {
-        "web": "http://localhost/rtdc/patient-flow-navigator?persona=bed_manager&scope=house&t=2026-07-04T19%3A36%3A22%2B00%3A00"
+        "web": "http://localhost/rtdc/patient-flow-navigator?persona=evs&scope=floor%3A3&t=2026-07-04T19%3A36%3A22%2B00%3A00"
     }
 }

--- a/docs/hummingbird/api-contract/fixtures/mobile-flow-window.json
+++ b/docs/hummingbird/api-contract/fixtures/mobile-flow-window.json
@@ -1,9 +1,10 @@
 {
     "data": {
         "window": {
-            "from": "2026-07-03T19:36:22+00:00",
-            "to": "2026-07-05T19:36:22+00:00",
-            "now": "2026-07-04T19:36:22+00:00"
+            "from": "2026-07-04T03:05:15+00:00",
+            "to": "2026-07-06T03:05:15+00:00",
+            "now": "2026-07-05T03:05:15+00:00",
+            "since": null
         },
         "lens": {
             "role_id": "bed_manager",
@@ -18,7 +19,8 @@
                 "snapshots",
                 "events",
                 "projections",
-                "spaces"
+                "spaces",
+                "duties"
             ],
             "event_kinds": [
                 "admit",
@@ -59,7 +61,7 @@
             "label": "House"
         },
         "spaces": {
-            "plates_version": "v1-2b3e9f90ad5d",
+            "plates_version": "v1-a8f91dc9a9e4",
             "floors": [
                 {
                     "floor": 1,
@@ -695,7 +697,7 @@
         "snapshots": [],
         "events": [
             {
-                "t": "2026-07-04T13:36:22+00:00",
+                "t": "2026-07-04T21:05:14+00:00",
                 "kind": "admit",
                 "entity": {
                     "type": "patient",
@@ -712,7 +714,7 @@
                 }
             },
             {
-                "t": "2026-07-04T15:36:22+00:00",
+                "t": "2026-07-04T23:05:14+00:00",
                 "kind": "barrier_opened",
                 "entity": {
                     "type": "barrier",
@@ -729,7 +731,7 @@
                 }
             },
             {
-                "t": "2026-07-04T17:36:22+00:00",
+                "t": "2026-07-05T01:05:14+00:00",
                 "kind": "transport_status",
                 "entity": {
                     "type": "transport",
@@ -746,7 +748,7 @@
                 }
             },
             {
-                "t": "2026-07-04T18:36:22+00:00",
+                "t": "2026-07-05T02:05:14+00:00",
                 "kind": "transport_status",
                 "entity": {
                     "type": "transport",
@@ -763,7 +765,7 @@
                 }
             },
             {
-                "t": "2026-07-04T18:51:22+00:00",
+                "t": "2026-07-05T02:20:14+00:00",
                 "kind": "evs_status",
                 "entity": {
                     "type": "evs",
@@ -782,7 +784,7 @@
         ],
         "projections": [
             {
-                "t": "2026-07-04T18:36:22+00:00",
+                "t": "2026-07-05T02:05:14+00:00",
                 "kind": "scheduled_or_case",
                 "confidence": "definite",
                 "unit_id": null,
@@ -796,7 +798,7 @@
                 "label": "OR 3 \u00b7 General Surgery",
                 "value": null,
                 "band": null,
-                "ends_at": "2026-07-04T22:36:22+00:00",
+                "ends_at": "2026-07-05T06:05:14+00:00",
                 "derived": false,
                 "provenance": {
                     "service": "or_schedule",
@@ -804,7 +806,7 @@
                 }
             },
             {
-                "t": "2026-07-04T19:36:22+00:00",
+                "t": "2026-07-05T03:05:15+00:00",
                 "kind": "surge_probability",
                 "confidence": "probable",
                 "unit_id": null,
@@ -823,7 +825,7 @@
                 }
             },
             {
-                "t": "2026-07-04T20:00:00+00:00",
+                "t": "2026-07-05T04:00:00+00:00",
                 "kind": "predicted_census",
                 "confidence": "probable",
                 "unit_id": 1,
@@ -845,7 +847,7 @@
                 }
             },
             {
-                "t": "2026-07-04T20:00:00+00:00",
+                "t": "2026-07-05T04:00:00+00:00",
                 "kind": "predicted_arrivals",
                 "confidence": "probable",
                 "unit_id": 24,
@@ -854,10 +856,10 @@
                 "entity": null,
                 "patient_context_ref": null,
                 "label": "Predicted ED arrivals",
-                "value": 2,
+                "value": 1,
                 "band": {
                     "lower": 0,
-                    "upper": 5
+                    "upper": 3
                 },
                 "ends_at": null,
                 "derived": false,
@@ -867,73 +869,7 @@
                 }
             },
             {
-                "t": "2026-07-04T20:06:22+00:00",
-                "kind": "expected_discharge",
-                "confidence": "definite",
-                "unit_id": 1,
-                "bed_id": 1,
-                "room": null,
-                "entity": {
-                    "type": "encounter",
-                    "ref": "1"
-                },
-                "patient_context_ref": "ptok_8d4a9ae0c199bcb8aa2dba8e",
-                "label": "Expected discharge",
-                "value": null,
-                "band": null,
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "rtdc_predictions \u00d7 encounter EDD",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-04T20:06:22+00:00",
-                "kind": "transport_due",
-                "confidence": "probable",
-                "unit_id": 1,
-                "bed_id": 1,
-                "room": null,
-                "entity": {
-                    "type": "encounter",
-                    "ref": "1"
-                },
-                "patient_context_ref": "ptok_8d4a9ae0c199bcb8aa2dba8e",
-                "label": "Likely discharge transport",
-                "value": null,
-                "band": null,
-                "ends_at": null,
-                "derived": true,
-                "provenance": {
-                    "service": "derived \u00b7 expected_discharge",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-04T20:26:22+00:00",
-                "kind": "evs_due",
-                "confidence": "probable",
-                "unit_id": 1,
-                "bed_id": 1,
-                "room": null,
-                "entity": {
-                    "type": "bed",
-                    "ref": "1"
-                },
-                "patient_context_ref": null,
-                "label": "Bed turn after discharge",
-                "value": null,
-                "band": null,
-                "ends_at": null,
-                "derived": true,
-                "provenance": {
-                    "service": "derived \u00b7 expected_discharge",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-04T20:36:22+00:00",
+                "t": "2026-07-05T04:05:14+00:00",
                 "kind": "evs_due",
                 "confidence": "definite",
                 "unit_id": 1,
@@ -955,7 +891,7 @@
                 }
             },
             {
-                "t": "2026-07-04T21:00:00+00:00",
+                "t": "2026-07-05T05:00:00+00:00",
                 "kind": "predicted_arrivals",
                 "confidence": "probable",
                 "unit_id": 24,
@@ -964,10 +900,10 @@
                 "entity": null,
                 "patient_context_ref": null,
                 "label": "Predicted ED arrivals",
-                "value": 2,
+                "value": 1,
                 "band": {
                     "lower": 0,
-                    "upper": 4
+                    "upper": 3
                 },
                 "ends_at": null,
                 "derived": false,
@@ -977,7 +913,7 @@
                 }
             },
             {
-                "t": "2026-07-04T21:36:22+00:00",
+                "t": "2026-07-05T05:05:14+00:00",
                 "kind": "transport_due",
                 "confidence": "definite",
                 "unit_id": null,
@@ -999,7 +935,7 @@
                 }
             },
             {
-                "t": "2026-07-04T22:00:00+00:00",
+                "t": "2026-07-05T06:00:00+00:00",
                 "kind": "predicted_census",
                 "confidence": "probable",
                 "unit_id": 1,
@@ -1021,273 +957,9 @@
                 }
             },
             {
-                "t": "2026-07-04T22:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "probable",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 4
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-04T23:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "probable",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 4
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T00:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
-                "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T00:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "probable",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T01:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "probable",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T02:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
-                "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T02:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T03:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T04:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
-                "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T04:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T05:00:00+00:00",
-                "kind": "predicted_arrivals",
-                "confidence": "possible",
-                "unit_id": 24,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted ED arrivals",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 3
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "ed_arrival_prediction",
-                    "reliability": null
-                }
-            },
-            {
-                "t": "2026-07-05T06:00:00+00:00",
-                "kind": "predicted_census",
-                "confidence": "possible",
-                "unit_id": 1,
-                "bed_id": null,
-                "room": null,
-                "entity": null,
-                "patient_context_ref": null,
-                "label": "Predicted census",
-                "value": 1,
-                "band": {
-                    "lower": 0,
-                    "upper": 2
-                },
-                "ends_at": null,
-                "derived": false,
-                "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
-                    "reliability": null
-                }
-            },
-            {
                 "t": "2026-07-05T06:00:00+00:00",
                 "kind": "predicted_arrivals",
-                "confidence": "possible",
+                "confidence": "probable",
                 "unit_id": 24,
                 "bed_id": null,
                 "room": null,
@@ -1309,7 +981,7 @@
             {
                 "t": "2026-07-05T07:00:00+00:00",
                 "kind": "predicted_arrivals",
-                "confidence": "possible",
+                "confidence": "probable",
                 "unit_id": 24,
                 "bed_id": null,
                 "room": null,
@@ -1319,7 +991,7 @@
                 "value": 2,
                 "band": {
                     "lower": 0,
-                    "upper": 5
+                    "upper": 4
                 },
                 "ends_at": null,
                 "derived": false,
@@ -1331,7 +1003,7 @@
             {
                 "t": "2026-07-05T08:00:00+00:00",
                 "kind": "predicted_census",
-                "confidence": "possible",
+                "confidence": "probable",
                 "unit_id": 1,
                 "bed_id": null,
                 "room": null,
@@ -1346,14 +1018,14 @@
                 "ends_at": null,
                 "derived": false,
                 "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
+                    "service": "demand_forecast",
                     "reliability": null
                 }
             },
             {
                 "t": "2026-07-05T08:00:00+00:00",
                 "kind": "predicted_arrivals",
-                "confidence": "possible",
+                "confidence": "probable",
                 "unit_id": 24,
                 "bed_id": null,
                 "room": null,
@@ -1375,7 +1047,7 @@
             {
                 "t": "2026-07-05T09:00:00+00:00",
                 "kind": "predicted_arrivals",
-                "confidence": "possible",
+                "confidence": "probable",
                 "unit_id": 24,
                 "bed_id": null,
                 "room": null,
@@ -1385,7 +1057,7 @@
                 "value": 2,
                 "band": {
                     "lower": 0,
-                    "upper": 6
+                    "upper": 5
                 },
                 "ends_at": null,
                 "derived": false,
@@ -1397,7 +1069,7 @@
             {
                 "t": "2026-07-05T10:00:00+00:00",
                 "kind": "predicted_census",
-                "confidence": "possible",
+                "confidence": "probable",
                 "unit_id": 1,
                 "bed_id": null,
                 "room": null,
@@ -1412,7 +1084,7 @@
                 "ends_at": null,
                 "derived": false,
                 "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
+                    "service": "demand_forecast",
                     "reliability": null
                 }
             },
@@ -1440,6 +1112,50 @@
             },
             {
                 "t": "2026-07-05T11:00:00+00:00",
+                "kind": "expected_discharge",
+                "confidence": "definite",
+                "unit_id": 1,
+                "bed_id": 1,
+                "room": null,
+                "entity": {
+                    "type": "encounter",
+                    "ref": "1"
+                },
+                "patient_context_ref": "ptok_8d4a9ae0c199bcb8aa2dba8e",
+                "label": "Expected discharge",
+                "value": null,
+                "band": null,
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "rtdc_predictions \u00d7 encounter EDD",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-05T11:00:00+00:00",
+                "kind": "transport_due",
+                "confidence": "probable",
+                "unit_id": 1,
+                "bed_id": 1,
+                "room": null,
+                "entity": {
+                    "type": "encounter",
+                    "ref": "1"
+                },
+                "patient_context_ref": "ptok_8d4a9ae0c199bcb8aa2dba8e",
+                "label": "Likely discharge transport",
+                "value": null,
+                "band": null,
+                "ends_at": null,
+                "derived": true,
+                "provenance": {
+                    "service": "derived \u00b7 expected_discharge",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-05T11:00:00+00:00",
                 "kind": "predicted_arrivals",
                 "confidence": "possible",
                 "unit_id": 24,
@@ -1451,7 +1167,7 @@
                 "value": 2,
                 "band": {
                     "lower": 0,
-                    "upper": 7
+                    "upper": 6
                 },
                 "ends_at": null,
                 "derived": false,
@@ -1461,9 +1177,31 @@
                 }
             },
             {
+                "t": "2026-07-05T11:20:00+00:00",
+                "kind": "evs_due",
+                "confidence": "probable",
+                "unit_id": 1,
+                "bed_id": 1,
+                "room": null,
+                "entity": {
+                    "type": "bed",
+                    "ref": "1"
+                },
+                "patient_context_ref": null,
+                "label": "Bed turn after discharge",
+                "value": null,
+                "band": null,
+                "ends_at": null,
+                "derived": true,
+                "provenance": {
+                    "service": "derived \u00b7 expected_discharge",
+                    "reliability": null
+                }
+            },
+            {
                 "t": "2026-07-05T12:00:00+00:00",
                 "kind": "predicted_census",
-                "confidence": "possible",
+                "confidence": "probable",
                 "unit_id": 1,
                 "bed_id": null,
                 "room": null,
@@ -1478,7 +1216,7 @@
                 "ends_at": null,
                 "derived": false,
                 "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
+                    "service": "demand_forecast",
                     "reliability": null
                 }
             },
@@ -1529,7 +1267,7 @@
             {
                 "t": "2026-07-05T14:00:00+00:00",
                 "kind": "predicted_census",
-                "confidence": "possible",
+                "confidence": "probable",
                 "unit_id": 1,
                 "bed_id": null,
                 "room": null,
@@ -1544,7 +1282,7 @@
                 "ends_at": null,
                 "derived": false,
                 "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
+                    "service": "demand_forecast",
                     "reliability": null
                 }
             },
@@ -1610,7 +1348,7 @@
                 "ends_at": null,
                 "derived": false,
                 "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
+                    "service": "demand_forecast",
                     "reliability": null
                 }
             },
@@ -1649,7 +1387,7 @@
                 "value": 2,
                 "band": {
                     "lower": 0,
-                    "upper": 7
+                    "upper": 6
                 },
                 "ends_at": null,
                 "derived": false,
@@ -1676,7 +1414,7 @@
                 "ends_at": null,
                 "derived": false,
                 "provenance": {
-                    "service": "demand_forecast (extrapolated past midnight)",
+                    "service": "demand_forecast",
                     "reliability": null
                 }
             },
@@ -1693,7 +1431,7 @@
                 "value": 2,
                 "band": {
                     "lower": 0,
-                    "upper": 7
+                    "upper": 6
                 },
                 "ends_at": null,
                 "derived": false,
@@ -1715,7 +1453,271 @@
                 "value": 2,
                 "band": {
                     "lower": 0,
-                    "upper": 7
+                    "upper": 6
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "ed_arrival_prediction",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-05T20:00:00+00:00",
+                "kind": "predicted_census",
+                "confidence": "possible",
+                "unit_id": 1,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted census",
+                "value": 1,
+                "band": {
+                    "lower": 0,
+                    "upper": 2
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "demand_forecast",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-05T20:00:00+00:00",
+                "kind": "predicted_arrivals",
+                "confidence": "possible",
+                "unit_id": 24,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted ED arrivals",
+                "value": 2,
+                "band": {
+                    "lower": 0,
+                    "upper": 6
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "ed_arrival_prediction",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-05T21:00:00+00:00",
+                "kind": "predicted_arrivals",
+                "confidence": "possible",
+                "unit_id": 24,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted ED arrivals",
+                "value": 2,
+                "band": {
+                    "lower": 0,
+                    "upper": 5
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "ed_arrival_prediction",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-05T22:00:00+00:00",
+                "kind": "predicted_census",
+                "confidence": "possible",
+                "unit_id": 1,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted census",
+                "value": 1,
+                "band": {
+                    "lower": 0,
+                    "upper": 2
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "demand_forecast",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-05T22:00:00+00:00",
+                "kind": "predicted_arrivals",
+                "confidence": "possible",
+                "unit_id": 24,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted ED arrivals",
+                "value": 1,
+                "band": {
+                    "lower": 0,
+                    "upper": 5
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "ed_arrival_prediction",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-05T23:00:00+00:00",
+                "kind": "predicted_arrivals",
+                "confidence": "possible",
+                "unit_id": 24,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted ED arrivals",
+                "value": 1,
+                "band": {
+                    "lower": 0,
+                    "upper": 4
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "ed_arrival_prediction",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-06T00:00:00+00:00",
+                "kind": "predicted_census",
+                "confidence": "possible",
+                "unit_id": 1,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted census",
+                "value": 1,
+                "band": {
+                    "lower": 0,
+                    "upper": 2
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "demand_forecast (extrapolated past midnight)",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-06T00:00:00+00:00",
+                "kind": "predicted_arrivals",
+                "confidence": "possible",
+                "unit_id": 24,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted ED arrivals",
+                "value": 1,
+                "band": {
+                    "lower": 0,
+                    "upper": 4
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "ed_arrival_prediction",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-06T01:00:00+00:00",
+                "kind": "predicted_arrivals",
+                "confidence": "possible",
+                "unit_id": 24,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted ED arrivals",
+                "value": 1,
+                "band": {
+                    "lower": 0,
+                    "upper": 4
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "ed_arrival_prediction",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-06T02:00:00+00:00",
+                "kind": "predicted_census",
+                "confidence": "possible",
+                "unit_id": 1,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted census",
+                "value": 1,
+                "band": {
+                    "lower": 0,
+                    "upper": 2
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "demand_forecast (extrapolated past midnight)",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-06T02:00:00+00:00",
+                "kind": "predicted_arrivals",
+                "confidence": "possible",
+                "unit_id": 24,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted ED arrivals",
+                "value": 1,
+                "band": {
+                    "lower": 0,
+                    "upper": 4
+                },
+                "ends_at": null,
+                "derived": false,
+                "provenance": {
+                    "service": "ed_arrival_prediction",
+                    "reliability": null
+                }
+            },
+            {
+                "t": "2026-07-06T03:00:00+00:00",
+                "kind": "predicted_arrivals",
+                "confidence": "possible",
+                "unit_id": 24,
+                "bed_id": null,
+                "room": null,
+                "entity": null,
+                "patient_context_ref": null,
+                "label": "Predicted ED arrivals",
+                "value": 1,
+                "band": {
+                    "lower": 0,
+                    "upper": 3
                 },
                 "ends_at": null,
                 "derived": false,
@@ -1724,15 +1726,38 @@
                     "reliability": null
                 }
             }
+        ],
+        "duties": [
+            {
+                "id": "barrier-1",
+                "kind": "barrier_resolve",
+                "label": "Logistical barrier",
+                "space_ref": null,
+                "unit_id": null,
+                "bed_id": null,
+                "centroid_m": null,
+                "due_at": "2026-07-04T23:05:14+00:00",
+                "window_status": "upcoming",
+                "tier": "info",
+                "patient_context_ref": null,
+                "provenance": {
+                    "service": "duty_projection"
+                },
+                "action": {
+                    "endpoint": "/api/mobile/v1/rtdc/barriers/1/resolve",
+                    "method": "POST",
+                    "label": "Resolve"
+                }
+            }
         ]
     },
     "meta": {
-        "as_of": "2026-07-04T19:36:22.652282Z",
+        "as_of": "2026-07-05T03:05:15.381610Z",
         "stale": false,
         "version": null,
         "count": 48
     },
     "links": {
-        "web": "http://localhost/rtdc/patient-flow-navigator?persona=bed_manager&scope=house&t=2026-07-04T19%3A36%3A22%2B00%3A00"
+        "web": "http://localhost/rtdc/patient-flow-navigator?persona=bed_manager&scope=house&t=2026-07-05T03%3A05%3A15%2B00%3A00"
     }
 }

--- a/docs/hummingbird/api-contract/hummingbird-bff.v1.yaml
+++ b/docs/hummingbird/api-contract/hummingbird-bff.v1.yaml
@@ -451,6 +451,35 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
 
+  /flow/spaces3d:
+    get:
+      tags: [flow]
+      summary:
+        Versioned 3D space-anchor asset for the native SceneKit/Filament
+        viewers — per-space centroid (metres) + unit/bed bridges to place
+        patient tokens and duty markers over the GLB shell. Geometry only,
+        no live state. Strong ETag; revalidate with If-None-Match.
+      parameters:
+        - name: If-None-Match
+          in: header
+          schema: { type: string }
+          description: "Previously returned ETag (the spaces3d version)."
+      responses:
+        "200":
+          {
+            description: OK,
+            content:
+              {
+                application/json:
+                  {
+                    schema: { $ref: "#/components/schemas/FlowSpaces3dEnvelope" },
+                  },
+              },
+          }
+        "304": { description: Not modified — render the cached anchors. }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+
   /flow/window:
     get:
       tags: [flow]
@@ -1816,6 +1845,94 @@ components:
                           items: { $ref: "#/components/schemas/FlowPlate" },
                         }
 
+    FlowSpace3d:
+      type: object
+      required: [space_ref, floor, category, centroid_m]
+      properties:
+        space_ref: { type: string }
+        floor: { type: integer }
+        category: { type: string }
+        unit_id: { type: integer, nullable: true }
+        bed_id: { type: integer, nullable: true }
+        centroid_m:
+          type: object
+          description: 3D centroid in metres; y is the vertical (floor) axis.
+          properties:
+            x: { type: number }
+            y: { type: number }
+            z: { type: number }
+
+    FlowSpaces3dEnvelope:
+      allOf:
+        - { $ref: "#/components/schemas/Envelope" }
+        - type: object
+          properties:
+            data:
+              type: object
+              required: [version, facility, spaces]
+              properties:
+                version: { type: string }
+                units: { type: string, description: Geometry unit contract note. }
+                facility:
+                  type: object
+                  properties:
+                    code: { type: string }
+                    cad_code: { type: string }
+                    name: { type: string }
+                spaces:
+                  type: array
+                  items: { $ref: "#/components/schemas/FlowSpace3d" }
+
+    FlowDuty:
+      type: object
+      description:
+        One persona duty — an actionable worklist item, spatially anchored
+        (centroid_m) and due-dated (due_at + window_status), with the governed
+        BFF endpoint that actions it. Patient identity only as
+        patient_context_ref at the lens depth; null for patient_dots:none.
+      required: [id, kind, label, tier]
+      properties:
+        id: { type: string }
+        kind:
+          type: string
+          enum:
+            [
+              transport_run,
+              bed_turn,
+              placement,
+              barrier_resolve,
+              staffing_fill,
+              approval,
+              discharge_leverage,
+            ]
+        label: { type: string }
+        space_ref: { type: string, nullable: true }
+        unit_id: { type: integer, nullable: true }
+        bed_id: { type: integer, nullable: true }
+        centroid_m:
+          type: object
+          nullable: true
+          properties:
+            x: { type: number }
+            y: { type: number }
+            z: { type: number }
+        due_at: { type: string, format: date-time, nullable: true }
+        window_status:
+          { type: string, nullable: true, enum: [overdue, due, upcoming] }
+        tier: { type: string, enum: [critical, warning, info] }
+        patient_context_ref: { type: string, nullable: true }
+        provenance:
+          type: object
+          properties:
+            service: { type: string }
+        action:
+          type: object
+          nullable: true
+          properties:
+            endpoint: { type: string }
+            method: { type: string }
+            label: { type: string }
+
     FlowTimelineEvent:
       type: object
       description:
@@ -2011,6 +2128,14 @@ components:
                     type: array,
                     items: { $ref: "#/components/schemas/FlowProjection" },
                   }
+                duties:
+                  type: array
+                  description:
+                    The persona's actionable worklist — spatially anchored,
+                    due-dated duties (NATIVE-4D-VIEWER-PLAN). Clamped to the
+                    lens duty_kinds, redacted per patient_dots, and served in
+                    full even on a `?since=` delta.
+                  items: { $ref: "#/components/schemas/FlowDuty" }
                 bed_statuses:
                   type: array
                   description:

--- a/docs/hummingbird/api-contract/hummingbird-bff.v1.yaml
+++ b/docs/hummingbird/api-contract/hummingbird-bff.v1.yaml
@@ -480,6 +480,17 @@ paths:
           in: query
           schema: { type: string }
           description: "Comma list of snapshots,events,projections,spaces (intersected with the lens)."
+        - name: since
+          in: query
+          schema: { type: string, format: date-time }
+          description:
+            "Delta refresh cursor. When present, `events` and `snapshots`
+            contain only items with t > since, while `projections`, `spaces`,
+            and `bed_statuses` are always recomputed and served in full.
+            Everything else (lens clamping, scope resolution, redaction)
+            behaves exactly like a full request, and the parsed value is
+            echoed back as `window.since`. Must parse as ISO8601 and lie
+            within [window.from, window.to); anything else is a 422."
       responses:
         "200":
           {
@@ -494,6 +505,13 @@ paths:
           }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
+        "422":
+          description:
+            Invalid `since` — not parseable as ISO8601, or outside
+            [window.from, window.to).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /rtdc/census:
     get:
@@ -1875,6 +1893,13 @@ components:
         confidence: { type: string, enum: [definite, probable, possible] }
         unit_id: { oneOf: [{ type: integer }, { type: "null" }] }
         bed_id: { oneOf: [{ type: integer }, { type: "null" }] }
+        room:
+          {
+            oneOf: [{ type: string }, { type: "null" }],
+            description:
+              OR room name (e.g. "OR 3") on scheduled_or_case items; null for
+              every other kind.,
+          }
         entity:
           oneOf:
             - type: "null"
@@ -1920,11 +1945,21 @@ components:
               properties:
                 window:
                   type: object
-                  required: [from, to, now]
+                  required: [from, to, now, since]
                   properties:
                     from: { type: string, format: date-time }
                     to: { type: string, format: date-time }
                     now: { type: string, format: date-time }
+                    since:
+                      oneOf:
+                        - { type: string, format: date-time }
+                        - { type: "null" }
+                      description:
+                        Echo of the parsed `since` delta cursor (null on a
+                        full request). When non-null, `events` and
+                        `snapshots` were filtered to t > since;
+                        `projections`, `spaces`, and `bed_statuses` are
+                        always full.
                 lens:
                   type: object
                   properties:
@@ -1976,6 +2011,27 @@ components:
                     type: array,
                     items: { $ref: "#/components/schemas/FlowProjection" },
                   }
+                bed_statuses:
+                  type: array
+                  description:
+                    Current bed state for the turn map — strictly "now", never
+                    historical or projected (past turns live in events,
+                    upcoming ones in projections). Present only when the
+                    requested scope is floor or unit AND the caller's lens
+                    event_kinds include bed_status; absent for every other
+                    lens/scope combination.
+                  items:
+                    type: object
+                    required: [bed_id, unit_id, status]
+                    properties:
+                      bed_id: { type: integer }
+                      unit_id: { type: integer }
+                      label: { oneOf: [{ type: string }, { type: "null" }] }
+                      status:
+                        {
+                          type: string,
+                          enum: [available, occupied, blocked, dirty],
+                        }
 
     CensusEnvelope:
       allOf:

--- a/hummingbird/androidApp/app/build.gradle.kts
+++ b/hummingbird/androidApp/app/build.gradle.kts
@@ -53,6 +53,10 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.1")
     implementation("com.squareup.okhttp3:okhttp:4.12.0") // Reverb (Pusher-protocol) websocket
+    // Phase-5 house-glance widget. Glance pulls glance-core + datastore + work-runtime
+    // transitively; the widget is app-driven only (updateAll after a foreground load) —
+    // no background WorkManager networking is scheduled.
+    implementation("androidx.glance:glance-appwidget:1.1.1")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.json:json:20240303")
     debugImplementation("androidx.compose.ui:ui-tooling")

--- a/hummingbird/androidApp/app/src/main/AndroidManifest.xml
+++ b/hummingbird/androidApp/app/src/main/AndroidManifest.xml
@@ -22,5 +22,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Phase-5 house-glance widget. App-driven updates (updateAll after a foreground
+             load); no background networking. -->
+        <receiver
+            android:name=".widget.HouseGlanceReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/house_glance_widget_info" />
+        </receiver>
     </application>
 </manifest>

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/MainActivity.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/MainActivity.kt
@@ -38,6 +38,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import net.acumenus.hummingbird.data.AppLock
 import net.acumenus.hummingbird.data.AuthPhase
 import net.acumenus.hummingbird.data.AuthViewModel
+import net.acumenus.hummingbird.notifications.UrgencyChannels
 import net.acumenus.hummingbird.ui.HummingbirdLaunchConfig
 import net.acumenus.hummingbird.ui.LockScreen
 import net.acumenus.hummingbird.ui.LoginScreen
@@ -51,6 +52,9 @@ class MainActivity : FragmentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         AppLock.init(this)
+        // Register the T1–T4 urgency notification channels at app start (FCM send still
+        // blocked on server credentials — registration only).
+        UrgencyChannels.register(this)
         // Test/demo affordance, mirrors iOS: `adb am start ... -e HB_AUTOLOGIN 1` lands on Home
         // for headless screenshots / UI tests. No-op for normal launches.
         val autologin = intent.getStringExtra("HB_AUTOLOGIN") == "1"

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/AltitudeViewModel.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/AltitudeViewModel.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
+import net.acumenus.hummingbird.widget.HouseGlanceStore
 
 class AltitudeViewModel(app: Application) : AndroidViewModel(app) {
     private val api = ApiClient()
@@ -96,6 +97,8 @@ class AltitudeViewModel(app: Application) : AndroidViewModel(app) {
 
     fun loadHome(bearer: String) = request {
         home = api.altitudeHome(bearer, selectedRole.id)
+        // Feed the house-glance widget on every home load (app-driven, no background work).
+        home?.let { runCatching { HouseGlanceStore.updateFromHome(getApplication<android.app.Application>(), it) } }
     }
 
     fun loadWorkspace(bearer: String) = request {

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/ApiClient.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/ApiClient.kt
@@ -243,18 +243,44 @@ class ApiClient(private val baseUrl: String = BASE_URL) {
         )
     }
 
-    suspend fun flowWindow(bearer: String, persona: String, scope: String? = null): FlowWindowData = withContext(Dispatchers.IO) {
+    suspend fun flowWindow(
+        bearer: String,
+        persona: String,
+        scope: String? = null,
+        since: String? = null,
+    ): FlowWindowData = flowWindowRaw(bearer, persona, scope, since).data
+
+    /**
+     * Flow window with the raw envelope text retained so the caller can persist the last
+     * FULL payload to the offline cache without re-serializing the hand-parsed DTOs.
+     * `since` (ISO8601) requests a delta: events/snapshots trimmed to t > since; projections,
+     * spaces and bed_statuses stay full. Out-of-range/malformed `since` ⇒ HTTP 422.
+     */
+    suspend fun flowWindowRaw(
+        bearer: String,
+        persona: String,
+        scope: String? = null,
+        since: String? = null,
+    ): FlowWindowFetch = withContext(Dispatchers.IO) {
         val path = buildString {
             append(withPersona("/api/mobile/v1/flow/window", persona))
             if (!scope.isNullOrBlank()) {
                 append(if (contains('?')) '&' else '?').append("scope=").append(urlPart(scope))
             }
+            if (!since.isNullOrBlank()) {
+                append(if (contains('?')) '&' else '?').append("since=").append(urlPart(since))
+            }
         }
-        parseFlowWindow(getEnvelope(path, bearer))
+        val (root, raw) = getEnvelopeRaw(path, bearer)
+        FlowWindowFetch(parseFlowWindow(root), raw)
     }
 
-    suspend fun flowFloors(bearer: String): FlowFloorsDocument = withContext(Dispatchers.IO) {
-        parseFlowFloors(getEnvelope("/api/mobile/v1/flow/floors", bearer))
+    suspend fun flowFloors(bearer: String): FlowFloorsDocument = flowFloorsRaw(bearer).first
+
+    /** Floors document with its raw envelope text retained for the offline cache. */
+    suspend fun flowFloorsRaw(bearer: String): Pair<FlowFloorsDocument, String> = withContext(Dispatchers.IO) {
+        val (root, raw) = getEnvelopeRaw("/api/mobile/v1/flow/floors", bearer)
+        parseFlowFloors(root) to raw
     }
 
     suspend fun revoke(bearer: String) = withContext(Dispatchers.IO) {
@@ -264,10 +290,13 @@ class ApiClient(private val baseUrl: String = BASE_URL) {
 
     // MARK: plumbing
 
-    private fun getEnvelope(path: String, bearer: String): JSONObject {
+    private fun getEnvelope(path: String, bearer: String): JSONObject = getEnvelopeRaw(path, bearer).first
+
+    /** Like [getEnvelope] but also returns the raw response body (for the offline cache). */
+    private fun getEnvelopeRaw(path: String, bearer: String): Pair<JSONObject, String> {
         val (code, text) = send("GET", path, null, bearer)
-        if (code !in 200..299) throw ApiException(errorMessage(text, code), code)
-        return JSONObject(text)
+        if (code !in 200..299) throw ApiException(errorMessage(text, code), code, errorCode(text))
+        return JSONObject(text) to text
     }
 
     private fun getData(path: String, bearer: String): JSONObject {
@@ -298,6 +327,11 @@ class ApiClient(private val baseUrl: String = BASE_URL) {
             conn.disconnect()
         }
     }
+
+    /** The envelope's `error.code` (e.g. "invalid_since"), when present. */
+    private fun errorCode(text: String): String? = runCatching {
+        JSONObject(text).optJSONObject("error")?.optStringOrNull("code")
+    }.getOrNull()
 
     private fun errorMessage(text: String, code: Int): String {
         runCatching {
@@ -754,6 +788,7 @@ class ApiClient(private val baseUrl: String = BASE_URL) {
                 from = window.optString("from"),
                 to = window.optString("to"),
                 now = window.optString("now"),
+                since = window.optStringOrNull("since"),
             ),
             lens = FlowLens(
                 roleId = lens.optString("role_id"),
@@ -776,8 +811,18 @@ class ApiClient(private val baseUrl: String = BASE_URL) {
             snapshots = data.optJSONArray("snapshots").objects().map(::parseFlowSnapshot),
             events = data.optJSONArray("events").objects().map(::parseFlowTimelineEvent),
             projections = data.optJSONArray("projections").objects().map(::parseFlowProjection),
+            // Optional turn-map layer — absent unless scope is floor/unit and the lens allows it.
+            bedStatuses = data.optJSONArray("bed_statuses").objects().map(::parseFlowBedStatus),
+            webLink = root.optJSONObject("links")?.optStringOrNull("web"),
         )
     }
+
+    private fun parseFlowBedStatus(o: JSONObject): FlowBedStatus = FlowBedStatus(
+        bedId = o.optInt("bed_id"),
+        unitId = o.optIntOrNull("unit_id"),
+        label = o.optStringOrNull("label") ?: "Bed ${o.optInt("bed_id")}",
+        status = o.optStringOrNull("status") ?: "occupied",
+    )
 
     private fun parseFlowFloorRollup(o: JSONObject): FlowFloorRollup = FlowFloorRollup(
         floor = o.optInt("floor"),
@@ -818,6 +863,7 @@ class ApiClient(private val baseUrl: String = BASE_URL) {
         toSpace = o.optStringOrNull("to_space"),
         patientContextRef = o.optStringOrNull("patient_context_ref"),
         provenanceSource = o.optJSONObject("provenance")?.optStringOrNull("source") ?: "",
+        entityRef = o.optJSONObject("entity")?.optStringOrNull("ref"),
     )
 
     private fun parseFlowProjection(o: JSONObject): FlowProjection {
@@ -830,6 +876,7 @@ class ApiClient(private val baseUrl: String = BASE_URL) {
             label = o.optStringOrNull("label") ?: humanize(o.optString("kind", "projection")),
             unitId = o.optIntOrNull("unit_id"),
             bedId = o.optIntOrNull("bed_id"),
+            room = o.optStringOrNull("room"),
             value = o.optIntOrNull("value"),
             bandLower = band?.optIntOrNull("lower"),
             bandUpper = band?.optIntOrNull("upper"),

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/AuthViewModel.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/AuthViewModel.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
+import net.acumenus.hummingbird.widget.HouseGlanceStore
 
 enum class AuthPhase { LOADING, LOGGED_OUT, NEEDS_PASSWORD_CHANGE, LOGGED_IN }
 
@@ -62,12 +63,18 @@ class AuthViewModel(app: Application) : AndroidViewModel(app) {
 
     fun logout() {
         val t = accessToken
-        viewModelScope.launch { if (t != null) api.revoke(t) }
+        viewModelScope.launch {
+            if (t != null) api.revoke(t)
+            // Reset the widget to its placeholder once this session's data is gone.
+            runCatching { HouseGlanceStore.clear(getApplication<android.app.Application>()) }
+        }
         clearTokens(); me = null; error = null; phase = AuthPhase.LOGGED_OUT
     }
 
     private fun clearTokens() {
         accessToken = null
         prefs.edit().remove("access").remove("refresh").apply()
+        // Never let one user's cached flow window survive into another session.
+        runCatching { FlowWindowCache(getApplication<android.app.Application>()).clearAll() }
     }
 }

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/FlowCacheLogic.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/FlowCacheLogic.kt
@@ -1,0 +1,44 @@
+package net.acumenus.hummingbird.data
+
+/** One offline-cache index record: which (user, persona, scope) window is on disk, and when. */
+data class FlowCacheEntry(
+    val key: String,
+    val userId: Int,
+    val persona: String,
+    val scope: String?,
+    val updatedAtMs: Long,
+)
+
+/**
+ * Pure LRU + keying rules for the offline window cache (no Android deps → unit-testable).
+ * The key embeds the authenticated user id so one user's cached window is never located
+ * for another; [find] additionally re-checks the user id as a belt-and-braces guard.
+ */
+object FlowCacheLogic {
+    const val MAX_ENTRIES = 20
+
+    fun cacheKey(userId: Int, persona: String, scope: String?): String =
+        "u$userId|$persona|${scope.orEmpty()}"
+
+    /**
+     * Upsert [entry] into the index. A same-key record is replaced (refreshed to the new
+     * timestamp); when the index would exceed [maxEntries] the oldest by [FlowCacheEntry.updatedAtMs]
+     * are dropped. Returns (kept newest-first, evicted) so the I/O layer can delete evicted files.
+     */
+    fun upsert(
+        entries: List<FlowCacheEntry>,
+        entry: FlowCacheEntry,
+        maxEntries: Int = MAX_ENTRIES,
+    ): Pair<List<FlowCacheEntry>, List<FlowCacheEntry>> {
+        val combined = (entries.filterNot { it.key == entry.key } + entry)
+            .sortedByDescending { it.updatedAtMs }
+        if (combined.size <= maxEntries) return combined to emptyList()
+        return combined.take(maxEntries) to combined.drop(maxEntries)
+    }
+
+    /** Locate the cached entry for this exact user+persona+scope (never cross-user). */
+    fun find(entries: List<FlowCacheEntry>, userId: Int, persona: String, scope: String?): FlowCacheEntry? {
+        val key = cacheKey(userId, persona, scope)
+        return entries.firstOrNull { it.key == key && it.userId == userId }
+    }
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/FlowDelta.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/FlowDelta.kt
@@ -1,0 +1,68 @@
+package net.acumenus.hummingbird.data
+
+/**
+ * Delta merge for the Flow Window (`?since=` refreshes).
+ *
+ * Contract: with `since` present the server trims `events` and `snapshots` to items with
+ * t > since; `projections`, `spaces` and `bed_statuses` come back FULL every time. So the
+ * client APPENDS new events/snapshots (deduped) and REPLACES projections/bed_statuses/spaces
+ * wholesale. The window frame (from/to/now), lens and scope always take the fresh values.
+ *
+ * Pure function — no Android deps — so the merge semantics are unit-testable in isolation.
+ */
+fun mergeFlowWindow(current: FlowWindowData, delta: FlowWindowData): FlowWindowData =
+    current.copy(
+        window = delta.window,
+        lens = delta.lens,
+        scope = delta.scope,
+        // spaces/projections/bed_statuses are always full in a delta response → replace.
+        spacesFloors = delta.spacesFloors,
+        projections = delta.projections,
+        bedStatuses = delta.bedStatuses,
+        // events/snapshots are trimmed to t > since → append the new ones, deduped.
+        events = appendEvents(current.events, delta.events),
+        snapshots = appendSnapshots(current.snapshots, delta.snapshots),
+        webLink = delta.webLink ?: current.webLink,
+    )
+
+/** Dedupe key for a timeline event: (t, kind, entity ref, label). */
+private fun eventKey(e: FlowTimelineEvent): String =
+    "${e.tMs}|${e.kind}|${e.entityRef ?: ""}|${e.label}"
+
+/** Dedupe key for a snapshot: (t, unit_id). */
+private fun snapshotKey(s: FlowSnapshot): String = "${s.tMs}|${s.unitId}"
+
+internal fun appendEvents(
+    existing: List<FlowTimelineEvent>,
+    incoming: List<FlowTimelineEvent>,
+): List<FlowTimelineEvent> {
+    if (incoming.isEmpty()) return existing
+    val seen = existing.mapTo(HashSet()) { eventKey(it) }
+    val merged = existing.toMutableList()
+    for (e in incoming) if (seen.add(eventKey(e))) merged += e
+    return merged.sortedBy { it.tMs }
+}
+
+internal fun appendSnapshots(
+    existing: List<FlowSnapshot>,
+    incoming: List<FlowSnapshot>,
+): List<FlowSnapshot> {
+    if (incoming.isEmpty()) return existing
+    val seen = existing.mapTo(HashSet()) { snapshotKey(it) }
+    val merged = existing.toMutableList()
+    for (s in incoming) if (seen.add(snapshotKey(s))) merged += s
+    return merged.sortedBy { it.tMs }
+}
+
+/**
+ * The `?since=` cursor for the next delta: the newest loaded event/snapshot time, ISO8601.
+ * Null when nothing is loaded yet (⇒ caller does a full load). The value is always ≤ now,
+ * so it lies inside [from, to); a window that has drifted far enough for it to fall out of
+ * range is handled by the server's 422 → full-load fallback.
+ */
+fun newestLoadedSinceIso(window: FlowWindowData): String? {
+    val newest = (window.events.map { it.tMs } + window.snapshots.map { it.tMs })
+        .filter { it > 0L }
+        .maxOrNull() ?: return null
+    return flowEpochMsToIso(newest)
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/FlowModels.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/FlowModels.kt
@@ -1,6 +1,9 @@
 package net.acumenus.hummingbird.data
 
+import java.time.Instant
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 
 /**
  * Flow Window models — GET /api/mobile/v1/flow/window + /flow/floors.
@@ -14,10 +17,18 @@ fun flowIsoToEpochMs(iso: String?): Long? =
     if (iso.isNullOrBlank()) null
     else runCatching { OffsetDateTime.parse(iso).toInstant().toEpochMilli() }.getOrNull()
 
+/** Epoch millis → ISO-8601 UTC offset string (the `?since=` param the delta path sends). */
+fun flowEpochMsToIso(ms: Long): String =
+    DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(
+        OffsetDateTime.ofInstant(Instant.ofEpochMilli(ms), ZoneOffset.UTC),
+    )
+
 data class FlowWindowRange(
     val from: String,
     val to: String,
     val now: String,
+    /** `window.since` — the server-echoed parsed delta cursor; null on a full load. */
+    val since: String? = null,
 )
 
 data class FlowLens(
@@ -80,6 +91,8 @@ data class FlowTimelineEvent(
     val toSpace: String?,
     val patientContextRef: String?,
     val provenanceSource: String,
+    /** `entity.ref` (ptok or non-patient ref) — part of the delta dedupe key. */
+    val entityRef: String? = null,
 ) {
     val tMs: Long by lazy { flowIsoToEpochMs(t) ?: 0L }
 }
@@ -91,6 +104,8 @@ data class FlowProjection(
     val label: String,
     val unitId: Int?,
     val bedId: Int?,
+    /** Room name — populated only on `scheduled_or_case` (e.g. "OR 3"); null elsewhere. */
+    val room: String?,
     val value: Int?,
     val bandLower: Int?,
     val bandUpper: Int?,
@@ -101,6 +116,7 @@ data class FlowProjection(
     val provenanceReliability: Double?,
 ) {
     val tMs: Long by lazy { flowIsoToEpochMs(t) ?: 0L }
+    val endsAtMs: Long? by lazy { flowIsoToEpochMs(endsAt) }
 
     /** Ghost grammar: definite 0.8, probable 0.5, possible 0.3 — never solid. */
     val confidenceAlpha: Float
@@ -111,6 +127,18 @@ data class FlowProjection(
         }
 }
 
+/**
+ * Strictly-current bed state for the EVS turn map. Present only when the
+ * scope is floor/unit AND the lens allows bed_status events; absent otherwise.
+ */
+data class FlowBedStatus(
+    val bedId: Int,
+    val unitId: Int?,
+    val label: String,
+    /** available | occupied | blocked | dirty */
+    val status: String,
+)
+
 data class FlowWindowData(
     val window: FlowWindowRange,
     val lens: FlowLens,
@@ -119,11 +147,20 @@ data class FlowWindowData(
     val snapshots: List<FlowSnapshot>,
     val events: List<FlowTimelineEvent>,
     val projections: List<FlowProjection>,
+    val bedStatuses: List<FlowBedStatus> = emptyList(),
+    /** `links.web` — the web Navigator deep link for this scope/t (PI clip target). */
+    val webLink: String? = null,
 ) {
     val fromMs: Long by lazy { flowIsoToEpochMs(window.from) ?: 0L }
     val toMs: Long by lazy { flowIsoToEpochMs(window.to) ?: 0L }
     val nowMs: Long by lazy { flowIsoToEpochMs(window.now) ?: 0L }
 }
+
+/** Parsed window plus the raw envelope text, so a FULL load can be cached verbatim. */
+data class FlowWindowFetch(
+    val data: FlowWindowData,
+    val raw: String,
+)
 
 /** One drawable plate on a floor: unit/zone, room/bay, bed, corridor, vertical_transport. */
 data class FlowPlate(

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/FlowWindowCache.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/FlowWindowCache.kt
@@ -1,0 +1,111 @@
+package net.acumenus.hummingbird.data
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+/**
+ * Offline cache of the last FULL (non-delta) flow window + floors payloads, keyed by
+ * (user id, persona, scope), living under context.filesDir/flow-cache. Atomic writes
+ * (temp file + rename), ~20-entry LRU. Window entries carry ptoks so they are user-keyed
+ * and never served across users; the floors payload is facility geometry (PHI-free) and is
+ * shared. The whole directory is cleared on the logout path.
+ */
+class FlowWindowCache(context: Context) {
+    private val dir = File(context.filesDir, DIR_NAME)
+    private val indexFile = File(dir, "index.json")
+    private val floorsFile = File(dir, "floors.json")
+
+    /** A recovered window: the raw envelopes to re-parse plus when it was cached. */
+    data class Cached(val windowRaw: String, val floorsRaw: String?, val updatedAtMs: Long)
+
+    @Synchronized
+    fun putWindow(userId: Int, persona: String, scope: String?, windowRaw: String, floorsRaw: String?) {
+        dir.mkdirs()
+        val now = System.currentTimeMillis()
+        val key = FlowCacheLogic.cacheKey(userId, persona, scope)
+        atomicWrite(
+            File(dir, fileNameFor(key)),
+            JSONObject()
+                .put("key", key)
+                .put("user_id", userId)
+                .put("persona", persona)
+                .put("scope", scope ?: JSONObject.NULL)
+                .put("updated_at_ms", now)
+                .put("window", windowRaw)
+                .toString(),
+        )
+        floorsRaw?.let {
+            atomicWrite(floorsFile, JSONObject().put("updated_at_ms", now).put("floors", it).toString())
+        }
+
+        val (kept, evicted) = FlowCacheLogic.upsert(readIndex(), FlowCacheEntry(key, userId, persona, scope, now))
+        evicted.forEach { File(dir, fileNameFor(it.key)).delete() }
+        writeIndex(kept)
+    }
+
+    @Synchronized
+    fun readWindow(userId: Int, persona: String, scope: String?): Cached? {
+        val entry = FlowCacheLogic.find(readIndex(), userId, persona, scope) ?: return null
+        val obj = runCatching { JSONObject(File(dir, fileNameFor(entry.key)).readText()) }.getOrNull() ?: return null
+        // Re-check identity to defend against a filename-hash collision serving a wrong record.
+        if (obj.optString("key") != entry.key || obj.optInt("user_id", -1) != userId) return null
+        val windowRaw = obj.optString("window").takeIf { it.isNotBlank() } ?: return null
+        val floorsRaw = runCatching { JSONObject(floorsFile.readText()).optString("floors") }
+            .getOrNull()?.takeIf { it.isNotBlank() }
+        return Cached(windowRaw, floorsRaw, obj.optLong("updated_at_ms", entry.updatedAtMs))
+    }
+
+    @Synchronized
+    fun clearAll() {
+        dir.deleteRecursively()
+    }
+
+    private fun readIndex(): List<FlowCacheEntry> {
+        val arr = runCatching { JSONArray(indexFile.readText()) }.getOrNull() ?: return emptyList()
+        return (0 until arr.length()).mapNotNull { i ->
+            val o = arr.optJSONObject(i) ?: return@mapNotNull null
+            val key = o.optString("key").takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            FlowCacheEntry(
+                key = key,
+                userId = o.optInt("user_id"),
+                persona = o.optString("persona"),
+                scope = if (o.isNull("scope")) null else o.optString("scope").takeIf { it.isNotBlank() },
+                updatedAtMs = o.optLong("updated_at_ms"),
+            )
+        }
+    }
+
+    private fun writeIndex(entries: List<FlowCacheEntry>) {
+        val arr = JSONArray()
+        entries.forEach { e ->
+            arr.put(
+                JSONObject()
+                    .put("key", e.key)
+                    .put("user_id", e.userId)
+                    .put("persona", e.persona)
+                    .put("scope", e.scope ?: JSONObject.NULL)
+                    .put("updated_at_ms", e.updatedAtMs),
+            )
+        }
+        atomicWrite(indexFile, arr.toString())
+    }
+
+    private fun fileNameFor(key: String): String = "win-${Integer.toHexString(key.hashCode())}.json"
+
+    private fun atomicWrite(target: File, text: String) {
+        val tmp = File(target.parentFile, "${target.name}.tmp")
+        tmp.writeText(text)
+        runCatching { Files.move(tmp.toPath(), target.toPath(), StandardCopyOption.ATOMIC_MOVE) }
+            .onFailure {
+                Files.move(tmp.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            }
+    }
+
+    companion object {
+        const val DIR_NAME = "flow-cache"
+    }
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/Models.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/Models.kt
@@ -608,5 +608,8 @@ data class EddyContext(
     val questionsSupported: List<String>,
 )
 
-/** Carries an HTTP status so the UI can react to 401 (re-auth). */
-class ApiException(message: String, val statusCode: Int? = null) : Exception(message)
+/**
+ * Carries an HTTP status so the UI can react to 401 (re-auth). `errorCode` mirrors the
+ * envelope's `error.code` (e.g. "invalid_since" on a 422 delta rejection).
+ */
+class ApiException(message: String, val statusCode: Int? = null, val errorCode: String? = null) : Exception(message)

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/notifications/UrgencyChannels.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/notifications/UrgencyChannels.kt
@@ -1,0 +1,42 @@
+package net.acumenus.hummingbird.notifications
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+
+/**
+ * The four urgency-tier notification channels from role-catalog.v1.json (`urgency_tiers`:
+ * T1 Critical, T2 High, T3 Awareness, T4 Digest), registered at app start so a future push
+ * can post into the right lane. Importance mapping: T1 high (with sound), T2 default,
+ * T3 low, T4 min.
+ *
+ * NOTE: registration only. Actual FCM sends remain blocked on server-side credentials
+ * (no push key provisioned yet) — see docs/hummingbird/DESIGN-ELEVATION-TODO.md Wave 3.
+ */
+object UrgencyChannels {
+
+    /** Tier id → channel id, using the catalog tier ids so payloads can map 1:1. */
+    private data class Tier(val id: String, val name: String, val importance: Int, val sound: Boolean)
+
+    private val tiers = listOf(
+        Tier("T1", "Critical", NotificationManager.IMPORTANCE_HIGH, sound = true),
+        Tier("T2", "High", NotificationManager.IMPORTANCE_DEFAULT, sound = false),
+        Tier("T3", "Awareness", NotificationManager.IMPORTANCE_LOW, sound = false),
+        Tier("T4", "Digest", NotificationManager.IMPORTANCE_MIN, sound = false),
+    )
+
+    fun channelId(tierId: String): String = "hb_urgency_${tierId.lowercase()}"
+
+    fun register(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = context.getSystemService(NotificationManager::class.java) ?: return
+        tiers.forEach { tier ->
+            val channel = NotificationChannel(channelId(tier.id), tier.name, tier.importance).apply {
+                description = "Urgency tier ${tier.id} — ${tier.name}"
+                if (!tier.sound) setSound(null, null)
+            }
+            manager.createNotificationChannel(channel)
+        }
+    }
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/MainScreen.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/MainScreen.kt
@@ -218,6 +218,7 @@ fun MainScreen(
                         HomeKind.OrBoard -> ORBoardScreen(
                             auth = auth,
                             forceError = launchConfig.forceError,
+                            personaId = selectedRole.id,
                             onOpenProfile = { detail = AltitudeDetail.Profile },
                             onOpenRoom = { room, webLink -> detail = AltitudeDetail.ORCase(room, webLink) },
                         )

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/altitude/AltitudeScreens.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/altitude/AltitudeScreens.kt
@@ -143,6 +143,9 @@ fun AltitudeHomeScreen(
                 auth = auth,
                 persona = vm.selectedRole.id,
                 modifier = Modifier.weight(1f).fillMaxWidth(),
+                // Discharge-leverage lane rows (hospitalist/intensivist) drill
+                // into the existing A2P patient context.
+                onOpenPatient = onOpenPatient,
             )
         } else {
         HbRefreshable(

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/capacity/CapacityDemandScreens.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/capacity/CapacityDemandScreens.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -38,6 +39,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
@@ -55,6 +60,9 @@ import net.acumenus.hummingbird.data.StrainDriver
 import net.acumenus.hummingbird.ui.components.RetryableMessage
 import net.acumenus.hummingbird.ui.components.StatusChip
 import net.acumenus.hummingbird.ui.components.panel
+import net.acumenus.hummingbird.ui.flow.FlowBoardMode
+import net.acumenus.hummingbird.ui.flow.FlowMapScreen
+import net.acumenus.hummingbird.ui.flow.ListMapSegment
 import net.acumenus.hummingbird.ui.theme.CapacityStatus
 import net.acumenus.hummingbird.ui.theme.Z
 
@@ -68,6 +76,7 @@ fun CapacityDemandScreen(
 ) {
     val vm: CapacityDemandViewModel = viewModel()
     val bearer = auth.accessToken ?: ""
+    var boardMode by remember { mutableStateOf(FlowBoardMode.List) }
 
     LaunchedEffect(bearer, forceError) {
         if (!forceError) {
@@ -100,8 +109,22 @@ fun CapacityDemandScreen(
             )
         },
     ) { inner ->
+        Column(Modifier.padding(inner).fillMaxSize()) {
+        ListMapSegment(
+            mode = boardMode,
+            onSelect = { boardMode = it },
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        )
+        if (boardMode == FlowBoardMode.Map) {
+            // §8 P6: curve-first strain-over-time lens; the map is secondary.
+            FlowMapScreen(
+                auth = auth,
+                persona = "capacity_lead",
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
+        } else {
         LazyColumn(
-            modifier = Modifier.padding(inner),
+            modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
@@ -139,6 +162,8 @@ fun CapacityDemandScreen(
                     }
                 }
             }
+        }
+        }
         }
     }
 }

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/evs/EvsScreens.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/evs/EvsScreens.kt
@@ -63,6 +63,9 @@ import net.acumenus.hummingbird.ui.components.RetryableMessage
 import net.acumenus.hummingbird.ui.components.hbConfirmHaptic
 import net.acumenus.hummingbird.ui.components.hbRejectHaptic
 import net.acumenus.hummingbird.ui.components.panel
+import net.acumenus.hummingbird.ui.flow.FlowBoardMode
+import net.acumenus.hummingbird.ui.flow.FlowMapScreen
+import net.acumenus.hummingbird.ui.flow.ListMapSegment
 import net.acumenus.hummingbird.ui.theme.CapacityStatus
 import net.acumenus.hummingbird.ui.theme.Z
 
@@ -76,6 +79,7 @@ fun BedTurnsScreen(
 ) {
     val vm: EvsViewModel = viewModel()
     val bearer = auth.accessToken ?: ""
+    var boardMode by remember { mutableStateOf(FlowBoardMode.List) }
 
     LaunchedEffect(bearer, forceError) {
         if (!forceError) {
@@ -108,10 +112,23 @@ fun BedTurnsScreen(
             )
         },
     ) { inner ->
+        Column(Modifier.padding(inner).fillMaxSize()) {
+        ListMapSegment(
+            mode = boardMode,
+            onSelect = { boardMode = it },
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        )
+        if (boardMode == FlowBoardMode.Map) {
+            FlowMapScreen(
+                auth = auth,
+                persona = "evs",
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
+        } else {
         HbRefreshable(
             refreshing = vm.loading,
             onRefresh = { vm.load(bearer) },
-            modifier = Modifier.padding(inner),
+            modifier = Modifier.weight(1f),
         ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -147,6 +164,8 @@ fun BedTurnsScreen(
                     }
                 }
             }
+        }
+        }
         }
         }
     }

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/executive/ExecutiveScreens.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/executive/ExecutiveScreens.kt
@@ -36,6 +36,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
@@ -54,6 +58,9 @@ import net.acumenus.hummingbird.ui.components.HbRefreshable
 import net.acumenus.hummingbird.ui.components.RetryableMessage
 import net.acumenus.hummingbird.ui.components.StatusChip
 import net.acumenus.hummingbird.ui.components.panel
+import net.acumenus.hummingbird.ui.flow.FlowBoardMode
+import net.acumenus.hummingbird.ui.flow.FlowMapScreen
+import net.acumenus.hummingbird.ui.flow.ListMapSegment
 import net.acumenus.hummingbird.ui.theme.CapacityStatus
 import net.acumenus.hummingbird.ui.theme.Z
 
@@ -68,6 +75,7 @@ fun HouseBriefScreen(
     val vm: ExecutiveViewModel = viewModel()
     val bearer = auth.accessToken ?: ""
     val uriHandler = LocalUriHandler.current
+    var boardMode by remember { mutableStateOf(FlowBoardMode.List) }
 
     LaunchedEffect(bearer, forceError) {
         if (!forceError) {
@@ -100,10 +108,24 @@ fun HouseBriefScreen(
             )
         },
     ) { inner ->
+        Column(Modifier.padding(inner).fillMaxSize()) {
+        ListMapSegment(
+            mode = boardMode,
+            onSelect = { boardMode = it },
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        )
+        if (boardMode == FlowBoardMode.Map) {
+            // §8 P9: the morning-brief time-lapse + forecast strip lens.
+            FlowMapScreen(
+                auth = auth,
+                persona = "executive",
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
+        } else {
         HbRefreshable(
             refreshing = vm.loading,
             onRefresh = { vm.load(bearer) },
-            modifier = Modifier.padding(inner),
+            modifier = Modifier.weight(1f),
         ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -144,6 +166,8 @@ fun HouseBriefScreen(
                     }
                 }
             }
+        }
+        }
         }
         }
     }

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/EvsTurnLayer.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/EvsTurnLayer.kt
@@ -1,0 +1,169 @@
+package net.acumenus.hummingbird.ui.flow
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.acumenus.hummingbird.data.FlowBedStatus
+import net.acumenus.hummingbird.data.FlowFloor
+import net.acumenus.hummingbird.data.FlowWindowData
+import net.acumenus.hummingbird.ui.theme.Z
+import kotlin.math.abs
+
+/**
+ * Bed-state tint fade: bed_statuses are strictly "now", so the tint layer fades
+ * as the user scrubs away from now (full within ~15 min, down to 25% at ±4h).
+ */
+fun bedStateFade(scrubT: Long, nowMs: Long): Float {
+    val hoursAway = abs(scrubT - nowMs) / 3_600_000f
+    return 1f - 0.75f * (hoursAway / 4f).coerceAtMost(1f)
+}
+
+/** True when the scrub position is far enough from now to caveat the tint layer. */
+fun bedStateIsStale(scrubT: Long, nowMs: Long): Boolean =
+    abs(scrubT - nowMs) >= 15 * 60_000L
+
+/**
+ * The turn map's bed treatment: dirty = warning tint, blocked = muted outline,
+ * occupied = neutral fill, available = faint success tint. Status is never by
+ * color alone — the tap detail names the state.
+ */
+fun evsBedPaints(statuses: List<FlowBedStatus>, fade: Float): Map<Int, FlowBedPaint> =
+    statuses.associate { bed ->
+        bed.bedId to when (bed.status) {
+            "dirty" -> FlowBedPaint(
+                fill = Z.statusWarning.copy(alpha = 0.35f * fade),
+                outline = Z.statusWarning.copy(alpha = (0.9f * fade).coerceAtLeast(0.3f)),
+            )
+            "blocked" -> FlowBedPaint(
+                fill = null,
+                outline = Z.inkMuted.copy(alpha = (0.55f * fade).coerceAtLeast(0.3f)),
+            )
+            "available" -> FlowBedPaint(
+                fill = Z.statusSuccess.copy(alpha = 0.16f * fade),
+                outline = null,
+            )
+            else -> FlowBedPaint( // occupied — neutral
+                fill = Z.inkMuted.copy(alpha = 0.18f * fade),
+                outline = null,
+            )
+        }
+    }
+
+private data class EvsTurnMark(
+    val bedRect: List<Double>,
+    val tMs: Long,
+    val alpha: Float,
+    val warning: Boolean,
+    val isolation: Boolean,
+)
+
+/**
+ * Turn markers over the floor plate (no pointer input — bed taps fall through):
+ * past evs_status events as solid ticks on their bed, future evs_due
+ * projections as dashed ghost outlines on the target bed with a time chip.
+ */
+@Composable
+fun EvsTurnOverlay(
+    floor: FlowFloor,
+    window: FlowWindowData,
+    scrubT: Long,
+    modifier: Modifier = Modifier,
+) {
+    val density = LocalDensity.current
+    val padPx = with(density) { floorPlatePad.toPx() }
+    val textMeasurer = rememberTextMeasurer()
+
+    val marks = remember(floor, window, scrubT) {
+        val bedRectById = floor.spaces
+            .filter { it.category == "bed" && it.bedId != null }
+            .associate { it.bedId!! to it.rect }
+        val bedIdByLabel = window.bedStatuses.associate { it.label.lowercase() to it.bedId }
+
+        val past = window.events
+            .filter { it.kind == "evs_status" && it.tMs <= scrubT }
+            .mapNotNull { event ->
+                val bedId = event.toSpace?.trim()?.lowercase()?.let(bedIdByLabel::get) ?: return@mapNotNull null
+                val rect = bedRectById[bedId] ?: return@mapNotNull null
+                EvsTurnMark(
+                    bedRect = rect,
+                    tMs = event.tMs,
+                    alpha = 1f,
+                    warning = event.tier == "warning" || event.tier == "critical",
+                    isolation = event.label.contains("isolation", ignoreCase = true),
+                )
+            }
+        val ahead = window.projections
+            .filter { it.kind == "evs_due" && it.tMs > scrubT }
+            .mapNotNull { ghost ->
+                val rect = ghost.bedId?.let(bedRectById::get) ?: return@mapNotNull null
+                EvsTurnMark(
+                    bedRect = rect,
+                    tMs = ghost.tMs,
+                    alpha = ghost.confidenceAlpha,
+                    warning = false,
+                    isolation = ghost.label.contains("isolation", ignoreCase = true),
+                )
+            }
+        past to ahead
+    }
+
+    Canvas(modifier.fillMaxSize()) {
+        val transform = FlowPlanTransform(floor.bounds, size, padPx)
+        val ghostDash = PathEffect.dashPathEffect(floatArrayOf(5.dp.toPx(), 4.dp.toPx()))
+
+        // Past turns: solid ticks on the bed (amber only when the turn ran hot).
+        marks.first.forEach { mark ->
+            val r = transform.rect(mark.bedRect)
+            val color = if (mark.warning) Z.statusWarning else Z.primary
+            drawLine(
+                color = color,
+                start = Offset(r.center.x - 3.dp.toPx(), r.center.y + 1.dp.toPx()),
+                end = Offset(r.center.x - 0.5.dp.toPx(), r.center.y + 3.5.dp.toPx()),
+                strokeWidth = 2.dp.toPx(),
+            )
+            drawLine(
+                color = color,
+                start = Offset(r.center.x - 0.5.dp.toPx(), r.center.y + 3.5.dp.toPx()),
+                end = Offset(r.center.x + 4.dp.toPx(), r.center.y - 3.dp.toPx()),
+                strokeWidth = 2.dp.toPx(),
+            )
+        }
+
+        // Upcoming turns: dashed ghost outline + a time chip so techs can pre-position.
+        marks.second.forEach { mark ->
+            val r = transform.rect(mark.bedRect).let {
+                Rect(it.left - 3.dp.toPx(), it.top - 3.dp.toPx(), it.right + 3.dp.toPx(), it.bottom + 3.dp.toPx())
+            }
+            drawRoundRect(
+                color = Z.ink.copy(alpha = mark.alpha),
+                topLeft = r.topLeft,
+                size = r.size,
+                cornerRadius = androidx.compose.ui.geometry.CornerRadius(4.dp.toPx()),
+                style = Stroke(width = 1.5.dp.toPx(), pathEffect = ghostDash),
+            )
+            val chip = flowClock(mark.tMs) + if (mark.isolation) " · ISO" else ""
+            drawText(
+                textMeasurer = textMeasurer,
+                text = chip,
+                topLeft = Offset(r.right + 3.dp.toPx(), r.top - 4.dp.toPx()),
+                style = TextStyle(
+                    color = (if (mark.isolation) Z.statusWarning else Z.ink).copy(alpha = mark.alpha),
+                    fontSize = 8.sp,
+                    fontFeatureSettings = "tnum",
+                ),
+            )
+        }
+    }
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/FloorPlateCanvas.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/FloorPlateCanvas.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
@@ -31,8 +32,11 @@ import kotlin.math.min
 internal fun occupancyAlpha(occupancyPct: Int): Float =
     0.10f + 0.35f * (occupancyPct.coerceIn(0, 100) / 100f)
 
+/** Canvas padding shared by FloorPlateCanvas and any overlay drawn on top of it. */
+internal val floorPlatePad = 12.dp
+
 /** Maps plan-view feet → canvas px for one floor (uniform scale, centered). */
-private class PlateTransform(bounds: List<Double>, canvas: Size, padPx: Float) {
+internal class FlowPlanTransform(bounds: List<Double>, canvas: Size, padPx: Float) {
     private val bx = bounds.getOrElse(0) { 0.0 }.toFloat()
     private val by = bounds.getOrElse(1) { 0.0 }.toFloat()
     private val bw = max(bounds.getOrElse(2) { 1.0 }.toFloat(), 0.001f)
@@ -48,7 +52,12 @@ private class PlateTransform(bounds: List<Double>, canvas: Size, padPx: Float) {
         val h = r.getOrElse(3) { 0.0 }.toFloat()
         return Rect(ox + x * scale, oy + y * scale, ox + (x + w) * scale, oy + (y + h) * scale)
     }
+
+    fun center(r: List<Double>): Offset = rect(r).center
 }
+
+/** Per-bed treatment for the EVS turn map — fill under the hairline, outline over it. */
+data class FlowBedPaint(val fill: Color?, val outline: Color?)
 
 /** Inflate a plate's rect to at least the minimum touch target, centered. */
 private fun Rect.expandedToTarget(minPx: Float): Rect {
@@ -58,7 +67,7 @@ private fun Rect.expandedToTarget(minPx: Float): Rect {
 }
 
 /** Smallest plate whose ≥44dp effective target contains the tap — beds win over rooms over units. */
-private fun hitTestPlate(pos: Offset, plates: List<FlowPlate>, transform: PlateTransform, minTargetPx: Float): FlowPlate? =
+private fun hitTestPlate(pos: Offset, plates: List<FlowPlate>, transform: FlowPlanTransform, minTargetPx: Float): FlowPlate? =
     plates
         .filter { transform.rect(it.rect).expandedToTarget(minTargetPx).contains(pos) }
         .minByOrNull { transform.rect(it.rect).let { r -> r.width * r.height } }
@@ -77,10 +86,11 @@ fun FloorPlateCanvas(
     selectedPlateId: Int?,
     onSelectPlate: (FlowPlate?) -> Unit,
     modifier: Modifier = Modifier,
+    bedPaints: Map<Int, FlowBedPaint> = emptyMap(),
 ) {
     val density = LocalDensity.current
     val minTargetPx = with(density) { 44.dp.toPx() }
-    val padPx = with(density) { 12.dp.toPx() }
+    val padPx = with(density) { floorPlatePad.toPx() }
     val occupancyByUnit = rollup?.units?.associate { it.unitId to it.occupancyPct } ?: emptyMap()
     val plates by rememberUpdatedState(floor.spaces)
     val bounds by rememberUpdatedState(floor.bounds)
@@ -91,12 +101,12 @@ fun FloorPlateCanvas(
             .fillMaxSize()
             .pointerInput(floor.floor) {
                 detectTapGestures { pos ->
-                    val transform = PlateTransform(bounds, Size(size.width.toFloat(), size.height.toFloat()), padPx)
+                    val transform = FlowPlanTransform(bounds, Size(size.width.toFloat(), size.height.toFloat()), padPx)
                     select(hitTestPlate(pos, plates, transform, minTargetPx))
                 }
             },
     ) {
-        val transform = PlateTransform(floor.bounds, size, padPx)
+        val transform = FlowPlanTransform(floor.bounds, size, padPx)
         val corner = CornerRadius(3.dp.toPx())
         val hairline = Stroke(width = 1.dp.toPx())
 
@@ -149,11 +159,21 @@ fun FloorPlateCanvas(
             )
         }
 
-        // 4. Beds — small outlined rects.
+        // 4. Beds — small outlined rects; the EVS lens paints current bed state
+        //    under/over the hairline (dirty/blocked/occupied/available).
         floor.spaces.filter { it.category == "bed" }.forEach { plate ->
             val r = transform.rect(plate.rect)
+            val paint = plate.bedId?.let { bedPaints[it] }
+            paint?.fill?.let { fill ->
+                drawRoundRect(
+                    color = fill,
+                    topLeft = r.topLeft,
+                    size = r.size,
+                    cornerRadius = CornerRadius(2.dp.toPx()),
+                )
+            }
             drawRoundRect(
-                color = Z.inkMuted,
+                color = paint?.outline ?: Z.inkMuted,
                 topLeft = r.topLeft,
                 size = r.size,
                 cornerRadius = CornerRadius(2.dp.toPx()),

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/FlowAggregateLenses.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/FlowAggregateLenses.kt
@@ -1,0 +1,673 @@
+package net.acumenus.hummingbird.ui.flow
+
+import android.content.Intent
+import android.provider.Settings
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.IosShare
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Replay
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.acumenus.hummingbird.data.FlowProjection
+import net.acumenus.hummingbird.data.FlowFloorRollup
+import net.acumenus.hummingbird.data.FlowWindowData
+import net.acumenus.hummingbird.ui.components.panel
+import net.acumenus.hummingbird.ui.theme.Z
+import java.net.URLEncoder
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/*
+ * Phase 3 — aggregate lens sections (§8 P9 executive, P6 capacity_lead,
+ * P10 staffing_coordinator, P8 pi_lead, hospitalist/intensivist leverage lane).
+ * All of it renders from the already-lensed window payload; the server decides
+ * what each role receives (executive: snapshots+projections+spaces only).
+ */
+
+// MARK: — pure helpers (unit-tested)
+
+/**
+ * Floor rollups with occupancy re-derived from the snapshot checkpoints at
+ * time t — what makes the house stack "breathe" during the executive/PI
+ * replay. At/after now (or with no checkpoints yet) the live rollups win.
+ */
+fun floorsAt(window: FlowWindowData, t: Long): List<FlowFloorRollup> {
+    if (t >= window.nowMs || window.snapshots.isEmpty()) return window.spacesFloors
+    return window.spacesFloors.map { floor ->
+        val units = floor.units.map { unit ->
+            val snap = window.snapshots
+                .filter { it.unitId == unit.unitId && it.tMs <= t }
+                .maxByOrNull { it.tMs }
+            if (snap == null) {
+                unit
+            } else {
+                unit.copy(
+                    staffed = snap.staffed,
+                    occupied = snap.occupied,
+                    available = snap.available,
+                    blocked = snap.blocked,
+                    occupancyPct = if (snap.staffed > 0) snap.occupied * 100 / snap.staffed else 0,
+                )
+            }
+        }
+        val staffed = units.sumOf { it.staffed }
+        val occupied = units.sumOf { it.occupied }
+        floor.copy(
+            units = units,
+            staffed = staffed,
+            occupied = occupied,
+            occupancyPct = if (staffed > 0) occupied * 100 / staffed else 0,
+        )
+    }
+}
+
+/** Total predicted arrivals in (now, now+24h] — the executive forecast strip headline. */
+fun arrivalsNext24hTotal(window: FlowWindowData): Int =
+    window.projections
+        .filter { it.kind == "predicted_arrivals" && it.tMs > window.nowMs }
+        .sumOf { it.value ?: 0 }
+
+/** Worst positive staffing gap per floor: `staffing_shift_gap.unit_id` → floor via the rollups. */
+fun worstGapByFloor(window: FlowWindowData): Map<Int, Int> {
+    val unitToFloor = window.spacesFloors
+        .flatMap { floor -> floor.units.map { it.unitId to floor.floor } }
+        .toMap()
+    return window.projections
+        .filter { it.kind == "staffing_shift_gap" && (it.value ?: 0) > 0 }
+        .mapNotNull { gap -> gap.unitId?.let(unitToFloor::get)?.let { floor -> floor to (gap.value ?: 0) } }
+        .groupBy({ it.first }, { it.second })
+        .mapValues { (_, gaps) -> gaps.max() }
+}
+
+/**
+ * Discharge-leverage ranking (§8 hospitalist/intensivist): expected discharges
+ * ordered definite > probable > possible, then earliest first.
+ */
+fun dischargeLeverageRows(projections: List<FlowProjection>): List<FlowProjection> =
+    projections
+        .filter { it.kind == "expected_discharge" }
+        .sortedWith(compareBy({ confidenceRank(it.confidence) }, { it.tMs }))
+
+private fun confidenceRank(confidence: String): Int = when (confidence) {
+    "definite" -> 0
+    "probable" -> 1
+    else -> 2
+}
+
+/** PI replay speed: ~4 hours of record per second of playback. */
+fun piReplayDurationMs(fromMs: Long, nowMs: Long): Long {
+    val hours = (nowMs - fromMs).coerceAtLeast(0L) / 3_600_000.0
+    return (hours / 4.0 * 1000.0).toLong().coerceAtLeast(1_000L)
+}
+
+/**
+ * The v1 "clip window" payload: a plain-text evidence summary of the visible
+ * range — scope, from–to, occupancy delta from snapshots, event counts by
+ * kind — shared via the system sheet (no backend write).
+ */
+fun clipSummary(
+    window: FlowWindowData,
+    fromMs: Long,
+    toMs: Long,
+    zone: ZoneId = ZoneId.systemDefault(),
+): String {
+    val fmt = DateTimeFormatter.ofPattern("MMM d HH:mm")
+    fun clock(ms: Long): String = fmt.format(Instant.ofEpochMilli(ms).atZone(zone))
+
+    val series = occupancySeries(window)
+    val startOcc = series.lastOrNull { it.tMs <= fromMs } ?: series.firstOrNull { it.tMs in fromMs..toMs }
+    val endOcc = series.lastOrNull { it.tMs <= toMs }
+    val occupancyLine = if (startOcc != null && endOcc != null) {
+        val delta = endOcc.value - startOcc.value
+        val sign = if (delta >= 0) "+" else "−"
+        "Occupancy ${startOcc.value} → ${endOcc.value} ($sign${kotlin.math.abs(delta)})"
+    } else {
+        "Occupancy: no checkpoints in range"
+    }
+
+    val counts = window.events
+        .filter { it.tMs in fromMs..toMs }
+        .groupingBy { it.kind }
+        .eachCount()
+        .entries
+        .sortedByDescending { it.value }
+    val eventsLine = if (counts.isEmpty()) {
+        "Events: none in range"
+    } else {
+        "Events: " + counts.joinToString(" · ") { "${it.key} ${it.value}" }
+    }
+
+    val link = clipWebLink(window, fromMs, toMs)
+    return buildString {
+        appendLine("Flow window clip — ${window.scope.label}")
+        appendLine("${clock(fromMs)} → ${clock(toMs)}")
+        appendLine(occupancyLine)
+        appendLine(eventsLine)
+        if (link != null) append(link)
+    }.trimEnd()
+}
+
+/** `links.web` with the clipped range appended as `from`/`to` (ISO-8601). */
+fun clipWebLink(window: FlowWindowData, fromMs: Long, toMs: Long): String? {
+    val base = window.webLink ?: return null
+    fun iso(ms: Long): String = URLEncoder.encode(
+        DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(Instant.ofEpochMilli(ms).atZone(ZoneId.of("UTC"))),
+        "UTF-8",
+    )
+    val joiner = if (base.contains('?')) "&" else "?"
+    return "$base${joiner}from=${iso(fromMs)}&to=${iso(toMs)}"
+}
+
+// MARK: — shared bits
+
+/** System reduced-motion signal (animator scale 0) — same check LoginScreen uses. */
+@Composable
+fun rememberReduceMotion(): Boolean {
+    val context = LocalContext.current
+    return remember {
+        Settings.Global.getFloat(context.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 1f) == 0f
+    }
+}
+
+@Composable
+private fun FlowSectionLabel(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text,
+        color = Z.inkMuted,
+        fontSize = 11.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier = modifier,
+    )
+}
+
+// MARK: — P9 · Executive (time-lapse brief + forecast strip)
+
+private enum class ExecPhase { Pending, Playing, Settled }
+
+/**
+ * The executive lens (§8 P9): on entry the Chronobar scrubs itself through the
+ * last 24h over ~15s while the house stack breathes from the snapshot
+ * checkpoints; it settles at now and reveals the forward half — the census
+ * ribbon plus a compact forecast strip. Reduced motion lands at now directly;
+ * "Replay" re-runs the lapse either way. No patient dots, no event lanes —
+ * the payload for this lens carries neither.
+ */
+@Composable
+internal fun ExecutiveFlowSection(
+    vm: FlowViewModel,
+    window: FlowWindowData,
+    onSelect: (FlowSelection?) -> Unit,
+) {
+    val reduceMotion = rememberReduceMotion()
+    var phase by rememberSaveable { mutableStateOf(if (reduceMotion) ExecPhase.Settled else ExecPhase.Pending) }
+
+    LaunchedEffect(Unit) {
+        if (phase == ExecPhase.Pending) {
+            phase = ExecPhase.Playing
+            vm.play(fromMs = window.fromMs, durationMs = 15_000L)
+        }
+    }
+    LaunchedEffect(vm.playing) {
+        if (phase == ExecPhase.Playing && !vm.playing) phase = ExecPhase.Settled
+    }
+
+    Column(Modifier.fillMaxSize().padding(horizontal = 12.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            FlowSectionLabel(
+                if (phase == ExecPhase.Settled) "Next 24 hours" else "Last 24 hours",
+                modifier = Modifier.weight(1f),
+            )
+            TextButton(
+                onClick = {
+                    phase = ExecPhase.Playing
+                    vm.play(fromMs = window.fromMs, durationMs = 15_000L)
+                },
+                modifier = Modifier.heightIn(min = 48.dp),
+            ) {
+                Icon(Icons.Filled.Replay, contentDescription = null, tint = Z.primary, modifier = Modifier.size(16.dp))
+                Text(" Replay", color = Z.primary, fontSize = 13.sp, fontWeight = FontWeight.Medium)
+            }
+        }
+
+        HouseStack(
+            floors = floorsAt(window, vm.scrubT),
+            onSelectFloor = {},
+            modifier = Modifier.weight(1f),
+        )
+
+        if (phase == ExecPhase.Settled) {
+            FlowCurve(
+                window = window,
+                scopeLabel = window.scope.label,
+                scrubT = vm.scrubT,
+                surgeMarker = window.projections.firstOrNull { it.kind == "surge_probability" },
+                onSelectProjection = { onSelect(FlowSelection.Ghost(it)) },
+                modifier = Modifier.height(150.dp),
+            )
+            ExecutiveForecastStrip(window = window, onSelect = onSelect)
+        }
+    }
+}
+
+/** Compact forecast strip: arrivals next 24h + surge probability, provenance on tap. */
+@Composable
+private fun ExecutiveForecastStrip(
+    window: FlowWindowData,
+    onSelect: (FlowSelection?) -> Unit,
+) {
+    val arrivals = remember(window) { arrivalsNext24hTotal(window) }
+    val arrivalsSample = remember(window) {
+        window.projections.firstOrNull { it.kind == "predicted_arrivals" && it.tMs > window.nowMs }
+    }
+    val surge = remember(window) { window.projections.firstOrNull { it.kind == "surge_probability" } }
+
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ForecastChip(
+            label = "Arrivals · next 24h",
+            value = "≈$arrivals",
+            qualifier = arrivalsSample?.confidence ?: "probable",
+            modifier = Modifier.weight(1f),
+            onTap = arrivalsSample?.let { sample -> { onSelect(FlowSelection.Ghost(sample)) } },
+        )
+        ForecastChip(
+            label = "Surge probability",
+            value = surge?.value?.let { "$it%" } ?: "—",
+            qualifier = surge?.confidence ?: "possible",
+            modifier = Modifier.weight(1f),
+            onTap = surge?.let { s -> { onSelect(FlowSelection.Ghost(s)) } },
+        )
+    }
+}
+
+@Composable
+private fun ForecastChip(
+    label: String,
+    value: String,
+    qualifier: String,
+    modifier: Modifier = Modifier,
+    onTap: (() -> Unit)? = null,
+) {
+    Column(
+        modifier
+            .heightIn(min = 48.dp)
+            .panel(corner = 10)
+            .let { if (onTap != null) it.clickable(onClick = onTap) else it }
+            .padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(label, color = Z.inkMuted, fontSize = 10.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text(value, color = Z.ink, fontSize = 16.sp, fontWeight = FontWeight.SemiBold, style = flowTabularNums)
+            // Confidence vocabulary, never "will".
+            Text(qualifier, color = Z.inkMuted, fontSize = 10.sp)
+        }
+    }
+}
+
+// MARK: — P6 · Capacity lead (curve-first, map-second)
+
+/**
+ * The capacity lens (§8 P6): the 48h occupancy-vs-staffed curve IS the primary
+ * surface (band ahead, surge marker at its t); the house stack is a secondary
+ * collapsible section. Tapping a floor filters the curve to that floor's
+ * units client-side (snapshots carry unit_id); unit chips narrow further.
+ */
+@Composable
+internal fun CapacityCurveSection(
+    vm: FlowViewModel,
+    window: FlowWindowData,
+    onSelect: (FlowSelection?) -> Unit,
+) {
+    var mapExpanded by rememberSaveable { mutableStateOf(false) }
+    var filterFloor by rememberSaveable { mutableStateOf<Int?>(null) }
+    var filterUnit by rememberSaveable { mutableStateOf<Int?>(null) }
+
+    val floorRollup = filterFloor?.let { f -> window.spacesFloors.firstOrNull { it.floor == f } }
+    val unitIds: Set<Int>? = when {
+        filterUnit != null -> setOf(filterUnit!!)
+        floorRollup != null -> floorRollup.units.map { it.unitId }.toSet()
+        else -> null
+    }
+    val scopeLabel = when {
+        filterUnit != null -> floorRollup?.units?.firstOrNull { it.unitId == filterUnit }?.name
+            ?: "Unit $filterUnit"
+        floorRollup != null -> floorRollup.label
+        else -> window.scope.label
+    }
+
+    Column(Modifier.fillMaxSize().padding(horizontal = 12.dp)) {
+        FlowCurve(
+            window = window,
+            unitIds = unitIds,
+            scopeLabel = "$scopeLabel · occupancy vs staffed",
+            scrubT = vm.scrubT,
+            surgeMarker = window.projections.firstOrNull { it.kind == "surge_probability" },
+            onSelectProjection = { onSelect(FlowSelection.Ghost(it)) },
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+        )
+
+        if (floorRollup != null) {
+            LazyRow(
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+            ) {
+                item {
+                    ScopeFilterChip("House", selected = false) {
+                        filterFloor = null
+                        filterUnit = null
+                    }
+                }
+                item {
+                    ScopeFilterChip(floorRollup.label, selected = filterUnit == null) { filterUnit = null }
+                }
+                items(floorRollup.units, key = { it.unitId }) { unit ->
+                    ScopeFilterChip(unit.abbr.ifBlank { unit.name }, selected = filterUnit == unit.unitId) {
+                        filterUnit = unit.unitId
+                    }
+                }
+            }
+        }
+
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .heightIn(min = 48.dp)
+                .clickable { mapExpanded = !mapExpanded },
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FlowSectionLabel("House map", modifier = Modifier.weight(1f))
+            Icon(
+                if (mapExpanded) Icons.Filled.KeyboardArrowDown else Icons.Filled.KeyboardArrowUp,
+                contentDescription = if (mapExpanded) "Collapse house map" else "Expand house map",
+                tint = Z.inkMuted,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        if (mapExpanded) {
+            Box(Modifier.fillMaxWidth().height(200.dp)) {
+                HouseStack(
+                    floors = window.spacesFloors,
+                    onSelectFloor = { floor ->
+                        filterFloor = floor
+                        filterUnit = null
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScopeFilterChip(label: String, selected: Boolean, onClick: () -> Unit) {
+    // 48dp touch target around a compact pill.
+    Box(
+        modifier = Modifier
+            .heightIn(min = 48.dp)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            label,
+            color = if (selected) Z.primary else Z.inkMuted,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier
+                .panel(corner = 8)
+                .padding(horizontal = 10.dp, vertical = 7.dp),
+        )
+    }
+}
+
+// MARK: — P10 · Staffing coordinator (coverage vs the curve)
+
+/**
+ * The staffing lens (§8 P10): the census curve with `staffing_shift_gap` step
+ * markers at their shift boundaries (warning tint only for real gaps), the
+ * next boundary detent emphasized, and the house stack tinted by the worst
+ * gap on each floor. Tapping a floor filters the curve to it.
+ */
+@Composable
+internal fun StaffingCurveSection(
+    vm: FlowViewModel,
+    window: FlowWindowData,
+    onSelect: (FlowSelection?) -> Unit,
+) {
+    var filterFloor by rememberSaveable { mutableStateOf<Int?>(null) }
+    val floorRollup = filterFloor?.let { f -> window.spacesFloors.firstOrNull { it.floor == f } }
+    val unitIds: Set<Int>? = floorRollup?.units?.map { it.unitId }?.toSet()
+    val floorUnitIds = unitIds
+
+    val gaps = remember(window, floorUnitIds) {
+        window.projections.filter {
+            it.kind == "staffing_shift_gap" && (floorUnitIds == null || it.unitId in floorUnitIds)
+        }
+    }
+    val accents = remember(window) {
+        worstGapByFloor(window).mapValues { (_, gap) ->
+            FloorAccent(
+                color = Z.statusWarning,
+                alpha = (0.15f + 0.06f * gap).coerceAtMost(0.45f),
+                label = "gap $gap",
+            )
+        }
+    }
+
+    Column(Modifier.fillMaxSize().padding(horizontal = 12.dp)) {
+        FlowCurve(
+            window = window,
+            unitIds = unitIds,
+            scopeLabel = "${floorRollup?.label ?: window.scope.label} · coverage vs census",
+            scrubT = vm.scrubT,
+            gapMarkers = gaps,
+            emphasizeNextShift = true,
+            onSelectProjection = { onSelect(FlowSelection.Ghost(it)) },
+            modifier = Modifier.weight(0.48f).fillMaxWidth(),
+        )
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(top = 4.dp)) {
+            FlowSectionLabel("Floors by worst gap", modifier = Modifier.weight(1f))
+            if (filterFloor != null) {
+                TextButton(onClick = { filterFloor = null }, modifier = Modifier.heightIn(min = 40.dp)) {
+                    Text("House", color = Z.primary, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+                }
+            }
+        }
+        HouseStack(
+            floors = window.spacesFloors,
+            onSelectFloor = { filterFloor = it },
+            accents = accents,
+            modifier = Modifier.weight(0.52f),
+        )
+    }
+}
+
+// MARK: — P8 · PI lead (replay + clip v1)
+
+/**
+ * The PI controls row (§8 P8): play/pause at ~4h/s over the past 24h (the
+ * same playback driver the executive time-lapse uses) and a "Clip window"
+ * button that shares the visible range — scope, from–to, occupancy delta,
+ * event counts by kind, and the web deep link with `?from=&to=` appended.
+ */
+@Composable
+internal fun PiControlsRow(
+    vm: FlowViewModel,
+    window: FlowWindowData,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val clipTo = vm.scrubT.coerceIn(window.fromMs, window.nowMs)
+
+    Row(
+        modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        TextButton(
+            onClick = {
+                if (vm.playing) {
+                    vm.pause()
+                } else {
+                    vm.play(
+                        fromMs = window.fromMs,
+                        durationMs = piReplayDurationMs(window.fromMs, window.nowMs),
+                    )
+                }
+            },
+            modifier = Modifier.heightIn(min = 48.dp),
+        ) {
+            Icon(
+                if (vm.playing) Icons.Filled.Pause else Icons.Filled.PlayArrow,
+                contentDescription = if (vm.playing) "Pause replay" else "Replay the past 24h at 4h per second",
+                tint = Z.primary,
+                modifier = Modifier.size(18.dp),
+            )
+            Text(
+                if (vm.playing) " Pause" else " Replay 4h/s",
+                color = Z.primary,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+        Text(
+            "${flowClock(window.fromMs)} → ${flowClock(clipTo)}",
+            color = Z.inkMuted,
+            fontSize = 11.sp,
+            style = flowTabularNums,
+            modifier = Modifier.weight(1f),
+        )
+        TextButton(
+            onClick = {
+                val text = clipSummary(window, window.fromMs, clipTo)
+                val send = Intent(Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_TEXT, text)
+                }
+                context.startActivity(Intent.createChooser(send, "Share flow clip"))
+            },
+            modifier = Modifier.heightIn(min = 48.dp),
+        ) {
+            Icon(Icons.Filled.IosShare, contentDescription = null, tint = Z.primary, modifier = Modifier.size(16.dp))
+            Text(" Clip window", color = Z.primary, fontSize = 13.sp, fontWeight = FontWeight.Medium)
+        }
+    }
+}
+
+// MARK: — hospitalist / intensivist · discharge-leverage lane
+
+/**
+ * The discharge-leverage lane (§8 hospitalist/intensivist): expected
+ * discharges ranked by confidence then time. Rows with a patient context ref
+ * open the existing A2P navigation; rows without one are label-only.
+ */
+@Composable
+internal fun DischargeLeverageLane(
+    window: FlowWindowData,
+    onOpenPatient: ((String) -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    val rows = remember(window) { dischargeLeverageRows(window.projections) }
+    if (rows.isEmpty()) return
+
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        FlowSectionLabel("Discharge leverage", modifier = Modifier.padding(top = 4.dp))
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .heightIn(max = 156.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            rows.forEachIndexed { index, row ->
+                val ref = row.patientContextRef
+                val tappable = ref != null && onOpenPatient != null
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(min = 48.dp)
+                        .let { base ->
+                            if (tappable) base.clickable { onOpenPatient?.invoke(ref!!) } else base
+                        },
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        "${index + 1}",
+                        color = Z.inkMuted,
+                        fontSize = 11.sp,
+                        style = flowTabularNums,
+                    )
+                    Text(
+                        row.label,
+                        color = Z.ink,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
+                    // Confidence vocabulary at ghost alpha — never "will".
+                    Text(
+                        row.confidence,
+                        color = Z.ink.copy(alpha = row.confidenceAlpha),
+                        fontSize = 11.sp,
+                    )
+                    Text(
+                        flowClock(row.tMs),
+                        color = Z.inkMuted,
+                        fontSize = 11.sp,
+                        style = flowTabularNums,
+                    )
+                    if (tappable) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = "Open patient context",
+                            tint = Z.inkMuted,
+                            modifier = Modifier.size(16.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/FlowCurve.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/FlowCurve.kt
@@ -1,0 +1,397 @@
+package net.acumenus.hummingbird.ui.flow
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.acumenus.hummingbird.data.FlowProjection
+import net.acumenus.hummingbird.data.FlowWindowData
+import net.acumenus.hummingbird.ui.theme.Z
+import kotlin.math.abs
+
+/**
+ * One point on the 48h census/occupancy curve. Past points come from snapshots
+ * (no band); future points come from `predicted_census` projections (band when
+ * the service provides one).
+ */
+data class FlowCurvePoint(
+    val tMs: Long,
+    val value: Int,
+    val bandLower: Int? = null,
+    val bandUpper: Int? = null,
+)
+
+/**
+ * Past occupancy series from hourly snapshots. `unitIds == null` = whole scope
+ * (sum every unit per checkpoint); otherwise the client-side filter the
+ * capacity lens uses when a floor/unit is tapped.
+ */
+fun occupancySeries(window: FlowWindowData, unitIds: Set<Int>? = null): List<FlowCurvePoint> =
+    window.snapshots
+        .asSequence()
+        .filter { unitIds == null || it.unitId in unitIds }
+        .groupBy { it.tMs }
+        .map { (t, rows) -> FlowCurvePoint(t, rows.sumOf { it.occupied }) }
+        .sortedBy { it.tMs }
+
+/**
+ * Future census series from `predicted_census` projections (2h steps).
+ * House scope prefers house-level rows (unit_id == null); when the payload is
+ * per-unit only, unit rows are summed per step (bands summed when present).
+ */
+fun predictedSeries(window: FlowWindowData, unitIds: Set<Int>? = null): List<FlowCurvePoint> {
+    val census = window.projections.filter { it.kind == "predicted_census" && it.value != null }
+    val rows = if (unitIds == null) {
+        census.filter { it.unitId == null }.ifEmpty { census }
+    } else {
+        census.filter { it.unitId != null && it.unitId in unitIds }
+    }
+    return rows
+        .groupBy { it.tMs }
+        .map { (t, group) ->
+            FlowCurvePoint(
+                tMs = t,
+                value = group.sumOf { it.value ?: 0 },
+                bandLower = if (group.any { it.bandLower != null }) group.sumOf { it.bandLower ?: it.value ?: 0 } else null,
+                bandUpper = if (group.any { it.bandUpper != null }) group.sumOf { it.bandUpper ?: it.value ?: 0 } else null,
+            )
+        }
+        .sortedBy { it.tMs }
+}
+
+/** Staffed capacity for the scope — the reference line the curve is judged against. */
+fun staffedCapacity(window: FlowWindowData, unitIds: Set<Int>? = null): Int =
+    window.spacesFloors
+        .asSequence()
+        .flatMap { it.units }
+        .filter { unitIds == null || it.unitId in unitIds }
+        .sumOf { it.staffed }
+
+/** "212/240 occupied" readout at t — snapshots behind now, predicted steps ahead. */
+fun curveReadout(window: FlowWindowData, unitIds: Set<Int>?, t: Long): String {
+    val staffed = staffedCapacity(window, unitIds)
+    if (t > window.nowMs) {
+        val step = predictedSeries(window, unitIds).lastOrNull { it.tMs <= t }
+        if (step != null) {
+            val band = if (step.bandLower != null && step.bandUpper != null) " (${step.bandLower}–${step.bandUpper})" else ""
+            return "≈${step.value}$band / $staffed staffed"
+        }
+    }
+    val past = occupancySeries(window, unitIds).lastOrNull { it.tMs <= t }
+    if (past != null) return "${past.value} / $staffed staffed"
+    // No checkpoints yet — fall back to the now-state rollups.
+    val occupiedNow = window.spacesFloors
+        .asSequence()
+        .flatMap { it.units }
+        .filter { unitIds == null || it.unitId in unitIds }
+        .sumOf { it.occupied }
+    return "$occupiedNow / $staffed staffed"
+}
+
+/**
+ * The shared 48h census/occupancy curve, aligned to the Chronobar window
+ * (§8 P6/P9/P10). Past = solid line from snapshots; future = dashed line +
+ * soft band ribbon from `predicted_census` (ghost grammar — dashed, never a
+ * status color); staffed capacity as a reference line; now marker; optional
+ * 07:00/19:00 detents; optional `staffing_shift_gap` step markers and a
+ * `surge_probability` marker, both tappable for provenance.
+ */
+@Composable
+fun FlowCurve(
+    window: FlowWindowData,
+    unitIds: Set<Int>? = null,
+    scopeLabel: String,
+    scrubT: Long,
+    gapMarkers: List<FlowProjection> = emptyList(),
+    surgeMarker: FlowProjection? = null,
+    showShiftDetents: Boolean = true,
+    emphasizeNextShift: Boolean = false,
+    onSelectProjection: ((FlowProjection) -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    val fromMs = window.fromMs
+    val toMs = window.toMs
+    val nowMs = window.nowMs
+    val span = (toMs - fromMs).coerceAtLeast(1L)
+
+    val past = remember(window, unitIds) { occupancySeries(window, unitIds) }
+    val future = remember(window, unitIds) { predictedSeries(window, unitIds) }
+    val staffed = remember(window, unitIds) { staffedCapacity(window, unitIds) }
+    val detents = remember(fromMs, toMs) { shiftDetentsMs(fromMs, toMs) }
+    // Gap markers aggregated per shift boundary: one step, summed headcount.
+    val gapSteps = remember(gapMarkers) {
+        gapMarkers.groupBy { it.tMs }.entries.sortedBy { it.key }
+    }
+
+    val textMeasurer = rememberTextMeasurer()
+    val labelStyle = TextStyle(color = Z.inkMuted, fontSize = 9.sp, fontFeatureSettings = "tnum")
+    val select by rememberUpdatedState(onSelectProjection)
+
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                scopeLabel,
+                color = Z.inkMuted,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                "${flowClock(scrubT)} · ${curveReadout(window, unitIds, scrubT)}",
+                color = Z.ink,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Medium,
+                style = flowTabularNums,
+            )
+        }
+
+        Canvas(
+            Modifier
+                .fillMaxWidth()
+                .weight(1f, fill = true)
+                .heightIn(min = 120.dp)
+                .pointerInput(gapSteps, surgeMarker, fromMs, span) {
+                    detectTapGestures { pos ->
+                        val handler = select ?: return@detectTapGestures
+                        fun xOf(ms: Long): Float = ((ms - fromMs).toFloat() / span.toFloat()) * size.width
+                        val slop = 22.dp.toPx()
+                        // Nearest tappable projected value: a gap step or the surge marker.
+                        val candidates = buildList {
+                            gapSteps.forEach { (t, rows) ->
+                                rows.maxByOrNull { it.value ?: 0 }?.let { add(it to abs(xOf(t) - pos.x)) }
+                            }
+                            surgeMarker?.let { add(it to abs(xOf(it.tMs) - pos.x)) }
+                        }
+                        candidates.minByOrNull { it.second }
+                            ?.takeIf { it.second <= slop }
+                            ?.let { handler(it.first) }
+                    }
+                },
+        ) {
+            val w = size.width
+            val h = size.height
+            val topPad = 12.dp.toPx()
+            val bottomPad = 12.dp.toPx()
+            val plotH = (h - topPad - bottomPad).coerceAtLeast(1f)
+            val maxValue = maxOf(
+                staffed,
+                past.maxOfOrNull { it.value } ?: 0,
+                future.maxOfOrNull { it.bandUpper ?: it.value } ?: 0,
+                1,
+            ) * 1.08f
+
+            fun x(ms: Long): Float = ((ms - fromMs).toFloat() / span.toFloat()) * w
+            fun y(value: Float): Float = topPad + plotH * (1f - (value / maxValue).coerceIn(0f, 1f))
+
+            // Staffed-capacity reference line.
+            if (staffed > 0) {
+                val yStaffed = y(staffed.toFloat())
+                drawLine(
+                    color = Z.inkMuted.copy(alpha = 0.7f),
+                    start = Offset(0f, yStaffed),
+                    end = Offset(w, yStaffed),
+                    strokeWidth = 1.dp.toPx(),
+                )
+                drawText(
+                    textMeasurer = textMeasurer,
+                    text = "staffed $staffed",
+                    style = labelStyle,
+                    topLeft = Offset(4.dp.toPx(), (yStaffed - 12.dp.toPx()).coerceAtLeast(0f)),
+                )
+            }
+
+            // Shift-boundary detents (07:00/19:00); the next one after now can be emphasized.
+            if (showShiftDetents) {
+                val nextShift = detents.firstOrNull { it > nowMs }
+                detents.forEach { detent ->
+                    val emphasized = emphasizeNextShift && detent == nextShift
+                    val dx = x(detent)
+                    drawLine(
+                        color = if (emphasized) Z.ink else Z.inkMuted.copy(alpha = 0.6f),
+                        start = Offset(dx, h - bottomPad),
+                        end = Offset(dx, h - bottomPad + (if (emphasized) 9.dp else 5.dp).toPx()),
+                        strokeWidth = (if (emphasized) 2.dp else 1.dp).toPx(),
+                        cap = StrokeCap.Round,
+                    )
+                    if (emphasized) {
+                        drawText(
+                            textMeasurer = textMeasurer,
+                            text = flowClock(detent),
+                            style = labelStyle.copy(color = Z.ink),
+                            topLeft = Offset((dx - 14.dp.toPx()).coerceAtLeast(0f), h - 11.dp.toPx()),
+                        )
+                    }
+                }
+            }
+
+            // Band ribbon ahead — a soft fill, never a status color.
+            val banded = future.filter { it.bandLower != null && it.bandUpper != null }
+            if (banded.size >= 2) {
+                val ribbon = Path().apply {
+                    banded.forEachIndexed { i, p ->
+                        val px = x(p.tMs)
+                        val py = y(p.bandUpper!!.toFloat())
+                        if (i == 0) moveTo(px, py) else lineTo(px, py)
+                    }
+                    banded.asReversed().forEach { p ->
+                        lineTo(x(p.tMs), y(p.bandLower!!.toFloat()))
+                    }
+                    close()
+                }
+                drawPath(ribbon, color = Z.primary.copy(alpha = 0.10f))
+            }
+
+            // Past: solid — the reviewable record.
+            if (past.size >= 2) {
+                val path = Path().apply {
+                    past.forEachIndexed { i, p ->
+                        val px = x(p.tMs)
+                        val py = y(p.value.toFloat())
+                        if (i == 0) moveTo(px, py) else lineTo(px, py)
+                    }
+                }
+                drawPath(path, color = Z.primary, style = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round))
+            } else {
+                past.firstOrNull()?.let { p ->
+                    drawCircle(Z.primary, radius = 3.dp.toPx(), center = Offset(x(p.tMs), y(p.value.toFloat())))
+                }
+            }
+
+            // Future: dashed ghost line, anchored to the last observed point when present.
+            val futureAnchor = past.lastOrNull()?.let { listOf(it) } ?: emptyList()
+            val futureLine = futureAnchor + future
+            if (futureLine.size >= 2) {
+                val dash = PathEffect.dashPathEffect(floatArrayOf(6.dp.toPx(), 5.dp.toPx()))
+                val path = Path().apply {
+                    futureLine.forEachIndexed { i, p ->
+                        val px = x(p.tMs)
+                        val py = y(p.value.toFloat())
+                        if (i == 0) moveTo(px, py) else lineTo(px, py)
+                    }
+                }
+                drawPath(
+                    path,
+                    color = Z.primary.copy(alpha = 0.55f),
+                    style = Stroke(width = 1.5.dp.toPx(), cap = StrokeCap.Round, pathEffect = dash),
+                )
+            }
+
+            // `now` marker.
+            val xNow = x(nowMs)
+            drawLine(
+                color = Z.ink,
+                start = Offset(xNow, topPad - 6.dp.toPx()),
+                end = Offset(xNow, h - bottomPad),
+                strokeWidth = 1.5.dp.toPx(),
+            )
+
+            // Scrub position (only when it isn't sitting at now).
+            if (abs(scrubT - nowMs) > 60_000L) {
+                drawLine(
+                    color = Z.inkMuted.copy(alpha = 0.8f),
+                    start = Offset(x(scrubT), topPad),
+                    end = Offset(x(scrubT), h - bottomPad),
+                    strokeWidth = 1.dp.toPx(),
+                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(3.dp.toPx(), 3.dp.toPx())),
+                )
+            }
+
+            // Staffing gap steps: dashed ghost step at each shift boundary,
+            // headcount label — warning tint only when the gap is real (> 0).
+            gapSteps.forEach { (t, rows) ->
+                val gap = rows.sumOf { (it.value ?: 0).coerceAtLeast(0) }
+                val color = if (gap > 0) Z.statusWarning else Z.inkMuted
+                val gx = x(t)
+                drawLine(
+                    color = color.copy(alpha = 0.8f),
+                    start = Offset(gx, h - bottomPad),
+                    end = Offset(gx, h - bottomPad - 14.dp.toPx()),
+                    strokeWidth = 2.dp.toPx(),
+                    cap = StrokeCap.Round,
+                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(3.dp.toPx(), 2.5.dp.toPx())),
+                )
+                drawText(
+                    textMeasurer = textMeasurer,
+                    text = if (gap > 0) "gap $gap" else "gap 0",
+                    style = labelStyle.copy(color = color),
+                    topLeft = Offset(
+                        (gx - 10.dp.toPx()).coerceIn(0f, w - 30.dp.toPx()),
+                        (h - bottomPad - 26.dp.toPx()).coerceAtLeast(0f),
+                    ),
+                )
+            }
+
+            // Surge probability marker at its own t — dashed ring, confidence alpha.
+            surgeMarker?.let { surge ->
+                val sx = x(surge.tMs)
+                val sy = topPad + 6.dp.toPx()
+                drawCircle(
+                    color = Z.ink.copy(alpha = surge.confidenceAlpha),
+                    radius = 5.dp.toPx(),
+                    center = Offset(sx, sy),
+                    style = Stroke(
+                        width = 1.5.dp.toPx(),
+                        pathEffect = PathEffect.dashPathEffect(floatArrayOf(3.dp.toPx(), 2.5.dp.toPx())),
+                    ),
+                )
+                surge.value?.let { v ->
+                    drawText(
+                        textMeasurer = textMeasurer,
+                        text = "surge $v%",
+                        style = labelStyle,
+                        topLeft = Offset((sx + 8.dp.toPx()).coerceAtMost(w - 44.dp.toPx()), sy - 6.dp.toPx()),
+                    )
+                }
+            }
+        }
+
+        // Encoding legend — the line style names the meaning, never color alone.
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
+            CurveLegendSwatch(solid = true, label = "occupied")
+            CurveLegendSwatch(solid = false, label = "predicted · band")
+            Text("— staffed", color = Z.inkMuted, fontSize = 9.sp)
+        }
+    }
+}
+
+@Composable
+private fun CurveLegendSwatch(solid: Boolean, label: String) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        Canvas(Modifier.size(width = 14.dp, height = 8.dp)) {
+            drawLine(
+                color = if (solid) Z.primary else Z.primary.copy(alpha = 0.55f),
+                start = Offset(0f, size.height / 2f),
+                end = Offset(size.width, size.height / 2f),
+                strokeWidth = 2.dp.toPx(),
+                pathEffect = if (solid) null else PathEffect.dashPathEffect(floatArrayOf(4f, 4f)),
+            )
+        }
+        Text(label, color = Z.inkMuted, fontSize = 9.sp)
+    }
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/FlowMapScreen.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/FlowMapScreen.kt
@@ -1,24 +1,37 @@
 package net.acumenus.hummingbird.ui.flow
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -27,11 +40,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import net.acumenus.hummingbird.data.AuthViewModel
+import net.acumenus.hummingbird.data.FlowFloor
 import net.acumenus.hummingbird.data.FlowProjection
 import net.acumenus.hummingbird.data.FlowTimelineEvent
 import net.acumenus.hummingbird.data.FlowWindowData
 import net.acumenus.hummingbird.ui.components.RetryableMessage
 import net.acumenus.hummingbird.ui.components.panel
+import net.acumenus.hummingbird.ui.evs.IsolationBadge
 import net.acumenus.hummingbird.ui.theme.CapacityStatus
 import net.acumenus.hummingbird.ui.theme.Z
 
@@ -67,10 +82,39 @@ fun ListMapSegment(
     }
 }
 
+/** Staleness caption shown when the window is served from the offline cache. */
+@Composable
+private fun OfflineCaption(asOfMs: Long) {
+    val clock = remember(asOfMs) {
+        java.time.format.DateTimeFormatter.ofPattern("HH:mm")
+            .format(java.time.Instant.ofEpochMilli(asOfMs).atZone(java.time.ZoneId.systemDefault()))
+    }
+    Text(
+        "Offline · showing data from $clock",
+        color = Z.statusWarning,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Medium,
+        modifier = Modifier.padding(horizontal = Z.s4, vertical = Z.s1),
+    )
+}
+
+private fun isOrPersona(persona: String): Boolean =
+    persona == "or_nurse" || persona == "periop_manager"
+
+/** Phase-3 aggregate lenses: curve/replay surfaces instead of event lanes. */
+private fun isAggregatePersona(persona: String): Boolean =
+    persona == "executive" || persona == "capacity_lead" ||
+        persona == "staffing_coordinator" || persona == "pi_lead"
+
+private fun isDischargeLeveragePersona(persona: String): Boolean =
+    persona == "hospitalist" || persona == "intensivist"
+
 /**
- * The Flow Window (Phase 1): scope header, house stack / floor plate, Chronobar,
- * persona timeline lanes, and a selection/provenance strip. For charge nurses the
- * first composition runs the start-of-shift replay from the last 07:00/19:00 detent.
+ * The Flow Window: scope header, house stack / floor plate, Chronobar, persona
+ * timeline lanes, and a selection/provenance strip. Persona layers on top:
+ * transport gets route arcs + the off-map gutter, EVS gets the turn map
+ * (bed-state tints + turn markers), OR lenses get room lanes as the primary
+ * layer with the floor plate as a collapsible secondary section.
  */
 @Composable
 fun FlowMapScreen(
@@ -78,13 +122,30 @@ fun FlowMapScreen(
     persona: String,
     scope: String? = null,
     modifier: Modifier = Modifier,
+    /** Existing A2P navigation — the discharge-leverage lane rows use it when a ptok is present. */
+    onOpenPatient: ((String) -> Unit)? = null,
 ) {
     val vm: FlowViewModel = viewModel()
     val bearer = auth.accessToken ?: ""
 
-    LaunchedEffect(bearer, persona, scope) {
+    // The OR floor: the floor whose plates contain a procedure room, resolved
+    // from the floors payload; the window's own scope floor is the fallback.
+    val procedureFloor = vm.floors?.floors?.firstOrNull { floor ->
+        floor.spaces.any { it.category == "procedure_room" }
+    }?.floor
+    val requestedScope = when {
+        scope != null -> scope
+        // The turn map's bed_statuses layer only exists at floor/unit scope —
+        // descending into a floor re-requests the window at that scope.
+        persona == "evs" && vm.selectedFloor != null -> "floor:${vm.selectedFloor}"
+        isOrPersona(persona) && procedureFloor != null -> "floor:$procedureFloor"
+        else -> null
+    }
+
+    val userId = auth.me?.id
+    LaunchedEffect(bearer, persona, requestedScope, userId) {
         while (true) {
-            vm.load(bearer, persona, scope)
+            vm.load(bearer, persona, requestedScope, userId)
             kotlinx.coroutines.delay(20000)
         }
     }
@@ -109,7 +170,7 @@ fun FlowMapScreen(
                     message = vm.error ?: "Check your connection and try again.",
                     tone = CapacityStatus.WARNING,
                     retryLabel = "Try again",
-                    onRetry = { vm.load(bearer, persona, scope) },
+                    onRetry = { vm.load(bearer, persona, requestedScope, userId) },
                 )
             }
             return@Column
@@ -121,40 +182,84 @@ fun FlowMapScreen(
             onBackToHouse = { vm.selectFloor(null) },
         )
 
+        vm.offlineAsOfMs?.let { asOf -> OfflineCaption(asOf) }
+
+        // Transport route layer inputs — resolved once per window/floors refresh.
+        val resolver = remember(window, vm.floors) {
+            if (persona == "transport") FlowSpaceResolver(window, vm.floors) else null
+        }
+        val trips = if (resolver != null) {
+            remember(window, resolver, vm.scrubT) { transportTrips(window, resolver, vm.scrubT) }
+        } else {
+            emptyList()
+        }
+
         Box(Modifier.weight(1f).fillMaxWidth()) {
             val floorNumber = vm.selectedFloor ?: window.scope.floor
-            if (window.scope.type == "house" && floorNumber == null) {
-                HouseStack(
-                    floors = window.spacesFloors,
-                    onSelectFloor = vm::selectFloor,
-                )
-            } else {
-                val resolvedFloor = floorNumber ?: window.spacesFloors.firstOrNull()?.floor
-                val geometry = vm.floors?.floors?.firstOrNull { it.floor == resolvedFloor }
-                val rollup = window.spacesFloors.firstOrNull { it.floor == resolvedFloor }
-                if (geometry != null) {
-                    FloorPlateCanvas(
-                        floor = geometry,
-                        rollup = rollup,
-                        ghosts = vm.ghostsUpTo(vm.scrubT),
-                        selectedPlateId = (vm.selection as? FlowSelection.Plate)?.plate?.id,
-                        onSelectPlate = { plate ->
-                            vm.selection = plate?.let { p ->
-                                // A bed carrying a ghost surfaces the projection (provenance chip).
-                                vm.ghostsUpTo(vm.scrubT).firstOrNull { it.bedId != null && it.bedId == p.bedId }
-                                    ?.let { FlowSelection.Ghost(it) }
-                                    ?: FlowSelection.Plate(p)
-                            }
-                        },
-                    )
-                } else {
-                    RetryableMessage(
-                        title = "No floor plate yet",
-                        message = "Floor ${resolvedFloor ?: "—"} has no mapped plates. Rollups stay available in the stack.",
-                        tone = CapacityStatus.INFO,
+            when {
+                isOrPersona(persona) -> {
+                    val orFloor = procedureFloor ?: window.scope.floor ?: 1
+                    OrRoomLanesSection(
+                        vm = vm,
+                        window = window,
+                        persona = persona,
+                        floorGeometry = vm.floors?.floors?.firstOrNull { it.floor == orFloor },
+                        rollup = window.spacesFloors.firstOrNull { it.floor == orFloor },
                     )
                 }
+                // Aggregate lenses (Phase 3) own their whole map body.
+                persona == "executive" -> ExecutiveFlowSection(
+                    vm = vm,
+                    window = window,
+                    onSelect = { vm.selection = it },
+                )
+                persona == "capacity_lead" -> CapacityCurveSection(
+                    vm = vm,
+                    window = window,
+                    onSelect = { vm.selection = it },
+                )
+                persona == "staffing_coordinator" -> StaffingCurveSection(
+                    vm = vm,
+                    window = window,
+                    onSelect = { vm.selection = it },
+                )
+                window.scope.type == "house" && floorNumber == null -> {
+                    HouseStack(
+                        // PI replay: the stack breathes from the snapshot checkpoints at t.
+                        floors = if (persona == "pi_lead") floorsAt(window, vm.scrubT) else window.spacesFloors,
+                        onSelectFloor = vm::selectFloor,
+                        arcs = houseTripArcs(trips),
+                    )
+                }
+                else -> {
+                    val resolvedFloor = floorNumber ?: window.spacesFloors.firstOrNull()?.floor
+                    val geometry = vm.floors?.floors?.firstOrNull { it.floor == resolvedFloor }
+                    val rollup = window.spacesFloors.firstOrNull { it.floor == resolvedFloor }
+                    if (geometry != null) {
+                        FloorLayerStack(
+                            persona = persona,
+                            geometry = geometry,
+                            rollup = rollup,
+                            window = window,
+                            vm = vm,
+                            trips = trips,
+                        )
+                    } else {
+                        RetryableMessage(
+                            title = "No floor plate yet",
+                            message = "Floor ${resolvedFloor ?: "—"} has no mapped plates. Rollups stay available in the stack.",
+                            tone = CapacityStatus.INFO,
+                        )
+                    }
+                }
             }
+        }
+
+        if (persona == "transport") {
+            OffMapTripGutter(
+                trips = offMapTrips(trips),
+                onSelect = { vm.selection = it },
+            )
         }
 
         Chronobar(
@@ -168,17 +273,39 @@ fun FlowMapScreen(
             modifier = Modifier.padding(horizontal = 8.dp),
         )
 
-        TimelineLanes(
-            fromMs = window.fromMs,
-            toMs = window.toMs,
-            nowMs = window.nowMs,
-            events = window.events,
-            projections = window.projections,
-            personaId = persona,
-            selection = vm.selection,
-            onSelect = { vm.selection = it },
-            modifier = Modifier.padding(horizontal = 12.dp),
-        )
+        when {
+            // OR lenses: the room lanes ARE the persona lanes.
+            isOrPersona(persona) -> {}
+            // PI: replay + clip controls instead of event lanes (§8 P8).
+            persona == "pi_lead" -> PiControlsRow(
+                vm = vm,
+                window = window,
+                modifier = Modifier.padding(horizontal = 12.dp),
+            )
+            // Executive/capacity/staffing carry their forward half in their
+            // own sections (curve, forecast strip, gap steps) — no lanes.
+            isAggregatePersona(persona) -> {}
+            else -> {
+                TimelineLanes(
+                    fromMs = window.fromMs,
+                    toMs = window.toMs,
+                    nowMs = window.nowMs,
+                    events = window.events,
+                    projections = window.projections,
+                    personaId = persona,
+                    selection = vm.selection,
+                    onSelect = { vm.selection = it },
+                    modifier = Modifier.padding(horizontal = 12.dp),
+                )
+                if (isDischargeLeveragePersona(persona)) {
+                    DischargeLeverageLane(
+                        window = window,
+                        onOpenPatient = onOpenPatient,
+                        modifier = Modifier.padding(horizontal = 12.dp),
+                    )
+                }
+            }
+        }
 
         FlowSelectionStrip(
             selection = vm.selection,
@@ -187,6 +314,190 @@ fun FlowMapScreen(
             scrubT = vm.scrubT,
             censusAt = vm::censusAt,
         )
+    }
+}
+
+/** The floor plate plus persona overlays (transport arcs / EVS turn map). */
+@Composable
+private fun FloorLayerStack(
+    persona: String,
+    geometry: FlowFloor,
+    rollup: net.acumenus.hummingbird.data.FlowFloorRollup?,
+    window: FlowWindowData,
+    vm: FlowViewModel,
+    trips: List<TransportTrip>,
+) {
+    val bedPaints = if (persona == "evs") {
+        val fade = bedStateFade(vm.scrubT, window.nowMs)
+        remember(window.bedStatuses, fade) { evsBedPaints(window.bedStatuses, fade) }
+    } else {
+        emptyMap()
+    }
+    // Transport/EVS ghosts are owned by their layers; other lenses keep the
+    // scrub-accumulated bed ghosts of Phase 1.
+    val baseGhosts = when (persona) {
+        "transport", "evs" -> emptyList()
+        else -> vm.ghostsUpTo(vm.scrubT)
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        FloorPlateCanvas(
+            floor = geometry,
+            rollup = rollup,
+            ghosts = baseGhosts,
+            selectedPlateId = (vm.selection as? FlowSelection.Plate)?.plate?.id,
+            onSelectPlate = { plate ->
+                vm.selection = plate?.let { p ->
+                    // A bed carrying a ghost surfaces the projection (provenance chip).
+                    val ghost = when (persona) {
+                        "transport" -> window.projections.firstOrNull {
+                            it.kind == "transport_due" && it.bedId != null && it.bedId == p.bedId
+                        }
+                        "evs" -> window.projections.firstOrNull {
+                            it.kind == "evs_due" && it.bedId != null && it.bedId == p.bedId
+                        }
+                        else -> vm.ghostsUpTo(vm.scrubT).firstOrNull { it.bedId != null && it.bedId == p.bedId }
+                    }
+                    ghost?.let { FlowSelection.Ghost(it) } ?: FlowSelection.Plate(p)
+                }
+            },
+            bedPaints = bedPaints,
+        )
+        if (persona == "transport") {
+            FloorTripArcsOverlay(floor = geometry, trips = trips)
+        }
+        if (persona == "evs") {
+            EvsTurnOverlay(floor = geometry, window = window, scrubT = vm.scrubT)
+            if (window.bedStatuses.isNotEmpty() && bedStateIsStale(vm.scrubT, window.nowMs)) {
+                Text(
+                    "Bed states shown at now",
+                    color = Z.inkMuted,
+                    fontSize = 10.sp,
+                    modifier = Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = 6.dp)
+                        .panel(corner = 8)
+                        .padding(horizontal = 8.dp, vertical = 3.dp),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * OR lenses' primary layer: room lanes against the Chronobar. The circulating
+ * nurse gets a room picker that highlights one lane; the floor plate stays
+ * available as a collapsible secondary section.
+ */
+@Composable
+private fun OrRoomLanesSection(
+    vm: FlowViewModel,
+    window: FlowWindowData,
+    persona: String,
+    floorGeometry: FlowFloor?,
+    rollup: net.acumenus.hummingbird.data.FlowFloorRollup?,
+) {
+    val lanes = remember(window) { buildRoomLanes(window) }
+    var pickedRoom by rememberSaveable(persona) { mutableStateOf<String?>(null) }
+    var plateExpanded by rememberSaveable { mutableStateOf(false) }
+
+    Column(Modifier.fillMaxSize().padding(horizontal = 12.dp)) {
+        if (persona == "or_nurse") {
+            RoomPicker(
+                rooms = lanes.map { it.room },
+                picked = pickedRoom,
+                onPick = { pickedRoom = it },
+            )
+        }
+
+        RoomLanes(
+            window = window,
+            lanes = lanes,
+            highlightRoom = if (persona == "or_nurse") pickedRoom else null,
+            selection = vm.selection,
+            onSelect = { vm.selection = it },
+            modifier = Modifier.weight(1f),
+        )
+
+        if (floorGeometry != null) {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 48.dp)
+                    .clickable { plateExpanded = !plateExpanded },
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    "Floor plate",
+                    color = Z.inkMuted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(
+                    if (plateExpanded) Icons.Filled.KeyboardArrowDown else Icons.Filled.KeyboardArrowUp,
+                    contentDescription = if (plateExpanded) "Collapse floor plate" else "Expand floor plate",
+                    tint = Z.inkMuted,
+                    modifier = Modifier.size(18.dp),
+                )
+            }
+            if (plateExpanded) {
+                Box(Modifier.fillMaxWidth().height(180.dp)) {
+                    FloorPlateCanvas(
+                        floor = floorGeometry,
+                        rollup = rollup,
+                        ghosts = emptyList(),
+                        selectedPlateId = (vm.selection as? FlowSelection.Plate)?.plate?.id,
+                        onSelectPlate = { plate ->
+                            vm.selection = plate?.let { FlowSelection.Plate(it) }
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RoomPicker(
+    rooms: List<String>,
+    picked: String?,
+    onPick: (String?) -> Unit,
+) {
+    var open by remember { mutableStateOf(false) }
+    Box {
+        TextButton(onClick = { open = true }, modifier = Modifier.heightIn(min = 48.dp)) {
+            Text(
+                picked?.let { "Room · $it" } ?: "All rooms",
+                color = Z.primary,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+            )
+            Icon(
+                Icons.Filled.ArrowDropDown,
+                contentDescription = null,
+                tint = Z.primary,
+                modifier = Modifier.size(18.dp),
+            )
+        }
+        DropdownMenu(expanded = open, onDismissRequest = { open = false }) {
+            DropdownMenuItem(
+                text = { Text("All rooms", fontSize = 13.sp) },
+                onClick = {
+                    onPick(null)
+                    open = false
+                },
+            )
+            rooms.forEach { room ->
+                DropdownMenuItem(
+                    text = { Text(room, fontSize = 13.sp) },
+                    onClick = {
+                        onPick(room)
+                        open = false
+                    },
+                )
+            }
+        }
     }
 }
 
@@ -202,7 +513,9 @@ private fun FlowScopeHeader(
             .padding(horizontal = 12.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (selectedFloor != null && window.scope.type == "house") {
+        // Ascend is offered whenever the user descended AND the lens may see
+        // the house (the scope itself may have been re-requested at floor level).
+        if (selectedFloor != null && window.lens.scopesAllowed.contains("house")) {
             IconButton(onClick = onBackToHouse, modifier = Modifier.size(32.dp)) {
                 Icon(
                     Icons.AutoMirrored.Filled.ArrowBack,
@@ -267,6 +580,7 @@ private fun FlowSelectionStrip(
 @Composable
 private fun EventDetail(event: FlowTimelineEvent, nowMs: Long) {
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (event.label.contains("isolation", ignoreCase = true)) IsolationBadge()
         Text(event.label, color = Z.ink, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
         Text(
             "${flowClock(event.tMs)} · ${flowOffsetLabel(event.tMs, nowMs)}",
@@ -287,6 +601,7 @@ private fun EventDetail(event: FlowTimelineEvent, nowMs: Long) {
 @Composable
 private fun GhostDetail(ghost: FlowProjection, nowMs: Long) {
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (ghost.label.contains("isolation", ignoreCase = true)) IsolationBadge()
         Text(ghost.label, color = Z.ink, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
         Text(
             "${flowClock(ghost.tMs)} · ${flowOffsetLabel(ghost.tMs, nowMs)}",
@@ -298,6 +613,7 @@ private fun GhostDetail(ghost: FlowProjection, nowMs: Long) {
     val qualifiers = buildList {
         add(ghost.confidence) // "definite" / "probable" / "possible" — never "will"
         if (ghost.derived) add("derived")
+        ghost.room?.let { add(it) }
         ghost.value?.let { v ->
             val band = if (ghost.bandLower != null && ghost.bandUpper != null) " (${ghost.bandLower}–${ghost.bandUpper})" else ""
             add("value $v$band")
@@ -318,6 +634,12 @@ private fun PlateDetail(
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(plate.label, color = Z.ink, fontSize = 13.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.weight(1f))
         Text(plate.category.replace('_', ' '), color = Z.inkMuted, fontSize = 11.sp)
+    }
+    // The turn map names the state — status is never by color alone.
+    plate.bedId?.let { bedId ->
+        window.bedStatuses.firstOrNull { it.bedId == bedId }?.let { bed ->
+            Text("Now: ${bed.status}", color = Z.inkMuted, fontSize = 11.sp)
+        }
     }
     plate.unitId?.let { unitId ->
         val snapshot = censusAt(scrubT, unitId)

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/FlowViewModel.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/FlowViewModel.kt
@@ -17,7 +17,12 @@ import net.acumenus.hummingbird.data.FlowPlate
 import net.acumenus.hummingbird.data.FlowProjection
 import net.acumenus.hummingbird.data.FlowSnapshot
 import net.acumenus.hummingbird.data.FlowTimelineEvent
+import net.acumenus.hummingbird.data.FlowWindowCache
 import net.acumenus.hummingbird.data.FlowWindowData
+import net.acumenus.hummingbird.data.mergeFlowWindow
+import net.acumenus.hummingbird.data.newestLoadedSinceIso
+import net.acumenus.hummingbird.widget.HouseGlanceStore
+import org.json.JSONObject
 import java.time.Instant
 import java.time.ZoneId
 
@@ -35,12 +40,16 @@ sealed interface FlowSelection {
  */
 class FlowViewModel(app: Application) : AndroidViewModel(app) {
     private val api = ApiClient()
+    private val cache = FlowWindowCache(app)
 
     var window by mutableStateOf<FlowWindowData?>(null); private set
     var floors by mutableStateOf<FlowFloorsDocument?>(null); private set
     var loading by mutableStateOf(false); private set
     var error by mutableStateOf<String?>(null); private set
     var needsReauth by mutableStateOf(false); private set
+
+    /** When non-null, the shown window came from the offline cache; value = when it was cached. */
+    var offlineAsOfMs by mutableStateOf<Long?>(null); private set
 
     /** Scrub time t, epoch millis, clamped to [window.from, window.to]. */
     var scrubT by mutableStateOf(0L); private set
@@ -51,28 +60,83 @@ class FlowViewModel(app: Application) : AndroidViewModel(app) {
     private var playbackJob: Job? = null
     private var shiftReplayDone = false
 
-    fun load(bearer: String, persona: String, scope: String? = null) {
+    /** The (persona, scope) the current window belongs to — gates whether a refresh can delta. */
+    private var loadedKey: String? = null
+    private var floorsRaw: String? = null
+
+    /**
+     * Load or refresh the window. When a window is already loaded for the same persona+scope
+     * (the 20s poll / re-snapshot / foreground-return path), sends `since=<newest loaded
+     * event/snapshot t>` and merges the delta per the contract; falls back to a full load on
+     * HTTP 422 (invalid_since) or a parse failure. On a hard load failure, serves the offline
+     * cache for this user with a staleness caption. [userId] keys the cache; null ⇒ no caching.
+     */
+    fun load(bearer: String, persona: String, scope: String? = null, userId: Int? = null) {
         loading = true
         viewModelScope.launch {
+            val key = "$persona|${scope ?: ""}"
+            val current = window
+            val canDelta = current != null && loadedKey == key
+            val since = if (canDelta) newestLoadedSinceIso(current!!) else null
             try {
-                val win = api.flowWindow(bearer, persona, scope)
-                if (floors == null) floors = api.flowFloors(bearer)
-                val firstLoad = window == null
-                window = win
-                scrubT = if (firstLoad || scrubT == 0L) {
-                    win.nowMs
-                } else {
-                    scrubT.coerceIn(win.fromMs, win.toMs)
+                if (floors == null) {
+                    val (doc, raw) = api.flowFloorsRaw(bearer)
+                    floors = doc
+                    floorsRaw = raw
                 }
+                val fetch = try {
+                    api.flowWindowRaw(bearer, persona, scope, since)
+                } catch (e: ApiException) {
+                    // Delta rejected (stale cursor) ⇒ retry once as a full load.
+                    if (since != null && (e.statusCode == 422 || e.errorCode == "invalid_since")) {
+                        api.flowWindowRaw(bearer, persona, scope, null)
+                    } else {
+                        throw e
+                    }
+                }
+                val fresh = fetch.data
+                val isDelta = since != null && fresh.window.since != null
+                val firstLoad = window == null
+                window = if (isDelta && current != null) mergeFlowWindow(current, fresh) else fresh
+                loadedKey = key
+                offlineAsOfMs = null
+                // Cache only FULL (non-delta) payloads, keyed by the authenticated user.
+                if (!isDelta && userId != null) {
+                    cache.putWindow(userId, persona, scope, fetch.raw, floorsRaw)
+                }
+                val win = window!!
+                scrubT = if (firstLoad || scrubT == 0L) win.nowMs else scrubT.coerceIn(win.fromMs, win.toMs)
                 error = null
+                writeGlance(win)
             } catch (e: ApiException) {
                 if (e.statusCode == 401) needsReauth = true
-                error = e.message
+                if (!serveFromCache(persona, scope, userId)) error = e.message
             } catch (e: Exception) {
-                error = e.message
+                if (!serveFromCache(persona, scope, userId)) error = e.message
             }
             loading = false
         }
+    }
+
+    /** Present the last cached FULL window for this user; returns true on a cache hit. */
+    private fun serveFromCache(persona: String, scope: String?, userId: Int?): Boolean {
+        if (window != null) return true // keep what's already shown rather than downgrade
+        if (userId == null) return false
+        val cached = cache.readWindow(userId, persona, scope) ?: return false
+        val doc = runCatching { api.parseFlowWindow(JSONObject(cached.windowRaw)) }.getOrNull() ?: return false
+        if (floors == null) {
+            cached.floorsRaw?.let { raw -> runCatching { api.parseFlowFloors(JSONObject(raw)) }.getOrNull()?.let { floors = it } }
+        }
+        window = doc
+        loadedKey = "$persona|${scope ?: ""}"
+        offlineAsOfMs = cached.updatedAtMs
+        scrubT = if (scrubT == 0L) doc.nowMs else scrubT.coerceIn(doc.fromMs, doc.toMs)
+        error = null
+        return true
+    }
+
+    private fun writeGlance(win: FlowWindowData) {
+        viewModelScope.launch { runCatching { HouseGlanceStore.updateFromFlow(getApplication<android.app.Application>(), win) } }
     }
 
     // MARK: time model helpers

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/HouseStack.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/HouseStack.kt
@@ -16,7 +16,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -24,39 +27,114 @@ import androidx.compose.ui.unit.sp
 import net.acumenus.hummingbird.data.FlowFloorRollup
 import net.acumenus.hummingbird.ui.theme.Z
 
+private val slabHeight = 44.dp
+private val slabGap = 4.dp
+
+/**
+ * A per-floor tint override (staffing lens: floors tinted by their worst
+ * shift gap). The label names the state — status never by color alone.
+ */
+data class FloorAccent(
+    val color: Color,
+    val alpha: Float,
+    val label: String,
+)
+
 /**
  * Exploded axonometric house stack: each floor is a sheared parallelogram slab,
  * stacked bottom-up with neutral occupancy heat. Tap a floor to descend into
- * its floor plate.
+ * its floor plate. Optional trip arcs (transport lens) bow along the left
+ * margin between floor slabs; single-floor trips render as short stubs.
+ * Optional accents replace the occupancy heat with a labeled lens tint.
  */
 @Composable
 fun HouseStack(
     floors: List<FlowFloorRollup>,
     onSelectFloor: (Int) -> Unit,
     modifier: Modifier = Modifier,
+    arcs: List<HouseTripArc> = emptyList(),
+    accents: Map<Int, FloorAccent> = emptyMap(),
 ) {
     // Top floor first — the building reads bottom-up.
     val ordered = floors.sortedByDescending { it.floor }
+    val slabIndex = ordered.mapIndexed { index, floor -> floor.floor to index }.toMap()
 
     Column(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        ordered.forEach { floor ->
-            FloorSlab(floor = floor, onClick = { onSelectFloor(floor.floor) })
+        Box {
+            Column(verticalArrangement = Arrangement.spacedBy(slabGap)) {
+                ordered.forEach { floor ->
+                    FloorSlab(
+                        floor = floor,
+                        accent = accents[floor.floor],
+                        onClick = { onSelectFloor(floor.floor) },
+                    )
+                }
+            }
+            if (arcs.isNotEmpty()) {
+                // Purely visual overlay — no pointer input, slab taps fall through.
+                Canvas(Modifier.matchParentSize()) {
+                    val step = (slabHeight + slabGap).toPx()
+                    val half = slabHeight.toPx() / 2f
+                    fun centerY(floor: Int): Float? = slabIndex[floor]?.let { it * step + half }
+
+                    arcs.forEachIndexed { index, arc ->
+                        val y0 = centerY(arc.fromFloor) ?: return@forEachIndexed
+                        val y1 = centerY(arc.toFloor) ?: return@forEachIndexed
+                        val x = 10.dp.toPx()
+                        val bow = 20.dp.toPx() + (index % 3) * 8.dp.toPx()
+                        val dash = if (arc.dashed) {
+                            PathEffect.dashPathEffect(floatArrayOf(5.dp.toPx(), 4.dp.toPx()))
+                        } else {
+                            null
+                        }
+                        if (arc.fromFloor == arc.toFloor) {
+                            // Trip contained on (or leaving) one floor: a short stub.
+                            drawLine(
+                                color = arc.color.copy(alpha = arc.alpha),
+                                start = Offset(x - 6.dp.toPx(), y0),
+                                end = Offset(x + 8.dp.toPx(), y0),
+                                strokeWidth = 1.5.dp.toPx(),
+                                pathEffect = dash,
+                            )
+                            drawCircle(
+                                color = arc.color.copy(alpha = arc.alpha),
+                                radius = 2.5.dp.toPx(),
+                                center = Offset(x + 8.dp.toPx(), y0),
+                            )
+                        } else {
+                            val path = Path().apply {
+                                moveTo(x, y0)
+                                quadraticBezierTo(x - bow, (y0 + y1) / 2f, x, y1)
+                            }
+                            drawPath(
+                                path,
+                                color = arc.color.copy(alpha = arc.alpha),
+                                style = Stroke(width = 1.5.dp.toPx(), pathEffect = dash),
+                            )
+                            drawCircle(
+                                color = arc.color.copy(alpha = arc.alpha),
+                                radius = 2.5.dp.toPx(),
+                                center = Offset(x, y0),
+                            )
+                        }
+                    }
+                }
+            }
         }
     }
 }
 
 @Composable
-private fun FloorSlab(floor: FlowFloorRollup, onClick: () -> Unit) {
+private fun FloorSlab(floor: FlowFloorRollup, accent: FloorAccent?, onClick: () -> Unit) {
     Box(
         Modifier
             .fillMaxWidth()
-            .height(44.dp)
+            .height(slabHeight)
             .clickable(onClick = onClick),
     ) {
         Canvas(Modifier.fillMaxSize()) {
@@ -73,7 +151,11 @@ private fun FloorSlab(floor: FlowFloorRollup, onClick: () -> Unit) {
                 close()
             }
             drawPath(slab, color = Z.surface)
-            drawPath(slab, color = Z.primary.copy(alpha = occupancyAlpha(floor.occupancyPct)))
+            if (accent != null) {
+                drawPath(slab, color = accent.color.copy(alpha = accent.alpha))
+            } else {
+                drawPath(slab, color = Z.primary.copy(alpha = occupancyAlpha(floor.occupancyPct)))
+            }
             drawPath(slab, color = Z.border, style = Stroke(width = 1.dp.toPx()))
         }
         Row(
@@ -96,6 +178,17 @@ private fun FloorSlab(floor: FlowFloorRollup, onClick: () -> Unit) {
                 modifier = Modifier.weight(1f),
                 maxLines = 1,
             )
+            // The accent names its state — tint is never the only signal.
+            accent?.let {
+                Text(
+                    it.label,
+                    color = it.color,
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    style = flowTabularNums,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+            }
             Text(
                 "${floor.occupied}/${floor.staffed}",
                 color = Z.ink,

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/RoomLanes.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/RoomLanes.kt
@@ -1,0 +1,292 @@
+package net.acumenus.hummingbird.ui.flow
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.acumenus.hummingbird.data.FlowProjection
+import net.acumenus.hummingbird.data.FlowTimelineEvent
+import net.acumenus.hummingbird.data.FlowWindowData
+import net.acumenus.hummingbird.ui.theme.Z
+import kotlin.math.abs
+
+private const val PACU_ROOM = "PACU"
+private const val DEFAULT_CASE_MS = 60 * 60_000L
+
+/** One scheduled case on a room lane, cascade-adjusted when the room runs long. */
+data class RoomLaneCase(
+    val projection: FlowProjection,
+    val scheduledStartMs: Long,
+    /** Cascade-adjusted start: max(scheduled, previous case's end). */
+    val startMs: Long,
+    val endMs: Long,
+    val driftMin: Long,
+)
+
+data class RoomLane(
+    val room: String,
+    val cases: List<RoomLaneCase>,
+    val milestones: List<FlowTimelineEvent>,
+)
+
+/** "OR 2" before "OR 10": compare by prefix, then trailing number. */
+private val roomOrder = compareBy<String>(
+    { it.replace(Regex("\\d+$"), "").trim() },
+    { Regex("(\\d+)$").find(it)?.groupValues?.get(1)?.toIntOrNull() ?: 0 },
+)
+
+/**
+ * Room lanes for the OR lenses: scheduled_or_case grouped by `room`,
+ * or_milestone events by `to_space`; PACU milestones collect into a bottom row.
+ * Within a room, a case overlapping its predecessor's end is pushed to start
+ * at that end — the delay cascade — and carries the drift in minutes.
+ */
+fun buildRoomLanes(window: FlowWindowData): List<RoomLane> {
+    val casesByRoom = window.projections
+        .filter { it.kind == "scheduled_or_case" && !it.room.isNullOrBlank() }
+        .groupBy { it.room!!.trim() }
+    val milestonesByRoom = window.events
+        .filter { it.kind == "or_milestone" && !it.toSpace.isNullOrBlank() }
+        .groupBy { it.toSpace!!.trim() }
+
+    val rooms = (casesByRoom.keys + milestonesByRoom.keys)
+        .filterNot { it.equals(PACU_ROOM, ignoreCase = true) }
+        .distinct()
+        .sortedWith(roomOrder)
+
+    val lanes = rooms.map { room ->
+        val scheduled = (casesByRoom[room] ?: emptyList()).sortedBy { it.tMs }
+        val cases = mutableListOf<RoomLaneCase>()
+        var previousEnd = Long.MIN_VALUE
+        scheduled.forEach { case ->
+            val duration = (case.endsAtMs?.minus(case.tMs))?.takeIf { it > 0 } ?: DEFAULT_CASE_MS
+            val start = maxOf(case.tMs, previousEnd)
+            val end = start + duration
+            cases += RoomLaneCase(
+                projection = case,
+                scheduledStartMs = case.tMs,
+                startMs = start,
+                endMs = end,
+                driftMin = ((start - case.tMs) / 60_000L).coerceAtLeast(0L),
+            )
+            previousEnd = end
+        }
+        RoomLane(room, cases, (milestonesByRoom[room] ?: emptyList()).sortedBy { it.tMs })
+    }
+
+    val pacuMilestones = milestonesByRoom.entries
+        .firstOrNull { it.key.equals(PACU_ROOM, ignoreCase = true) }
+        ?.value.orEmpty().sortedBy { it.tMs }
+    return if (pacuMilestones.isEmpty()) lanes else lanes + RoomLane(PACU_ROOM, emptyList(), pacuMilestones)
+}
+
+/**
+ * The OR lenses' primary layer: one lane per room aligned to the Chronobar's
+ * 48h domain. Case bars are solid once started, dashed ghosts when still ahead;
+ * milestone ticks carry their labels via the tap → selection strip; drift shows
+ * as a "+Xm" chip at the pushed case's start.
+ */
+@Composable
+fun RoomLanes(
+    window: FlowWindowData,
+    lanes: List<RoomLane>,
+    highlightRoom: String?,
+    selection: FlowSelection?,
+    onSelect: (FlowSelection?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val fromMs = window.fromMs
+    val span = (window.toMs - window.fromMs).coerceAtLeast(1L)
+    val nowMs = window.nowMs
+    val density = LocalDensity.current
+    val tapSlopPx = with(density) { 22.dp.toPx() }
+    val textMeasurer = rememberTextMeasurer()
+    val select by rememberUpdatedState(onSelect)
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        if (lanes.isEmpty()) {
+            Text(
+                "No cases or milestones in this window yet.",
+                color = Z.inkMuted,
+                fontSize = 12.sp,
+            )
+            return@Column
+        }
+        lanes.forEach { lane ->
+            val highlighted = highlightRoom != null && lane.room.equals(highlightRoom, ignoreCase = true)
+            val dimmed = highlightRoom != null && !highlighted
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .height(48.dp)
+                    .background(
+                        if (highlighted) Z.primary.copy(alpha = 0.10f) else Z.bg.copy(alpha = 0f),
+                        RoundedCornerShape(6.dp),
+                    ),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    lane.room,
+                    color = if (highlighted) Z.ink else Z.inkMuted,
+                    fontSize = 11.sp,
+                    fontWeight = if (highlighted) FontWeight.SemiBold else FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.width(56.dp),
+                    style = flowTabularNums,
+                )
+                Canvas(
+                    Modifier
+                        .weight(1f)
+                        .fillMaxSize()
+                        .pointerInput(fromMs, span, lane) {
+                            detectTapGestures { pos ->
+                                fun xOf(ms: Long): Float = ((ms - fromMs).toFloat() / span.toFloat()) * size.width
+                                val tickHit = lane.milestones.minByOrNull { abs(xOf(it.tMs) - pos.x) }
+                                val tickDist = tickHit?.let { abs(xOf(it.tMs) - pos.x) } ?: Float.MAX_VALUE
+                                val barHit = lane.cases.firstOrNull { case ->
+                                    pos.x in (xOf(case.startMs) - tapSlopPx / 2)..(xOf(case.endMs) + tapSlopPx / 2)
+                                }
+                                select(
+                                    when {
+                                        tickDist <= tapSlopPx -> tickHit?.let { FlowSelection.Event(it) }
+                                        barHit != null -> FlowSelection.Ghost(barHit.projection)
+                                        else -> null
+                                    },
+                                )
+                            }
+                        },
+                ) {
+                    val laneAlpha = if (dimmed) 0.35f else 1f
+                    val cy = size.height / 2f
+                    fun x(ms: Long): Float = ((ms - fromMs).toFloat() / span.toFloat()) * size.width
+
+                    drawLine(
+                        color = Z.border.copy(alpha = 0.5f * laneAlpha),
+                        start = Offset(0f, cy),
+                        end = Offset(size.width, cy),
+                        strokeWidth = 1.dp.toPx(),
+                    )
+                    val xNow = x(nowMs)
+                    drawLine(
+                        color = Z.border.copy(alpha = laneAlpha),
+                        start = Offset(xNow, 3.dp.toPx()),
+                        end = Offset(xNow, size.height - 3.dp.toPx()),
+                        strokeWidth = 1.dp.toPx(),
+                    )
+
+                    val barHeight = 16.dp.toPx()
+                    val corner = CornerRadius(4.dp.toPx())
+                    val ghostDash = PathEffect.dashPathEffect(floatArrayOf(5.dp.toPx(), 4.dp.toPx()))
+                    lane.cases.forEach { case ->
+                        val left = x(case.startMs)
+                        val right = x(case.endMs).coerceAtLeast(left + 6.dp.toPx())
+                        val top = cy - barHeight / 2f
+                        val barSize = Size(right - left, barHeight)
+                        if (case.startMs <= nowMs) {
+                            // Started (or should have): the record half — solid.
+                            drawRoundRect(
+                                color = Z.primary.copy(alpha = 0.30f * laneAlpha),
+                                topLeft = Offset(left, top),
+                                size = barSize,
+                                cornerRadius = corner,
+                            )
+                            drawRoundRect(
+                                color = Z.primary.copy(alpha = 0.9f * laneAlpha),
+                                topLeft = Offset(left, top),
+                                size = barSize,
+                                cornerRadius = corner,
+                                style = Stroke(width = 1.dp.toPx()),
+                            )
+                        } else {
+                            // Still ahead: ghost grammar — dashed outline, never a solid fill.
+                            drawRoundRect(
+                                color = Z.ink.copy(alpha = case.projection.confidenceAlpha * laneAlpha),
+                                topLeft = Offset(left, top),
+                                size = barSize,
+                                cornerRadius = corner,
+                                style = Stroke(width = 1.5.dp.toPx(), pathEffect = ghostDash),
+                            )
+                        }
+                        if (case.driftMin > 0) {
+                            drawText(
+                                textMeasurer = textMeasurer,
+                                text = "+${case.driftMin}m",
+                                topLeft = Offset(left, top - 11.dp.toPx()),
+                                style = TextStyle(
+                                    color = Z.statusWarning.copy(alpha = laneAlpha),
+                                    fontSize = 8.sp,
+                                    fontWeight = FontWeight.Medium,
+                                    fontFeatureSettings = "tnum",
+                                ),
+                            )
+                        }
+                        if (selection is FlowSelection.Ghost && selection.projection == case.projection) {
+                            drawRoundRect(
+                                color = Z.gold,
+                                topLeft = Offset(left - 2.dp.toPx(), top - 2.dp.toPx()),
+                                size = Size(barSize.width + 4.dp.toPx(), barSize.height + 4.dp.toPx()),
+                                cornerRadius = CornerRadius(6.dp.toPx()),
+                                style = Stroke(width = 1.5.dp.toPx()),
+                            )
+                        }
+                    }
+
+                    lane.milestones.forEach { milestone ->
+                        val mx = x(milestone.tMs)
+                        drawLine(
+                            color = Z.primary.copy(alpha = laneAlpha),
+                            start = Offset(mx, cy - 7.dp.toPx()),
+                            end = Offset(mx, cy + 7.dp.toPx()),
+                            strokeWidth = 2.dp.toPx(),
+                        )
+                        if (selection is FlowSelection.Event && selection.event == milestone) {
+                            drawCircle(
+                                color = Z.gold,
+                                radius = 8.dp.toPx(),
+                                center = Offset(mx, cy),
+                                style = Stroke(width = 1.5.dp.toPx()),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/TransportRoutesLayer.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/flow/TransportRoutesLayer.kt
@@ -1,0 +1,340 @@
+package net.acumenus.hummingbird.ui.flow
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import net.acumenus.hummingbird.data.FlowFloor
+import net.acumenus.hummingbird.data.FlowFloorsDocument
+import net.acumenus.hummingbird.data.FlowWindowData
+import net.acumenus.hummingbird.ui.components.panel
+import net.acumenus.hummingbird.ui.theme.Z
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+/** A trip endpoint resolved to the map: a floor plus an optional plan-feet anchor rect. */
+data class FlowSpacePoint(val floor: Int, val rect: List<Double>?)
+
+/**
+ * One transport trip drawable on the map: a past transport_status event (solid
+ * arc) or a transport_due projection still ahead of the scrub time (dashed
+ * ghost). Ghost trips from derived discharges have no destination — they render
+ * as departure stubs from the origin bed's unit.
+ */
+data class TransportTrip(
+    val selection: FlowSelection,
+    val label: String,
+    val fromRaw: String?,
+    val toRaw: String?,
+    val from: FlowSpacePoint?,
+    val to: FlowSpacePoint?,
+    val ghost: Boolean,
+    val alpha: Float,
+    /** STAT/at-risk tier → warning tint; NEVER the critical color for trips. */
+    val warning: Boolean,
+)
+
+/**
+ * Resolves the transport from_space/to_space vocabulary against the floors
+ * payload: unit abbreviation ("ED") → full unit name ("3 West — Medical ICU
+ * (MICU)") → bed label ("MICU-01" = {ABBR}-{NN}: resolve the bed's unit and use
+ * that unit's plate centroid). Anything else (free-text destinations like
+ * "Main Lobby Discharge") is unresolvable → the off-map gutter.
+ */
+class FlowSpaceResolver(window: FlowWindowData, floors: FlowFloorsDocument?) {
+    private data class UnitRef(val unitId: Int, val floor: Int)
+
+    private val unitsByAbbr: Map<String, UnitRef>
+    private val unitsByName: Map<String, UnitRef>
+    private val unitPlateRect = mutableMapOf<Int, Pair<Int, List<Double>>>()
+    private val bedPlateRect = mutableMapOf<Int, Pair<Int, List<Double>>>()
+    private val bedUnit: Map<String, Int> // bed label → unit_id (from bed_statuses when present)
+
+    init {
+        val byAbbr = mutableMapOf<String, UnitRef>()
+        val byName = mutableMapOf<String, UnitRef>()
+        window.spacesFloors.forEach { floor ->
+            floor.units.forEach { unit ->
+                val ref = UnitRef(unit.unitId, floor.floor)
+                if (unit.abbr.isNotBlank()) byAbbr.putIfAbsent(unit.abbr.lowercase(), ref)
+                if (unit.name.isNotBlank()) byName.putIfAbsent(unit.name.lowercase(), ref)
+            }
+        }
+        unitsByAbbr = byAbbr
+        unitsByName = byName
+        floors?.floors?.forEach { floor ->
+            floor.spaces.forEach { plate ->
+                when {
+                    (plate.category == "unit" || plate.category == "zone") && plate.unitId != null ->
+                        unitPlateRect.putIfAbsent(plate.unitId, floor.floor to plate.rect)
+                    plate.category == "bed" && plate.bedId != null ->
+                        bedPlateRect.putIfAbsent(plate.bedId, floor.floor to plate.rect)
+                }
+            }
+        }
+        bedUnit = window.bedStatuses
+            .filter { it.unitId != null }
+            .associate { it.label.lowercase() to it.unitId!! }
+    }
+
+    fun resolveSpace(raw: String?): FlowSpacePoint? {
+        val s = raw?.trim()?.lowercase().orEmpty()
+        if (s.isEmpty()) return null
+        unitsByAbbr[s]?.let { return unitPoint(it) }
+        unitsByName[s]?.let { return unitPoint(it) }
+        bedUnit[s]?.let { unitId -> return resolveUnit(unitId) }
+        // Bed label pattern {ABBR}-{NN}: the bed's unit owns the endpoint.
+        val match = Regex("^(.+)-(\\d+)$").find(s)
+        if (match != null) {
+            unitsByAbbr[match.groupValues[1]]?.let { return unitPoint(it) }
+        }
+        return null
+    }
+
+    fun resolveUnit(unitId: Int?): FlowSpacePoint? {
+        if (unitId == null) return null
+        unitPlateRect[unitId]?.let { (floor, rect) -> return FlowSpacePoint(floor, rect) }
+        val ref = unitsByAbbr.values.firstOrNull { it.unitId == unitId }
+            ?: unitsByName.values.firstOrNull { it.unitId == unitId }
+        return ref?.let { FlowSpacePoint(it.floor, null) }
+    }
+
+    fun resolveBed(bedId: Int?): FlowSpacePoint? {
+        if (bedId == null) return null
+        bedPlateRect[bedId]?.let { (floor, rect) -> return FlowSpacePoint(floor, rect) }
+        return null
+    }
+
+    private fun unitPoint(ref: UnitRef): FlowSpacePoint {
+        unitPlateRect[ref.unitId]?.let { (floor, rect) -> return FlowSpacePoint(floor, rect) }
+        return FlowSpacePoint(ref.floor, null)
+    }
+}
+
+/**
+ * The transporter's trips at scrub time t: transport_status events at/before t
+ * (the replayed record) plus transport_due projections still ahead of t (ghost
+ * trips — dashed, confidence-mapped, provenance on tap).
+ */
+fun transportTrips(window: FlowWindowData, resolver: FlowSpaceResolver, scrubT: Long): List<TransportTrip> {
+    val past = window.events
+        .filter { it.kind == "transport_status" && it.tMs <= scrubT }
+        .map { event ->
+            TransportTrip(
+                selection = FlowSelection.Event(event),
+                label = event.label,
+                fromRaw = event.fromSpace,
+                toRaw = event.toSpace,
+                from = resolver.resolveSpace(event.fromSpace),
+                to = resolver.resolveSpace(event.toSpace),
+                ghost = false,
+                alpha = 0.85f,
+                warning = event.tier == "warning" || event.tier == "critical",
+            )
+        }
+    val ahead = window.projections
+        .filter { it.kind == "transport_due" && it.tMs > scrubT }
+        .map { ghost ->
+            TransportTrip(
+                selection = FlowSelection.Ghost(ghost),
+                label = ghost.label,
+                fromRaw = null,
+                toRaw = null,
+                from = resolver.resolveBed(ghost.bedId) ?: resolver.resolveUnit(ghost.unitId),
+                to = null,
+                ghost = true,
+                alpha = ghost.confidenceAlpha,
+                warning = false,
+            )
+        }
+    return past + ahead
+}
+
+/** Trips with a free-text endpoint the map can't place — surfaced in the gutter. */
+fun offMapTrips(trips: List<TransportTrip>): List<TransportTrip> =
+    trips.filter {
+        (it.from == null && !it.fromRaw.isNullOrBlank()) ||
+            (it.to == null && !it.toRaw.isNullOrBlank())
+    }
+
+private fun tripColor(trip: TransportTrip): Color = when {
+    trip.ghost -> Z.ink
+    trip.warning -> Z.statusWarning
+    else -> Z.primary
+}
+
+private fun DrawScope.drawArrowHead(tip: Offset, towards: Offset, color: Color, alpha: Float) {
+    val angle = atan2(tip.y - towards.y, tip.x - towards.x)
+    val len = 5.dp.toPx()
+    listOf(angle + 0.5f, angle - 0.5f).forEach { a ->
+        drawLine(
+            color = color.copy(alpha = alpha),
+            start = tip,
+            end = Offset(tip.x - len * cos(a), tip.y - len * sin(a)),
+            strokeWidth = 1.5.dp.toPx(),
+        )
+    }
+}
+
+private fun DrawScope.drawTripArc(start: Offset, end: Offset, trip: TransportTrip) {
+    val color = tripColor(trip)
+    val mid = Offset((start.x + end.x) / 2f, (start.y + end.y) / 2f)
+    val lift = 18.dp.toPx() + (end - start).getDistance() * 0.12f
+    val control = Offset(mid.x, mid.y - lift)
+    val path = Path().apply {
+        moveTo(start.x, start.y)
+        quadraticBezierTo(control.x, control.y, end.x, end.y)
+    }
+    val dash = if (trip.ghost) PathEffect.dashPathEffect(floatArrayOf(5.dp.toPx(), 4.dp.toPx())) else null
+    drawPath(
+        path,
+        color = color.copy(alpha = trip.alpha),
+        style = Stroke(width = 1.5.dp.toPx(), pathEffect = dash),
+    )
+    drawCircle(color = color.copy(alpha = trip.alpha), radius = 2.5.dp.toPx(), center = start)
+    drawArrowHead(end, control, color, trip.alpha)
+}
+
+/** Short curved stub — a trip leaving (or entering) the displayed floor. */
+private fun DrawScope.drawTripStub(anchor: Offset, trip: TransportTrip, departing: Boolean) {
+    val color = tripColor(trip)
+    val dx = 22.dp.toPx()
+    val far = Offset(anchor.x + dx, anchor.y - dx)
+    val control = Offset(anchor.x + dx * 0.2f, anchor.y - dx)
+    val (start, end) = if (departing) anchor to far else far to anchor
+    val path = Path().apply {
+        moveTo(start.x, start.y)
+        quadraticBezierTo(control.x, control.y, end.x, end.y)
+    }
+    val dash = if (trip.ghost) PathEffect.dashPathEffect(floatArrayOf(5.dp.toPx(), 4.dp.toPx())) else null
+    drawPath(
+        path,
+        color = color.copy(alpha = trip.alpha),
+        style = Stroke(width = 1.5.dp.toPx(), pathEffect = dash),
+    )
+    drawCircle(color = color.copy(alpha = trip.alpha), radius = 2.5.dp.toPx(), center = start)
+    drawArrowHead(end, control, color, trip.alpha)
+}
+
+/**
+ * Same-floor trip arcs drawn over the FloorPlateCanvas (no pointer input — taps
+ * fall through to the plates). Trips with one endpoint on this floor render as
+ * stubs; ghost trips (no destination) as departure stubs at confidence alpha.
+ */
+@Composable
+fun FloorTripArcsOverlay(
+    floor: FlowFloor,
+    trips: List<TransportTrip>,
+    modifier: Modifier = Modifier,
+) {
+    val density = LocalDensity.current
+    val padPx = with(density) { floorPlatePad.toPx() }
+    Canvas(modifier.fillMaxSize()) {
+        val transform = FlowPlanTransform(floor.bounds, size, padPx)
+        fun anchor(point: FlowSpacePoint?): Offset? =
+            point?.takeIf { it.floor == floor.floor }?.rect?.let(transform::center)
+
+        trips.forEach { trip ->
+            val start = anchor(trip.from)
+            val end = anchor(trip.to)
+            when {
+                start != null && end != null -> drawTripArc(start, end, trip)
+                start != null -> drawTripStub(start, trip, departing = true)
+                end != null -> drawTripStub(end, trip, departing = false)
+            }
+        }
+    }
+}
+
+/** A trip reduced to floors for the house stack; fromFloor == toFloor renders as a stub. */
+data class HouseTripArc(
+    val fromFloor: Int,
+    val toFloor: Int,
+    val color: Color,
+    val dashed: Boolean,
+    val alpha: Float,
+)
+
+/** House-stack arcs: cross-floor trips, plus same-/single-floor trips as stubs. */
+fun houseTripArcs(trips: List<TransportTrip>): List<HouseTripArc> =
+    trips.mapNotNull { trip ->
+        val from = trip.from?.floor
+        val to = trip.to?.floor
+        val a = from ?: to ?: return@mapNotNull null
+        HouseTripArc(
+            fromFloor = a,
+            toFloor = to ?: a,
+            color = tripColor(trip),
+            dashed = trip.ghost,
+            alpha = trip.alpha,
+        )
+    }
+
+/**
+ * The "Off-map" gutter: trips whose endpoint is free text the map can't place
+ * ("Main Lobby Discharge", SNFs, home health) listed as tappable chips.
+ */
+@Composable
+fun OffMapTripGutter(
+    trips: List<TransportTrip>,
+    onSelect: (FlowSelection) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (trips.isEmpty()) return
+    Row(
+        modifier
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp)
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("Off-map", color = Z.inkMuted, fontSize = 10.sp)
+        trips.forEach { trip ->
+            val text = when {
+                trip.from == null && !trip.fromRaw.isNullOrBlank() && trip.to == null && !trip.toRaw.isNullOrBlank() ->
+                    "${trip.fromRaw} → ${trip.toRaw}"
+                trip.to == null && !trip.toRaw.isNullOrBlank() -> "→ ${trip.toRaw}"
+                else -> "${trip.fromRaw} →"
+            }
+            Box(
+                Modifier
+                    .heightIn(min = 48.dp)
+                    .clickable { onSelect(trip.selection) },
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text,
+                    color = Z.inkMuted,
+                    fontSize = 11.sp,
+                    maxLines = 1,
+                    modifier = Modifier
+                        .panel(corner = 8)
+                        .padding(horizontal = 8.dp, vertical = 5.dp),
+                )
+            }
+        }
+    }
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/improvement/ImprovementScreens.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/improvement/ImprovementScreens.kt
@@ -35,6 +35,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
@@ -51,6 +55,9 @@ import net.acumenus.hummingbird.data.PdsaCycle
 import net.acumenus.hummingbird.ui.components.HbRefreshable
 import net.acumenus.hummingbird.ui.components.RetryableMessage
 import net.acumenus.hummingbird.ui.components.panel
+import net.acumenus.hummingbird.ui.flow.FlowBoardMode
+import net.acumenus.hummingbird.ui.flow.FlowMapScreen
+import net.acumenus.hummingbird.ui.flow.ListMapSegment
 import net.acumenus.hummingbird.ui.theme.CapacityStatus
 import net.acumenus.hummingbird.ui.theme.Z
 
@@ -65,6 +72,7 @@ fun ImprovementScreen(
 ) {
     val vm: ImprovementViewModel = viewModel()
     val bearer = auth.accessToken ?: ""
+    var boardMode by remember { mutableStateOf(FlowBoardMode.List) }
 
     LaunchedEffect(bearer, forceError) {
         if (!forceError) {
@@ -97,10 +105,24 @@ fun ImprovementScreen(
             )
         },
     ) { inner ->
+        Column(Modifier.padding(inner).fillMaxSize()) {
+        ListMapSegment(
+            mode = boardMode,
+            onSelect = { boardMode = it },
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        )
+        if (boardMode == FlowBoardMode.Map) {
+            // §8 P8: the pattern, not the patient — replay + clip-to-share.
+            FlowMapScreen(
+                auth = auth,
+                persona = "pi_lead",
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
+        } else {
         HbRefreshable(
             refreshing = vm.loading,
             onRefresh = { vm.load(bearer) },
-            modifier = Modifier.padding(inner),
+            modifier = Modifier.weight(1f),
         ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -133,6 +155,8 @@ fun ImprovementScreen(
                     }
                 }
             }
+        }
+        }
         }
         }
     }

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/or/ORScreens.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/or/ORScreens.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
@@ -40,6 +41,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
@@ -56,6 +61,9 @@ import net.acumenus.hummingbird.data.ORNextInfo
 import net.acumenus.hummingbird.data.ORRoom
 import net.acumenus.hummingbird.ui.components.RetryableMessage
 import net.acumenus.hummingbird.ui.components.panel
+import net.acumenus.hummingbird.ui.flow.FlowBoardMode
+import net.acumenus.hummingbird.ui.flow.FlowMapScreen
+import net.acumenus.hummingbird.ui.flow.ListMapSegment
 import net.acumenus.hummingbird.ui.theme.CapacityStatus
 import net.acumenus.hummingbird.ui.theme.Z
 
@@ -64,11 +72,16 @@ import net.acumenus.hummingbird.ui.theme.Z
 fun ORBoardScreen(
     auth: AuthViewModel,
     forceError: Boolean = false,
+    personaId: String = "or_nurse",
     onOpenProfile: () -> Unit = {},
     onOpenRoom: (ORRoom, String?) -> Unit,
 ) {
     val vm: ORViewModel = viewModel()
     val bearer = auth.accessToken ?: ""
+    var boardMode by remember { mutableStateOf(FlowBoardMode.List) }
+    // The flow lens persona comes from the confirmed profile role; only the
+    // two OR lenses are valid here.
+    val flowPersona = if (personaId == "periop_manager") "periop_manager" else "or_nurse"
 
     LaunchedEffect(bearer, forceError) {
         if (!forceError) {
@@ -101,8 +114,21 @@ fun ORBoardScreen(
             )
         },
     ) { inner ->
+        Column(Modifier.padding(inner).fillMaxSize()) {
+        ListMapSegment(
+            mode = boardMode,
+            onSelect = { boardMode = it },
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        )
+        if (boardMode == FlowBoardMode.Map) {
+            FlowMapScreen(
+                auth = auth,
+                persona = flowPersona,
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
+        } else {
         LazyColumn(
-            modifier = Modifier.padding(inner),
+            modifier = Modifier.weight(1f),
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
@@ -132,6 +158,8 @@ fun ORBoardScreen(
                     }
                 }
             }
+        }
+        }
         }
     }
 }

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/staffing/StaffingScreens.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/staffing/StaffingScreens.kt
@@ -37,6 +37,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
@@ -55,6 +59,9 @@ import net.acumenus.hummingbird.ui.components.HbRefreshable
 import net.acumenus.hummingbird.ui.components.RetryableMessage
 import net.acumenus.hummingbird.ui.components.StatusChip
 import net.acumenus.hummingbird.ui.components.panel
+import net.acumenus.hummingbird.ui.flow.FlowBoardMode
+import net.acumenus.hummingbird.ui.flow.FlowMapScreen
+import net.acumenus.hummingbird.ui.flow.ListMapSegment
 import net.acumenus.hummingbird.ui.theme.CapacityStatus
 import net.acumenus.hummingbird.ui.theme.Z
 
@@ -68,6 +75,7 @@ fun StaffingScreen(
 ) {
     val vm: StaffingViewModel = viewModel()
     val bearer = auth.accessToken ?: ""
+    var boardMode by remember { mutableStateOf(FlowBoardMode.List) }
 
     LaunchedEffect(bearer, forceError) {
         if (!forceError) {
@@ -100,10 +108,24 @@ fun StaffingScreen(
             )
         },
     ) { inner ->
+        Column(Modifier.padding(inner).fillMaxSize()) {
+        ListMapSegment(
+            mode = boardMode,
+            onSelect = { boardMode = it },
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        )
+        if (boardMode == FlowBoardMode.Map) {
+            // §8 P10: coverage vs the curve — gap steps at shift boundaries.
+            FlowMapScreen(
+                auth = auth,
+                persona = "staffing_coordinator",
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
+        } else {
         HbRefreshable(
             refreshing = vm.loading,
             onRefresh = { vm.load(bearer) },
-            modifier = Modifier.padding(inner),
+            modifier = Modifier.weight(1f),
         ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -142,6 +164,8 @@ fun StaffingScreen(
                     }
                 }
             }
+        }
+        }
         }
         }
     }

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/transport/TransportScreens.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/transport/TransportScreens.kt
@@ -64,6 +64,9 @@ import net.acumenus.hummingbird.ui.components.HbRefreshable
 import net.acumenus.hummingbird.ui.components.RetryableMessage
 import net.acumenus.hummingbird.ui.components.hbConfirmHaptic
 import net.acumenus.hummingbird.ui.components.panel
+import net.acumenus.hummingbird.ui.flow.FlowBoardMode
+import net.acumenus.hummingbird.ui.flow.FlowMapScreen
+import net.acumenus.hummingbird.ui.flow.ListMapSegment
 import net.acumenus.hummingbird.ui.theme.CapacityStatus
 import net.acumenus.hummingbird.ui.theme.Z
 
@@ -78,6 +81,7 @@ fun TransportJobsScreen(
     val vm: TransportViewModel = viewModel()
     val bearer = auth.accessToken ?: ""
     val view = LocalView.current
+    var boardMode by remember { mutableStateOf(FlowBoardMode.List) }
 
     LaunchedEffect(bearer, forceError) {
         if (!forceError) {
@@ -110,10 +114,23 @@ fun TransportJobsScreen(
             )
         },
     ) { inner ->
+        Column(Modifier.padding(inner).fillMaxSize()) {
+        ListMapSegment(
+            mode = boardMode,
+            onSelect = { boardMode = it },
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+        )
+        if (boardMode == FlowBoardMode.Map) {
+            FlowMapScreen(
+                auth = auth,
+                persona = "transport",
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
+        } else {
         HbRefreshable(
             refreshing = vm.loading,
             onRefresh = { vm.load(bearer) },
-            modifier = Modifier.padding(inner),
+            modifier = Modifier.weight(1f),
         ) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
@@ -170,6 +187,8 @@ fun TransportJobsScreen(
                     }
                 }
             }
+        }
+        }
         }
         }
     }

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/widget/HouseGlanceReceiver.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/widget/HouseGlanceReceiver.kt
@@ -1,0 +1,9 @@
+package net.acumenus.hummingbird.widget
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+/** Home-screen receiver that hosts the [HouseGlanceWidget]. Registered in the manifest. */
+class HouseGlanceReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = HouseGlanceWidget()
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/widget/HouseGlanceSnapshot.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/widget/HouseGlanceSnapshot.kt
@@ -1,0 +1,90 @@
+package net.acumenus.hummingbird.widget
+
+import net.acumenus.hummingbird.data.AltitudeHome
+import net.acumenus.hummingbird.data.FlowWindowData
+import org.json.JSONObject
+import kotlin.math.roundToInt
+
+/**
+ * The compact house-glance the app writes on every altitude-home / flow-window load and the
+ * Glance widget reads back. Every metric is nullable so a partial load only updates what it
+ * knows; [merge] overlays fresh non-null fields onto the last snapshot. Pure + JSON-only so
+ * the derivation is testable without Android.
+ */
+data class HouseGlanceSnapshot(
+    val occupancyPct: Int? = null,
+    val netBedNeed: Int? = null,
+    val forYouCount: Int? = null,
+    val next4hGhostCount: Int? = null,
+    val updatedAtMs: Long = 0L,
+) {
+    val isEmpty: Boolean
+        get() = occupancyPct == null && netBedNeed == null && forYouCount == null && next4hGhostCount == null
+
+    fun toJson(): String = JSONObject().apply {
+        occupancyPct?.let { put("occupancy_pct", it) }
+        netBedNeed?.let { put("net_bed_need", it) }
+        forYouCount?.let { put("for_you_count", it) }
+        next4hGhostCount?.let { put("next_4h_ghost_count", it) }
+        put("updated_at_ms", updatedAtMs)
+    }.toString()
+
+    companion object {
+        private const val FOUR_HOURS_MS = 4 * 60 * 60 * 1000L
+
+        fun fromJson(text: String): HouseGlanceSnapshot? = runCatching {
+            val o = JSONObject(text)
+            HouseGlanceSnapshot(
+                occupancyPct = o.intOrNull("occupancy_pct"),
+                netBedNeed = o.intOrNull("net_bed_need"),
+                forYouCount = o.intOrNull("for_you_count"),
+                next4hGhostCount = o.intOrNull("next_4h_ghost_count"),
+                updatedAtMs = o.optLong("updated_at_ms", 0L),
+            )
+        }.getOrNull()
+
+        private fun JSONObject.intOrNull(key: String): Int? = if (has(key) && !isNull(key)) optInt(key) else null
+
+        /** Overlay [partial]'s known fields onto [base]; stamps [nowMs] as the update time. */
+        fun merge(base: HouseGlanceSnapshot?, partial: HouseGlanceSnapshot, nowMs: Long): HouseGlanceSnapshot =
+            HouseGlanceSnapshot(
+                occupancyPct = partial.occupancyPct ?: base?.occupancyPct,
+                netBedNeed = partial.netBedNeed ?: base?.netBedNeed,
+                forYouCount = partial.forYouCount ?: base?.forYouCount,
+                next4hGhostCount = partial.next4hGhostCount ?: base?.next4hGhostCount,
+                updatedAtMs = nowMs,
+            )
+
+        /**
+         * Flow-window derived slice: occupancy from the floor rollups and the count of
+         * projection ghosts landing in the next 4h. Net bed need isn't in the window rollup,
+         * so it is left for a home load to supply.
+         */
+        fun fromFlow(window: FlowWindowData): HouseGlanceSnapshot {
+            val staffed = window.spacesFloors.sumOf { it.staffed }
+            val occupied = window.spacesFloors.sumOf { it.occupied }
+            val occupancy = if (staffed > 0) (occupied * 100.0 / staffed).roundToInt() else null
+            val horizon = window.nowMs + FOUR_HOURS_MS
+            val next4h = window.projections.count { it.tMs in window.nowMs..horizon }
+            return HouseGlanceSnapshot(occupancyPct = occupancy, next4hGhostCount = next4h)
+        }
+
+        /**
+         * Altitude-home derived slice: For You head count, plus occupancy / net bed need
+         * scraped from any matching glance tile value.
+         */
+        fun fromHome(home: AltitudeHome): HouseGlanceSnapshot = HouseGlanceSnapshot(
+            occupancyPct = tileValue(home, "occup"),
+            netBedNeed = tileValue(home, "bed_need") ?: tileValue(home, "net_bed"),
+            forYouCount = home.forYouHead.size,
+        )
+
+        private fun tileValue(home: AltitudeHome, keyFragment: String): Int? =
+            home.tiles.firstOrNull { it.key.contains(keyFragment, ignoreCase = true) }
+                ?.let { firstSignedInt(it.value) }
+
+        /** First signed integer embedded in a tile value like "84%" or "+3 beds". */
+        private fun firstSignedInt(value: String): Int? =
+            Regex("-?\\d+").find(value)?.value?.toIntOrNull()
+    }
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/widget/HouseGlanceStore.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/widget/HouseGlanceStore.kt
@@ -1,0 +1,51 @@
+package net.acumenus.hummingbird.widget
+
+import android.content.Context
+import androidx.glance.appwidget.updateAll
+import net.acumenus.hummingbird.data.AltitudeHome
+import net.acumenus.hummingbird.data.FlowWindowData
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+/**
+ * Persists the house-glance snapshot (a small file under filesDir/glance) and pushes it to
+ * the widget. App-driven only: writes happen on a foreground altitude-home / flow-window
+ * load, and each write ends with GlanceAppWidget.updateAll — there is NO background /
+ * WorkManager networking behind the widget.
+ */
+object HouseGlanceStore {
+    private const val DIR = "glance"
+    private const val FILE = "house.json"
+
+    private fun file(context: Context): File = File(File(context.filesDir, DIR), FILE)
+
+    fun read(context: Context): HouseGlanceSnapshot? =
+        runCatching { file(context).readText() }.getOrNull()?.let(HouseGlanceSnapshot::fromJson)
+
+    suspend fun updateFromFlow(context: Context, window: FlowWindowData) =
+        write(context, HouseGlanceSnapshot.fromFlow(window))
+
+    suspend fun updateFromHome(context: Context, home: AltitudeHome) =
+        write(context, HouseGlanceSnapshot.fromHome(home))
+
+    /** Wipe the snapshot on logout and reset the widget to its placeholder. */
+    suspend fun clear(context: Context) {
+        runCatching { file(context).delete() }
+        HouseGlanceWidget().updateAll(context)
+    }
+
+    private suspend fun write(context: Context, partial: HouseGlanceSnapshot) {
+        val merged = HouseGlanceSnapshot.merge(read(context), partial, System.currentTimeMillis())
+        atomicWrite(file(context), merged.toJson())
+        HouseGlanceWidget().updateAll(context)
+    }
+
+    private fun atomicWrite(target: File, text: String) {
+        target.parentFile?.mkdirs()
+        val tmp = File(target.parentFile, "${target.name}.tmp")
+        tmp.writeText(text)
+        runCatching { Files.move(tmp.toPath(), target.toPath(), StandardCopyOption.ATOMIC_MOVE) }
+            .onFailure { Files.move(tmp.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING) }
+    }
+}

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/widget/HouseGlanceWidget.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/widget/HouseGlanceWidget.kt
@@ -1,0 +1,129 @@
+package net.acumenus.hummingbird.widget
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.appWidgetBackground
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.width
+import androidx.glance.text.FontFamily
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+/**
+ * Glance colors mirror the Zephyrus `Z` palette (System A blue/slate + the rationed status
+ * ramp). Glance can't reach the Compose `Z` object's ColorProviders, so the hex values are
+ * duplicated here — keep them in sync. Projections read as warning (amber), never critical.
+ */
+private object GlanceZ {
+    val bg = ColorProvider(Color(0xFF1E293B))       // Z.surface
+    val ink = ColorProvider(Color(0xFFF8FAFC))      // Z.ink
+    val inkMuted = ColorProvider(Color(0xFF94A3B8)) // Z.inkMuted
+    val primary = ColorProvider(Color(0xFF60A5FA))  // Z.statusInfo (interactive blue on dark)
+    val warning = ColorProvider(Color(0xFFE5A84B))  // Z.statusWarning
+}
+
+// monospace ⇒ tabular alignment for the metrics
+private val metricStyle = TextStyle(
+    color = GlanceZ.ink,
+    fontSize = 22.sp,
+    fontWeight = FontWeight.Medium,
+    fontFamily = FontFamily.Monospace,
+)
+
+private val labelStyle = TextStyle(color = GlanceZ.inkMuted, fontSize = 11.sp)
+private val kickerStyle = TextStyle(color = GlanceZ.primary, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+
+/**
+ * Small house-glance widget: occupancy %, net bed need, For You count, next-4h ghost count,
+ * and an updated-at stamp. Fed by [HouseGlanceStore]; renders a tasteful placeholder until
+ * the app has synced once.
+ */
+class HouseGlanceWidget : GlanceAppWidget() {
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val snapshot = HouseGlanceStore.read(context)
+        provideContent { Content(snapshot) }
+    }
+}
+
+@Composable
+private fun Content(snapshot: HouseGlanceSnapshot?) {
+    val root = GlanceModifier
+        .fillMaxSize()
+        .appWidgetBackground()
+        .background(GlanceZ.bg)
+        .cornerRadius(16.dp)
+        .padding(12.dp)
+
+    if (snapshot == null || snapshot.isEmpty) {
+        Column(modifier = root, verticalAlignment = Alignment.CenterVertically) {
+            Text("Hummingbird", style = kickerStyle)
+            Spacer(GlanceModifier.height(4.dp))
+            Text("Open Hummingbird to sync", style = labelStyle)
+        }
+        return
+    }
+
+    Column(modifier = root) {
+        Row(modifier = GlanceModifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Text("House", style = kickerStyle)
+            Spacer(GlanceModifier.width(6.dp))
+            Text(updatedLabel(snapshot.updatedAtMs), style = labelStyle)
+        }
+        Spacer(GlanceModifier.height(6.dp))
+        Row(modifier = GlanceModifier.fillMaxWidth()) {
+            Metric(label = "Occupied", value = snapshot.occupancyPct?.let { "$it%" } ?: DASH)
+            Spacer(GlanceModifier.width(12.dp))
+            Metric(label = "Bed need", value = snapshot.netBedNeed?.let(::signed) ?: DASH)
+        }
+        Spacer(GlanceModifier.height(6.dp))
+        Row(modifier = GlanceModifier.fillMaxWidth()) {
+            Metric(label = "For You", value = snapshot.forYouCount?.toString() ?: DASH)
+            Spacer(GlanceModifier.width(12.dp))
+            Metric(
+                label = "Next 4h",
+                value = snapshot.next4hGhostCount?.toString() ?: DASH,
+                valueColor = GlanceZ.warning, // projections render as warning, never critical
+            )
+        }
+    }
+}
+
+@Composable
+private fun Metric(label: String, value: String, valueColor: ColorProvider = GlanceZ.ink) {
+    Column {
+        Text(value, style = metricStyle.copy(color = valueColor))
+        Text(label, style = labelStyle)
+    }
+}
+
+private const val DASH = "—"
+
+private fun signed(v: Int): String = if (v > 0) "+$v" else v.toString()
+
+private fun updatedLabel(ms: Long): String {
+    if (ms <= 0L) return ""
+    val clock = DateTimeFormatter.ofPattern("HH:mm")
+        .format(Instant.ofEpochMilli(ms).atZone(ZoneId.systemDefault()))
+    return "Updated $clock"
+}

--- a/hummingbird/androidApp/app/src/main/res/xml/house_glance_widget_info.xml
+++ b/hummingbird/androidApp/app/src/main/res/xml/house_glance_widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="140dp"
+    android:minHeight="80dp"
+    android:targetCellWidth="2"
+    android:targetCellHeight="2"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:initialLayout="@layout/glance_default_loading_layout" />

--- a/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/data/FlowCacheLogicTest.kt
+++ b/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/data/FlowCacheLogicTest.kt
@@ -1,0 +1,77 @@
+package net.acumenus.hummingbird.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure offline-cache keying + LRU rules: user/persona/scope keys, newest-wins eviction, and
+ * the cross-user isolation guarantee (one user's cache is never located for another).
+ */
+class FlowCacheLogicTest {
+
+    private fun entry(userId: Int, persona: String, scope: String?, at: Long) =
+        FlowCacheEntry(FlowCacheLogic.cacheKey(userId, persona, scope), userId, persona, scope, at)
+
+    @Test
+    fun keyEmbedsUserPersonaAndScope() {
+        assertEquals("u7|bed_manager|house", FlowCacheLogic.cacheKey(7, "bed_manager", "house"))
+        assertEquals("u7|bed_manager|", FlowCacheLogic.cacheKey(7, "bed_manager", null))
+        // Different users ⇒ different keys, even for the same persona/scope.
+        assertTrue(FlowCacheLogic.cacheKey(1, "evs", "floor:3") != FlowCacheLogic.cacheKey(2, "evs", "floor:3"))
+    }
+
+    @Test
+    fun upsertEvictsOldestBeyondCapacity() {
+        var entries = emptyList<FlowCacheEntry>()
+        var evictedAll = emptyList<FlowCacheEntry>()
+        listOf(
+            entry(1, "a", null, 1L),
+            entry(1, "b", null, 2L),
+            entry(1, "c", null, 3L),
+            entry(1, "d", null, 4L),
+        ).forEach {
+            val (kept, evicted) = FlowCacheLogic.upsert(entries, it, maxEntries = 3)
+            entries = kept
+            evictedAll = evictedAll + evicted
+        }
+
+        assertEquals(3, entries.size)
+        // Oldest (persona "a", ts 1) is evicted; the newest three survive.
+        assertEquals(listOf("a"), evictedAll.map { it.persona })
+        assertEquals(setOf("b", "c", "d"), entries.map { it.persona }.toSet())
+    }
+
+    @Test
+    fun upsertRefreshesSameKeyInPlace() {
+        val (afterFirst, _) = FlowCacheLogic.upsert(emptyList(), entry(1, "bed_manager", "house", 1L), maxEntries = 3)
+        val (afterRefresh, evicted) = FlowCacheLogic.upsert(afterFirst, entry(1, "bed_manager", "house", 9L), maxEntries = 3)
+
+        assertEquals(1, afterRefresh.size)
+        assertEquals(9L, afterRefresh.first().updatedAtMs)
+        assertTrue(evicted.isEmpty())
+    }
+
+    @Test
+    fun findNeverServesAnotherUsersCache() {
+        val entries = listOf(
+            entry(1, "bed_manager", "house", 1L),
+            entry(2, "bed_manager", "house", 2L),
+        )
+
+        val forUser1 = FlowCacheLogic.find(entries, 1, "bed_manager", "house")
+        assertEquals(1, forUser1?.userId)
+
+        // User 3 has nothing cached — must return null, not user 1's or user 2's record.
+        assertNull(FlowCacheLogic.find(entries, 3, "bed_manager", "house"))
+    }
+
+    @Test
+    fun findMatchesScopeExactly() {
+        val entries = listOf(entry(1, "evs", "floor:3", 1L))
+        assertEquals("floor:3", FlowCacheLogic.find(entries, 1, "evs", "floor:3")?.scope)
+        assertNull(FlowCacheLogic.find(entries, 1, "evs", null))
+        assertNull(FlowCacheLogic.find(entries, 1, "evs", "floor:4"))
+    }
+}

--- a/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/data/FlowDeltaTest.kt
+++ b/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/data/FlowDeltaTest.kt
@@ -1,0 +1,161 @@
+package net.acumenus.hummingbird.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Delta-merge contract: append+dedupe events (by t, kind, entity ref, label) and snapshots
+ * (by t, unit_id); REPLACE projections, bed_statuses and spaces wholesale; take the fresh
+ * window frame. Plus the `?since=` cursor derivation.
+ */
+class FlowDeltaTest {
+
+    private val t1 = "2026-07-04T10:00:00+00:00"
+    private val t2 = "2026-07-04T11:00:00+00:00"
+    private val t3 = "2026-07-04T12:00:00+00:00"
+
+    private fun range(from: String, to: String, now: String, since: String? = null) =
+        FlowWindowRange(from = from, to = to, now = now, since = since)
+
+    private val lens = FlowLens("bed_manager", emptyList(), emptyList(), emptyList(), emptyList(), "full", emptyList(), 48)
+    private val scope = FlowScope("house", null, null, null, "House")
+
+    private fun event(t: String, kind: String, label: String, entityRef: String? = null) = FlowTimelineEvent(
+        t = t, kind = kind, label = label, tier = "info",
+        unitId = 1, fromSpace = null, toSpace = null, patientContextRef = entityRef,
+        provenanceSource = "prod.operational_events", entityRef = entityRef,
+    )
+
+    private fun snapshot(t: String, unitId: Int) =
+        FlowSnapshot(t = t, unitId = unitId, staffed = 10, occupied = 5, available = 5, blocked = 0)
+
+    private fun projection(kind: String) = FlowProjection(
+        t = t3, kind = kind, confidence = "probable", label = kind, unitId = 1, bedId = null, room = null,
+        value = null, bandLower = null, bandUpper = null, endsAt = null, derived = false,
+        patientContextRef = null, provenanceService = "svc", provenanceReliability = 0.8,
+    )
+
+    private fun bedStatus(bedId: Int, status: String) = FlowBedStatus(bedId, 1, "MICU-0$bedId", status)
+
+    private fun floor(n: Int) = FlowFloorRollup(n, "Floor $n", 20, 10, 50, emptyList())
+
+    private fun window(
+        range: FlowWindowRange,
+        events: List<FlowTimelineEvent> = emptyList(),
+        snapshots: List<FlowSnapshot> = emptyList(),
+        projections: List<FlowProjection> = emptyList(),
+        bedStatuses: List<FlowBedStatus> = emptyList(),
+        floors: List<FlowFloorRollup> = emptyList(),
+        webLink: String? = null,
+    ) = FlowWindowData(range, lens, scope, floors, snapshots, events, projections, bedStatuses, webLink)
+
+    @Test
+    fun appendsNewEventsAndDedupesByKey() {
+        val current = window(
+            range(t1, t3, t2),
+            events = listOf(event(t1, "admit", "Admitted to MICU"), event(t2, "discharge", "Discharged")),
+        )
+        val delta = window(
+            range(t1, t3, t3, since = t2),
+            // e2 duplicate (same t, kind, ref, label) + a genuinely new event.
+            events = listOf(event(t2, "discharge", "Discharged"), event(t3, "transfer", "Transfer")),
+        )
+
+        val merged = mergeFlowWindow(current, delta)
+
+        assertEquals(3, merged.events.size)
+        assertEquals(listOf("admit", "discharge", "transfer"), merged.events.map { it.kind })
+    }
+
+    @Test
+    fun keepsEventsThatShareTimeKindLabelButDifferInEntityRef() {
+        val current = window(range(t1, t3, t2), events = listOf(event(t2, "bed_request", "Bed request", entityRef = "ref_a")))
+        val delta = window(
+            range(t1, t3, t3, since = t2),
+            events = listOf(event(t2, "bed_request", "Bed request", entityRef = "ref_b")),
+        )
+
+        val merged = mergeFlowWindow(current, delta)
+
+        assertEquals(2, merged.events.size)
+        assertEquals(setOf("ref_a", "ref_b"), merged.events.mapNotNull { it.entityRef }.toSet())
+    }
+
+    @Test
+    fun appendsSnapshotsAndDedupesByTimeAndUnit() {
+        val current = window(range(t1, t3, t2), snapshots = listOf(snapshot(t1, 1), snapshot(t1, 2)))
+        val delta = window(
+            range(t1, t3, t3, since = t2),
+            snapshots = listOf(snapshot(t1, 1), snapshot(t2, 1)), // dup (t1,unit1) + new (t2,unit1)
+        )
+
+        val merged = mergeFlowWindow(current, delta)
+
+        assertEquals(3, merged.snapshots.size)
+    }
+
+    @Test
+    fun replacesProjectionsBedStatusesAndSpacesWholesale() {
+        val current = window(
+            range(t1, t3, t2),
+            projections = listOf(projection("surge_probability"), projection("predicted_census")),
+            bedStatuses = listOf(bedStatus(1, "dirty"), bedStatus(2, "occupied")),
+            floors = listOf(floor(1), floor(2)),
+        )
+        val delta = window(
+            range(t1, t3, t3, since = t2),
+            projections = listOf(projection("expected_discharge")),
+            bedStatuses = listOf(bedStatus(3, "available")),
+            floors = listOf(floor(9)),
+        )
+
+        val merged = mergeFlowWindow(current, delta)
+
+        assertEquals(listOf("expected_discharge"), merged.projections.map { it.kind })
+        assertEquals(listOf(3), merged.bedStatuses.map { it.bedId })
+        assertEquals(listOf(9), merged.spacesFloors.map { it.floor })
+    }
+
+    @Test
+    fun takesTheFreshWindowFrame() {
+        val current = window(range(t1, t3, t2))
+        val delta = window(range(t2, t3, t3, since = t2))
+
+        val merged = mergeFlowWindow(current, delta)
+
+        assertEquals(t2, merged.window.from)
+        assertEquals(t3, merged.window.now)
+        assertEquals(t2, merged.window.since)
+    }
+
+    @Test
+    fun sinceCursorIsNewestLoadedEventOrSnapshot() {
+        val win = window(
+            range(t1, t3, t3),
+            events = listOf(event(t1, "admit", "a")),
+            snapshots = listOf(snapshot(t2, 1)),
+        )
+        // Newest of {t1 event, t2 snapshot} is t2.
+        assertEquals(flowEpochMsToIso(flowIsoToEpochMs(t2)!!), newestLoadedSinceIso(win))
+    }
+
+    @Test
+    fun sinceCursorIsNullWhenNothingLoaded() {
+        assertNull(newestLoadedSinceIso(window(range(t1, t3, t3))))
+    }
+
+    @Test
+    fun mergeDoesNotMutateProjectionCountUpward() {
+        // Guards the "projections always full ⇒ replace, never accumulate" rule under repeat.
+        val current = window(range(t1, t3, t2), projections = listOf(projection("surge_probability")))
+        val delta = window(range(t1, t3, t3, since = t2), projections = listOf(projection("surge_probability")))
+        val once = mergeFlowWindow(current, delta)
+        val twice = mergeFlowWindow(once, delta)
+        assertEquals(1, twice.projections.size)
+        assertFalse(twice.projections.size > 1)
+        assertTrue(twice.events.isEmpty())
+    }
+}

--- a/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/data/SharedDtoFixtureDecodeTest.kt
+++ b/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/data/SharedDtoFixtureDecodeTest.kt
@@ -78,6 +78,29 @@ class SharedDtoFixtureDecodeTest {
         val census = window.projections.first { it.kind == "predicted_census" }
         assertEquals(0, census.bandLower)
         assertEquals(2, census.bandUpper)
+
+        // Phase 2: scheduled_or_case carries its room; other kinds stay roomless.
+        val orCase = window.projections.first { it.kind == "scheduled_or_case" }
+        assertEquals("OR 3", orCase.room)
+        assertTrue(window.projections.filter { it.kind != "scheduled_or_case" }.all { it.room == null })
+        // bed_statuses is absent at house scope — the parser must tolerate that.
+        assertTrue(window.bedStatuses.isEmpty())
+        // Phase 3: links.web feeds the PI clip deep link.
+        assertTrue(window.webLink!!.contains("/rtdc/patient-flow-navigator"))
+    }
+
+    @Test
+    fun decodesEvsFlowWindowFixtureWithBedStatuses() {
+        val window = api.parseFlowWindow(fixture("mobile-flow-window-evs.json"))
+
+        assertEquals("evs", window.lens.roleId)
+        assertEquals("floor", window.scope.type)
+        assertTrue(window.bedStatuses.isNotEmpty())
+        val first = window.bedStatuses.first()
+        assertEquals("MICU-01", first.label)
+        assertEquals("occupied", first.status)
+        assertTrue(window.bedStatuses.all { it.status in setOf("available", "occupied", "blocked", "dirty") })
+        assertTrue(window.projections.any { it.kind == "evs_due" && it.bedId != null })
     }
 
     @Test
@@ -85,7 +108,7 @@ class SharedDtoFixtureDecodeTest {
         val doc = api.parseFlowFloors(fixture("mobile-flow-floors.json"))
 
         assertTrue(doc.floors.isNotEmpty())
-        assertEquals("v1-346c77a48494", doc.version)
+        assertEquals("v1-2b3e9f90ad5d", doc.version)
         val floor3 = doc.floors.first { it.floor == 3 }
         assertEquals(4, floor3.bounds.size)
         assertEquals(4, floor3.spaces.size)

--- a/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/ui/flow/AggregateLensLogicTest.kt
+++ b/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/ui/flow/AggregateLensLogicTest.kt
@@ -1,0 +1,299 @@
+package net.acumenus.hummingbird.ui.flow
+
+import net.acumenus.hummingbird.data.FlowFloorRollup
+import net.acumenus.hummingbird.data.FlowLens
+import net.acumenus.hummingbird.data.FlowProjection
+import net.acumenus.hummingbird.data.FlowScope
+import net.acumenus.hummingbird.data.FlowSnapshot
+import net.acumenus.hummingbird.data.FlowTimelineEvent
+import net.acumenus.hummingbird.data.FlowUnitRollup
+import net.acumenus.hummingbird.data.FlowWindowData
+import net.acumenus.hummingbird.data.FlowWindowRange
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.ZoneId
+
+/**
+ * Phase 3 aggregate-lens pure logic: curve series, snapshot replay rollups,
+ * staffing gap tinting, discharge-leverage ranking, and the PI clip payload.
+ */
+class AggregateLensLogicTest {
+
+    // Window: from 2026-07-03T12:00Z, now 2026-07-04T12:00Z, to 2026-07-05T12:00Z.
+    private val fromIso = "2026-07-03T12:00:00+00:00"
+    private val nowIso = "2026-07-04T12:00:00+00:00"
+    private val toIso = "2026-07-05T12:00:00+00:00"
+
+    private fun ms(iso: String): Long = net.acumenus.hummingbird.data.flowIsoToEpochMs(iso)!!
+
+    private fun unit(id: Int, abbr: String, staffed: Int, occupied: Int) = FlowUnitRollup(
+        unitId = id,
+        abbr = abbr,
+        name = abbr,
+        staffed = staffed,
+        occupied = occupied,
+        available = staffed - occupied,
+        blocked = 0,
+        occupancyPct = if (staffed > 0) occupied * 100 / staffed else 0,
+    )
+
+    private fun snapshot(iso: String, unitId: Int, occupied: Int, staffed: Int = 10) = FlowSnapshot(
+        t = iso,
+        unitId = unitId,
+        staffed = staffed,
+        occupied = occupied,
+        available = staffed - occupied,
+        blocked = 0,
+    )
+
+    private fun projection(
+        iso: String,
+        kind: String,
+        unitId: Int? = null,
+        value: Int? = null,
+        bandLower: Int? = null,
+        bandUpper: Int? = null,
+        confidence: String = "probable",
+        label: String = kind,
+        patientContextRef: String? = null,
+    ) = FlowProjection(
+        t = iso,
+        kind = kind,
+        confidence = confidence,
+        label = label,
+        unitId = unitId,
+        bedId = null,
+        room = null,
+        value = value,
+        bandLower = bandLower,
+        bandUpper = bandUpper,
+        endsAt = null,
+        derived = false,
+        patientContextRef = patientContextRef,
+        provenanceService = "demand_forecast",
+        provenanceReliability = 0.86,
+    )
+
+    private fun event(iso: String, kind: String) = FlowTimelineEvent(
+        t = iso,
+        kind = kind,
+        label = kind,
+        tier = "info",
+        unitId = 1,
+        fromSpace = null,
+        toSpace = null,
+        patientContextRef = null,
+        provenanceSource = "prod.operational_events",
+    )
+
+    private fun window(
+        snapshots: List<FlowSnapshot> = emptyList(),
+        events: List<FlowTimelineEvent> = emptyList(),
+        projections: List<FlowProjection> = emptyList(),
+        webLink: String? = null,
+    ) = FlowWindowData(
+        window = FlowWindowRange(from = fromIso, to = toIso, now = nowIso),
+        lens = FlowLens(
+            roleId = "capacity_lead",
+            scopesAllowed = listOf("house"),
+            layers = listOf("snapshots", "projections", "spaces"),
+            eventKinds = emptyList(),
+            projectionKinds = emptyList(),
+            patientDots = "none",
+            actions = emptyList(),
+            defaultZoomHours = 48,
+        ),
+        scope = FlowScope(type = "house", floor = null, unitId = null, patientContextRef = null, label = "House"),
+        spacesFloors = listOf(
+            FlowFloorRollup(
+                floor = 3,
+                label = "Floor 3",
+                staffed = 30,
+                occupied = 24,
+                occupancyPct = 80,
+                units = listOf(unit(1, "MICU", 10, 9), unit(2, "TEL3", 20, 15)),
+            ),
+            FlowFloorRollup(
+                floor = 4,
+                label = "Floor 4",
+                staffed = 20,
+                occupied = 12,
+                occupancyPct = 60,
+                units = listOf(unit(3, "MED4", 20, 12)),
+            ),
+        ),
+        snapshots = snapshots,
+        events = events,
+        projections = projections,
+        webLink = webLink,
+    )
+
+    // MARK: FlowCurve series
+
+    @Test
+    fun occupancySeriesSumsUnitsForHouseAndFiltersForUnit() {
+        val win = window(
+            snapshots = listOf(
+                snapshot("2026-07-04T08:00:00+00:00", unitId = 1, occupied = 7),
+                snapshot("2026-07-04T08:00:00+00:00", unitId = 2, occupied = 12),
+                snapshot("2026-07-04T09:00:00+00:00", unitId = 1, occupied = 8),
+            ),
+        )
+
+        val house = occupancySeries(win)
+        assertEquals(2, house.size)
+        assertEquals(19, house.first().value) // 7 + 12 at 08:00
+        assertEquals(8, house.last().value) // only unit 1 checkpointed at 09:00
+
+        val unitOnly = occupancySeries(win, setOf(1))
+        assertEquals(listOf(7, 8), unitOnly.map { it.value })
+    }
+
+    @Test
+    fun predictedSeriesPrefersHouseRowsAndSumsPerUnitFallback() {
+        val houseRow = projection("2026-07-04T14:00:00+00:00", "predicted_census", unitId = null, value = 40, bandLower = 37, bandUpper = 43)
+        val unitRows = listOf(
+            projection("2026-07-04T14:00:00+00:00", "predicted_census", unitId = 1, value = 9, bandLower = 8, bandUpper = 10),
+            projection("2026-07-04T14:00:00+00:00", "predicted_census", unitId = 2, value = 16, bandLower = 15, bandUpper = 18),
+        )
+
+        // House-level rows win at house scope.
+        val withHouse = predictedSeries(window(projections = listOf(houseRow) + unitRows))
+        assertEquals(1, withHouse.size)
+        assertEquals(40, withHouse.first().value)
+
+        // Per-unit-only payload: units are summed per 2h step.
+        val summed = predictedSeries(window(projections = unitRows))
+        assertEquals(25, summed.first().value)
+        assertEquals(23, summed.first().bandLower)
+        assertEquals(28, summed.first().bandUpper)
+
+        // Unit filter keeps the client-side scope selection honest.
+        val filtered = predictedSeries(window(projections = listOf(houseRow) + unitRows), setOf(2))
+        assertEquals(listOf(16), filtered.map { it.value })
+    }
+
+    @Test
+    fun staffedCapacityRespectsUnitFilter() {
+        val win = window()
+        assertEquals(50, staffedCapacity(win))
+        assertEquals(20, staffedCapacity(win, setOf(2)))
+    }
+
+    // MARK: executive / PI replay
+
+    @Test
+    fun floorsAtRebuildsFloorHeatFromSnapshots() {
+        val win = window(
+            snapshots = listOf(
+                snapshot("2026-07-04T02:00:00+00:00", unitId = 1, occupied = 2, staffed = 10),
+                snapshot("2026-07-04T06:00:00+00:00", unitId = 1, occupied = 5, staffed = 10),
+            ),
+        )
+        val t = ms("2026-07-04T04:00:00+00:00")
+
+        val floors = floorsAt(win, t)
+        val floor3 = floors.first { it.floor == 3 }
+        val micu = floor3.units.first { it.unitId == 1 }
+        assertEquals(2, micu.occupied) // 02:00 checkpoint, not the 06:00 one
+        // Units without a checkpoint at t keep their live rollup.
+        assertEquals(15, floor3.units.first { it.unitId == 2 }.occupied)
+        assertEquals(17, floor3.occupied)
+
+        // At/after now the live rollups win untouched.
+        assertEquals(win.spacesFloors, floorsAt(win, win.nowMs))
+    }
+
+    @Test
+    fun arrivalsNext24hTotalOnlyCountsTheFutureHalf() {
+        val win = window(
+            projections = listOf(
+                projection("2026-07-04T10:00:00+00:00", "predicted_arrivals", unitId = 24, value = 9), // past — excluded
+                projection("2026-07-04T13:00:00+00:00", "predicted_arrivals", unitId = 24, value = 2),
+                projection("2026-07-04T14:00:00+00:00", "predicted_arrivals", unitId = 24, value = 3),
+            ),
+        )
+        assertEquals(5, arrivalsNext24hTotal(win))
+    }
+
+    // MARK: staffing lens
+
+    @Test
+    fun worstGapByFloorMapsUnitsThroughTheFloorsPayload() {
+        val win = window(
+            projections = listOf(
+                projection("2026-07-04T19:00:00+00:00", "staffing_shift_gap", unitId = 1, value = 2),
+                projection("2026-07-04T19:00:00+00:00", "staffing_shift_gap", unitId = 2, value = 3),
+                projection("2026-07-05T07:00:00+00:00", "staffing_shift_gap", unitId = 3, value = 0), // covered — no tint
+                projection("2026-07-05T07:00:00+00:00", "staffing_shift_gap", unitId = 99, value = 4), // unknown unit — dropped
+            ),
+        )
+        val worst = worstGapByFloor(win)
+        assertEquals(mapOf(3 to 3), worst)
+        assertFalse(worst.containsKey(4))
+    }
+
+    // MARK: discharge leverage
+
+    @Test
+    fun dischargeLeverageRanksConfidenceThenTime() {
+        val possibleEarly = projection("2026-07-04T13:00:00+00:00", "expected_discharge", confidence = "possible", label = "A")
+        val definiteLate = projection("2026-07-04T18:00:00+00:00", "expected_discharge", confidence = "definite", label = "B", patientContextRef = "ptok_b")
+        val probableMid = projection("2026-07-04T15:00:00+00:00", "expected_discharge", confidence = "probable", label = "C")
+        val definiteEarly = projection("2026-07-04T14:00:00+00:00", "expected_discharge", confidence = "definite", label = "D", patientContextRef = "ptok_d")
+        val notADischarge = projection("2026-07-04T13:30:00+00:00", "transport_due", confidence = "definite", label = "E")
+
+        val ranked = dischargeLeverageRows(listOf(possibleEarly, definiteLate, probableMid, definiteEarly, notADischarge))
+        assertEquals(listOf("D", "B", "C", "A"), ranked.map { it.label })
+    }
+
+    // MARK: PI clip
+
+    @Test
+    fun clipSummaryCarriesScopeRangeOccupancyDeltaAndEventCounts() {
+        val win = window(
+            snapshots = listOf(
+                snapshot("2026-07-03T12:00:00+00:00", unitId = 1, occupied = 4),
+                snapshot("2026-07-04T10:00:00+00:00", unitId = 1, occupied = 9),
+            ),
+            events = listOf(
+                event("2026-07-03T15:00:00+00:00", "admit"),
+                event("2026-07-03T16:00:00+00:00", "admit"),
+                event("2026-07-04T01:00:00+00:00", "evs_status"),
+                event("2026-07-04T13:00:00+00:00", "admit"), // after the clip range
+            ),
+            webLink = "http://localhost/rtdc/patient-flow-navigator?persona=pi_lead",
+        )
+
+        val summary = clipSummary(win, win.fromMs, ms("2026-07-04T11:00:00+00:00"), zone = ZoneId.of("UTC"))
+        assertTrue(summary.contains("House"))
+        assertTrue(summary.contains("Occupancy 4 → 9 (+5)"))
+        assertTrue(summary.contains("admit 2"))
+        assertTrue(summary.contains("evs_status 1"))
+        assertFalse(summary.contains("admit 3"))
+        assertTrue(summary.contains("&from=2026-07-03T12%3A00"))
+        assertTrue(summary.contains("&to=2026-07-04T11%3A00"))
+    }
+
+    @Test
+    fun clipWebLinkAppendsRangeWithCorrectJoiner() {
+        val bare = window(webLink = "http://localhost/nav")
+        val linked = clipWebLink(bare, bare.fromMs, bare.nowMs)!!
+        assertTrue(linked.startsWith("http://localhost/nav?from="))
+        assertTrue(linked.contains("&to="))
+
+        val withQuery = window(webLink = "http://localhost/nav?persona=pi_lead")
+        assertTrue(clipWebLink(withQuery, withQuery.fromMs, withQuery.nowMs)!!.contains("?persona=pi_lead&from="))
+
+        assertNull(clipWebLink(window(webLink = null), 0L, 1L))
+    }
+
+    @Test
+    fun piReplayDurationIsFourHoursPerSecond() {
+        val win = window()
+        assertEquals(6_000L, piReplayDurationMs(win.fromMs, win.nowMs)) // 24h at 4h/s
+    }
+}

--- a/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/widget/HouseGlanceSnapshotTest.kt
+++ b/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/widget/HouseGlanceSnapshotTest.kt
@@ -1,0 +1,88 @@
+package net.acumenus.hummingbird.widget
+
+import net.acumenus.hummingbird.data.FlowFloorRollup
+import net.acumenus.hummingbird.data.FlowLens
+import net.acumenus.hummingbird.data.FlowProjection
+import net.acumenus.hummingbird.data.FlowScope
+import net.acumenus.hummingbird.data.FlowWindowData
+import net.acumenus.hummingbird.data.FlowWindowRange
+import net.acumenus.hummingbird.data.flowIsoToEpochMs
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Widget-feed derivation: occupancy + next-4h ghost count from the window, and field-preserving merge. */
+class HouseGlanceSnapshotTest {
+
+    private val now = "2026-07-04T12:00:00+00:00"
+    private fun plus(hours: Long) = "2026-07-04T${(12 + hours).toString().padStart(2, '0')}:00:00+00:00"
+
+    private fun projection(t: String) = FlowProjection(
+        t = t, kind = "predicted_arrivals", confidence = "probable", label = "arrivals",
+        unitId = 1, bedId = null, room = null, value = null, bandLower = null, bandUpper = null,
+        endsAt = null, derived = false, patientContextRef = null, provenanceService = "svc", provenanceReliability = null,
+    )
+
+    private fun window(floors: List<FlowFloorRollup>, projections: List<FlowProjection>) = FlowWindowData(
+        window = FlowWindowRange(from = "2026-07-03T12:00:00+00:00", to = "2026-07-05T12:00:00+00:00", now = now),
+        lens = FlowLens("bed_manager", emptyList(), emptyList(), emptyList(), emptyList(), "full", emptyList(), 48),
+        scope = FlowScope("house", null, null, null, "House"),
+        spacesFloors = floors,
+        snapshots = emptyList(),
+        events = emptyList(),
+        projections = projections,
+        bedStatuses = emptyList(),
+    )
+
+    @Test
+    fun fromFlowComputesOccupancyAndNext4hGhostCount() {
+        val win = window(
+            floors = listOf(
+                FlowFloorRollup(1, "F1", staffed = 10, occupied = 8, occupancyPct = 80, units = emptyList()),
+                FlowFloorRollup(2, "F2", staffed = 10, occupied = 4, occupancyPct = 40, units = emptyList()),
+            ),
+            projections = listOf(
+                projection(plus(1)),   // within 4h
+                projection(plus(3)),   // within 4h
+                projection(plus(6)),   // beyond 4h
+                projection(now),       // exactly now — inclusive
+            ),
+        )
+
+        val snap = HouseGlanceSnapshot.fromFlow(win)
+
+        assertEquals(60, snap.occupancyPct) // (8+4)/(10+10) = 60%
+        assertEquals(3, snap.next4hGhostCount)
+    }
+
+    @Test
+    fun fromFlowLeavesOccupancyNullWithoutStaffedBeds() {
+        val snap = HouseGlanceSnapshot.fromFlow(window(emptyList(), emptyList()))
+        assertNull(snap.occupancyPct)
+        assertEquals(0, snap.next4hGhostCount)
+    }
+
+    @Test
+    fun mergePreservesKnownFieldsAcrossPartialWrites() {
+        val fromHome = HouseGlanceSnapshot(forYouCount = 5, netBedNeed = 3)
+        val base = HouseGlanceSnapshot.merge(null, fromHome, nowMs = 1000L)
+        // A later flow-only write updates occupancy + next-4h but must keep For You / bed need.
+        val fromFlow = HouseGlanceSnapshot(occupancyPct = 84, next4hGhostCount = 7)
+        val merged = HouseGlanceSnapshot.merge(base, fromFlow, nowMs = 2000L)
+
+        assertEquals(84, merged.occupancyPct)
+        assertEquals(7, merged.next4hGhostCount)
+        assertEquals(5, merged.forYouCount)
+        assertEquals(3, merged.netBedNeed)
+        assertEquals(2000L, merged.updatedAtMs)
+    }
+
+    @Test
+    fun jsonRoundTrips() {
+        val snap = HouseGlanceSnapshot(occupancyPct = 71, netBedNeed = -2, forYouCount = 9, next4hGhostCount = 4, updatedAtMs = 42L)
+        val back = HouseGlanceSnapshot.fromJson(snap.toJson())
+        assertEquals(snap, back)
+        assertTrue(flowIsoToEpochMs(now)!! > 0)
+    }
+}

--- a/hummingbird/iosApp/Hummingbird/Features/Capacity/CapacityDemandView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Capacity/CapacityDemandView.swift
@@ -49,43 +49,66 @@ struct CapacityDemandView: View {
     @EnvironmentObject var auth: AuthStore
     @StateObject private var vm = CapacityDemandViewModel(api: APIClient(baseURL: URL(string: AppConfig.baseURL)!))
     @State private var showProfile = false
+    @State private var viewMode: FlowHomeMode = .list
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: Z.s4) {
-                    AltitudeContextCard(domain: "ops")
-                    if let s = vm.strain { strainHeader(s) }
-                    if vm.approvals.isEmpty && vm.isLoading {
-                        SkeletonRows()
-                    } else if vm.approvals.isEmpty && vm.errorMessage != nil {
-                        RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load approvals",
-                                         message: vm.errorMessage ?? "", tone: .warning) { Task { await vm.load(bearer: auth.accessToken ?? "") } }
-                    } else if vm.approvals.isEmpty {
-                        RetryableMessage(symbol: "checkmark.circle", title: "Inbox clear",
-                                         message: "No operational actions awaiting your approval.", tone: .success)
-                    } else {
-                        sectionLabel("APPROVALS (\(vm.approvals.count))")
-                        ForEach(vm.approvals) { approvalRow($0) }
-                    }
+            Group {
+                if viewMode == .map {
+                    // The Flow Window — "strain over time" (P6): curve-first (occupancy vs
+                    // staffed with the forecast band), the house map one fold below.
+                    FlowMapView(persona: "capacity_lead", scope: .house)
+                } else {
+                    listBody
                 }
-                .padding(Z.s4)
             }
             .background(Z.bg)
             .navigationTitle("Capacity & Demand")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar { ToolbarItem(placement: .topBarTrailing) {
-                Button { showProfile = true } label: { Image(systemName: "person.crop.circle").foregroundStyle(Z.ink) }.accessibilityLabel("Profile and settings")
-            } }
-            .sheet(isPresented: $showProfile) { ProfileView() }
-            .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
-            .task {
-                let token = auth.accessToken ?? ""
-                while !Task.isCancelled { await vm.load(bearer: token); try? await Task.sleep(for: .seconds(20)) }
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Picker("View", selection: $viewMode) {
+                        Text("List").tag(FlowHomeMode.list)
+                        Text("Map").tag(FlowHomeMode.map)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 160)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button { showProfile = true } label: { Image(systemName: "person.crop.circle").foregroundStyle(Z.ink) }.accessibilityLabel("Profile and settings")
+                }
             }
+            .sheet(isPresented: $showProfile) { ProfileView() }
             .onChange(of: vm.needsReauth) { _, n in if n { Task { await auth.logout() } } }
         }
         .tint(Z.primary)
+    }
+
+    private var listBody: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Z.s4) {
+                AltitudeContextCard(domain: "ops")
+                if let s = vm.strain { strainHeader(s) }
+                if vm.approvals.isEmpty && vm.isLoading {
+                    SkeletonRows()
+                } else if vm.approvals.isEmpty && vm.errorMessage != nil {
+                    RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load approvals",
+                                     message: vm.errorMessage ?? "", tone: .warning) { Task { await vm.load(bearer: auth.accessToken ?? "") } }
+                } else if vm.approvals.isEmpty {
+                    RetryableMessage(symbol: "checkmark.circle", title: "Inbox clear",
+                                     message: "No operational actions awaiting your approval.", tone: .success)
+                } else {
+                    sectionLabel("APPROVALS (\(vm.approvals.count))")
+                    ForEach(vm.approvals) { approvalRow($0) }
+                }
+            }
+            .padding(Z.s4)
+        }
+        .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
+        .task {
+            let token = auth.accessToken ?? ""
+            while !Task.isCancelled { await vm.load(bearer: token); try? await Task.sleep(for: .seconds(20)) }
+        }
     }
 
     private func strainHeader(_ s: ExecStrain) -> some View {

--- a/hummingbird/iosApp/Hummingbird/Features/EVS/BedTurnsView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/EVS/BedTurnsView.swift
@@ -52,6 +52,7 @@ struct BedTurnsView: View {
     @EnvironmentObject var auth: AuthStore
     @StateObject private var vm: EvsTurnsViewModel
     @State private var showProfile = false
+    @State private var viewMode: FlowHomeMode = .list
 
     private let refreshInterval: Duration = .seconds(20)
 
@@ -61,26 +62,27 @@ struct BedTurnsView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: Z.s4) {
-                    AltitudeContextCard(domain: "evs")
-                    if vm.queue == nil && vm.isLoading {
-                        SkeletonRows()
-                    } else if vm.queue == nil && vm.errorMessage != nil {
-                        RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load turns",
-                                         message: vm.errorMessage ?? "", tone: .warning) {
-                            Task { await vm.load(bearer: auth.accessToken ?? "") }
-                        }
-                    } else if let q = vm.queue {
-                        content(q)
-                    }
+            Group {
+                if viewMode == .map {
+                    // The Flow Window — "the turn map": house heat first; tapping a floor
+                    // descends and lights bed states + turn markers at floor scope.
+                    FlowMapView(persona: "evs", scope: .house)
+                } else {
+                    listBody
                 }
-                .padding(Z.s4)
             }
             .background(Z.bg)
             .navigationTitle("Bed Turns")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Picker("View", selection: $viewMode) {
+                        Text("List").tag(FlowHomeMode.list)
+                        Text("Map").tag(FlowHomeMode.map)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 160)
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button { showProfile = true } label: {
                         Image(systemName: "person.crop.circle").foregroundStyle(Z.ink)
@@ -89,19 +91,38 @@ struct BedTurnsView: View {
                 }
             }
             .sheet(isPresented: $showProfile) { ProfileView() }
-            .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
-            .task {
-                let token = auth.accessToken ?? ""
-                while !Task.isCancelled {
-                    await vm.load(bearer: token)
-                    try? await Task.sleep(for: refreshInterval)
-                }
-            }
             .onChange(of: vm.needsReauth) { _, needs in
                 if needs { Task { await auth.logout() } }
             }
         }
         .tint(Z.primary)
+    }
+
+    private var listBody: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Z.s4) {
+                AltitudeContextCard(domain: "evs")
+                if vm.queue == nil && vm.isLoading {
+                    SkeletonRows()
+                } else if vm.queue == nil && vm.errorMessage != nil {
+                    RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load turns",
+                                     message: vm.errorMessage ?? "", tone: .warning) {
+                        Task { await vm.load(bearer: auth.accessToken ?? "") }
+                    }
+                } else if let q = vm.queue {
+                    content(q)
+                }
+            }
+            .padding(Z.s4)
+        }
+        .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
+        .task {
+            let token = auth.accessToken ?? ""
+            while !Task.isCancelled {
+                await vm.load(bearer: token)
+                try? await Task.sleep(for: refreshInterval)
+            }
+        }
     }
 
     @ViewBuilder

--- a/hummingbird/iosApp/Hummingbird/Features/EVS/TurnDetailView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/EVS/TurnDetailView.swift
@@ -190,6 +190,7 @@ struct TurnDetailView: View {
             title: turn.isolationRequired ? "Isolation bed-turn" : "Bed turn",
             detail: turn.locationLabel ?? "Bed",
             isStat: turn.priority == "stat",
-            statusRaw: newStatus, statusLabel: statusLabel(newStatus))
+            statusRaw: newStatus, statusLabel: statusLabel(newStatus),
+            slaDeadline: FlowTime.parse(turn.neededAt))
     }
 }

--- a/hummingbird/iosApp/Hummingbird/Features/Executive/ExecutiveHomeView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Executive/ExecutiveHomeView.swift
@@ -33,46 +33,70 @@ struct ExecutiveHomeView: View {
     @EnvironmentObject var auth: AuthStore
     @StateObject private var vm = ExecutiveHomeViewModel(api: APIClient(baseURL: URL(string: AppConfig.baseURL)!))
     @State private var showProfile = false
+    @State private var viewMode: FlowHomeMode = .list
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: Z.s4) {
-                    AltitudeContextCard(domain: "ops")
-                    EddyContextButton(scopeRef: "house")
-                    if vm.brief == nil && vm.isLoading {
-                        SkeletonRows()
-                    } else if vm.brief == nil, let e = vm.errorMessage {
-                        RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load the brief",
-                                         message: e, tone: .warning) { Task { await vm.load(bearer: auth.accessToken ?? "") } }
-                    } else if let b = vm.brief {
-                        strainCard(b.strain)
-                        if let one = b.strain.drivers.first(where: { $0.status != "success" }) {
-                            theOneThing(one)
-                        }
-                        sectionLabel("HOUSE KPIS")
-                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: Z.s3) {
-                            ForEach(b.hero) { kpiTile($0) }
-                        }
-                    }
+            Group {
+                if viewMode == .map {
+                    // The Flow Window — the executive time-lapse brief (P9): the house
+                    // breathes through the last 24h, then shows tomorrow's band. House
+                    // scope, aggregate heat only — the lens never serves patient detail.
+                    FlowMapView(persona: "executive", scope: .house)
+                } else {
+                    listBody
                 }
-                .padding(Z.s4)
             }
             .background(Z.bg)
             .navigationTitle("House Brief")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar { ToolbarItem(placement: .topBarTrailing) {
-                Button { showProfile = true } label: { Image(systemName: "person.crop.circle").foregroundStyle(Z.ink) }.accessibilityLabel("Profile and settings")
-            } }
-            .sheet(isPresented: $showProfile) { ProfileView() }
-            .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
-            .task {
-                let token = auth.accessToken ?? ""
-                while !Task.isCancelled { await vm.load(bearer: token); try? await Task.sleep(for: .seconds(30)) }
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Picker("View", selection: $viewMode) {
+                        Text("List").tag(FlowHomeMode.list)
+                        Text("Map").tag(FlowHomeMode.map)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 160)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button { showProfile = true } label: { Image(systemName: "person.crop.circle").foregroundStyle(Z.ink) }.accessibilityLabel("Profile and settings")
+                }
             }
+            .sheet(isPresented: $showProfile) { ProfileView() }
             .onChange(of: vm.needsReauth) { _, n in if n { Task { await auth.logout() } } }
         }
         .tint(Z.primary)
+    }
+
+    private var listBody: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Z.s4) {
+                AltitudeContextCard(domain: "ops")
+                EddyContextButton(scopeRef: "house")
+                if vm.brief == nil && vm.isLoading {
+                    SkeletonRows()
+                } else if vm.brief == nil, let e = vm.errorMessage {
+                    RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load the brief",
+                                     message: e, tone: .warning) { Task { await vm.load(bearer: auth.accessToken ?? "") } }
+                } else if let b = vm.brief {
+                    strainCard(b.strain)
+                    if let one = b.strain.drivers.first(where: { $0.status != "success" }) {
+                        theOneThing(one)
+                    }
+                    sectionLabel("HOUSE KPIS")
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: Z.s3) {
+                        ForEach(b.hero) { kpiTile($0) }
+                    }
+                }
+            }
+            .padding(Z.s4)
+        }
+        .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
+        .task {
+            let token = auth.accessToken ?? ""
+            while !Task.isCancelled { await vm.load(bearer: token); try? await Task.sleep(for: .seconds(30)) }
+        }
     }
 
     private func strainCard(_ s: ExecStrain) -> some View {

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/FloorPlateView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/FloorPlateView.swift
@@ -1,5 +1,28 @@
 import SwiftUI
 
+/// A same-floor transport route in plan feet, styled by the trip's state (P1 lens).
+struct FlowPlanRoute: Identifiable {
+    let id: String
+    let from: CGPoint
+    let to: CGPoint
+    let ghost: Bool
+    let opacity: Double
+    let warning: Bool
+}
+
+/// A turn marker on a bed plate (P2 lens): a solid tick for a past evs_status, a dashed
+/// ghost outline + due-time chip for an upcoming evs_due.
+struct FlowTurnMark: Identifiable {
+    let id: String
+    let bedId: Int
+    let ghost: Bool
+    let opacity: Double
+    let timeText: String?
+    let isolation: Bool
+    let warning: Bool
+    let selection: FlowSelection
+}
+
 /// One floor's 2.5D plate map (D4): unit/zone plates filled with a neutral occupancy heat
 /// (Z.primary at 0.10–0.45 opacity — occupancy is capacity information, never urgency, so
 /// no red/coral here), rooms/bays as subtle outlines, beds as small outline rects, and
@@ -11,6 +34,12 @@ struct FloorPlateView: View {
     /// Ghosts accumulated up to the scrub time (already filtered by the store).
     let ghosts: [FlowProjection]
     let selection: FlowSelection?
+    /// bed_id → current state (turn-map tint). Now-only data: callers fade it via
+    /// `bedStateOpacity` when the scrub time leaves now.
+    var bedStates: [Int: FlowBedStatus] = [:]
+    var bedStateOpacity: Double = 1
+    var turnMarks: [FlowTurnMark] = []
+    var routes: [FlowPlanRoute] = []
     let onSelect: (FlowSelection) -> Void
 
     var body: some View {
@@ -62,6 +91,9 @@ struct FloorPlateView: View {
             context.stroke(path, with: .color(Z.border), lineWidth: 1)
         }
 
+        drawBedStates(in: &context, transform: transform)
+        drawRoutes(in: &context, transform: transform)
+
         // Ghost overlays: dashed 1.5pt rounded-rect outlines on the bed's rect, opacity by
         // confidence, ink-colored — never a solid fill, never a status color.
         for (projection, plate) in ghostPlates() {
@@ -73,6 +105,8 @@ struct FloorPlateView: View {
                 style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
         }
 
+        drawTurnMarks(in: &context, transform: transform)
+
         // Gold selection ring (focus layer, not a status color).
         if let selectedRect = selectedRect(transform: transform) {
             let path = Path(roundedRect: selectedRect.insetBy(dx: -2, dy: -2), cornerRadius: 4)
@@ -82,6 +116,89 @@ struct FloorPlateView: View {
 
     private func plates(of categories: Set<String>) -> [FlowPlate] {
         floor.spaces.filter { categories.contains($0.category) }
+    }
+
+    /// Turn-map tints (now-only bed state): dirty = warning fill, blocked = muted outline,
+    /// occupied = neutral fill, available = faint success. Tap detail carries the status
+    /// word, so state is never color alone.
+    private func drawBedStates(in context: inout GraphicsContext, transform: PlateTransform) {
+        guard !bedStates.isEmpty, bedStateOpacity > 0 else { return }
+        for plate in plates(of: ["bed"]) {
+            guard let bedId = plate.bedId, let state = bedStates[bedId] else { continue }
+            let rect = ghostRect(transform.rect(plate.rect)).insetBy(dx: 2, dy: 2)
+            let path = Path(roundedRect: rect, cornerRadius: 2)
+            switch state.status {
+            case "dirty":
+                context.fill(path, with: .color(Z.status(.warning).opacity(0.30 * bedStateOpacity)))
+                context.stroke(path, with: .color(Z.status(.warning).opacity(0.6 * bedStateOpacity)), lineWidth: 1)
+            case "blocked":
+                context.stroke(path, with: .color(Z.inkMuted.opacity(0.7 * bedStateOpacity)), lineWidth: 1.5)
+            case "occupied":
+                context.fill(path, with: .color(Z.primary.opacity(0.20 * bedStateOpacity)))
+            case "available":
+                context.fill(path, with: .color(Z.status(.success).opacity(0.12 * bedStateOpacity)))
+            default:
+                break
+            }
+        }
+    }
+
+    /// Same-floor transport arcs: quadratic curves between plate centroids, solid for real
+    /// trips (warning tint for STAT), dashed at confidence opacity for ghosts.
+    private func drawRoutes(in context: inout GraphicsContext, transform: PlateTransform) {
+        for route in routes {
+            let start = transform.point(route.from)
+            let end = transform.point(route.to)
+            let color = route.warning ? Z.status(.warning) : (route.ghost ? Z.ink : Z.primary)
+            let shading = GraphicsContext.Shading.color(color.opacity(route.opacity))
+            var path = Path()
+            path.move(to: start)
+            path.addQuadCurve(to: end, control: CGPoint(x: (start.x + end.x) / 2,
+                                                        y: min(start.y, end.y) - 24))
+            context.stroke(path, with: shading, style: route.ghost
+                ? StrokeStyle(lineWidth: 1.5, dash: [4, 3])
+                : StrokeStyle(lineWidth: 1.5))
+            let dot = CGRect(x: end.x - 3, y: end.y - 3, width: 6, height: 6)
+            if route.ghost {
+                context.stroke(Path(ellipseIn: dot), with: shading, lineWidth: 1.5)
+            } else {
+                context.fill(Path(ellipseIn: dot), with: shading)
+            }
+        }
+    }
+
+    /// Turn markers: solid tick on the bed for past turn events; dashed outline + due-time
+    /// chip for upcoming turns; "ISO" chip when the turn is an isolation clean.
+    private func drawTurnMarks(in context: inout GraphicsContext, transform: PlateTransform) {
+        let beds = plates(of: ["bed"])
+        for mark in turnMarks {
+            guard let plate = beds.first(where: { $0.bedId == mark.bedId }) else { continue }
+            let rect = ghostRect(transform.rect(plate.rect))
+            let color = mark.warning || mark.isolation ? Z.status(.warning) : (mark.ghost ? Z.ink : Z.primary)
+            if mark.ghost {
+                context.stroke(Path(roundedRect: rect, cornerRadius: 3),
+                               with: .color(color.opacity(mark.opacity)),
+                               style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
+                if let timeText = mark.timeText {
+                    context.draw(
+                        Text(timeText)
+                            .font(.system(size: 9, weight: .medium)).monospacedDigit()
+                            .foregroundStyle(Z.inkMuted),
+                        at: CGPoint(x: rect.midX, y: rect.minY - 7), anchor: .center)
+                }
+            } else {
+                // Solid tick — a small filled notch on the bed's corner.
+                let tick = CGRect(x: rect.maxX - 5, y: rect.minY - 1, width: 6, height: 6)
+                context.fill(Path(ellipseIn: tick), with: .color(color.opacity(mark.opacity)))
+            }
+            if mark.isolation {
+                context.draw(
+                    Text("ISO")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundStyle(Z.status(.warning)),
+                    at: CGPoint(x: rect.minX - 2, y: rect.midY), anchor: .trailing)
+            }
+        }
     }
 
     /// Neutral occupancy heat: 0% → 0.10, 100% → 0.45.
@@ -125,12 +242,14 @@ struct FloorPlateView: View {
     // MARK: Hit testing
 
     /// Taps resolve to the nearest plate so the effective target is always ≥ 44pt even for
-    /// tiny bed rects. A ghost on the tapped bed wins over the bare plate.
+    /// tiny bed rects. A turn mark or ghost on the tapped bed wins over the bare plate.
     private func handleTap(at location: CGPoint, size: CGSize) {
         let transform = PlateTransform(bounds: floor.bounds, size: size)
         guard let plate = hitPlate(at: location, transform: transform) else { return }
-        if let bedId = plate.bedId,
-           let ghost = ghosts.first(where: { $0.bedId == bedId }) {
+        if let bedId = plate.bedId, let mark = turnMarks.first(where: { $0.bedId == bedId }) {
+            onSelect(mark.selection)
+        } else if let bedId = plate.bedId,
+                  let ghost = ghosts.first(where: { $0.bedId == bedId }) {
             onSelect(.projection(ghost))
         } else {
             onSelect(.plate(plate))
@@ -191,5 +310,10 @@ struct PlateTransform {
             y: (CGFloat(raw[1]) - origin.y) * scale + offset.y,
             width: CGFloat(raw[2]) * scale,
             height: CGFloat(raw[3]) * scale)
+    }
+
+    func point(_ plan: CGPoint) -> CGPoint {
+        CGPoint(x: (plan.x - origin.x) * scale + offset.x,
+                y: (plan.y - origin.y) * scale + offset.y)
     }
 }

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/Flow3DView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/Flow3DView.swift
@@ -1,0 +1,152 @@
+import SceneKit
+import simd
+import SwiftUI
+
+/// The native 3D twin (SceneKit) — the foundation of the NATIVE-4D-VIEWER
+/// (docs/hummingbird/NATIVE-4D-VIEWER-PLAN.md, Phase B). Renders the hospital as
+/// exploded floor plates of room/bed segments placed by their facility-space 3D
+/// centroids (the `/flow/spaces3d` asset), with free orbit / pinch / pan camera.
+///
+/// Phase B: geometry + camera + bed-state coloring, to parity with the web
+/// viewer's shell. Patient tokens, the duty markers, and Chronobar-driven time
+/// are layered on in Phase C. This replaces the 2.5D FloorPlate/HouseStack
+/// renderers (deleted in Phase D once every persona reaches 3D parity).
+struct Flow3DView: UIViewRepresentable {
+    let spaces: FlowSpaces3dDocument
+    var bedStatuses: [FlowBedStatus] = []
+    /// nil = whole-house exploded stack; set = descend to one floor.
+    var selectedFloor: Int?
+
+    func makeUIView(context: Context) -> SCNView {
+        let view = SCNView()
+        view.allowsCameraControl = true // free orbit / pinch / pan
+        view.autoenablesDefaultLighting = false
+        view.antialiasingMode = .multisampling4X
+        view.backgroundColor = UIColor(red: 0.07, green: 0.078, blue: 0.078, alpha: 1) // navigator bg
+        view.rendersContinuously = false
+        apply(to: view)
+        return view
+    }
+
+    func updateUIView(_ view: SCNView, context: Context) {
+        // Rebuild only when the inputs that shape geometry change (bed state / floor / dataset).
+        apply(to: view)
+    }
+
+    /// Build the scene AND point the view's camera at the framing camera we placed
+    /// (with allowsCameraControl on, SceneKit needs an explicit pointOfView or it
+    /// starts from a default that misses the geometry — the classic "black view").
+    private func apply(to view: SCNView) {
+        let scene = Self.buildScene(spaces: spaces, bedStatuses: bedStatuses, selectedFloor: selectedFloor)
+        view.scene = scene
+        view.pointOfView = scene.rootNode.childNode(withName: "flow-camera", recursively: true)
+    }
+
+    // MARK: - Scene
+
+    private static func buildScene(spaces: FlowSpaces3dDocument, bedStatuses: [FlowBedStatus], selectedFloor: Int?) -> SCNScene {
+        let scene = SCNScene()
+
+        let ambient = SCNNode()
+        ambient.light = SCNLight()
+        ambient.light!.type = .ambient
+        ambient.light!.intensity = 950
+        scene.rootNode.addChildNode(ambient)
+
+        let key = SCNNode()
+        key.light = SCNLight()
+        key.light!.type = .directional
+        key.light!.intensity = 900
+        key.eulerAngles = SCNVector3(-1.0, 0.4, 0)
+        scene.rootNode.addChildNode(key)
+
+        // Exploded-floor Y offset by floor rank (a true-3D take on the axonometric stack).
+        let floors = Array(Set(spaces.spaces.map(\.floor))).sorted()
+        var rank: [Int: Int] = [:]
+        for (index, floor) in floors.enumerated() { rank[floor] = index }
+        let gap: Float = 14
+
+        let visible = selectedFloor.map { f in spaces.spaces.filter { $0.floor == f } } ?? spaces.spaces
+
+        // Frame on the clinical core (beds/rooms) so campus/floor-slab outliers in the CAD
+        // catalog can't blow up the camera distance and push everything sub-pixel.
+        let coreCats: Set<String> = ["bed", "bay", "room", "procedure_room", "imaging"]
+        let core = visible.filter { coreCats.contains($0.category) }
+        let framing = core.isEmpty ? visible : core
+        let cx = framing.map { Float($0.centroidM.x) }.reduce(0, +) / Float(max(framing.count, 1))
+        let cz = framing.map { Float($0.centroidM.z) }.reduce(0, +) / Float(max(framing.count, 1))
+        let framingRefs = Set(framing.map(\.spaceRef))
+
+        let statusByBed = Dictionary(bedStatuses.map { ($0.bedId, $0.status) }, uniquingKeysWith: { a, _ in a })
+
+        var lo = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
+        var hi = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
+        for space in visible {
+            let p = SIMD3<Float>(Float(space.centroidM.x) - cx, Float(rank[space.floor] ?? 0) * gap, Float(space.centroidM.z) - cz)
+            let node = segmentNode(for: space, statusByBed: statusByBed)
+            node.position = SCNVector3(p.x, p.y, p.z)
+            scene.rootNode.addChildNode(node)
+            if framingRefs.contains(space.spaceRef) {
+                lo = simd_min(lo, p)
+                hi = simd_max(hi, p)
+            }
+        }
+
+        let center = (lo + hi) * 0.5
+        let extent = min(max(hi.x - lo.x, hi.y - lo.y, hi.z - lo.z, 60), 900)
+        scene.rootNode.addChildNode(cameraNode(center: center, extent: extent))
+        return scene
+    }
+
+    private static func cameraNode(center: SIMD3<Float>, extent: Float) -> SCNNode {
+        let camera = SCNCamera()
+        camera.fieldOfView = 55
+        camera.zNear = 1
+        camera.zFar = Double(extent) * 12 + 2000
+        let node = SCNNode()
+        node.camera = camera
+        node.position = SCNVector3(center.x + extent * 0.55, center.y + extent * 0.45, center.z + extent * 1.5)
+        node.look(at: SCNVector3(center.x, center.y, center.z))
+        node.name = "flow-camera"
+        return node
+    }
+
+    private static func segmentNode(for space: FlowSpace3d, statusByBed: [Int: String]) -> SCNNode {
+        let (w, h, d, color): (CGFloat, CGFloat, CGFloat, UIColor) = {
+            switch space.category {
+            case "bed", "bay":
+                return (4, 1.4, 4, bedColor(space.bedId.flatMap { statusByBed[$0] }))
+            case "room", "procedure_room", "imaging":
+                return (7, 1.0, 7, UIColor(white: 0.62, alpha: 0.92))
+            case "corridor", "vertical_transport":
+                return (5, 0.5, 5, UIColor(white: 0.34, alpha: 0.85))
+            case "floor", "zone":
+                return (3, 0.3, 3, UIColor(white: 0.22, alpha: 0.55))
+            default:
+                return (5, 0.9, 5, UIColor(white: 0.5, alpha: 0.88))
+            }
+        }()
+
+        let box = SCNBox(width: w, height: h, length: d, chamferRadius: 0.4)
+        let material = SCNMaterial()
+        material.diffuse.contents = color
+        material.emission.contents = color.withAlphaComponent(0.28)
+        box.materials = [material]
+
+        let node = SCNNode(geometry: box)
+        node.name = space.spaceRef // for raycast picking (Phase C inspector)
+        return node
+    }
+
+    /// Bed status → the navigator's status palette (never color alone once the
+    /// Phase C inspector labels it; here it is the at-a-glance heat).
+    private static func bedColor(_ status: String?) -> UIColor {
+        switch status {
+        case "occupied": return UIColor(red: 0.47, green: 0.75, blue: 0.44, alpha: 1) // teal-green
+        case "dirty": return UIColor(red: 0.88, green: 0.64, blue: 0.25, alpha: 1) // amber
+        case "blocked": return UIColor(red: 0.94, green: 0.40, blue: 0.33, alpha: 1) // coral
+        case "available": return UIColor(white: 0.86, alpha: 1)
+        default: return UIColor(white: 0.7, alpha: 0.9)
+        }
+    }
+}

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/FlowCurveView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/FlowCurveView.swift
@@ -1,0 +1,379 @@
+import SwiftUI
+
+/// The 48h census/occupancy curve (§8 P6/P9/P10), sharing the Chronobar's time domain
+/// [now−24h, now+24h]: a solid past line summed from the hourly per-unit snapshots, a
+/// dashed `predicted_census` line ahead with a soft band ribbon (band.lower/upper), a
+/// `now` tick, a scrub-time tick, a staffed-capacity reference line, and optional
+/// shift-boundary detents. Persona overlays: staffing-gap step markers (P10) and a
+/// surge-probability marker (P6/P9) — both tappable into the standard provenance detail.
+struct FlowCurveView: View {
+    @ObservedObject var store: FlowWindowStore
+    /// Client-side spatial filter: nil = whole scope (sum every unit); else sum these units
+    /// only. Snapshots and predicted_census are per-unit, so no re-fetch is needed.
+    var unitIds: Set<Int>? = nil
+    var showShiftDetents = true
+    /// `staffing_shift_gap` projections drawn as step markers at their `t` (P10).
+    var gapSteps: [FlowProjection] = []
+    /// `surge_probability` drawn as a marker at its `t` (P6/P9).
+    var surgeMarker: FlowProjection? = nil
+    /// The detent to emphasize (P10: the next shift boundary — "tonight's exposure").
+    var emphasizedDetent: Date? = nil
+    var onSelect: ((FlowSelection) -> Void)? = nil
+
+    private let chartHeight: CGFloat = 148
+    private let topPad: CGFloat = 14
+
+    var body: some View {
+        let past = pastPoints
+        let future = futurePoints
+        if past.count <= 1 && future.count <= 1 {
+            // No series either side — say so instead of drawing an empty instrument.
+            Text("No census series in this window yet.")
+                .font(.system(size: 12))
+                .foregroundStyle(Z.inkMuted)
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+        } else {
+            VStack(alignment: .leading, spacing: Z.s2) {
+                GeometryReader { geo in
+                    ZStack(alignment: .topLeading) {
+                        chartCanvas(past: past, future: future, size: geo.size)
+                        markerOverlay(size: geo.size)
+                    }
+                }
+                .frame(height: chartHeight)
+                legend(future: future)
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(accessibilityText(past: past, future: future))
+        }
+    }
+
+    // MARK: Series
+
+    private struct Point {
+        let t: Date
+        let v: Double
+    }
+
+    private struct BandPoint {
+        let t: Date
+        let v: Double
+        let lower: Double?
+        let upper: Double?
+    }
+
+    private func included(_ unitId: Int?) -> Bool {
+        guard let unitIds else { return true }
+        guard let unitId else { return false }
+        return unitIds.contains(unitId)
+    }
+
+    /// Past half: per-unit hourly checkpoints summed per timestamp; anchored at now with the
+    /// live rollup so the line always meets the present. Prefers per-unit rows; falls back to
+    /// scope-total rows (unit_id null) so both server shapes sum once, never twice.
+    private var pastPoints: [Point] {
+        let snapshots = store.window?.snapshots ?? []
+        let unitRows = snapshots.filter { $0.unitId != nil }
+        let source = unitRows.isEmpty ? snapshots : unitRows
+        var byTime: [Date: Double] = [:]
+        for snap in source {
+            guard let t = snap.time, t <= store.nowDate, included(snap.unitId) else { continue }
+            byTime[t, default: 0] += Double(snap.occupied ?? 0)
+        }
+        var points = byTime.map { Point(t: $0.key, v: $0.value) }.sorted { $0.t < $1.t }
+        if let live = liveOccupied { points.append(Point(t: store.nowDate, v: Double(live))) }
+        return points
+    }
+
+    /// Future half: predicted_census (2h steps) summed per timestamp, band summed the same
+    /// way; anchored at now on the live occupancy so the dashed line continues the solid one.
+    private var futurePoints: [BandPoint] {
+        let all = (store.window?.projections ?? []).filter { $0.kind == "predicted_census" }
+        let unitRows = all.filter { $0.unitId != nil }
+        let source = unitRows.isEmpty ? all : unitRows
+        struct Acc { var v = 0.0; var lower: Double?; var upper: Double? }
+        var byTime: [Date: Acc] = [:]
+        for projection in source {
+            guard let t = projection.time, t >= store.nowDate, included(projection.unitId) else { continue }
+            var acc = byTime[t] ?? Acc()
+            acc.v += projection.value ?? 0
+            if let lo = projection.band?.lower { acc.lower = (acc.lower ?? 0) + lo }
+            if let up = projection.band?.upper { acc.upper = (acc.upper ?? 0) + up }
+            byTime[t] = acc
+        }
+        var points = byTime
+            .map { BandPoint(t: $0.key, v: $0.value.v, lower: $0.value.lower, upper: $0.value.upper) }
+            .sorted { $0.t < $1.t }
+        if !points.isEmpty, let live = liveOccupied {
+            points.insert(BandPoint(t: store.nowDate, v: Double(live), lower: nil, upper: nil), at: 0)
+        }
+        return points
+    }
+
+    /// Units in the current filter, from the live spaces rollup.
+    private var filteredUnits: [FlowUnitRollup] {
+        (store.window?.spaces?.floors ?? [])
+            .flatMap(\.units)
+            .filter { included($0.unitId) }
+    }
+
+    private var liveOccupied: Int? {
+        let units = filteredUnits
+        guard !units.isEmpty else { return nil }
+        return units.reduce(0) { $0 + $1.occupied }
+    }
+
+    /// The staffed-capacity reference line (sum of staffed beds in the filter).
+    private var staffedCapacity: Int? {
+        let units = filteredUnits
+        guard !units.isEmpty else { return nil }
+        return units.reduce(0) { $0 + $1.staffed }
+    }
+
+    // MARK: Chart
+
+    private func chartCanvas(past: [Point], future: [BandPoint], size: CGSize) -> some View {
+        let staffed = staffedCapacity
+        let maxValue = max(
+            Double(staffed ?? 0),
+            past.map(\.v).max() ?? 0,
+            future.map { $0.upper ?? $0.v }.max() ?? 0,
+            1)
+
+        return Canvas { context, size in
+            let plotHeight = size.height - topPad
+            func x(_ date: Date) -> CGFloat { xPosition(for: date, width: size.width) }
+            func y(_ value: Double) -> CGFloat {
+                topPad + plotHeight * CGFloat(1 - min(max(value / (maxValue * 1.1), 0), 1))
+            }
+
+            // Shift detents behind everything.
+            if showShiftDetents {
+                for boundary in store.shiftBoundaries {
+                    let emphasized = emphasizedDetent.map { abs($0.timeIntervalSince(boundary)) < 60 } ?? false
+                    var line = Path()
+                    line.move(to: CGPoint(x: x(boundary), y: topPad))
+                    line.addLine(to: CGPoint(x: x(boundary), y: size.height))
+                    context.stroke(line, with: .color(Z.inkMuted.opacity(emphasized ? 0.7 : 0.25)),
+                                   lineWidth: emphasized ? 1.5 : 1)
+                    if emphasized {
+                        context.draw(
+                            Text(Self.hourText(boundary))
+                                .font(.system(size: 9, weight: .semibold)).monospacedDigit()
+                                .foregroundStyle(Z.inkMuted),
+                            at: CGPoint(x: x(boundary), y: 5), anchor: .center)
+                    }
+                }
+            }
+
+            // Forecast band — a soft ribbon, never a solid alarm fill.
+            let banded = future.filter { $0.lower != nil && $0.upper != nil }
+            if banded.count > 1 {
+                var ribbon = Path()
+                ribbon.move(to: CGPoint(x: x(banded[0].t), y: y(banded[0].upper ?? banded[0].v)))
+                for point in banded.dropFirst() {
+                    ribbon.addLine(to: CGPoint(x: x(point.t), y: y(point.upper ?? point.v)))
+                }
+                for point in banded.reversed() {
+                    ribbon.addLine(to: CGPoint(x: x(point.t), y: y(point.lower ?? point.v)))
+                }
+                ribbon.closeSubpath()
+                context.fill(ribbon, with: .color(Z.primary.opacity(0.12)))
+            }
+
+            // Staffed-capacity reference line.
+            if let staffed {
+                var capacity = Path()
+                capacity.move(to: CGPoint(x: 0, y: y(Double(staffed))))
+                capacity.addLine(to: CGPoint(x: size.width, y: y(Double(staffed))))
+                context.stroke(capacity, with: .color(Z.inkMuted.opacity(0.6)),
+                               style: StrokeStyle(lineWidth: 1, dash: [2, 3]))
+                context.draw(
+                    Text("staffed \(staffed)")
+                        .font(.system(size: 9, weight: .medium)).monospacedDigit()
+                        .foregroundStyle(Z.inkMuted),
+                    at: CGPoint(x: size.width - 4, y: y(Double(staffed)) - 7), anchor: .trailing)
+            }
+
+            // Past line — solid.
+            if past.count > 1 {
+                var line = Path()
+                line.move(to: CGPoint(x: x(past[0].t), y: y(past[0].v)))
+                for point in past.dropFirst() {
+                    line.addLine(to: CGPoint(x: x(point.t), y: y(point.v)))
+                }
+                context.stroke(line, with: .color(Z.primary), lineWidth: 2)
+            }
+
+            // Future line — dashed ghost.
+            if future.count > 1 {
+                var line = Path()
+                line.move(to: CGPoint(x: x(future[0].t), y: y(future[0].v)))
+                for point in future.dropFirst() {
+                    line.addLine(to: CGPoint(x: x(point.t), y: y(point.v)))
+                }
+                context.stroke(line, with: .color(Z.primary.opacity(0.7)),
+                               style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
+            }
+
+            // `now` tick and the scrub-time tick (matches the Chronobar/lanes indicators).
+            var nowTick = Path()
+            nowTick.move(to: CGPoint(x: x(store.nowDate), y: topPad))
+            nowTick.addLine(to: CGPoint(x: x(store.nowDate), y: size.height))
+            context.stroke(nowTick, with: .color(Z.ink.opacity(0.8)), lineWidth: 1.5)
+
+            var scrubTick = Path()
+            scrubTick.move(to: CGPoint(x: x(store.t), y: topPad))
+            scrubTick.addLine(to: CGPoint(x: x(store.t), y: size.height))
+            context.stroke(scrubTick, with: .color(Z.inkMuted.opacity(0.6)), lineWidth: 1)
+        }
+    }
+
+    // MARK: Markers (44pt tap targets, SwiftUI-overlaid on the canvas)
+
+    @ViewBuilder
+    private func markerOverlay(size: CGSize) -> some View {
+        // Gap steps grouped per timestamp: the marker shows the summed exposure at that
+        // boundary; tapping selects the worst single projection (its provenance chip).
+        ForEach(groupedGapSteps, id: \.t) { group in
+            gapMarker(group, size: size)
+        }
+        if let surge = surgeMarker, let t = surge.time {
+            surgeMarkerView(surge, at: t, size: size)
+        }
+    }
+
+    private struct GapGroup {
+        let t: Date
+        let total: Int
+        let worst: FlowProjection
+    }
+
+    private var groupedGapSteps: [GapGroup] {
+        let dated = gapSteps.compactMap { projection -> (Date, FlowProjection)? in
+            guard let t = projection.time else { return nil }
+            return (t, projection)
+        }
+        return Dictionary(grouping: dated, by: \.0).compactMap { t, rows -> GapGroup? in
+            let projections = rows.map(\.1)
+            let total = projections.reduce(0) { $0 + ($1.gapHeadcount ?? 0) }
+            guard let worst = projections.max(by: { ($0.gapHeadcount ?? 0) < ($1.gapHeadcount ?? 0) }) else { return nil }
+            return GapGroup(t: t, total: total, worst: worst)
+        }
+        .sorted { $0.t < $1.t }
+    }
+
+    private func gapMarker(_ group: GapGroup, size: CGSize) -> some View {
+        // Positive gap = uncovered headcount → amber (a real staffing exposure, not coral).
+        let short = group.total > 0
+        let tint = short ? Z.status(.warning) : Z.inkMuted
+        return Button {
+            onSelect?(.projection(group.worst))
+        } label: {
+            VStack(spacing: 2) {
+                Text(short ? "short \(group.total)" : "covered")
+                    .font(.system(size: 9, weight: .semibold)).monospacedDigit()
+                    .foregroundStyle(tint)
+                Rectangle()
+                    .fill(tint)
+                    .frame(width: 2, height: 10)
+            }
+            .frame(width: 44, height: 44, alignment: .bottom)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .position(x: xPosition(for: group.t, width: size.width), y: size.height - 22)
+        .accessibilityLabel("\(group.worst.label ?? "Staffing gap"), short \(group.total) at \(Self.hourText(group.t))")
+    }
+
+    private func surgeMarkerView(_ surge: FlowProjection, at t: Date, size: CGSize) -> some View {
+        Button {
+            onSelect?(.projection(surge))
+        } label: {
+            HStack(spacing: 3) {
+                Image(systemName: "waveform.path.ecg")
+                    .font(.system(size: 9, weight: .semibold))
+                Text("surge \(Int(surge.value ?? 0))%")
+                    .font(.system(size: 9, weight: .semibold)).monospacedDigit()
+            }
+            .foregroundStyle(Z.inkMuted)
+            .padding(.horizontal, Z.s2)
+            .padding(.vertical, 3)
+            .background(Capsule().fill(Z.bg))
+            .overlay(Capsule().strokeBorder(
+                Z.inkMuted.opacity(surge.confidenceLevel.ghostOpacity),
+                style: StrokeStyle(lineWidth: 1, dash: [3, 2])))
+            .frame(minWidth: 44, minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .position(x: min(max(xPosition(for: t, width: size.width), 40), size.width - 40), y: topPad + 8)
+        .accessibilityLabel("\(surge.label ?? "Surge probability"), \(Int(surge.value ?? 0)) percent, \(surge.confidence)")
+    }
+
+    // MARK: Legend
+
+    private func legend(future: [BandPoint]) -> some View {
+        HStack(spacing: Z.s3) {
+            HStack(spacing: 4) {
+                Rectangle().fill(Z.primary).frame(width: 12, height: 2)
+                Text("Last 24 hours").font(.system(size: 10)).foregroundStyle(Z.inkMuted)
+            }
+            if future.count > 1 {
+                HStack(spacing: 4) {
+                    Line(dash: [3, 2]).stroke(Z.primary.opacity(0.7), style: StrokeStyle(lineWidth: 1.5, dash: [3, 2]))
+                        .frame(width: 12, height: 2)
+                    Text("Next 24 hours").font(.system(size: 10)).foregroundStyle(Z.inkMuted)
+                }
+                if let source = forecastSource {
+                    Spacer()
+                    Text("Source: \(source)")
+                        .font(.system(size: 9, weight: .medium)).monospacedDigit()
+                        .foregroundStyle(Z.inkMuted)
+                        .lineLimit(1)
+                }
+            }
+        }
+    }
+
+    /// The forecast half's provenance (defensible-by-default: the ribbon cites its service).
+    private var forecastSource: String? {
+        (store.window?.projections ?? [])
+            .first { $0.kind == "predicted_census" }?
+            .provenance?.service
+    }
+
+    // MARK: Geometry & copy
+
+    private func xPosition(for date: Date, width: CGFloat) -> CGFloat {
+        let span = max(store.toDate.timeIntervalSince(store.fromDate), 1)
+        let fraction = min(max(date.timeIntervalSince(store.fromDate) / span, 0), 1)
+        return CGFloat(fraction) * width
+    }
+
+    private static func hourText(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        return f.string(from: date)
+    }
+
+    private func accessibilityText(past: [Point], future: [BandPoint]) -> String {
+        var parts: [String] = ["48 hour occupancy curve"]
+        if let now = liveOccupied { parts.append("now \(now) occupied") }
+        if let staffed = staffedCapacity { parts.append("\(staffed) staffed") }
+        if let peak = future.map(\.v).max() { parts.append("projected up to \(Int(peak))") }
+        return parts.joined(separator: ", ")
+    }
+}
+
+/// A short horizontal line segment for legends.
+private struct Line: Shape {
+    var dash: [CGFloat] = []
+
+    func path(in rect: CGRect) -> Path {
+        var p = Path()
+        p.move(to: CGPoint(x: rect.minX, y: rect.midY))
+        p.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+        return p
+    }
+}

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/FlowLensPanels.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/FlowLensPanels.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// The executive forward half (P9): next-24h posture as two defensible numbers — predicted
+/// ED arrivals (the hourly forecast summed) and surge probability — each citing its source.
+/// Tapping surge opens the standard projection detail (provenance chip included).
+struct FlowForecastStrip: View {
+    let arrivalsTotal: Int?
+    let arrivalsSource: String?
+    let surge: FlowProjection?
+    var onSelect: ((FlowSelection) -> Void)? = nil
+
+    var body: some View {
+        Panel(padding: Z.s3) {
+            HStack(spacing: 0) {
+                cell(value: arrivalsTotal.map { "\($0)" } ?? "—",
+                     label: "ED arrivals · next 24h",
+                     source: arrivalsSource)
+                Rectangle().fill(Z.border).frame(width: 1, height: 44)
+                surgeCell
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var surgeCell: some View {
+        if let surge {
+            Button {
+                onSelect?(.projection(surge))
+            } label: {
+                cell(value: "\(Int(surge.value ?? 0))%",
+                     label: "Surge probability",
+                     source: surge.provenance?.service)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Surge probability \(Int(surge.value ?? 0)) percent, \(surge.confidence). Shows source detail.")
+        } else {
+            cell(value: "—", label: "Surge probability", source: nil)
+        }
+    }
+
+    private func cell(value: String, label: String, source: String?) -> some View {
+        VStack(spacing: 2) {
+            Text(value)
+                .font(.system(size: 22, weight: .semibold)).monospacedDigit()
+                .foregroundStyle(Z.ink)
+            Text(label)
+                .font(.system(size: 11))
+                .foregroundStyle(Z.inkMuted)
+            if let source {
+                Text("Source: \(source)")
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(Z.inkMuted)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+/// The active curve filter (P6): which slice of the house the curve is summing, with a
+/// 44pt clear affordance back to the wider scope.
+struct FlowFilterChip: View {
+    let label: String
+    let onClear: () -> Void
+
+    var body: some View {
+        Button(action: onClear) {
+            HStack(spacing: Z.s1) {
+                Text(label)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Z.ink)
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Z.inkMuted)
+            }
+            .padding(.horizontal, Z.s3)
+            .frame(minHeight: 32)
+            .background(Capsule().fill(Z.surface))
+            .overlay(Capsule().strokeBorder(Z.border, lineWidth: 1))
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Curve filtered to \(label). Clear filter.")
+    }
+}

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/FlowMapView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/FlowMapView.swift
@@ -11,18 +11,33 @@ enum FlowHomeMode: String, CaseIterable {
 /// FloorPlate once descended / for unit scope), the Chronobar, the persona's timeline lanes,
 /// and the selection/provenance detail strip.
 ///
-/// Start-of-shift moment (charge nurse): on first appearance the scrubber rewinds to the
-/// last shift boundary (07:00/19:00) and auto-replays the unit's story up to now —
-/// DESIGN-ELEVATION Wave 3 rendered spatially. Skipped under Reduce Motion.
+/// Entry replays (skipped under Reduce Motion, re-runnable either way):
+/// - Charge nurse: the scrubber rewinds to the last shift boundary (07:00/19:00) and
+///   auto-replays the unit's story up to now (DESIGN-ELEVATION Wave 3, spatially).
+/// - Executive (P9): a ~15s time-lapse of the last 24 hours — the floor heat re-renders
+///   from snapshots as the Chronobar scrubs itself — then settles at now and reveals the
+///   forward half (curve + forecast strip).
+/// - PI lead (P8): playback runs at ~4h/s process-replay pace; "Clip window" shares the
+///   replayed range as text + the web deep link (v1 clip-to-share; no PDSA write yet).
 struct FlowMapView: View {
     @EnvironmentObject var auth: AuthStore
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
     @StateObject private var store: FlowWindowStore
 
     let persona: String
     let scope: FlowScopeRequest
 
     @State private var didStartShiftReplay = false
+    @State private var showFloorPlate = false
+    /// Executive: whether the forward half (curve + forecast strip) is revealed — false
+    /// while the entry time-lapse is still walking the past 24h.
+    @State private var revealForecast = false
+    /// Capacity lead: the unit the curve is filtered to (client-side; snapshots and
+    /// predicted_census are per-unit). Nil falls back to the descended floor, then house.
+    @State private var curveUnitId: Int?
+    /// Capacity lead: the map is the secondary surface — collapsed by default.
+    @State private var showHouseMap = false
 
     init(persona: String, scope: FlowScopeRequest) {
         self.persona = persona
@@ -38,13 +53,20 @@ struct FlowMapView: View {
                 } else if store.window == nil, let message = store.errorMessage {
                     RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load the flow window",
                                      message: message, tone: .warning) {
-                        Task { await store.load(bearer: auth.accessToken ?? "", persona: persona, scope: scope) }
+                        Task { await store.load(bearer: auth.accessToken ?? "", userId: auth.me?.id, persona: persona, scope: scope) }
                     }
                 } else if store.window != nil {
                     header
+                    if let stale = store.staleAsOf { stalenessCaption(stale) }
                     mapLayer
+                    if isExecutiveLens { executiveReplayRow }
                     ChronobarView(store: store)
-                    TimelineLanes(store: store) { store.selection = $0 }
+                    if isPILens { piControls }
+                    if !isExecutiveLens {
+                        TimelineLanes(store: store) { store.selection = $0 }
+                    }
+                    if isExecutiveLens { executiveForwardSection }
+                    if isClinicianLens { DischargeLeverageLane(store: store) }
                     detailStrip
                 }
             }
@@ -55,8 +77,8 @@ struct FlowMapView: View {
             let token = auth.accessToken ?? ""
             store.startLive(bearer: token)
             defer { store.stopLive() }
-            await store.load(bearer: token, persona: persona, scope: scope)
-            runStartOfShiftReplayIfNeeded()
+            await store.load(bearer: token, userId: auth.me?.id, persona: persona, scope: scope)
+            runEntryReplayIfNeeded()
             // Park until cancelled so the websocket stays open while the map is visible;
             // `hospital.beds` events re-snapshot the window (no 15s poll needed here).
             while !Task.isCancelled {
@@ -65,6 +87,20 @@ struct FlowMapView: View {
         }
         .onChange(of: store.needsReauth) { _, needs in
             if needs { Task { await auth.logout() } }
+        }
+        .onChange(of: scenePhase) { _, phase in
+            // Foreground return delta-refreshes the head (keeps the user's scrub position).
+            if phase == .active {
+                Task { await store.refreshForeground(bearer: auth.accessToken ?? "") }
+            }
+        }
+        .onChange(of: store.isPlaying) { _, playing in
+            // Executive: the time-lapse settling (for any reason) reveals the forward half.
+            if isExecutiveLens, !playing, didStartShiftReplay {
+                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.35)) {
+                    revealForecast = true
+                }
+            }
         }
     }
 
@@ -96,21 +132,375 @@ struct FlowMapView: View {
         Role.by(id: persona)?.title ?? persona.replacingOccurrences(of: "_", with: " ").capitalized
     }
 
+    /// Shown when the surface is presenting the offline cache after a failed load. The past
+    /// half still scrubs; this dates what you're looking at.
+    private func stalenessCaption(_ asOf: Date) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "wifi.slash")
+                .font(.system(size: 11, weight: .semibold))
+            Text("Showing data from \(asOf.formatted(date: .omitted, time: .shortened))")
+                .font(.system(size: 12, weight: .medium))
+                .monospacedDigit()
+        }
+        .foregroundStyle(Z.status(.warning))
+        .padding(.horizontal, Z.s3)
+        .padding(.vertical, Z.s2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Z.status(.warning).opacity(0.12)))
+    }
+
+    // MARK: Persona lenses
+
+    private var isTransportLens: Bool { persona == "transport" }
+    private var isEVSLens: Bool { persona == "evs" }
+    private var isORLens: Bool { persona == "or_nurse" || persona == "periop_manager" }
+    private var isExecutiveLens: Bool { persona == "executive" }
+    private var isCapacityLens: Bool { persona == "capacity_lead" }
+    private var isStaffingLens: Bool { persona == "staffing_coordinator" }
+    private var isPILens: Bool { persona == "pi_lead" }
+    private var isClinicianLens: Bool { persona == "hospitalist" || persona == "intensivist" }
+    /// Lenses whose floor heat time-travels with the scrubber (replay is the point).
+    private var isReplayHeatLens: Bool { isExecutiveLens || isPILens }
+
     // MARK: Spatial layer
 
     @ViewBuilder
     private var mapLayer: some View {
-        let isHouse = (scope == .house)
-        if isHouse, store.selectedFloor == nil {
-            Panel(padding: Z.s3) {
-                HouseStackView(rollups: store.window?.spaces?.floors ?? [],
-                               floorsDocument: store.floors) { floor in
-                    store.selectedFloor = floor
-                    store.selection = nil
+        if isORLens {
+            orLayer
+        } else if isCapacityLens {
+            capacityLayer
+        } else if isStaffingLens {
+            staffingLayer
+        } else if scope == .house, store.selectedFloor == nil {
+            houseLayer
+            transportGutter
+        } else {
+            floorPanel(floorNumber: store.selectedFloor ?? scopedFloorNumber)
+            transportGutter
+        }
+    }
+
+    /// Floor rollups for the spatial layer: replay lenses re-read occupancy from the
+    /// snapshot series at the scrub time; everyone else sees the live rollup.
+    private var displayFloorRollups: [FlowFloorRollup] {
+        isReplayHeatLens ? store.floorRollups(at: store.t) : (store.window?.spaces?.floors ?? [])
+    }
+
+    private var houseLayer: some View {
+        Panel(padding: Z.s3) {
+            HouseStackView(rollups: displayFloorRollups,
+                           floorsDocument: store.floors,
+                           gapByFloor: isStaffingLens ? worstGapByFloor : [:]) { floor in
+                if isCapacityLens { curveUnitId = nil } // floor descent re-frames the curve
+                store.descend(to: floor)
+            }
+            .overlayPreferenceValue(FloorSlabAnchorKey.self) { anchors in
+                if isTransportLens {
+                    TransportHouseArcs(trips: resolvedTrips, anchors: anchors,
+                                       boundsByFloor: boundsByFloor)
                 }
             }
-        } else {
-            floorPanel(floorNumber: store.selectedFloor ?? unitFloorNumber)
+        }
+    }
+
+    // MARK: Executive lens (P9) — time-lapse + forward half
+
+    /// "Last 24 hours" caption + the replay affordance (always present: Reduce Motion users
+    /// get the same story on demand instead of on entry).
+    private var executiveReplayRow: some View {
+        HStack(spacing: Z.s2) {
+            sectionCaption("LAST 24 HOURS")
+            Spacer()
+            Button {
+                revealForecast = false
+                store.play(from: store.fromDate)
+            } label: {
+                Label("Replay", systemImage: "arrow.counterclockwise")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Z.primary)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Replay the last 24 hours")
+        }
+    }
+
+    @ViewBuilder
+    private var executiveForwardSection: some View {
+        if revealForecast {
+            VStack(alignment: .leading, spacing: Z.s3) {
+                sectionCaption("NEXT 24 HOURS")
+                Panel(padding: Z.s3) {
+                    FlowCurveView(store: store, surgeMarker: surgeProjection) { store.selection = $0 }
+                }
+                FlowForecastStrip(arrivalsTotal: predictedArrivalsTotal,
+                                  arrivalsSource: predictedArrivalsSource,
+                                  surge: surgeProjection) { store.selection = $0 }
+            }
+            .transition(.opacity)
+        }
+    }
+
+    private var surgeProjection: FlowProjection? {
+        store.window?.projections.first { $0.kind == "surge_probability" }
+    }
+
+    /// Predicted ED arrivals summed across the next-24h hourly buckets.
+    private var predictedArrivalsTotal: Int? {
+        let arrivals = (store.window?.projections ?? []).filter { $0.kind == "predicted_arrivals" }
+        guard !arrivals.isEmpty else { return nil }
+        return Int(arrivals.reduce(0.0) { $0 + ($1.value ?? 0) })
+    }
+
+    private var predictedArrivalsSource: String? {
+        (store.window?.projections ?? [])
+            .first { $0.kind == "predicted_arrivals" }?
+            .provenance?.service
+    }
+
+    // MARK: Capacity lead lens (P6) — curve first, map second
+
+    private var capacityLayer: some View {
+        VStack(alignment: .leading, spacing: Z.s3) {
+            Panel(padding: Z.s3) {
+                VStack(alignment: .leading, spacing: Z.s2) {
+                    HStack(spacing: Z.s2) {
+                        sectionCaption("OCCUPANCY VS STAFFED")
+                        Spacer()
+                        if let label = curveFilterLabel {
+                            FlowFilterChip(label: label) {
+                                curveUnitId = nil
+                                store.descend(to: nil)
+                            }
+                        }
+                    }
+                    FlowCurveView(store: store,
+                                  unitIds: capacityCurveUnitIds,
+                                  surgeMarker: surgeProjection) { store.selection = $0 }
+                }
+            }
+            DisclosureGroup(isExpanded: $showHouseMap) {
+                VStack(alignment: .leading, spacing: Z.s2) {
+                    if store.selectedFloor == nil {
+                        houseLayer
+                    } else {
+                        floorPanel(floorNumber: store.selectedFloor)
+                    }
+                    Text("Tap a floor, then a unit, to focus the curve.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Z.inkMuted)
+                }
+                .padding(.top, Z.s2)
+            } label: {
+                Text("House map")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Z.ink)
+                    .frame(minHeight: 44, alignment: .leading)
+            }
+            .tint(Z.inkMuted)
+        }
+    }
+
+    /// The curve's unit filter: an explicitly tapped unit wins; otherwise the descended
+    /// floor's units; otherwise the whole house. Client-side only — snapshots and
+    /// predicted_census already arrive per-unit at house scope.
+    private var capacityCurveUnitIds: Set<Int>? {
+        if let unitId = curveUnitId { return [unitId] }
+        if let floor = store.selectedFloor,
+           let rollup = store.window?.spaces?.floors.first(where: { $0.floor == floor }) {
+            return Set(rollup.units.map(\.unitId))
+        }
+        return nil
+    }
+
+    private var curveFilterLabel: String? {
+        if let unitId = curveUnitId {
+            return unitRollups[unitId]?.abbr ?? unitRollups[unitId]?.name ?? "Unit \(unitId)"
+        }
+        if let floor = store.selectedFloor {
+            return store.window?.spaces?.floors.first { $0.floor == floor }?.label ?? "Floor \(floor)"
+        }
+        return nil
+    }
+
+    // MARK: Staffing lens (P10) — coverage vs the curve
+
+    private var staffingLayer: some View {
+        VStack(alignment: .leading, spacing: Z.s3) {
+            Panel(padding: Z.s3) {
+                VStack(alignment: .leading, spacing: Z.s2) {
+                    sectionCaption("COVERAGE VS CENSUS")
+                    FlowCurveView(store: store,
+                                  gapSteps: staffingGapSteps,
+                                  emphasizedDetent: nextShiftBoundary) { store.selection = $0 }
+                }
+            }
+            if scope == .house, store.selectedFloor == nil {
+                houseLayer
+            } else {
+                floorPanel(floorNumber: store.selectedFloor ?? scopedFloorNumber)
+            }
+        }
+    }
+
+    private var staffingGapSteps: [FlowProjection] {
+        (store.window?.projections ?? []).filter { $0.kind == "staffing_shift_gap" }
+    }
+
+    /// The next shift boundary after now — P10's signature detent ("tonight's exposure").
+    private var nextShiftBoundary: Date? {
+        store.shiftBoundaries.first { $0 > store.nowDate }
+    }
+
+    /// Floor → worst staffing-gap headcount, joining staffing_shift_gap.unit_id to its
+    /// manifest floor through the spaces rollup.
+    private var worstGapByFloor: [Int: Int] {
+        var floorByUnit: [Int: Int] = [:]
+        for floor in store.window?.spaces?.floors ?? [] {
+            for unit in floor.units { floorByUnit[unit.unitId] = floor.floor }
+        }
+        var worst: [Int: Int] = [:]
+        for projection in staffingGapSteps {
+            guard let unitId = projection.unitId, let floor = floorByUnit[unitId],
+                  let gap = projection.gapHeadcount, gap > 0 else { continue }
+            worst[floor] = max(worst[floor] ?? 0, gap)
+        }
+        return worst
+    }
+
+    // MARK: PI lens (P8) — process replay + clip-to-share
+
+    private var piControls: some View {
+        HStack(spacing: Z.s2) {
+            Button {
+                store.play(from: store.fromDate)
+            } label: {
+                Label("Replay 24h", systemImage: "arrow.counterclockwise")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Z.primary)
+                    .padding(.horizontal, Z.s3)
+                    .frame(minHeight: 44)
+                    .background(Capsule().strokeBorder(Z.border, lineWidth: 1))
+                    .contentShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Replay the last 24 hours at process pace")
+            Spacer()
+            ShareLink(item: clipText) {
+                Label("Clip window", systemImage: "scissors")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Z.primary)
+                    .padding(.horizontal, Z.s3)
+                    .frame(minHeight: 44)
+                    .background(Capsule().strokeBorder(Z.border, lineWidth: 1))
+                    .contentShape(Capsule())
+            }
+            .accessibilityLabel("Clip the replayed window to share")
+        }
+    }
+
+    /// The clip range: the replay head defines the end — a head parked at/near now clips
+    /// the whole past half. Always within the past (the future is projection, not evidence).
+    private var clipRange: (from: Date, to: Date) {
+        let end = min(store.t, store.nowDate)
+        if end <= store.fromDate.addingTimeInterval(300) || end >= store.nowDate.addingTimeInterval(-60) {
+            return (store.fromDate, store.nowDate)
+        }
+        return (store.fromDate, end)
+    }
+
+    /// v1 clip-to-share (the PDSA attach endpoint doesn't exist yet): a plain-text summary
+    /// — scope, range, occupancy delta from snapshots, event counts by kind — plus the web
+    /// 4D-Navigator deep link with the clipped range appended.
+    private var clipText: String {
+        let range = clipRange
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d HH:mm"
+        var lines = [
+            "Flow window clip · \(store.window?.scope.label ?? "House")",
+            "\(formatter.string(from: range.from)) – \(formatter.string(from: range.to))",
+        ]
+        if let delta = occupancyDelta(range) {
+            let sign = delta.change >= 0 ? "+" : ""
+            lines.append("Occupancy \(delta.start) → \(delta.end) (\(sign)\(delta.change))")
+        }
+        let counts = eventCountsText(range)
+        if !counts.isEmpty { lines.append("Events: \(counts)") }
+        if let url = clipURL(range) { lines.append(url.absoluteString) }
+        return lines.joined(separator: "\n")
+    }
+
+    /// House occupancy at the clip edges from the snapshot series (nearest checkpoint ≤ t).
+    private func occupancyDelta(_ range: (from: Date, to: Date)) -> (start: Int, end: Int, change: Int)? {
+        let unitIds = (store.window?.spaces?.floors ?? []).flatMap { $0.units.map(\.unitId) }
+        guard !unitIds.isEmpty, !(store.window?.snapshots.isEmpty ?? true) else { return nil }
+        func occupancy(at t: Date) -> Int? {
+            let values = unitIds.compactMap { store.censusAt(t, unitId: $0)?.occupied }
+            return values.isEmpty ? nil : values.reduce(0, +)
+        }
+        guard let start = occupancy(at: range.from), let end = occupancy(at: range.to) else { return nil }
+        return (start, end, end - start)
+    }
+
+    private func eventCountsText(_ range: (from: Date, to: Date)) -> String {
+        let events = (store.window?.events ?? []).filter {
+            guard let t = $0.time else { return false }
+            return t >= range.from && t <= range.to
+        }
+        guard !events.isEmpty else { return "" }
+        var countsByKind: [String: Int] = [:]
+        for event in events { countsByKind[event.kind, default: 0] += 1 }
+        let ordered = countsByKind.sorted { lhs, rhs in
+            lhs.value == rhs.value ? lhs.key < rhs.key : lhs.value > rhs.value
+        }
+        let parts: [String] = ordered.map { entry in
+            let kind = entry.key.replacingOccurrences(of: "_", with: " ")
+            return "\(kind) ×\(entry.value)"
+        }
+        return parts.joined(separator: ", ")
+    }
+
+    /// links.web with the clipped range appended (`?from=&to=`), for the A3 handoff.
+    private func clipURL(_ range: (from: Date, to: Date)) -> URL? {
+        guard let link = store.webLink, var components = URLComponents(string: link) else { return nil }
+        var items = components.queryItems ?? []
+        items.append(URLQueryItem(name: "from", value: FlowTime.formatter.string(from: range.from)))
+        items.append(URLQueryItem(name: "to", value: FlowTime.formatter.string(from: range.to)))
+        components.queryItems = items
+        return components.url
+    }
+
+    private func sectionCaption(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11, weight: .semibold)).tracking(0.5)
+            .foregroundStyle(Z.inkMuted)
+    }
+
+    /// The OR lens leads with the room lanes; the floor plate stays one fold away.
+    private var orLayer: some View {
+        VStack(alignment: .leading, spacing: Z.s3) {
+            Panel(padding: Z.s3) {
+                RoomLanesView(store: store, persona: persona) { store.selection = $0 }
+            }
+            DisclosureGroup(isExpanded: $showFloorPlate) {
+                floorPanel(floorNumber: store.selectedFloor ?? scopedFloorNumber)
+                    .padding(.top, Z.s2)
+            } label: {
+                Text("Floor plate")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Z.ink)
+                    .frame(minHeight: 44, alignment: .leading)
+            }
+            .tint(Z.inkMuted)
+        }
+    }
+
+    @ViewBuilder
+    private var transportGutter: some View {
+        if isTransportLens {
+            OffMapGutter(trips: resolvedTrips) { store.selection = $0 }
         }
     }
 
@@ -119,8 +509,8 @@ struct FlowMapView: View {
         VStack(alignment: .leading, spacing: Z.s2) {
             if scope == .house {
                 Button {
-                    store.selectedFloor = nil
-                    store.selection = nil
+                    if isCapacityLens { curveUnitId = nil }
+                    store.descend(to: nil)
                 } label: {
                     Label("House", systemImage: "chevron.left")
                         .font(.system(size: 13, weight: .medium))
@@ -133,9 +523,25 @@ struct FlowMapView: View {
                 Panel(padding: Z.s2) {
                     FloorPlateView(floor: floor,
                                    unitRollups: unitRollups,
-                                   ghosts: store.ghostsUpTo(store.t),
-                                   selection: store.selection) { store.selection = $0 }
+                                   ghosts: plateGhosts,
+                                   selection: store.selection,
+                                   bedStates: isEVSLens ? store.bedStatesById : [:],
+                                   bedStateOpacity: bedStateOpacity,
+                                   turnMarks: isEVSLens ? turnMarks : [],
+                                   routes: isTransportLens ? planRoutes(on: floor.floor) : []) { selected in
+                        store.selection = selected
+                        // Capacity lens: a tapped unit plate focuses the curve on that unit.
+                        if isCapacityLens, case .plate(let plate) = selected, let unitId = plate.unitId {
+                            curveUnitId = unitId
+                        }
+                    }
                         .frame(height: 240)
+                }
+                if isEVSLens, !store.bedStatesById.isEmpty, bedStateOpacity < 1 {
+                    // Bed state is strictly current — say so instead of pretending to replay it.
+                    Text("Bed states shown at now")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Z.inkMuted)
                 }
             } else {
                 Panel {
@@ -152,17 +558,24 @@ struct FlowMapView: View {
         }
     }
 
-    /// For unit scope: the floor the payload names, else the floor whose plates carry the unit.
-    private var unitFloorNumber: Int? {
+    /// The floor to frame for floor/unit scope: the payload's floor first (server truth),
+    /// then the request, then the first floor with geometry.
+    private var scopedFloorNumber: Int? {
         if let floor = store.window?.scope.floor { return floor }
-        guard case .unit(let unitId) = scope else { return store.floors?.floors.first?.floor }
-        if let floor = store.floors?.floors.first(where: { f in f.spaces.contains { $0.unitId == unitId } }) {
-            return floor.floor
+        switch scope {
+        case .floor(let number):
+            return number ?? store.floors?.floors.first?.floor ?? 1
+        case .unit(let unitId):
+            if let floor = store.floors?.floors.first(where: { f in f.spaces.contains { $0.unitId == unitId } }) {
+                return floor.floor
+            }
+            if let floor = store.window?.spaces?.floors.first(where: { f in f.units.contains { $0.unitId == unitId } }) {
+                return floor.floor
+            }
+            return store.floors?.floors.first?.floor
+        case .house:
+            return store.floors?.floors.first?.floor
         }
-        if let floor = store.window?.spaces?.floors.first(where: { f in f.units.contains { $0.unitId == unitId } }) {
-            return floor.floor
-        }
-        return store.floors?.floors.first?.floor
     }
 
     private func geometryFloor(_ number: Int?) -> FlowFloor? {
@@ -172,10 +585,93 @@ struct FlowMapView: View {
 
     private var unitRollups: [Int: FlowUnitRollup] {
         var byId: [Int: FlowUnitRollup] = [:]
-        for floor in store.window?.spaces?.floors ?? [] {
+        for floor in displayFloorRollups {
             for unit in floor.units { byId[unit.unitId] = unit }
         }
         return byId
+    }
+
+    // MARK: Layer data (transport routes, EVS turn map)
+
+    /// Generic bed ghosts, minus kinds a persona layer already renders its own way
+    /// (trips as arcs, turns as marks) so nothing draws twice.
+    private var plateGhosts: [FlowProjection] {
+        var excluded: Set<String> = []
+        if isTransportLens { excluded.insert("transport_due") }
+        if isEVSLens { excluded.insert("evs_due") }
+        return store.ghostsUpTo(store.t).filter { !excluded.contains($0.kind) }
+    }
+
+    private var resolvedTrips: [ResolvedTrip] {
+        guard isTransportLens else { return [] }
+        let resolver = FlowSpaceResolver(window: store.window, floors: store.floors)
+        return FlowTripBuilder.trips(window: store.window, at: store.t)
+            .map { ResolvedTrip(trip: $0, resolver: resolver) }
+    }
+
+    private var boundsByFloor: [Int: [Double]] {
+        Dictionary((store.floors?.floors ?? []).map { ($0.floor, $0.bounds) },
+                   uniquingKeysWith: { first, _ in first })
+    }
+
+    private func planRoutes(on floor: Int) -> [FlowPlanRoute] {
+        resolvedTrips.compactMap { resolved in
+            guard let from = resolved.from, let to = resolved.to,
+                  from.floor == floor, to.floor == floor,
+                  let fromPlan = from.plan, let toPlan = to.plan else { return nil }
+            return FlowPlanRoute(id: resolved.id, from: fromPlan, to: toPlan,
+                                 ghost: resolved.trip.ghost, opacity: resolved.trip.opacity,
+                                 warning: resolved.trip.warning)
+        }
+    }
+
+    /// Bed states are strictly current; fade the tint once the scrub time leaves now.
+    private var bedStateOpacity: Double {
+        abs(store.t.timeIntervalSince(store.nowDate)) <= 30 * 60 ? 1 : 0.25
+    }
+
+    /// Turn markers for the EVS floor plate: the latest past evs_status per bed as a solid
+    /// tick, the next upcoming evs_due per bed as a dashed ghost with its due time.
+    private var turnMarks: [FlowTurnMark] {
+        guard isEVSLens, let window = store.window else { return [] }
+        let bedIdByLabel = store.bedIdByLabel
+
+        var latestByBed: [Int: FlowTimelineEvent] = [:]
+        for event in window.events where event.kind == "evs_status" {
+            guard let time = event.time, time <= store.t,
+                  let bedId = event.toSpace.flatMap({ bedIdByLabel[$0] }) else { continue }
+            if let current = latestByBed[bedId], (current.time ?? .distantPast) >= time { continue }
+            latestByBed[bedId] = event
+        }
+
+        var nextDueByBed: [Int: FlowProjection] = [:]
+        for projection in window.projections where projection.kind == "evs_due" {
+            guard let time = projection.time, time >= store.t, let bedId = projection.bedId else { continue }
+            if let current = nextDueByBed[bedId], (current.time ?? .distantFuture) <= time { continue }
+            nextDueByBed[bedId] = projection
+        }
+
+        let past = latestByBed.map { bedId, event in
+            FlowTurnMark(id: "event|\(event.id)", bedId: bedId, ghost: false, opacity: 0.9,
+                         timeText: nil, isolation: isIsolationTurn(event.label),
+                         warning: event.capacity == .warning || event.capacity == .critical,
+                         selection: .event(event))
+        }
+        let upcoming = nextDueByBed.map { bedId, projection in
+            FlowTurnMark(id: "projection|\(projection.id)", bedId: bedId, ghost: true,
+                         opacity: projection.confidenceLevel.ghostOpacity,
+                         timeText: timeText(projection.time),
+                         isolation: isIsolationTurn(projection.label),
+                         warning: false,
+                         selection: .projection(projection))
+        }
+        return (past + upcoming).sorted { $0.id < $1.id }
+    }
+
+    // The payload has no isolation flag — the label is the only honest signal, so the ISO
+    // chip appears exactly when the request says isolation.
+    private func isIsolationTurn(_ label: String?) -> Bool {
+        label?.localizedCaseInsensitiveContains("isolation") ?? false
     }
 
     // MARK: Detail strip
@@ -196,6 +692,11 @@ struct FlowMapView: View {
                     if let unitId = plate.unitId, let rollup = unitRollups[unitId] {
                         Text("\(rollup.occupied)/\(rollup.staffed) occupied · \(Int(rollup.occupancyPct))%")
                             .font(.system(size: 12)).monospacedDigit()
+                            .foregroundStyle(Z.inkMuted)
+                    } else if let bedId = plate.bedId, let state = store.bedStatesById[bedId] {
+                        // The status word, so bed state is never communicated by tint alone.
+                        Text(statusLabel(state.status))
+                            .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(Z.inkMuted)
                     } else {
                         Text(plate.category.replacingOccurrences(of: "_", with: " "))
@@ -232,12 +733,26 @@ struct FlowMapView: View {
                     Text([projection.confidence, timeText(projection.time)].compactMap { $0 }.joined(separator: " · "))
                         .font(.system(size: 12)).monospacedDigit()
                         .foregroundStyle(Z.inkMuted)
-                    if let provenance = projection.provenance {
-                        provenanceChip(provenance.chipText)
+                    if projection.provenance != nil {
+                        provenanceChip(projectionChipText(projection))
                     }
                 }
             }
         }
+    }
+
+    /// Derived ghosts cite their chain explicitly ("Derived · expected discharge"), plus
+    /// the reliability score when the source service reported one.
+    private func projectionChipText(_ projection: FlowProjection) -> String {
+        guard projection.derived == true else { return projection.provenance?.chipText ?? "" }
+        let origin = (projection.provenance?.service ?? "")
+            .replacingOccurrences(of: "derived · ", with: "")
+            .replacingOccurrences(of: "_", with: " ")
+        var parts = ["Derived · \(origin.isEmpty ? "projection" : origin)"]
+        if let reliability = projection.provenance?.reliability {
+            parts.append("reliability \(String(format: "%.2f", reliability))")
+        }
+        return parts.joined(separator: " · ")
     }
 
     private func provenanceChip(_ text: String) -> some View {
@@ -257,15 +772,34 @@ struct FlowMapView: View {
         return f.string(from: date)
     }
 
-    // MARK: Start-of-shift replay
+    // MARK: Entry replays (charge nurse start-of-shift · executive time-lapse · PI pace)
 
-    private func runStartOfShiftReplayIfNeeded() {
-        guard persona == "charge_nurse", !didStartShiftReplay, store.window != nil else { return }
-        didStartShiftReplay = true
-        let boundary = FlowWindowStore.lastShiftBoundary(before: store.nowDate)
-        store.t = store.clamp(boundary)
-        if !reduceMotion {
-            store.play()
+    private func runEntryReplayIfNeeded() {
+        guard !didStartShiftReplay, store.window != nil else { return }
+        switch persona {
+        case "charge_nurse":
+            didStartShiftReplay = true
+            let boundary = FlowWindowStore.lastShiftBoundary(before: store.nowDate)
+            store.t = store.clamp(boundary)
+            if !reduceMotion {
+                store.play()
+            }
+        case "executive":
+            didStartShiftReplay = true
+            if reduceMotion {
+                // No autoplay: land at now with the forward half revealed; the Replay
+                // button tells the same 24h story on demand.
+                store.t = store.nowDate
+                revealForecast = true
+            } else {
+                revealForecast = false
+                store.play(from: store.fromDate) // ~15s full past-half time-lapse
+            }
+        case "pi_lead":
+            didStartShiftReplay = true
+            store.playRate = 4 * 3600 // process-replay pace: ~4 sim-hours per second
+        default:
+            break
         }
     }
 }

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/FlowMapView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/FlowMapView.swift
@@ -172,6 +172,8 @@ struct FlowMapView: View {
             capacityLayer
         } else if isStaffingLens {
             staffingLayer
+        } else if is3DLens, let spaces = store.spaces3d {
+            flow3DLayer(spaces: spaces)
         } else if scope == .house, store.selectedFloor == nil {
             houseLayer
             transportGutter
@@ -185,6 +187,22 @@ struct FlowMapView: View {
     /// snapshot series at the scrub time; everyone else sees the live rollup.
     private var displayFloorRollups: [FlowFloorRollup] {
         isReplayHeatLens ? store.floorRollups(at: store.t) : (store.window?.spaces?.floors ?? [])
+    }
+
+    /// Phase B (NATIVE-4D-VIEWER): bed_manager / house_supervisor render the native SceneKit
+    /// twin instead of the 2.5D stack. The 2.5D renderers are deleted in Phase D once every
+    /// persona reaches 3D parity; other lenses keep the 2.5D layer until then.
+    private var is3DLens: Bool { persona == "bed_manager" || persona == "house_supervisor" }
+
+    private func flow3DLayer(spaces: FlowSpaces3dDocument) -> some View {
+        Panel(padding: Z.s2) {
+            Flow3DView(spaces: spaces,
+                       bedStatuses: store.window?.bedStatuses ?? [],
+                       selectedFloor: store.selectedFloor)
+                .frame(height: 420)
+                .cornerRadius(12)
+                .accessibilityLabel("Native 3D hospital view")
+        }
     }
 
     private var houseLayer: some View {

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/FlowModels.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/FlowModels.swift
@@ -56,6 +56,7 @@ struct FlowWindowData: Decodable, Equatable {
     let snapshots: [FlowSnapshot]
     let events: [FlowTimelineEvent]
     let projections: [FlowProjection]
+    let bedStatuses: [FlowBedStatus]
 
     // The server omits any layer the lens excludes (the executive lens has
     // no `events` at all), so every layer decodes as absent-means-empty.
@@ -68,21 +69,86 @@ struct FlowWindowData: Decodable, Equatable {
         snapshots = try container.decodeIfPresent([FlowSnapshot].self, forKey: .snapshots) ?? []
         events = try container.decodeIfPresent([FlowTimelineEvent].self, forKey: .events) ?? []
         projections = try container.decodeIfPresent([FlowProjection].self, forKey: .projections) ?? []
+        bedStatuses = try container.decodeIfPresent([FlowBedStatus].self, forKey: .bedStatuses) ?? []
+    }
+
+    /// Memberwise initializer used to assemble a merged window from a `?since=` delta
+    /// response (the Decodable init only builds from the wire).
+    init(window: FlowWindow, lens: FlowLens, scope: FlowScope, spaces: FlowSpaces?,
+         snapshots: [FlowSnapshot], events: [FlowTimelineEvent],
+         projections: [FlowProjection], bedStatuses: [FlowBedStatus]) {
+        self.window = window
+        self.lens = lens
+        self.scope = scope
+        self.spaces = spaces
+        self.snapshots = snapshots
+        self.events = events
+        self.projections = projections
+        self.bedStatuses = bedStatuses
     }
 
     private enum CodingKeys: String, CodingKey {
-        case window, lens, scope, spaces, snapshots, events, projections
+        case window, lens, scope, spaces, snapshots, events, projections, bedStatuses
     }
+}
+
+extension FlowWindowData {
+    /// Client merge for a `?since=` delta response (the delta carries only `events`/`snapshots`
+    /// with t > since; `projections`, `spaces`, and `bed_statuses` come back full):
+    /// append the new events (dedupe by t·kind·entity.ref·label) and snapshots (dedupe by
+    /// t·unit_id), then REPLACE projections, bed_statuses, spaces, and the window frame
+    /// wholesale. The caller keeps the user's scrub position and selection — this rebuilds
+    /// data only.
+    func merged(delta: FlowWindowData) -> FlowWindowData {
+        var mergedEvents = events
+        var eventKeys = Set(events.map(Self.eventDedupeKey))
+        for event in delta.events where eventKeys.insert(Self.eventDedupeKey(event)).inserted {
+            mergedEvents.append(event)
+        }
+        var mergedSnapshots = snapshots
+        var snapshotKeys = Set(snapshots.map(Self.snapshotDedupeKey))
+        for snapshot in delta.snapshots where snapshotKeys.insert(Self.snapshotDedupeKey(snapshot)).inserted {
+            mergedSnapshots.append(snapshot)
+        }
+        return FlowWindowData(
+            window: delta.window, lens: delta.lens, scope: delta.scope,
+            spaces: delta.spaces ?? spaces,
+            snapshots: mergedSnapshots, events: mergedEvents,
+            projections: delta.projections, bedStatuses: delta.bedStatuses)
+    }
+
+    private static func eventDedupeKey(_ event: FlowTimelineEvent) -> String {
+        [event.t, event.kind, event.entity?.ref ?? "", event.label ?? ""].joined(separator: "\u{01}")
+    }
+
+    private static func snapshotDedupeKey(_ snapshot: FlowSnapshot) -> String {
+        "\(snapshot.t)\u{01}\(snapshot.unitId.map(String.init) ?? "")"
+    }
+}
+
+/// Strictly-current bed state for the turn map. The server sends `bed_statuses` only at
+/// floor/unit scope for lenses whose event kinds include `bed_status` (evs) — absent
+/// everywhere else, so it decodes as absent-means-empty.
+struct FlowBedStatus: Decodable, Equatable, Identifiable {
+    let bedId: Int
+    let unitId: Int
+    let label: String?
+    let status: String // available | occupied | blocked | dirty
+
+    var id: Int { bedId }
 }
 
 struct FlowWindow: Decodable, Equatable {
     let from: String
     let to: String
     let now: String
+    /// Echo of the parsed `?since=` the server applied (nullable; nil on full loads).
+    let since: String?
 
     var fromDate: Date? { FlowTime.parse(from) }
     var toDate: Date? { FlowTime.parse(to) }
     var nowDate: Date? { FlowTime.parse(now) }
+    var sinceDate: Date? { FlowTime.parse(since) }
 }
 
 /// The role lens the server applied: which scopes/layers/kinds this persona may see.
@@ -207,6 +273,8 @@ struct FlowProjection: Decodable, Equatable, Identifiable {
     let confidence: String
     let unitId: Int?
     let bedId: Int?
+    /// OR room name ("OR 3") on `scheduled_or_case`; null on every other kind.
+    let room: String?
     let entity: FlowEntityRef?
     let patientContextRef: String?
     let label: String?
@@ -223,6 +291,17 @@ struct FlowProjection: Decodable, Equatable, Identifiable {
 
     var time: Date? { FlowTime.parse(t) }
     var confidenceLevel: FlowConfidence { FlowConfidence(apiValue: confidence) }
+}
+
+extension FlowProjection {
+    /// `staffing_shift_gap` → the gap as needed headcount. The two sources encode it
+    /// differently: staffing *requests* carry `headcount_needed` (positive = gap), staffing
+    /// *plans* carry `scheduled − minimum_safe` (negative = below safe). Nil for other kinds.
+    var gapHeadcount: Int? {
+        guard kind == "staffing_shift_gap", let value else { return nil }
+        let raw = Int(value)
+        return entity?.type == "staffing_plan" ? max(0, -raw) : max(0, raw)
+    }
 }
 
 struct FlowProjectionProvenance: Decodable, Equatable {

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/FlowModels.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/FlowModels.swift
@@ -57,6 +57,7 @@ struct FlowWindowData: Decodable, Equatable {
     let events: [FlowTimelineEvent]
     let projections: [FlowProjection]
     let bedStatuses: [FlowBedStatus]
+    let duties: [FlowDuty]
 
     // The server omits any layer the lens excludes (the executive lens has
     // no `events` at all), so every layer decodes as absent-means-empty.
@@ -70,13 +71,14 @@ struct FlowWindowData: Decodable, Equatable {
         events = try container.decodeIfPresent([FlowTimelineEvent].self, forKey: .events) ?? []
         projections = try container.decodeIfPresent([FlowProjection].self, forKey: .projections) ?? []
         bedStatuses = try container.decodeIfPresent([FlowBedStatus].self, forKey: .bedStatuses) ?? []
+        duties = try container.decodeIfPresent([FlowDuty].self, forKey: .duties) ?? []
     }
 
     /// Memberwise initializer used to assemble a merged window from a `?since=` delta
     /// response (the Decodable init only builds from the wire).
     init(window: FlowWindow, lens: FlowLens, scope: FlowScope, spaces: FlowSpaces?,
          snapshots: [FlowSnapshot], events: [FlowTimelineEvent],
-         projections: [FlowProjection], bedStatuses: [FlowBedStatus]) {
+         projections: [FlowProjection], bedStatuses: [FlowBedStatus], duties: [FlowDuty]) {
         self.window = window
         self.lens = lens
         self.scope = scope
@@ -85,10 +87,11 @@ struct FlowWindowData: Decodable, Equatable {
         self.events = events
         self.projections = projections
         self.bedStatuses = bedStatuses
+        self.duties = duties
     }
 
     private enum CodingKeys: String, CodingKey {
-        case window, lens, scope, spaces, snapshots, events, projections, bedStatuses
+        case window, lens, scope, spaces, snapshots, events, projections, bedStatuses, duties
     }
 }
 
@@ -114,7 +117,8 @@ extension FlowWindowData {
             window: delta.window, lens: delta.lens, scope: delta.scope,
             spaces: delta.spaces ?? spaces,
             snapshots: mergedSnapshots, events: mergedEvents,
-            projections: delta.projections, bedStatuses: delta.bedStatuses)
+            projections: delta.projections, bedStatuses: delta.bedStatuses,
+            duties: delta.duties) // duties are current worklist — always full
     }
 
     private static func eventDedupeKey(_ event: FlowTimelineEvent) -> String {
@@ -136,6 +140,57 @@ struct FlowBedStatus: Decodable, Equatable, Identifiable {
     let status: String // available | occupied | blocked | dirty
 
     var id: Int { bedId }
+}
+
+/// A persona duty — an actionable worklist item, spatially anchored (centroidM)
+/// and due-dated (dueAt + windowStatus), with the governed BFF endpoint that
+/// actions it. The "what's due to me, where, when" the native 3D viewer renders.
+struct FlowDuty: Decodable, Equatable, Identifiable {
+    let id: String
+    let kind: String // transport_run|bed_turn|placement|barrier_resolve|staffing_fill|approval|discharge_leverage
+    let label: String
+    let spaceRef: String?
+    let unitId: Int?
+    let bedId: Int?
+    let centroidM: FlowCentroid3d?
+    let dueAt: String?
+    let windowStatus: String? // overdue | due | upcoming
+    let tier: String // critical | warning | info
+    let patientContextRef: String?
+    let action: FlowDutyAction?
+
+    var dueDate: Date? { FlowTime.parse(dueAt) }
+}
+
+struct FlowDutyAction: Decodable, Equatable {
+    let endpoint: String
+    let method: String
+    let label: String
+}
+
+struct FlowCentroid3d: Decodable, Equatable {
+    let x: Double
+    let y: Double
+    let z: Double
+}
+
+/// The 3D space-anchor asset (GET /flow/spaces3d): per-space centroids (metres,
+/// y is the vertical/floor axis) the native SceneKit/Filament scene places
+/// segments and tokens by. Geometry only, ETag-cached.
+struct FlowSpaces3dDocument: Decodable, Equatable {
+    let version: String
+    let spaces: [FlowSpace3d]
+}
+
+struct FlowSpace3d: Decodable, Equatable, Identifiable {
+    let spaceRef: String
+    let floor: Int
+    let category: String
+    let unitId: Int?
+    let bedId: Int?
+    let centroidM: FlowCentroid3d
+
+    var id: String { spaceRef }
 }
 
 struct FlowWindow: Decodable, Equatable {

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/FlowWindowCache.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/FlowWindowCache.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// On-disk cache of the last FULL (non-delta) Flow Window per (user, persona, scope), so a
+/// failed load (offline / server error) can still present the last-known window — and its
+/// past half stays fully scrubbable offline. Records store the raw envelope bytes verbatim
+/// (window + floors), keyed by the authenticated user id so one user's cache is never served
+/// to another. FLOW-WINDOW-PLAN §7.2 (offline), Phase 5.
+///
+/// Storage: JSON files under Application Support/FlowCache, written atomically, capped LRU at
+/// ~20 records (a signed-in worker touches a handful of scopes; older ones age out).
+enum FlowWindowCache {
+    /// One cached window: the raw `/flow/window` and `/flow/floors` envelope bytes plus the
+    /// wall-clock capture time (drives the "Showing data from HH:mm" staleness caption).
+    struct Record: Codable {
+        let schemaVersion: Int
+        let userId: Int
+        let persona: String
+        let scope: String
+        let capturedAt: Date
+        let window: Data
+        let floors: Data?
+    }
+
+    private static let schemaVersion = 1
+    private static let maxEntries = 20
+
+    private static var directory: URL? {
+        let fm = FileManager.default
+        guard let base = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return nil }
+        let dir = base.appendingPathComponent("FlowCache", isDirectory: true)
+        if !fm.fileExists(atPath: dir.path) {
+            try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        return dir
+    }
+
+    /// Stable, filesystem-safe filename for a cache key. Percent-encoding keeps persona/scope
+    /// separators (`|`, `:`) out of the path without a hash dependency.
+    private static func fileURL(userId: Int, persona: String, scope: String) -> URL? {
+        let raw = "\(userId)|\(persona)|\(scope)"
+        let safe = raw.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? "\(userId)"
+        return directory?.appendingPathComponent("\(safe).json")
+    }
+
+    static func save(userId: Int, persona: String?, scope: String, window: Data, floors: Data?) {
+        guard let url = fileURL(userId: userId, persona: persona ?? "", scope: scope) else { return }
+        let record = Record(schemaVersion: schemaVersion, userId: userId, persona: persona ?? "",
+                            scope: scope, capturedAt: Date(), window: window, floors: floors)
+        guard let encoded = try? JSONEncoder().encode(record) else { return }
+        try? encoded.write(to: url, options: .atomic)
+        pruneLRU()
+    }
+
+    static func load(userId: Int, persona: String?, scope: String) -> Record? {
+        guard let url = fileURL(userId: userId, persona: persona ?? "", scope: scope),
+              let data = try? Data(contentsOf: url),
+              let record = try? JSONDecoder().decode(Record.self, from: data),
+              record.schemaVersion == schemaVersion,
+              record.userId == userId else { return nil }
+        // Touch modification time so this key counts as recently used for LRU pruning.
+        try? FileManager.default.setAttributes([.modificationDate: Date()], ofItemAtPath: url.path)
+        return record
+    }
+
+    /// Clear the whole cache — hooked to sign-out (a signed-out device keeps no operational
+    /// state) and the belt-and-braces guard against ever serving another user's window.
+    static func clearAll() {
+        guard let directory,
+              let contents = try? FileManager.default.contentsOfDirectory(at: directory,
+                includingPropertiesForKeys: nil) else { return }
+        for url in contents { try? FileManager.default.removeItem(at: url) }
+    }
+
+    /// Keep at most `maxEntries` records, dropping the least-recently-modified first.
+    private static func pruneLRU() {
+        guard let directory,
+              let contents = try? FileManager.default.contentsOfDirectory(at: directory,
+                includingPropertiesForKeys: [.contentModificationDateKey]),
+              contents.count > maxEntries else { return }
+        let sorted = contents.sorted { lhs, rhs in
+            let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? .distantPast
+            return l < r
+        }
+        for url in sorted.prefix(contents.count - maxEntries) {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+}

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/FlowWindowStore.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/FlowWindowStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WidgetKit
 
 /// What the map/lanes detail strip is showing: a tapped plate, a past event, or a
 /// projected ghost (with its provenance chip).
@@ -9,14 +10,18 @@ enum FlowSelection: Equatable {
 }
 
 /// The requested spatial scope for a Flow Window surface. Serialized to the
-/// `scope=house|unit:{id}` query the lens endpoint expects (server clamps to the lens).
+/// `scope=house|floor:{n}|unit:{id}` query the lens endpoint expects (server clamps to
+/// the lens). A nil floor sends bare `floor` and lets the server resolve the lens
+/// default (the periop floor for OR lenses).
 enum FlowScopeRequest: Equatable {
     case house
+    case floor(Int?)
     case unit(Int)
 
     var queryValue: String {
         switch self {
         case .house: return "house"
+        case .floor(let number): return number.map { "floor:\($0)" } ?? "floor"
         case .unit(let id): return "unit:\(id)"
         }
     }
@@ -38,13 +43,37 @@ final class FlowWindowStore: ObservableObject {
     @Published var errorMessage: String?
     @Published var needsReauth = false
     @Published var live = false
+    /// The web 4D-Navigator deep link from the window envelope (`links.web`) — the PI lens
+    /// appends `from=`/`to=` to it for clip-to-share.
+    @Published var webLink: String?
+    /// When set, the surface is showing a cached window because the live load failed — drives
+    /// the "Showing data from HH:mm" staleness caption. Cleared on any fresh (network) load.
+    @Published var staleAsOf: Date?
+
+    /// Persona playback pace in sim-seconds per wall-second (PI replays at ~4h/s). Nil keeps
+    /// the default proportional pace (a full past half in `replayDuration` seconds).
+    var playRate: TimeInterval?
 
     let api: APIClient
     private var bearerToken = ""
+    private var userId: Int?
     private var persona: String?
     private var scope: FlowScopeRequest = .house
     private var didSetInitialT = false
     private var playbackTask: Task<Void, Never>?
+    /// The persona+scope the currently-loaded window is for — the delta-refresh guard (a delta
+    /// is only valid against the same lens+scope; anything else forces a full load).
+    private var loadedScopeKey: String?
+    /// Raw plates-asset bytes, kept so a full-window cache write always includes the geometry.
+    private var floorsRawData: Data?
+
+    /// Snake_case-aware decoder for reading cached envelope bytes back into DTOs (mirrors the
+    /// APIClient decoder — cached blobs are the raw wire JSON).
+    private static let cacheDecoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .convertFromSnakeCase
+        return d
+    }()
 
     /// Wall duration of a full past-half replay; shorter scrub spans replay proportionally.
     private let replayDuration: TimeInterval = 15
@@ -64,36 +93,164 @@ final class FlowWindowStore: ObservableObject {
 
     // MARK: Loading
 
-    func load(bearer: String, persona: String?, scope: FlowScopeRequest) async {
+    func load(bearer: String, userId: Int?, persona: String?, scope: FlowScopeRequest) async {
         bearerToken = bearer
+        self.userId = userId
         self.persona = persona
         self.scope = scope
+        await fetch()
+    }
+
+    /// The scope actually sent: the EVS turn map re-scopes to the descended floor because
+    /// `bed_statuses` only exists at floor/unit scope — house payloads never carry it.
+    private var requestScope: FlowScopeRequest {
+        if persona == "evs", let floor = selectedFloor { return .floor(floor) }
+        return scope
+    }
+
+    private func scopeKey(_ scopeValue: String) -> String { "\(persona ?? "")|\(scopeValue)" }
+
+    /// A FULL (non-delta) load: fetch the whole window, cache its raw bytes for offline, and
+    /// (on failure) present the last cached window with a staleness caption. This is the path
+    /// for a first load, a scope change (EVS descent), and any delta fallback.
+    private func fetch() async {
         isLoading = true
         defer { isLoading = false }
+        let scopeValue = requestScope.queryValue
+        // The plates asset is versioned + cacheable; a miss only costs the geometry layer.
+        if floors == nil, let (env, data) = try? await api.flowFloorsRaw(bearer: bearerToken) {
+            floors = env.data
+            floorsRawData = data
+        }
         do {
-            let env = try await api.flowWindow(persona: persona, scope: scope.queryValue, bearer: bearer)
+            let (env, data) = try await api.flowWindowRaw(persona: persona, scope: scopeValue, bearer: bearerToken)
             window = env.data
+            webLink = env.links?["web"]
             errorMessage = nil
-            // First load lands the scrubber on `now`; later refreshes keep the user's t.
-            if !didSetInitialT, let now = env.data.window.nowDate {
-                t = now
-                didSetInitialT = true
+            staleAsOf = nil
+            loadedScopeKey = scopeKey(scopeValue)
+            landInitialTIfNeeded(env.data)
+            // Persist the last FULL window + floors for this (user, persona, scope).
+            if let userId {
+                FlowWindowCache.save(userId: userId, persona: persona, scope: scopeValue,
+                                     window: data, floors: floorsRawData)
             }
+            writeHouseGlance(scopeValue: scopeValue)
         } catch let error as APIError {
             if error.statusCode == 401 { needsReauth = true }
             errorMessage = error.message
+            presentCachedIfPossible(scopeValue: scopeValue)
         } catch {
             errorMessage = error.localizedDescription
+            presentCachedIfPossible(scopeValue: scopeValue)
         }
-        // The plates asset is versioned + cacheable; a miss only costs the geometry layer.
-        if floors == nil, let env = try? await api.flowFloors(bearer: bearer) {
-            floors = env.data
+    }
+
+    /// Delta refresh (Reverb re-snapshot / foreground return): when a window is already loaded
+    /// for the same persona+scope, request only events/snapshots newer than the newest we hold
+    /// (`?since=`) and merge them per the contract. A 422 (invalid_since) or any decode failure
+    /// falls back to a full load; a transient network error keeps the loaded window for the
+    /// next tick (the frame never resets the user's scrub position or selection).
+    private func refresh() async {
+        let scopeValue = requestScope.queryValue
+        guard window != nil,
+              loadedScopeKey == scopeKey(scopeValue),
+              let since = newestLoadedTime else {
+            await fetch()
+            return
         }
+        do {
+            let env = try await api.flowWindow(persona: persona, scope: scopeValue,
+                                               since: Self.iso(since), bearer: bearerToken)
+            window = window?.merged(delta: env.data) ?? env.data
+            webLink = env.links?["web"] ?? webLink
+            errorMessage = nil
+            staleAsOf = nil
+            writeHouseGlance(scopeValue: scopeValue)
+        } catch let error as APIError where error.statusCode == 422 {
+            await fetch()
+        } catch is DecodingError {
+            await fetch()
+        } catch let error as APIError {
+            if error.statusCode == 401 { needsReauth = true; errorMessage = error.message }
+            // Otherwise transient — keep the loaded window; the next live/foreground tick retries.
+        } catch {
+            // Transient network error — keep the loaded window; retry on the next tick.
+        }
+    }
+
+    private func landInitialTIfNeeded(_ data: FlowWindowData) {
+        // First load lands the scrubber on `now`; later refreshes keep the user's t.
+        guard !didSetInitialT, let now = data.window.nowDate else { return }
+        t = now
+        didSetInitialT = true
+    }
+
+    /// The newest event/snapshot timestamp we hold — the `?since=` anchor. Nil when the lens
+    /// carries neither layer (then a delta has nothing to anchor on → full load).
+    private var newestLoadedTime: Date? {
+        let eventTimes = (window?.events ?? []).compactMap { $0.time }
+        let snapshotTimes = (window?.snapshots ?? []).compactMap { $0.time }
+        return (eventTimes + snapshotTimes).max()
+    }
+
+    private static func iso(_ date: Date) -> String { FlowTime.formatter.string(from: date) }
+
+    /// Present the last cached window for this (user, persona, scope) after a failed load.
+    /// The full payload restores in memory so the past half scrubs fully offline; the caption
+    /// times it. Never crosses users — the cache is keyed by (and re-checks) the user id.
+    private func presentCachedIfPossible(scopeValue: String) {
+        guard window == nil, let userId,
+              let record = FlowWindowCache.load(userId: userId, persona: persona, scope: scopeValue),
+              let env = try? Self.cacheDecoder.decode(Envelope<FlowWindowData>.self, from: record.window)
+        else { return }
+        window = env.data
+        webLink = env.links?["web"] ?? webLink
+        loadedScopeKey = scopeKey(scopeValue)
+        if let floorsData = record.floors,
+           let floorsEnv = try? Self.cacheDecoder.decode(Envelope<FlowFloorsDocument>.self, from: floorsData) {
+            floors = floorsEnv.data
+            floorsRawData = floorsData
+        }
+        // Land the scrubber on the cached `now` so the accumulated past is scrubbable offline.
+        if let now = env.data.window.nowDate { t = now }
+        didSetInitialT = true
+        staleAsOf = record.capturedAt
+    }
+
+    /// Contribute the "next 4h" ghost count to the home-screen glance widget on every Flow
+    /// Window load — house scope only (the glance is a house widget; a unit/floor ghost count
+    /// would mislead). Merges so it never clobbers the RTDC occupancy / net-bed-need writer.
+    private func writeHouseGlance(scopeValue: String) {
+        guard scopeValue == "house", let window, let now = window.window.nowDate else { return }
+        let horizon = now.addingTimeInterval(4 * 3600)
+        let ghostCount = window.projections.filter {
+            guard let time = $0.time else { return false }
+            return time > now && time <= horizon
+        }.count
+        HouseGlanceCache.merge { $0.next4hGhostCount = ghostCount }
+        WidgetCenter.shared.reloadTimelines(ofKind: HouseGlanceCache.widgetKind)
+    }
+
+    /// Descend into a floor (nil ascends back to the house). Personas whose lens serves
+    /// bed-level state refetch at the new scope; everyone else re-frames client-side only.
+    func descend(to floor: Int?) {
+        selectedFloor = floor
+        selection = nil
+        guard persona == "evs" else { return }
+        Task { await self.fetch() }
     }
 
     private func reload() async {
         guard didSetInitialT else { return }
-        await load(bearer: bearerToken, persona: persona, scope: scope)
+        await refresh()
+    }
+
+    /// Foreground return: delta-refresh the head without disturbing the user's scrub position.
+    func refreshForeground(bearer: String) async {
+        guard didSetInitialT else { return }
+        bearerToken = bearer
+        await refresh()
     }
 
     func startLive(bearer: String) {
@@ -138,6 +295,59 @@ final class FlowWindowStore: ObservableObject {
             .max { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }
     }
 
+    /// Floor rollups with occupancy re-read from the snapshot series at `t` — the heat
+    /// time-travel behind the executive time-lapse and the PI process replay. Falls back to
+    /// the live rollups when there is no snapshot series yet or `t` is at/near now (live
+    /// truth beats an hourly checkpoint there).
+    func floorRollups(at t: Date) -> [FlowFloorRollup] {
+        let live = window?.spaces?.floors ?? []
+        guard !(window?.snapshots.isEmpty ?? true),
+              t < nowDate.addingTimeInterval(-30 * 60) else { return live }
+        return live.map { floor in
+            var occupiedSum = 0
+            var staffedSum = 0
+            let units = floor.units.map { unit -> FlowUnitRollup in
+                guard let snap = censusAt(t, unitId: unit.unitId), let occupied = snap.occupied else {
+                    // No checkpoint ≤ t for this unit — keep the live rollup (honest fallback).
+                    occupiedSum += unit.occupied
+                    staffedSum += unit.staffed
+                    return unit
+                }
+                let staffed = snap.staffed ?? unit.staffed
+                occupiedSum += occupied
+                staffedSum += staffed
+                let pct = staffed > 0 ? 100.0 * Double(occupied) / Double(staffed) : 0
+                return FlowUnitRollup(
+                    unitId: unit.unitId, abbr: unit.abbr, name: unit.name, type: unit.type,
+                    serviceLine: unit.serviceLine, acuity: unit.acuity, cadCode: unit.cadCode,
+                    facilitySpaceId: unit.facilitySpaceId, staffed: staffed, occupied: occupied,
+                    available: snap.available ?? unit.available, blocked: snap.blocked ?? unit.blocked,
+                    occupancyPct: snap.occupancyPct ?? pct, evsOpen: unit.evsOpen,
+                    transportActive: unit.transportActive, barriersOpen: unit.barriersOpen,
+                    staffingStatus: unit.staffingStatus)
+            }
+            let pct = staffedSum > 0 ? 100.0 * Double(occupiedSum) / Double(staffedSum) : 0
+            return FlowFloorRollup(
+                floor: floor.floor, label: floor.label, units: units, staffed: staffedSum,
+                occupied: occupiedSum, available: floor.available, blocked: floor.blocked,
+                occupancyPct: pct, evsOpen: floor.evsOpen,
+                transportActive: floor.transportActive, barriersOpen: floor.barriersOpen)
+        }
+    }
+
+    /// bed_id → current state (the turn-map tint source). Empty unless the server sent
+    /// `bed_statuses` (floor/unit scope + a bed_status-granted lens).
+    var bedStatesById: [Int: FlowBedStatus] {
+        Dictionary((window?.bedStatuses ?? []).map { ($0.bedId, $0) }, uniquingKeysWith: { first, _ in first })
+    }
+
+    /// bed label ("MICU-01") → bed_id, for joining events whose to_space is a bed label.
+    var bedIdByLabel: [String: Int] {
+        Dictionary((window?.bedStatuses ?? []).compactMap { status in
+            status.label.map { ($0, status.bedId) }
+        }, uniquingKeysWith: { first, _ in first })
+    }
+
     /// The most recent shift boundary (07:00 / 19:00 local) at or before `date`.
     static func lastShiftBoundary(before date: Date, calendar: Calendar = .current) -> Date {
         let day = calendar.startOfDay(for: date)
@@ -171,18 +381,24 @@ final class FlowWindowStore: ObservableObject {
     }
 
     /// Replay from the current scrub position to `now`. If t is already at/after now,
-    /// restart from the beginning of the past half.
-    func play(from start: Date? = nil) {
+    /// restart from the beginning of the past half. `rate` (sim-seconds per wall-second)
+    /// overrides the persona pace (`playRate`), which overrides the default proportional
+    /// pace (a full 24h past half in `replayDuration` seconds).
+    func play(from start: Date? = nil, rate rateOverride: TimeInterval? = nil) {
         pause()
         let now = nowDate
         if let start { t = clamp(start) }
         if t >= now { t = fromDate }
         let span = now.timeIntervalSince(t)
         guard span > 1 else { return }
-        // Proportional pace: a full 24h past half replays in `replayDuration` seconds.
-        let fullSpan: TimeInterval = 24 * 3600
-        let duration = max(3, replayDuration * span / fullSpan)
-        let rate = span / duration // sim-seconds per wall-second
+        let rate: TimeInterval // sim-seconds per wall-second
+        if let fixed = rateOverride ?? playRate, fixed > 0 {
+            rate = fixed
+        } else {
+            let fullSpan: TimeInterval = 24 * 3600
+            let duration = max(3, replayDuration * span / fullSpan)
+            rate = span / duration
+        }
         isPlaying = true
         playbackTask = Task { [weak self] in
             let tick: TimeInterval = 1.0 / 30.0

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/FlowWindowStore.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/FlowWindowStore.swift
@@ -35,6 +35,8 @@ enum FlowScopeRequest: Equatable {
 final class FlowWindowStore: ObservableObject {
     @Published var window: FlowWindowData?
     @Published var floors: FlowFloorsDocument?
+    /// The 3D space-anchor asset — per-space metre centroids the native scene places by.
+    @Published var spaces3d: FlowSpaces3dDocument?
     @Published var t: Date = .now
     @Published var selectedFloor: Int?
     @Published var isPlaying = false
@@ -121,6 +123,10 @@ final class FlowWindowStore: ObservableObject {
         if floors == nil, let (env, data) = try? await api.flowFloorsRaw(bearer: bearerToken) {
             floors = env.data
             floorsRawData = data
+        }
+        // The 3D anchors are versioned + cacheable too; the native scene needs them once.
+        if spaces3d == nil, let env = try? await api.flowSpaces3d(bearer: bearerToken) {
+            spaces3d = env.data
         }
         do {
             let (env, data) = try await api.flowWindowRaw(persona: persona, scope: scopeValue, bearer: bearerToken)

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/HouseStackView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/HouseStackView.swift
@@ -1,5 +1,14 @@
 import SwiftUI
 
+/// Floor number → slab bounds, published so overlay layers (transport route arcs) can
+/// anchor endpoints to the exact slab rows without duplicating stack layout math.
+struct FloorSlabAnchorKey: PreferenceKey {
+    static var defaultValue: [Int: Anchor<CGRect>] = [:]
+    static func reduce(value: inout [Int: Anchor<CGRect>], nextValue: () -> [Int: Anchor<CGRect>]) {
+        value.merge(nextValue()) { $1 }
+    }
+}
+
 /// House scope: an exploded axonometric stack of floor slabs (D4). Each floor is a
 /// sheared parallelogram filled with the same neutral occupancy heat the plate view uses,
 /// labeled with its occupied/staffed count. Tapping a floor descends into FloorPlateView.
@@ -8,6 +17,9 @@ struct HouseStackView: View {
     let rollups: [FlowFloorRollup]
     /// The plates asset — floors with geometry that can be descended into.
     let floorsDocument: FlowFloorsDocument?
+    /// Floor → worst staffing-gap headcount (P10 lens): tints the slab amber and adds a
+    /// "short N" word so the gap is never color alone. Empty for every other lens.
+    var gapByFloor: [Int: Int] = [:]
     let onDescend: (Int) -> Void
 
     private let shear: CGFloat = 26
@@ -31,12 +43,15 @@ struct HouseStackView: View {
 
     private func slabRow(_ number: Int) -> some View {
         let rollup = rollups.first { $0.floor == number }
+        let gap = gapByFloor[number] ?? 0
         return Button {
             onDescend(number)
         } label: {
             ZStack {
                 SlabShape(shear: shear)
-                    .fill(Z.primary.opacity(heatOpacity(rollup)))
+                    .fill(gap > 0
+                          ? Z.status(.warning).opacity(gapOpacity(gap))
+                          : Z.primary.opacity(heatOpacity(rollup)))
                 SlabShape(shear: shear)
                     .stroke(Z.border, lineWidth: 1)
                 HStack(spacing: Z.s2) {
@@ -44,6 +59,12 @@ struct HouseStackView: View {
                         .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(Z.ink)
                     Spacer()
+                    if gap > 0 {
+                        Text("short \(gap)")
+                            .font(.system(size: 11, weight: .semibold))
+                            .monospacedDigit()
+                            .foregroundStyle(Z.status(.warning))
+                    }
                     if let rollup {
                         Text("\(rollup.occupied)/\(rollup.staffed)")
                             .font(.system(size: 13, weight: .semibold))
@@ -68,7 +89,8 @@ struct HouseStackView: View {
             .contentShape(SlabShape(shear: shear))
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(accessibilityText(number, rollup))
+        .anchorPreference(key: FloorSlabAnchorKey.self, value: .bounds) { [number: $0] }
+        .accessibilityLabel(accessibilityText(number, rollup, gap: gap))
     }
 
     /// Same neutral heat ramp as FloorPlateView: 0% → 0.10, 100% → 0.45. Never coral.
@@ -77,13 +99,25 @@ struct HouseStackView: View {
         return 0.10 + 0.35 * fraction
     }
 
+    /// Coverage-gap tint (P10): amber scaled by the worst shortfall, capped well below an
+    /// alarm read — the gap is a planning exposure, not a live breach.
+    private func gapOpacity(_ gap: Int) -> Double {
+        min(0.12 + 0.07 * Double(gap), 0.38)
+    }
+
     private func floorLabel(_ number: Int) -> String {
         floorsDocument?.floors.first { $0.floor == number }?.label ?? "Floor \(number)"
     }
 
-    private func accessibilityText(_ number: Int, _ rollup: FlowFloorRollup?) -> String {
-        guard let rollup else { return "\(floorLabel(number)), no census" }
-        return "\(rollup.label), \(rollup.occupied) of \(rollup.staffed) beds occupied"
+    private func accessibilityText(_ number: Int, _ rollup: FlowFloorRollup?, gap: Int) -> String {
+        var text: String
+        if let rollup {
+            text = "\(rollup.label), \(rollup.occupied) of \(rollup.staffed) beds occupied"
+        } else {
+            text = "\(floorLabel(number)), no census"
+        }
+        if gap > 0 { text += ", short \(gap) staff at the worst shift" }
+        return text
     }
 }
 

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/RoomLanesView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/RoomLanesView.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+
+/// The OR lens primary layer — P4 "My room's day" / P7 "All rooms, the cascade": one lane
+/// per room aligned to the Chronobar's 48h span. Case bars run scheduled start → end,
+/// solid once started, dashed ghosts at confidence opacity ahead of now. When a case's end
+/// overlaps the next case's scheduled start, the next bar slides to the predecessor's end
+/// and carries a "+Xm" drift chip (the cascade). Milestone ticks mark in-room / procedure /
+/// PACU transitions; PACU collects into a bottom lane. The payload carries no patient
+/// identity for these lenses — rooms and procedures only.
+struct RoomLanesView: View {
+    @ObservedObject var store: FlowWindowStore
+    let persona: String
+    let onSelect: (FlowSelection) -> Void
+
+    @State private var focusedRoom: String?
+
+    private let laneHeight: CGFloat = 34
+    private let labelWidth: CGFloat = 52
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Z.s2) {
+            if persona == "or_nurse", rooms.count > 1 {
+                roomPicker
+            }
+            if rooms.isEmpty && pacuMilestones.isEmpty {
+                Text("No cases on the schedule in this window.")
+                    .font(.system(size: 13))
+                    .foregroundStyle(Z.inkMuted)
+            } else {
+                ForEach(rooms, id: \.self) { room in
+                    laneRow(label: room, bars: bars(for: room), ticks: milestones(in: room))
+                        .opacity(rowOpacity(room))
+                }
+                if !pacuMilestones.isEmpty {
+                    laneRow(label: "PACU", bars: [], ticks: pacuMilestones)
+                }
+            }
+        }
+    }
+
+    // MARK: Rooms
+
+    /// Rooms come from the data, not a roster: scheduled cases' `room` plus rooms named by
+    /// milestones. PACU is a stage, not a room — it gets its own bottom lane.
+    private var rooms: [String] {
+        var names = Set<String>()
+        for projection in store.window?.projections ?? [] where projection.kind == "scheduled_or_case" {
+            if let room = projection.room { names.insert(room) }
+        }
+        for event in store.window?.events ?? [] where event.kind == "or_milestone" {
+            if let room = event.toSpace, room != "PACU" { names.insert(room) }
+        }
+        return names.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+    }
+
+    private func rowOpacity(_ room: String) -> Double {
+        guard persona == "or_nurse", let focusedRoom, rooms.count > 1 else { return 1 }
+        return room == focusedRoom ? 1 : 0.4
+    }
+
+    private var roomPicker: some View {
+        Menu {
+            ForEach(rooms, id: \.self) { room in
+                Button(room) { focusedRoom = room }
+            }
+        } label: {
+            HStack(spacing: Z.s1) {
+                Text("Room · \(focusedRoom ?? rooms.first ?? "—")")
+                    .font(.system(size: 13, weight: .medium))
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+            }
+            .foregroundStyle(Z.primary)
+            .frame(minHeight: 44, alignment: .leading)
+        }
+        .onAppear { if focusedRoom == nil { focusedRoom = rooms.first } }
+        .accessibilityLabel("Choose your room")
+    }
+
+    // MARK: Case cascade
+
+    private struct CaseBar: Identifiable {
+        let projection: FlowProjection
+        let start: Date
+        let end: Date
+        let scheduledStart: Date
+
+        var id: String { projection.id }
+        var driftMinutes: Int { max(0, Int(start.timeIntervalSince(scheduledStart) / 60)) }
+    }
+
+    /// Cascade drift: within a room, a case whose predecessor runs past its scheduled
+    /// start slides to the predecessor's end, keeping its duration.
+    private func bars(for room: String) -> [CaseBar] {
+        let cases = (store.window?.projections ?? [])
+            .filter { $0.kind == "scheduled_or_case" && $0.room == room }
+            .compactMap { projection -> (FlowProjection, Date, Date)? in
+                guard let start = projection.time else { return nil }
+                let end = FlowTime.parse(projection.endsAt) ?? start.addingTimeInterval(3600)
+                return (projection, start, max(end, start))
+            }
+            .sorted { $0.1 < $1.1 }
+
+        var result: [CaseBar] = []
+        var cursor = Date.distantPast
+        for (projection, scheduledStart, scheduledEnd) in cases {
+            let start = max(scheduledStart, cursor)
+            let end = start.addingTimeInterval(scheduledEnd.timeIntervalSince(scheduledStart))
+            result.append(CaseBar(projection: projection, start: start, end: end, scheduledStart: scheduledStart))
+            cursor = end
+        }
+        return result
+    }
+
+    private func milestones(in room: String) -> [FlowTimelineEvent] {
+        (store.window?.events ?? []).filter { $0.kind == "or_milestone" && $0.toSpace == room }
+    }
+
+    private var pacuMilestones: [FlowTimelineEvent] {
+        (store.window?.events ?? []).filter { $0.kind == "or_milestone" && $0.toSpace == "PACU" }
+    }
+
+    // MARK: Lane rendering
+
+    private func laneRow(label: String, bars: [CaseBar], ticks: [FlowTimelineEvent]) -> some View {
+        HStack(spacing: Z.s2) {
+            Text(label)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Z.inkMuted)
+                .lineLimit(2)
+                .frame(width: labelWidth, alignment: .leading)
+            GeometryReader { geo in
+                laneTrack(bars: bars, ticks: ticks, width: geo.size.width, height: geo.size.height)
+            }
+            .frame(height: laneHeight)
+        }
+    }
+
+    private func laneTrack(bars: [CaseBar], ticks: [FlowTimelineEvent],
+                           width: CGFloat, height: CGFloat) -> some View {
+        let midY = height / 2
+        return ZStack(alignment: .leading) {
+            Rectangle()
+                .fill(Z.border.opacity(0.5))
+                .frame(height: 1)
+                .position(x: width / 2, y: midY)
+
+            // Scrub-time indicator, aligned with the Chronobar thumb.
+            Rectangle()
+                .fill(Z.inkMuted.opacity(0.6))
+                .frame(width: 1, height: height)
+                .position(x: x(for: store.t, width: width), y: midY)
+
+            ForEach(bars) { bar in
+                caseBarView(bar, width: width, midY: midY)
+            }
+
+            ForEach(ticks) { event in
+                tickButton(event, width: width, midY: midY)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func caseBarView(_ bar: CaseBar, width: CGFloat, midY: CGFloat) -> some View {
+        let startX = x(for: bar.start, width: width)
+        let endX = x(for: bar.end, width: width)
+        let barWidth = max(endX - startX, 8)
+        let started = bar.start <= store.nowDate
+        let opacity = bar.projection.confidenceLevel.ghostOpacity
+
+        Button {
+            onSelect(.projection(bar.projection))
+        } label: {
+            ZStack(alignment: .topLeading) {
+                Group {
+                    if started {
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Z.primary.opacity(0.35))
+                            .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Z.primary, lineWidth: 1))
+                    } else {
+                        // Ghost grammar: dashed outline at confidence opacity, never a solid fill.
+                        RoundedRectangle(cornerRadius: 4)
+                            .strokeBorder(Z.ink.opacity(opacity), style: StrokeStyle(lineWidth: 1.5, dash: [4, 3]))
+                    }
+                }
+                .frame(width: barWidth, height: 14)
+
+                if bar.driftMinutes > 0 {
+                    Text("+\(bar.driftMinutes)m")
+                        .font(.system(size: 9, weight: .semibold)).monospacedDigit()
+                        .foregroundStyle(Z.status(.warning))
+                        .offset(y: -12)
+                }
+            }
+            .frame(width: barWidth, height: 44) // full-height touch target around the 14pt bar
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .position(x: startX + barWidth / 2, y: midY)
+        .accessibilityLabel(caseAccessibilityText(bar))
+    }
+
+    private func tickButton(_ event: FlowTimelineEvent, width: CGFloat, midY: CGFloat) -> some View {
+        Button {
+            onSelect(.event(event))
+        } label: {
+            Rectangle()
+                .fill(Z.primary)
+                .frame(width: 2, height: 12)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .position(x: x(for: event.time, width: width), y: midY)
+        .accessibilityLabel(event.label ?? event.kind)
+    }
+
+    private func caseAccessibilityText(_ bar: CaseBar) -> String {
+        var parts = [bar.projection.label ?? "Scheduled case"]
+        if bar.driftMinutes > 0 { parts.append("running \(bar.driftMinutes) minutes behind schedule") }
+        return parts.joined(separator: ", ")
+    }
+
+    private func x(for date: Date?, width: CGFloat) -> CGFloat {
+        guard let date else { return 0 }
+        let span = max(store.toDate.timeIntervalSince(store.fromDate), 1)
+        let fraction = min(max(date.timeIntervalSince(store.fromDate) / span, 0), 1)
+        return CGFloat(fraction) * width
+    }
+}

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/TimelineLanes.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/TimelineLanes.swift
@@ -38,6 +38,9 @@ struct TimelineLanes: View {
             Lane(id: "turnsTrips", label: "Turns & Trips",
                  eventKinds: ["evs_status", "transport_status"],
                  projectionKinds: ["evs_due", "transport_due"]),
+            Lane(id: "staffing", label: "Staffing",
+                 eventKinds: ["staffing_fill"],
+                 projectionKinds: ["staffing_shift_gap"]),
         ]
         if lens.roleId == "bed_manager" || lens.roleId == "house_supervisor" {
             candidates.append(Lane(id: "placements", label: "Placements",
@@ -144,5 +147,125 @@ struct TimelineLanes: View {
         let span = max(store.toDate.timeIntervalSince(store.fromDate), 1)
         let fraction = min(max(date.timeIntervalSince(store.fromDate) / span, 0), 1)
         return CGFloat(fraction) * width
+    }
+}
+
+/// Hospitalist / intensivist: the "Discharge leverage" lane — expected_discharge ghosts as
+/// a rounding order, ranked definite > probable > possible then earliest. These lenses are
+/// patient_dots `unit`, so only shared-unit patients carry a context ref: rows with a ref
+/// open the existing A2P patient context; the rest render label-only (no dead-end taps).
+struct DischargeLeverageLane: View {
+    @ObservedObject var store: FlowWindowStore
+
+    var body: some View {
+        let ranked = rankedDischarges
+        if !ranked.isEmpty {
+            VStack(alignment: .leading, spacing: Z.s2) {
+                Text("DISCHARGE LEVERAGE")
+                    .font(.system(size: 11, weight: .semibold)).tracking(0.5)
+                    .foregroundStyle(Z.inkMuted)
+                ForEach(Array(ranked.enumerated()), id: \.element.id) { index, projection in
+                    row(rank: index + 1, projection)
+                }
+            }
+        }
+    }
+
+    /// Rounding order: confidence first (a definite discharge unblocks a bed you can plan
+    /// on), then the earliest expected time.
+    private var rankedDischarges: [FlowProjection] {
+        (store.window?.projections ?? [])
+            .filter { $0.kind == "expected_discharge" }
+            .sorted { a, b in
+                let ra = Self.confidenceRank(a.confidenceLevel)
+                let rb = Self.confidenceRank(b.confidenceLevel)
+                if ra != rb { return ra < rb }
+                return (a.time ?? .distantFuture) < (b.time ?? .distantFuture)
+            }
+    }
+
+    private static func confidenceRank(_ confidence: FlowConfidence) -> Int {
+        switch confidence {
+        case .definite: return 0
+        case .probable: return 1
+        case .possible: return 2
+        }
+    }
+
+    @ViewBuilder
+    private func row(rank: Int, _ projection: FlowProjection) -> some View {
+        if let ref = projection.patientContextRef {
+            NavigationLink {
+                PatientOperationalContextView(contextRef: ref)
+            } label: {
+                rowContent(rank: rank, projection, tappable: true)
+            }
+            .buttonStyle(.plain)
+        } else {
+            rowContent(rank: rank, projection, tappable: false)
+        }
+    }
+
+    private func rowContent(rank: Int, _ projection: FlowProjection, tappable: Bool) -> some View {
+        Panel(padding: Z.s3) {
+            HStack(spacing: Z.s3) {
+                Text("\(rank)")
+                    .font(.system(size: 15, weight: .semibold)).monospacedDigit()
+                    .foregroundStyle(Z.inkMuted)
+                    .frame(width: 20, alignment: .center)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(projection.label ?? "Expected discharge")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Z.ink)
+                        .lineLimit(1)
+                    Text(subtitle(projection))
+                        .font(.system(size: 12)).monospacedDigit()
+                        .foregroundStyle(Z.inkMuted)
+                }
+                Spacer()
+                // Ghost grammar: a dashed ring at confidence opacity, never a solid fill.
+                Circle()
+                    .stroke(Z.ink.opacity(projection.confidenceLevel.ghostOpacity),
+                            style: StrokeStyle(lineWidth: 1.5, dash: [2, 2]))
+                    .frame(width: 10, height: 10)
+                if tappable {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(Z.inkMuted)
+                }
+            }
+            .frame(minHeight: 28)
+        }
+        .accessibilityLabel(accessibilityText(rank: rank, projection, tappable: tappable))
+    }
+
+    private func subtitle(_ projection: FlowProjection) -> String {
+        var parts: [String] = []
+        if let abbr = projection.unitId.flatMap({ unitAbbrs[$0] }) { parts.append(abbr) }
+        if let time = projection.time { parts.append("by \(Self.hourText(time))") }
+        parts.append(projection.confidence)
+        return parts.joined(separator: " · ")
+    }
+
+    private var unitAbbrs: [Int: String] {
+        var byId: [Int: String] = [:]
+        for floor in store.window?.spaces?.floors ?? [] {
+            for unit in floor.units {
+                if let abbr = unit.abbr { byId[unit.unitId] = abbr }
+            }
+        }
+        return byId
+    }
+
+    private func accessibilityText(rank: Int, _ projection: FlowProjection, tappable: Bool) -> String {
+        var text = "Rank \(rank), \(projection.label ?? "expected discharge"), \(subtitle(projection))"
+        if tappable { text += ". Opens patient context." }
+        return text
+    }
+
+    private static func hourText(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        return f.string(from: date)
     }
 }

--- a/hummingbird/iosApp/Hummingbird/Features/Flow/TransportRoutesLayer.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Flow/TransportRoutesLayer.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+
+// The transporter's route layer (P1 lens): completed/active trips as solid arcs between
+// origin and destination, upcoming trips as dashed ghost arcs with confidence-mapped
+// opacity, and an "Off-map" gutter for endpoints that name no mappable space.
+
+// MARK: Trips
+
+/// One trip drawn on the map: the latest transport_status at/before the scrub time
+/// (solid), or a transport_due projection still ahead of it (ghost).
+struct FlowTrip: Identifiable {
+    let id: String
+    let fromLabel: String?
+    let toLabel: String?
+    let ghost: Bool
+    let opacity: Double
+    /// STAT tier renders in the warning tint — never coral (earned urgency).
+    let warning: Bool
+    let unitId: Int?
+    let bedId: Int?
+    let time: Date?
+    let selection: FlowSelection
+}
+
+enum FlowTripBuilder {
+    /// Trips visible at scrub time `t`: per transport request, the latest status event at
+    /// or before t (solid); plus every transport_due still due at or after t (ghost).
+    static func trips(window: FlowWindowData?, at t: Date) -> [FlowTrip] {
+        guard let window else { return [] }
+
+        var latestByRef: [String: FlowTimelineEvent] = [:]
+        for event in window.events where event.kind == "transport_status" {
+            guard let time = event.time, time <= t else { continue }
+            let key = event.entity?.ref ?? event.id
+            if let current = latestByRef[key], (current.time ?? .distantPast) >= time { continue }
+            latestByRef[key] = event
+        }
+
+        var trips: [FlowTrip] = latestByRef.values
+            .sorted { ($0.time ?? .distantPast) < ($1.time ?? .distantPast) }
+            .map { event in
+                FlowTrip(id: "event|\(event.id)",
+                         fromLabel: event.fromSpace, toLabel: event.toSpace,
+                         ghost: false, opacity: 0.85,
+                         warning: event.capacity == .warning || event.capacity == .critical,
+                         unitId: event.unitId, bedId: nil, time: event.time,
+                         selection: .event(event))
+            }
+
+        for projection in window.projections where projection.kind == "transport_due" {
+            guard let time = projection.time, time >= t else { continue }
+            let route = parseRoute(label: projection.label)
+            trips.append(FlowTrip(id: "projection|\(projection.id)",
+                                  fromLabel: route?.from, toLabel: route?.to,
+                                  ghost: true, opacity: projection.confidenceLevel.ghostOpacity,
+                                  warning: false,
+                                  unitId: projection.unitId, bedId: projection.bedId, time: time,
+                                  selection: .projection(projection)))
+        }
+        return trips
+    }
+
+    /// transport_due carries its route only in the label ("Transport due · ED → MICU-01");
+    /// derived ghosts ("Likely discharge transport") have no route text at all.
+    static func parseRoute(label: String?) -> (from: String, to: String)? {
+        guard let tail = label?.components(separatedBy: " · ").last else { return nil }
+        let parts = tail.components(separatedBy: " → ")
+        guard parts.count == 2 else { return nil }
+        let from = parts[0].trimmingCharacters(in: .whitespaces)
+        let to = parts[1].trimmingCharacters(in: .whitespaces)
+        guard !from.isEmpty, !to.isEmpty else { return nil }
+        return (from, to)
+    }
+}
+
+// MARK: Space resolution
+
+/// Resolves the data plane's space vocabulary — unit abbreviation ("ED"), full unit name
+/// ("3 West — Medical ICU (MICU)"), or bed label ("MICU-01") — to a floor + plate centroid.
+/// Free text ("Main Lobby Discharge") stays unresolved and lands in the off-map gutter.
+struct FlowSpaceResolver {
+    struct Endpoint {
+        let floor: Int
+        /// Plate centroid in plan feet; nil when the unit has census but no geometry.
+        let plan: CGPoint?
+    }
+
+    private var unitIdByAbbr: [String: Int] = [:]
+    private var unitIdByName: [String: Int] = [:]
+    private var floorByUnitId: [Int: Int] = [:]
+    private var planByUnitId: [Int: (floor: Int, point: CGPoint)] = [:]
+
+    init(window: FlowWindowData?, floors: FlowFloorsDocument?) {
+        for floor in window?.spaces?.floors ?? [] {
+            for unit in floor.units {
+                floorByUnitId[unit.unitId] = floor.floor
+                if let abbr = unit.abbr { unitIdByAbbr[abbr.lowercased()] = unit.unitId }
+                if let name = unit.name { unitIdByName[name.lowercased()] = unit.unitId }
+            }
+        }
+        for floor in floors?.floors ?? [] {
+            for plate in floor.spaces where plate.category == "unit" {
+                guard let unitId = plate.unitId, plate.rect.count >= 4 else { continue }
+                planByUnitId[unitId] = (floor.floor, CGPoint(x: plate.rect[0] + plate.rect[2] / 2,
+                                                            y: plate.rect[1] + plate.rect[3] / 2))
+            }
+        }
+    }
+
+    func endpoint(space raw: String?) -> Endpoint? {
+        guard let space = raw?.trimmingCharacters(in: .whitespaces), !space.isEmpty else { return nil }
+        let key = space.lowercased()
+        if let unitId = unitIdByAbbr[key] ?? unitIdByName[key] {
+            return endpoint(unitId: unitId)
+        }
+        // Bed label {ABBR}-{NN}: resolve the bed's unit, use the unit's plate centroid.
+        let parts = space.split(separator: "-")
+        if parts.count >= 2, Int(parts.last ?? "") != nil,
+           let unitId = unitIdByAbbr[parts.dropLast().joined(separator: "-").lowercased()] {
+            return endpoint(unitId: unitId)
+        }
+        return nil
+    }
+
+    func endpoint(unitId: Int?) -> Endpoint? {
+        guard let unitId else { return nil }
+        if let plan = planByUnitId[unitId] { return Endpoint(floor: plan.floor, plan: plan.point) }
+        if let floor = floorByUnitId[unitId] { return Endpoint(floor: floor, plan: nil) }
+        return nil
+    }
+}
+
+/// A trip joined to its resolved endpoints. Origins of derived discharge ghosts (no route
+/// text) fall back to the projection's bed/unit; a discharge's destination is off-map by
+/// nature and simply doesn't draw.
+struct ResolvedTrip: Identifiable {
+    let trip: FlowTrip
+    let from: FlowSpaceResolver.Endpoint?
+    let to: FlowSpaceResolver.Endpoint?
+
+    var id: String { trip.id }
+
+    init(trip: FlowTrip, resolver: FlowSpaceResolver) {
+        self.trip = trip
+        from = trip.fromLabel != nil
+            ? resolver.endpoint(space: trip.fromLabel)
+            : resolver.endpoint(unitId: trip.unitId)
+        to = resolver.endpoint(space: trip.toLabel)
+    }
+
+    /// Chip copy for the off-map gutter — only trips that NAME a space we can't map.
+    var offMapText: String? {
+        let fromLost = trip.fromLabel != nil && from == nil
+        let toLost = trip.toLabel != nil && to == nil
+        switch (fromLost, toLost) {
+        case (true, true): return "\(trip.fromLabel ?? "") → \(trip.toLabel ?? "")"
+        case (false, true): return "→ \(trip.toLabel ?? "")"
+        case (true, false): return "\(trip.fromLabel ?? "") →"
+        case (false, false): return nil
+        }
+    }
+}
+
+// MARK: House arcs
+
+/// Route arcs over the house stack: solid past trips, dashed ghosts, warning tint for
+/// STAT. Cross-floor trips bow between slabs; same-floor trips hump over their slab.
+/// Ghosts with only an origin (derived discharge trips) draw a dashed departure ring.
+struct TransportHouseArcs: View {
+    let trips: [ResolvedTrip]
+    let anchors: [Int: Anchor<CGRect>]
+    /// Plan bounds per floor ([x, y, w, h]) for positioning endpoints along a slab.
+    let boundsByFloor: [Int: [Double]]
+
+    var body: some View {
+        GeometryReader { proxy in
+            let slabRects = anchors.mapValues { proxy[$0] }
+            Canvas { context, _ in
+                for (index, resolved) in trips.enumerated() {
+                    draw(resolved, index: index, slabs: slabRects, in: &context)
+                }
+            }
+        }
+        .allowsHitTesting(false) // arcs annotate; slabs stay tappable underneath
+    }
+
+    private func draw(_ resolved: ResolvedTrip, index: Int,
+                      slabs: [Int: CGRect], in context: inout GraphicsContext) {
+        let trip = resolved.trip
+        let color = trip.warning ? Z.status(.warning) : (trip.ghost ? Z.ink : Z.primary)
+        let shading = GraphicsContext.Shading.color(color.opacity(trip.opacity))
+        let style = trip.ghost
+            ? StrokeStyle(lineWidth: 1.5, dash: [4, 3])
+            : StrokeStyle(lineWidth: 1.5)
+
+        guard let from = resolved.from, let fromSlab = slabs[from.floor] else { return }
+        let start = point(for: from, in: fromSlab, defaultFraction: 0.3)
+
+        guard let to = resolved.to, let toSlab = slabs[to.floor] else {
+            // Origin-only ghost (derived discharge trip): a dashed departure ring.
+            if trip.ghost {
+                let ring = CGRect(x: start.x - 4, y: start.y - 4, width: 8, height: 8)
+                context.stroke(Path(ellipseIn: ring), with: shading, style: style)
+            }
+            return
+        }
+        let end = point(for: to, in: toSlab, defaultFraction: 0.7)
+
+        var path = Path()
+        path.move(to: start)
+        if from.floor == to.floor {
+            // Same-floor: hump above the slab.
+            path.addQuadCurve(to: end, control: CGPoint(x: (start.x + end.x) / 2, y: start.y - 18))
+        } else {
+            // Cross-floor: bow sideways; stagger overlapping trips by index.
+            let bow: CGFloat = 28 + CGFloat(index % 3) * 14
+            path.addQuadCurve(to: end,
+                              control: CGPoint(x: max(start.x, end.x) + bow, y: (start.y + end.y) / 2))
+        }
+        context.stroke(path, with: shading, style: style)
+
+        // Destination marker: filled for real trips, open for ghosts.
+        let dot = CGRect(x: end.x - 3, y: end.y - 3, width: 6, height: 6)
+        if trip.ghost {
+            context.stroke(Path(ellipseIn: dot), with: shading, lineWidth: 1.5)
+        } else {
+            context.fill(Path(ellipseIn: dot), with: shading)
+        }
+    }
+
+    /// Endpoint x along the slab from its plan-x fraction when geometry exists;
+    /// otherwise a fixed origin/destination station.
+    private func point(for endpoint: FlowSpaceResolver.Endpoint,
+                       in slab: CGRect, defaultFraction: CGFloat) -> CGPoint {
+        var fraction = defaultFraction
+        if let plan = endpoint.plan, let bounds = boundsByFloor[endpoint.floor],
+           bounds.count >= 4, bounds[2] > 0 {
+            fraction = min(max((plan.x - bounds[0]) / bounds[2], 0.1), 0.9)
+        }
+        return CGPoint(x: slab.minX + fraction * slab.width, y: slab.midY)
+    }
+}
+
+// MARK: Off-map gutter
+
+/// Trips whose named origin/destination isn't a mappable space (lobbies, SNFs, home
+/// health) — listed as chips under the map instead of silently dropped.
+struct OffMapGutter: View {
+    let trips: [ResolvedTrip]
+    let onSelect: (FlowSelection) -> Void
+
+    private var items: [(id: String, text: String, trip: ResolvedTrip)] {
+        trips.compactMap { resolved in
+            resolved.offMapText.map { (resolved.id, $0, resolved) }
+        }
+    }
+
+    var body: some View {
+        if !items.isEmpty {
+            VStack(alignment: .leading, spacing: Z.s2) {
+                Text("OFF-MAP")
+                    .font(.system(size: 11, weight: .semibold)).tracking(0.5)
+                    .foregroundStyle(Z.inkMuted)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: Z.s2) {
+                        ForEach(items, id: \.id) { item in
+                            chip(item.text, trip: item.trip)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func chip(_ text: String, trip: ResolvedTrip) -> some View {
+        Button {
+            onSelect(trip.trip.selection)
+        } label: {
+            HStack(spacing: Z.s1) {
+                Image(systemName: trip.trip.ghost ? "clock" : "figure.walk")
+                    .font(.system(size: 10, weight: .medium))
+                Text(text)
+                    .font(.system(size: 12, weight: .medium))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(trip.trip.warning ? Z.status(.warning) : Z.inkMuted)
+            .padding(.horizontal, Z.s3)
+            .frame(height: 44) // full-height touch target even though the capsule reads small
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .background(
+            Capsule().fill(Z.surface)
+                .padding(.vertical, Z.s2)
+        )
+        .overlay(
+            Capsule()
+                .strokeBorder(Z.border, style: trip.trip.ghost
+                    ? StrokeStyle(lineWidth: 1, dash: [4, 3])
+                    : StrokeStyle(lineWidth: 1))
+                .padding(.vertical, Z.s2)
+        )
+        .accessibilityLabel("Off-map trip, \(text)")
+    }
+}

--- a/hummingbird/iosApp/Hummingbird/Features/Home/HomeView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Home/HomeView.swift
@@ -70,12 +70,14 @@ struct HomeView: View {
     }
 
     /// The personas whose census home offers the spatial Flow Window, and at which scope
-    /// (charge nurse → own unit's floor board; house supervisor → the whole house).
+    /// (charge nurse → own unit's floor board; house supervisor → the whole house;
+    /// hospitalist/intensivist → house, since their patients span floors and the map adds
+    /// the discharge-leverage rounding order).
     private var mapScope: FlowScopeRequest? {
         switch profile.roleId {
         case "charge_nurse":
             return profile.unitId.map { FlowScopeRequest.unit($0) } ?? .house
-        case "house_supervisor":
+        case "house_supervisor", "hospitalist", "intensivist":
             return .house
         default:
             return nil

--- a/hummingbird/iosApp/Hummingbird/Features/Improvement/ImprovementView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Improvement/ImprovementView.swift
@@ -36,46 +36,69 @@ struct ImprovementView: View {
     @EnvironmentObject var auth: AuthStore
     @StateObject private var vm = ImprovementViewModel(api: APIClient(baseURL: URL(string: AppConfig.baseURL)!))
     @State private var showProfile = false
+    @State private var viewMode: FlowHomeMode = .list
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: Z.s4) {
-                    AltitudeContextCard(domain: "ops")
-                    if !vm.loaded && vm.isLoading {
-                        SkeletonRows()
-                    } else if !vm.loaded, let e = vm.errorMessage {
-                        RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load improvement",
-                                         message: e, tone: .warning) { Task { await vm.load(bearer: auth.accessToken ?? "") } }
-                    } else {
-                        summary
-                        if !vm.activeCycles.isEmpty {
-                            sectionLabel("ACTIVE PDSA CYCLES (\(vm.activeCycles.count))")
-                            ForEach(vm.activeCycles) { cycleRow($0) }
-                        }
-                        if !vm.opportunities.isEmpty {
-                            sectionLabel("OPPORTUNITIES (by impact)")
-                            ForEach(vm.opportunities) { oppRow($0) }
-                        }
-                    }
+            Group {
+                if viewMode == .map {
+                    // The Flow Window — "the pattern, not the patient" (P8): de-identified
+                    // process replay at ~4h/s with clip-to-share for PDSA evidence.
+                    FlowMapView(persona: "pi_lead", scope: .house)
+                } else {
+                    listBody
                 }
-                .padding(Z.s4)
             }
             .background(Z.bg)
             .navigationTitle("Improvement")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar { ToolbarItem(placement: .topBarTrailing) {
-                Button { showProfile = true } label: { Image(systemName: "person.crop.circle").foregroundStyle(Z.ink) }.accessibilityLabel("Profile and settings")
-            } }
-            .sheet(isPresented: $showProfile) { ProfileView() }
-            .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
-            .task {
-                let token = auth.accessToken ?? ""
-                while !Task.isCancelled { await vm.load(bearer: token); try? await Task.sleep(for: .seconds(30)) }
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Picker("View", selection: $viewMode) {
+                        Text("List").tag(FlowHomeMode.list)
+                        Text("Map").tag(FlowHomeMode.map)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 160)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button { showProfile = true } label: { Image(systemName: "person.crop.circle").foregroundStyle(Z.ink) }.accessibilityLabel("Profile and settings")
+                }
             }
+            .sheet(isPresented: $showProfile) { ProfileView() }
             .onChange(of: vm.needsReauth) { _, n in if n { Task { await auth.logout() } } }
         }
         .tint(Z.primary)
+    }
+
+    private var listBody: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Z.s4) {
+                AltitudeContextCard(domain: "ops")
+                if !vm.loaded && vm.isLoading {
+                    SkeletonRows()
+                } else if !vm.loaded, let e = vm.errorMessage {
+                    RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load improvement",
+                                     message: e, tone: .warning) { Task { await vm.load(bearer: auth.accessToken ?? "") } }
+                } else {
+                    summary
+                    if !vm.activeCycles.isEmpty {
+                        sectionLabel("ACTIVE PDSA CYCLES (\(vm.activeCycles.count))")
+                        ForEach(vm.activeCycles) { cycleRow($0) }
+                    }
+                    if !vm.opportunities.isEmpty {
+                        sectionLabel("OPPORTUNITIES (by impact)")
+                        ForEach(vm.opportunities) { oppRow($0) }
+                    }
+                }
+            }
+            .padding(Z.s4)
+        }
+        .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
+        .task {
+            let token = auth.accessToken ?? ""
+            while !Task.isCancelled { await vm.load(bearer: token); try? await Task.sleep(for: .seconds(30)) }
+        }
     }
 
     private var summary: some View {

--- a/hummingbird/iosApp/Hummingbird/Features/OR/ORBoardView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/OR/ORBoardView.swift
@@ -31,42 +31,71 @@ final class ORBoardViewModel: ObservableObject {
 
 struct ORBoardView: View {
     @EnvironmentObject var auth: AuthStore
+    @EnvironmentObject var profile: ProfileStore
     @StateObject private var vm = ORBoardViewModel(api: APIClient(baseURL: URL(string: AppConfig.baseURL)!))
     @State private var showProfile = false
+    @State private var viewMode: FlowHomeMode = .list
+
+    // Both OR personas share this board; the Flow Window lens tells them apart
+    // (one room's day vs the whole cascade).
+    private var orPersona: String {
+        profile.roleId == "periop_manager" ? "periop_manager" : "or_nurse"
+    }
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: Z.s4) {
-                    AltitudeContextCard(domain: "or")
-                    if vm.board == nil && vm.isLoading {
-                        SkeletonRows()
-                    } else if vm.board == nil, let e = vm.errorMessage {
-                        RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load the OR board",
-                                         message: e, tone: .warning) { Task { await vm.load(bearer: auth.accessToken ?? "") } }
-                    } else if let b = vm.board {
-                        metrics(b.metrics)
-                        sectionLabel("ROOMS")
-                        ForEach(b.rooms) { roomCard($0) }
-                    }
+            Group {
+                if viewMode == .map {
+                    // The Flow Window at periop-floor scope: room lanes against the 48h scrubber.
+                    ORFlowMapSection(persona: orPersona)
+                } else {
+                    listBody
                 }
-                .padding(Z.s4)
             }
             .background(Z.bg)
             .navigationTitle("OR Board")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar { ToolbarItem(placement: .topBarTrailing) {
-                Button { showProfile = true } label: { Image(systemName: "person.crop.circle").foregroundStyle(Z.ink) }.accessibilityLabel("Profile and settings")
-            } }
-            .sheet(isPresented: $showProfile) { ProfileView() }
-            .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
-            .task {
-                let token = auth.accessToken ?? ""
-                while !Task.isCancelled { await vm.load(bearer: token); try? await Task.sleep(for: .seconds(20)) }
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Picker("View", selection: $viewMode) {
+                        Text("List").tag(FlowHomeMode.list)
+                        Text("Map").tag(FlowHomeMode.map)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 160)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button { showProfile = true } label: { Image(systemName: "person.crop.circle").foregroundStyle(Z.ink) }.accessibilityLabel("Profile and settings")
+                }
             }
+            .sheet(isPresented: $showProfile) { ProfileView() }
             .onChange(of: vm.needsReauth) { _, n in if n { Task { await auth.logout() } } }
         }
         .tint(Z.primary)
+    }
+
+    private var listBody: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Z.s4) {
+                AltitudeContextCard(domain: "or")
+                if vm.board == nil && vm.isLoading {
+                    SkeletonRows()
+                } else if vm.board == nil, let e = vm.errorMessage {
+                    RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load the OR board",
+                                     message: e, tone: .warning) { Task { await vm.load(bearer: auth.accessToken ?? "") } }
+                } else if let b = vm.board {
+                    metrics(b.metrics)
+                    sectionLabel("ROOMS")
+                    ForEach(b.rooms) { roomCard($0) }
+                }
+            }
+            .padding(Z.s4)
+        }
+        .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
+        .task {
+            let token = auth.accessToken ?? ""
+            while !Task.isCancelled { await vm.load(bearer: token); try? await Task.sleep(for: .seconds(20)) }
+        }
     }
 
     private func metrics(_ m: ORMetrics) -> some View {
@@ -145,5 +174,34 @@ struct ORBoardView: View {
 
     private func sectionLabel(_ t: String) -> some View {
         Text(t).font(.system(size: 11, weight: .semibold)).tracking(0.5).foregroundStyle(Z.inkMuted).padding(.top, Z.s2)
+    }
+}
+
+/// Resolves the periop floor before mounting the Flow Window: the floor whose plates
+/// include a procedure room; when the plates asset can't say, bare floor scope lets the
+/// server's lens default (the periop floor) decide.
+private struct ORFlowMapSection: View {
+    @EnvironmentObject var auth: AuthStore
+    let persona: String
+
+    @State private var scope: FlowScopeRequest?
+
+    var body: some View {
+        Group {
+            if let scope {
+                FlowMapView(persona: persona, scope: scope)
+            } else {
+                ScrollView { SkeletonRows().padding(Z.s4) }
+            }
+        }
+        .task {
+            guard scope == nil else { return }
+            let api = APIClient(baseURL: URL(string: AppConfig.baseURL)!)
+            let floors = try? await api.flowFloors(bearer: auth.accessToken ?? "").data
+            let procedureFloor = floors?.floors.first { floor in
+                floor.spaces.contains { $0.category == "procedure_room" }
+            }?.floor
+            scope = .floor(procedureFloor)
+        }
     }
 }

--- a/hummingbird/iosApp/Hummingbird/Features/RTDC/HouseCapacityView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/RTDC/HouseCapacityView.swift
@@ -48,13 +48,15 @@ final class HouseCapacityViewModel: ObservableObject {
     /// widget itself has no network or token).
     private func cacheGlance(_ h: HouseRollup) {
         let status = h.occupancy.percent >= 100 ? "critical" : (h.occupancy.percent >= 90 ? "warning" : "success")
-        HouseGlanceCache.save(HouseGlanceSnapshot(
-            occupancyPercent: h.occupancy.percent,
-            occupied: h.occupancy.occupied,
-            staffed: h.occupancy.staffed,
-            pendingPlacements: h.pendingPlacements,
-            statusRaw: status,
-            updatedAt: Date()))
+        // Merge only the fields RTDC owns — the flow window separately writes next4hGhostCount.
+        HouseGlanceCache.merge {
+            $0.occupancyPercent = h.occupancy.percent
+            $0.occupied = h.occupancy.occupied
+            $0.staffed = h.occupancy.staffed
+            $0.pendingPlacements = h.pendingPlacements
+            $0.netBedNeed = h.netBedNeed
+            $0.statusRaw = status
+        }
         WidgetCenter.shared.reloadTimelines(ofKind: HouseGlanceCache.widgetKind)
     }
 }

--- a/hummingbird/iosApp/Hummingbird/Features/RTDC/HouseCapacityView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/RTDC/HouseCapacityView.swift
@@ -69,7 +69,7 @@ struct HouseCapacityView: View {
     @State private var autoOpenPlacement = false
     @State private var autoPlacementIndex = 0
     @State private var didAutoOpen = false
-    @State private var viewMode: FlowHomeMode = .list
+    @State private var viewMode: FlowHomeMode = ProcessInfo.processInfo.environment["HB_HOME_MODE"] == "map" ? .map : .list
 
     private let refreshInterval: Duration = .seconds(20)
 

--- a/hummingbird/iosApp/Hummingbird/Features/Staffing/StaffingView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Staffing/StaffingView.swift
@@ -39,46 +39,69 @@ struct StaffingView: View {
     @EnvironmentObject var auth: AuthStore
     @StateObject private var vm = StaffingViewModel(api: APIClient(baseURL: URL(string: AppConfig.baseURL)!))
     @State private var showProfile = false
+    @State private var viewMode: FlowHomeMode = .list
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: Z.s4) {
-                    AltitudeContextCard(domain: "staffing")
-                    if vm.overview == nil && vm.isLoading {
-                        SkeletonRows()
-                    } else if vm.overview == nil, let e = vm.errorMessage {
-                        RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load staffing",
-                                         message: e, tone: .warning) { Task { await vm.load(bearer: auth.accessToken ?? "") } }
-                    } else if let o = vm.overview {
-                        metrics(o.metrics)
-                        if !o.unitsAtRisk.isEmpty {
-                            sectionLabel("BELOW MINIMUM-SAFE (\(o.unitsAtRisk.count))")
-                            ForEach(o.unitsAtRisk) { unitRow($0) }
-                        }
-                        if !o.queue.isEmpty {
-                            sectionLabel("OPEN REQUESTS (\(o.queue.count))")
-                            ForEach(o.queue) { requestRow($0) }
-                        }
-                    }
+            Group {
+                if viewMode == .map {
+                    // The Flow Window — "coverage vs the curve" (P10): predicted census
+                    // against staffing-gap steps at shift boundaries; floors tinted by gap.
+                    FlowMapView(persona: "staffing_coordinator", scope: .house)
+                } else {
+                    listBody
                 }
-                .padding(Z.s4)
             }
             .background(Z.bg)
             .navigationTitle("Staffing")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar { ToolbarItem(placement: .topBarTrailing) {
-                Button { showProfile = true } label: { Image(systemName: "person.crop.circle").foregroundStyle(Z.ink) }.accessibilityLabel("Profile and settings")
-            } }
-            .sheet(isPresented: $showProfile) { ProfileView() }
-            .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
-            .task {
-                let token = auth.accessToken ?? ""
-                while !Task.isCancelled { await vm.load(bearer: token); try? await Task.sleep(for: .seconds(20)) }
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Picker("View", selection: $viewMode) {
+                        Text("List").tag(FlowHomeMode.list)
+                        Text("Map").tag(FlowHomeMode.map)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 160)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button { showProfile = true } label: { Image(systemName: "person.crop.circle").foregroundStyle(Z.ink) }.accessibilityLabel("Profile and settings")
+                }
             }
+            .sheet(isPresented: $showProfile) { ProfileView() }
             .onChange(of: vm.needsReauth) { _, n in if n { Task { await auth.logout() } } }
         }
         .tint(Z.primary)
+    }
+
+    private var listBody: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Z.s4) {
+                AltitudeContextCard(domain: "staffing")
+                if vm.overview == nil && vm.isLoading {
+                    SkeletonRows()
+                } else if vm.overview == nil, let e = vm.errorMessage {
+                    RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load staffing",
+                                     message: e, tone: .warning) { Task { await vm.load(bearer: auth.accessToken ?? "") } }
+                } else if let o = vm.overview {
+                    metrics(o.metrics)
+                    if !o.unitsAtRisk.isEmpty {
+                        sectionLabel("BELOW MINIMUM-SAFE (\(o.unitsAtRisk.count))")
+                        ForEach(o.unitsAtRisk) { unitRow($0) }
+                    }
+                    if !o.queue.isEmpty {
+                        sectionLabel("OPEN REQUESTS (\(o.queue.count))")
+                        ForEach(o.queue) { requestRow($0) }
+                    }
+                }
+            }
+            .padding(Z.s4)
+        }
+        .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
+        .task {
+            let token = auth.accessToken ?? ""
+            while !Task.isCancelled { await vm.load(bearer: token); try? await Task.sleep(for: .seconds(20)) }
+        }
     }
 
     private func metrics(_ m: StaffingMetrics) -> some View {

--- a/hummingbird/iosApp/Hummingbird/Features/Transport/JobDetailView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Transport/JobDetailView.swift
@@ -206,7 +206,8 @@ struct JobDetailView: View {
             title: job.priority == "stat" ? "STAT transport" : "Transport trip",
             detail: "\(job.origin ?? "—") → \(job.destination ?? "—")",
             isStat: job.priority == "stat",
-            statusRaw: newStatus, statusLabel: statusLabel(newStatus))
+            statusRaw: newStatus, statusLabel: statusLabel(newStatus),
+            slaDeadline: FlowTime.parse(job.neededAt))
     }
 
     private func nextAction(after s: String) -> (label: String, status: String)? {

--- a/hummingbird/iosApp/Hummingbird/Features/Transport/TransportJobsView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Transport/TransportJobsView.swift
@@ -61,6 +61,7 @@ struct TransportJobsView: View {
     @EnvironmentObject var auth: AuthStore
     @StateObject private var vm: TransportJobsViewModel
     @State private var showProfile = false
+    @State private var viewMode: FlowHomeMode = .list
 
     private let refreshInterval: Duration = .seconds(20)
 
@@ -70,26 +71,27 @@ struct TransportJobsView: View {
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: Z.s4) {
-                    AltitudeContextCard(domain: "transport")
-                    if vm.queue == nil && vm.isLoading {
-                        SkeletonRows()
-                    } else if vm.queue == nil && vm.errorMessage != nil {
-                        RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load trips",
-                                         message: vm.errorMessage ?? "", tone: .warning) {
-                            Task { await vm.load(bearer: auth.accessToken ?? "") }
-                        }
-                    } else if let q = vm.queue {
-                        content(q)
-                    }
+            Group {
+                if viewMode == .map {
+                    // The Flow Window — "my day in the building": trips as routes over the
+                    // house stack. A presentation mode of this home, not a new tab.
+                    FlowMapView(persona: "transport", scope: .house)
+                } else {
+                    listBody
                 }
-                .padding(Z.s4)
             }
             .background(Z.bg)
             .navigationTitle("Transport")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Picker("View", selection: $viewMode) {
+                        Text("List").tag(FlowHomeMode.list)
+                        Text("Map").tag(FlowHomeMode.map)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 160)
+                }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button { showProfile = true } label: {
                         Image(systemName: "person.crop.circle").foregroundStyle(Z.ink)
@@ -98,19 +100,38 @@ struct TransportJobsView: View {
                 }
             }
             .sheet(isPresented: $showProfile) { ProfileView() }
-            .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
-            .task {
-                let token = auth.accessToken ?? ""
-                while !Task.isCancelled {
-                    await vm.load(bearer: token)
-                    try? await Task.sleep(for: refreshInterval)
-                }
-            }
             .onChange(of: vm.needsReauth) { _, needs in
                 if needs { Task { await auth.logout() } }
             }
         }
         .tint(Z.primary)
+    }
+
+    private var listBody: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Z.s4) {
+                AltitudeContextCard(domain: "transport")
+                if vm.queue == nil && vm.isLoading {
+                    SkeletonRows()
+                } else if vm.queue == nil && vm.errorMessage != nil {
+                    RetryableMessage(symbol: "wifi.exclamationmark", title: "Can't load trips",
+                                     message: vm.errorMessage ?? "", tone: .warning) {
+                        Task { await vm.load(bearer: auth.accessToken ?? "") }
+                    }
+                } else if let q = vm.queue {
+                    content(q)
+                }
+            }
+            .padding(Z.s4)
+        }
+        .refreshable { await vm.load(bearer: auth.accessToken ?? "") }
+        .task {
+            let token = auth.accessToken ?? ""
+            while !Task.isCancelled {
+                await vm.load(bearer: token)
+                try? await Task.sleep(for: refreshInterval)
+            }
+        }
     }
 
     @ViewBuilder

--- a/hummingbird/iosApp/Hummingbird/LiveActivity/HouseGlanceCache.swift
+++ b/hummingbird/iosApp/Hummingbird/LiveActivity/HouseGlanceCache.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Last-known house snapshot, cached to the App Group so the glance widget renders
 /// without network or auth (widgets get no bearer token; the app is the only writer).
+/// New fields are optional so a blob written by an older build still decodes.
 struct HouseGlanceSnapshot: Codable {
     var occupancyPercent: Int
     var occupied: Int
@@ -11,6 +12,11 @@ struct HouseGlanceSnapshot: Codable {
     /// never color alone.
     var statusRaw: String
     var updatedAt: Date
+    /// Net bed need (by-2pm sum) from the RTDC house rollup.
+    var netBedNeed: Int? = nil
+    /// Count of projected "ghost" items landing in the next 4h — written from the Flow
+    /// Window load so the glance shows what is coming, not just what is.
+    var next4hGhostCount: Int? = nil
 }
 
 enum HouseGlanceCache {
@@ -28,6 +34,18 @@ enum HouseGlanceCache {
         guard let defaults = UserDefaults(suiteName: appGroupId),
               let data = defaults.data(forKey: key) else { return nil }
         return try? JSONDecoder().decode(HouseGlanceSnapshot.self, from: data)
+    }
+
+    /// Update only the fields a given writer owns (RTDC owns occupancy/net-bed-need; the Flow
+    /// Window owns next4hGhostCount) without clobbering the others. Seeds a calm zero snapshot
+    /// when nothing is cached yet.
+    static func merge(_ mutate: (inout HouseGlanceSnapshot) -> Void) {
+        var snapshot = load() ?? HouseGlanceSnapshot(
+            occupancyPercent: 0, occupied: 0, staffed: 0, pendingPlacements: 0,
+            statusRaw: "info", updatedAt: Date())
+        mutate(&snapshot)
+        snapshot.updatedAt = Date()
+        save(snapshot)
     }
 
     static func clear() {
@@ -57,5 +75,9 @@ enum ForYouGlanceCache {
         guard let defaults = UserDefaults(suiteName: HouseGlanceCache.appGroupId),
               let data = defaults.data(forKey: key) else { return nil }
         return try? JSONDecoder().decode(ForYouGlanceSnapshot.self, from: data)
+    }
+
+    static func clear() {
+        UserDefaults(suiteName: HouseGlanceCache.appGroupId)?.removeObject(forKey: key)
     }
 }

--- a/hummingbird/iosApp/Hummingbird/LiveActivity/JobActivityAttributes.swift
+++ b/hummingbird/iosApp/Hummingbird/LiveActivity/JobActivityAttributes.swift
@@ -12,6 +12,9 @@ struct HBJobActivityAttributes: ActivityAttributes {
         /// Worker-language label, e.g. "En route".
         var statusLabel: String
         var updatedAt: Date
+        /// SLA deadline (transport `needed_at` / EVS due). When it is still ahead, the island
+        /// and lock screen render a live `Text(timerInterval:)` countdown; nil / past hides it.
+        var slaDeadline: Date? = nil
     }
 
     /// "transport" | "evs"

--- a/hummingbird/iosApp/Hummingbird/LiveActivity/JobActivityController.swift
+++ b/hummingbird/iosApp/Hummingbird/LiveActivity/JobActivityController.swift
@@ -10,11 +10,15 @@ enum JobActivityController {
     private static let terminal: Set<String> = ["completed", "cancelled", "unable_to_complete"]
 
     static func sync(kind: String, id: Int, title: String, detail: String,
-                     isStat: Bool, statusRaw: String, statusLabel: String) {
+                     isStat: Bool, statusRaw: String, statusLabel: String,
+                     slaDeadline: Date? = nil) {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
 
+        // Updates are app-driven: the worker's own lifecycle taps push each new ContentState
+        // locally — no APNs push token yet, so no server round-trip is involved here.
         let state = HBJobActivityAttributes.ContentState(
-            statusRaw: statusRaw, statusLabel: statusLabel, updatedAt: Date())
+            statusRaw: statusRaw, statusLabel: statusLabel, updatedAt: Date(),
+            slaDeadline: slaDeadline)
         let content = ActivityContent(state: state, staleDate: nil)
         let existing = Activity<HBJobActivityAttributes>.activities
             .first { $0.attributes.kind == kind && $0.attributes.jobId == id }
@@ -49,7 +53,8 @@ enum JobActivityController {
         guard ProcessInfo.processInfo.environment["HB_DEMO_LIVE_ACTIVITY"] == "1" else { return }
         sync(kind: "transport", id: 999_999, title: "STAT transport",
              detail: "ED Room 4 → CT Imaging", isStat: true,
-             statusRaw: "en_route", statusLabel: "En route")
+             statusRaw: "en_route", statusLabel: "En route",
+             slaDeadline: Date().addingTimeInterval(18 * 60))
     }
     #endif
 }

--- a/hummingbird/iosApp/Hummingbird/Networking/APIClient.swift
+++ b/hummingbird/iosApp/Hummingbird/Networking/APIClient.swift
@@ -216,15 +216,33 @@ struct APIClient {
 
     // MARK: Flow Window (48h spatiotemporal lens)
 
-    /// GET /api/mobile/v1/flow/window?persona=&scope= — the persona-lensed 48h window
+    /// GET /api/mobile/v1/flow/window?persona=&scope=&since= — the persona-lensed 48h window
     /// (snapshots + events + projections + per-floor rollups) for a scope the lens allows.
-    func flowWindow(persona: String?, scope: String?, bearer: String) async throws -> Envelope<FlowWindowData> {
+    /// `since` (ISO-8601, within [window.from, window.to]) requests a delta: only events and
+    /// snapshots with t > since come back; projections/spaces/bed_statuses stay full. An
+    /// out-of-range/malformed `since` is a 422 (invalid_since) — callers fall back to a full load.
+    func flowWindow(persona: String?, scope: String?, since: String? = nil, bearer: String) async throws -> Envelope<FlowWindowData> {
+        try await getEnvelope(path: flowWindowPath(persona: persona, scope: scope, since: since),
+                              bearer: bearer, as: FlowWindowData.self)
+    }
+
+    /// As `flowWindow`, but also returns the raw envelope bytes so the caller can persist the
+    /// last FULL window to the offline cache verbatim (no round-trip through Encodable DTOs).
+    func flowWindowRaw(persona: String?, scope: String?, since: String? = nil, bearer: String) async throws -> (Envelope<FlowWindowData>, Data) {
+        let data = try await send(path: flowWindowPath(persona: persona, scope: scope, since: since),
+                                  method: "GET", body: nil, bearer: bearer)
+        return (try Self.decoder.decode(Envelope<FlowWindowData>.self, from: data), data)
+    }
+
+    private func flowWindowPath(persona: String?, scope: String?, since: String?) -> String {
         var path = withPersona("/api/mobile/v1/flow/window", persona)
         if let scope, !scope.isEmpty {
-            let separator = path.contains("?") ? "&" : "?"
-            path += "\(separator)scope=\(Self.queryValue(scope))"
+            path += "\(path.contains("?") ? "&" : "?")scope=\(Self.queryValue(scope))"
         }
-        return try await getEnvelope(path: path, bearer: bearer, as: FlowWindowData.self)
+        if let since, !since.isEmpty {
+            path += "\(path.contains("?") ? "&" : "?")since=\(Self.queryValue(since))"
+        }
+        return path
     }
 
     /// GET /api/mobile/v1/flow/floors — the versioned floor-plates asset (plan-view rects).
@@ -232,6 +250,13 @@ struct APIClient {
     /// enough at < 60 KB gzipped per floor.
     func flowFloors(bearer: String) async throws -> Envelope<FlowFloorsDocument> {
         try await getEnvelope(path: "/api/mobile/v1/flow/floors", bearer: bearer, as: FlowFloorsDocument.self)
+    }
+
+    /// As `flowFloors`, but returns the raw bytes too (persisted alongside the window in the
+    /// offline cache so the plates render offline).
+    func flowFloorsRaw(bearer: String) async throws -> (Envelope<FlowFloorsDocument>, Data) {
+        let data = try await send(path: "/api/mobile/v1/flow/floors", method: "GET", body: nil, bearer: bearer)
+        return (try Self.decoder.decode(Envelope<FlowFloorsDocument>.self, from: data), data)
     }
 
     /// POST /api/mobile/v1/devices — register this device's APNs token for push.

--- a/hummingbird/iosApp/Hummingbird/Networking/APIClient.swift
+++ b/hummingbird/iosApp/Hummingbird/Networking/APIClient.swift
@@ -259,6 +259,13 @@ struct APIClient {
         return (try Self.decoder.decode(Envelope<FlowFloorsDocument>.self, from: data), data)
     }
 
+    /// GET /api/mobile/v1/flow/spaces3d — the versioned 3D space-anchor asset (per-space
+    /// metre centroids + unit/bed bridges) the native SceneKit scene places segments and
+    /// tokens by. ETag-cacheable; fetched once per session.
+    func flowSpaces3d(bearer: String) async throws -> Envelope<FlowSpaces3dDocument> {
+        try await getEnvelope(path: "/api/mobile/v1/flow/spaces3d", bearer: bearer, as: FlowSpaces3dDocument.self)
+    }
+
     /// POST /api/mobile/v1/devices — register this device's APNs token for push.
     func registerDevice(pushToken: String, appVersion: String?, osVersion: String?,
                         deviceName: String?, bearer: String) async throws {

--- a/hummingbird/iosApp/Hummingbird/Networking/AuthStore.swift
+++ b/hummingbird/iosApp/Hummingbird/Networking/AuthStore.swift
@@ -116,8 +116,14 @@ final class AuthStore: ObservableObject {
         me = nil
         errorMessage = nil
         phase = .loggedOut
-        // A signed-out device must not keep operational state on the lock screen.
+        // A signed-out device must not keep operational state on the lock screen or in a
+        // cache that could outlive the session — end activities, drop the offline flow cache
+        // (also the belt-and-braces guard against ever serving another user's window), and
+        // clear the App-Group glance snapshots.
         JobActivityController.endAll()
+        FlowWindowCache.clearAll()
+        HouseGlanceCache.clear()
+        ForYouGlanceCache.clear()
     }
 
     private func clearTokens() {

--- a/hummingbird/iosApp/HummingbirdWidgets/HouseGlanceWidget.swift
+++ b/hummingbird/iosApp/HummingbirdWidgets/HouseGlanceWidget.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 import WidgetKit
 
-/// Home-screen glance: occupancy + pending placements from the last in-app sync.
-/// Deliberately calm — one number, one status word, one queue count. Tapping opens
-/// the app (default deep link); the widget never shows PHI.
+/// Home-screen glance: occupancy, net bed need, For You count, and the "next 4h" ghost count
+/// — all from the last in-app sync (App-Group cache; the widget has no network or token and
+/// never shows PHI). Deliberately calm: numbers and one status word, coral reserved for a real
+/// at-capacity breach. Tapping opens the app.
 struct HouseGlanceWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: HouseGlanceCache.widgetKind, provider: HouseGlanceProvider()) { entry in
@@ -11,80 +12,158 @@ struct HouseGlanceWidget: Widget {
                 .containerBackground(HBActivityPalette.bg, for: .widget)
         }
         .configurationDisplayName("House at a glance")
-        .description("Occupancy and pending placements from your last sync.")
-        .supportedFamilies([.systemSmall])
+        .description("Occupancy, bed need, and what's coming in the next 4 hours.")
+        .supportedFamilies([.systemSmall, .systemMedium])
     }
 }
 
 struct HouseGlanceEntry: TimelineEntry {
     let date: Date
     let snapshot: HouseGlanceSnapshot?
+    let forYou: ForYouGlanceSnapshot?
 }
 
 struct HouseGlanceProvider: TimelineProvider {
     func placeholder(in context: Context) -> HouseGlanceEntry {
         HouseGlanceEntry(date: .now, snapshot: HouseGlanceSnapshot(
             occupancyPercent: 84, occupied: 201, staffed: 240,
-            pendingPlacements: 6, statusRaw: "warning", updatedAt: .now))
+            pendingPlacements: 6, statusRaw: "warning", updatedAt: .now,
+            netBedNeed: 4, next4hGhostCount: 7),
+            forYou: ForYouGlanceSnapshot(pending: 5, critical: 1, updatedAt: .now))
     }
 
     func getSnapshot(in context: Context, completion: @escaping (HouseGlanceEntry) -> Void) {
-        completion(HouseGlanceEntry(date: .now, snapshot: HouseGlanceCache.load()))
+        completion(HouseGlanceEntry(date: .now, snapshot: HouseGlanceCache.load(), forYou: ForYouGlanceCache.load()))
     }
 
     func getTimeline(in context: Context, completion: @escaping (Timeline<HouseGlanceEntry>) -> Void) {
-        let entry = HouseGlanceEntry(date: .now, snapshot: HouseGlanceCache.load())
-        // The app reloads this timeline on every fresh rollup; the 30-minute horizon
-        // only ages the "updated" line when the app hasn't synced.
+        let entry = HouseGlanceEntry(date: .now, snapshot: HouseGlanceCache.load(), forYou: ForYouGlanceCache.load())
+        // The app reloads this timeline on every fresh rollup / flow-window load; the 30-minute
+        // horizon only ages the "updated" line when the app hasn't synced.
         completion(Timeline(entries: [entry], policy: .after(.now + 30 * 60)))
     }
 }
 
 private struct HouseGlanceView: View {
+    @Environment(\.widgetFamily) private var family
     let entry: HouseGlanceEntry
 
     var body: some View {
         if let snapshot = entry.snapshot {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("HOUSE")
-                    .font(.system(size: 10, weight: .semibold))
-                    .tracking(0.6)
-                    .foregroundStyle(HBActivityPalette.inkMuted)
-                Text("\(snapshot.occupancyPercent)%")
-                    .font(.system(size: 34, weight: .semibold))
-                    .monospacedDigit()
-                    .foregroundStyle(HBActivityPalette.ink)
-                    .minimumScaleFactor(0.7)
-                HStack(spacing: 5) {
-                    Circle().fill(statusColor(snapshot.statusRaw)).frame(width: 7, height: 7)
-                    Text(statusWord(snapshot.statusRaw))
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(statusColor(snapshot.statusRaw))
-                }
-                Spacer(minLength: 0)
-                Text("\(snapshot.pendingPlacements) placements pending")
-                    .font(.system(size: 11))
-                    .monospacedDigit()
-                    .foregroundStyle(HBActivityPalette.inkMuted)
-                    .lineLimit(1)
-                Text(snapshot.updatedAt, style: .relative)
-                    .font(.system(size: 10))
-                    .foregroundStyle(HBActivityPalette.inkMuted.opacity(0.8))
-                    .lineLimit(1)
+            if family == .systemMedium {
+                mediumBody(snapshot)
+            } else {
+                smallBody(snapshot)
             }
         } else {
-            VStack(alignment: .leading, spacing: 6) {
-                Text("HOUSE")
-                    .font(.system(size: 10, weight: .semibold))
-                    .tracking(0.6)
-                    .foregroundStyle(HBActivityPalette.inkMuted)
-                Text("Open Hummingbird to sync")
-                    .font(.system(size: 12))
-                    .foregroundStyle(HBActivityPalette.ink)
-                Spacer(minLength: 0)
-            }
+            emptyBody
         }
     }
+
+    // MARK: Small
+
+    private func smallBody(_ s: HouseGlanceSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            header
+            Text("\(s.occupancyPercent)%")
+                .font(.system(size: 32, weight: .semibold))
+                .monospacedDigit()
+                .foregroundStyle(HBActivityPalette.ink)
+                .minimumScaleFactor(0.7)
+            statusRow(s)
+            Spacer(minLength: 0)
+            comingLine(s)
+            Text(s.updatedAt, style: .relative)
+                .font(.system(size: 10))
+                .foregroundStyle(HBActivityPalette.inkMuted.opacity(0.8))
+                .lineLimit(1)
+        }
+    }
+
+    /// The "what's coming / what's needed" line — degrades gracefully when a writer hasn't run
+    /// yet (net bed need from RTDC, next-4h from the flow window, For You from its queue).
+    private func comingLine(_ s: HouseGlanceSnapshot) -> some View {
+        var parts: [String] = []
+        if let need = s.netBedNeed { parts.append("net \(signed(need)) beds") }
+        else { parts.append("\(s.pendingPlacements) pending") }
+        if let ghosts = s.next4hGhostCount { parts.append("\(ghosts) in 4h") }
+        if let pending = entry.forYou?.pending { parts.append("\(pending) for you") }
+        return Text(parts.joined(separator: " · "))
+            .font(.system(size: 11))
+            .monospacedDigit()
+            .foregroundStyle(HBActivityPalette.inkMuted)
+            .lineLimit(2)
+    }
+
+    // MARK: Medium
+
+    private func mediumBody(_ s: HouseGlanceSnapshot) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                header
+                Spacer()
+                statusRow(s)
+            }
+            HStack(alignment: .top, spacing: 12) {
+                statTile("\(s.occupancyPercent)%", "Occupancy")
+                statTile(s.netBedNeed.map { signed($0) } ?? "\(s.pendingPlacements)",
+                         s.netBedNeed != nil ? "Net bed need" : "Pending")
+                statTile(entry.forYou.map { "\($0.pending)" } ?? "—", "For you")
+                statTile(s.next4hGhostCount.map { "\($0)" } ?? "—", "Next 4h")
+            }
+            Spacer(minLength: 0)
+            Text(s.updatedAt, style: .relative)
+                .font(.system(size: 10))
+                .foregroundStyle(HBActivityPalette.inkMuted.opacity(0.8))
+                .lineLimit(1)
+        }
+    }
+
+    private func statTile(_ value: String, _ label: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(value)
+                .font(.system(size: 22, weight: .semibold))
+                .monospacedDigit()
+                .foregroundStyle(HBActivityPalette.ink)
+                .minimumScaleFactor(0.6)
+                .lineLimit(1)
+            Text(label)
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(HBActivityPalette.inkMuted)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Shared
+
+    private var header: some View {
+        Text("HOUSE")
+            .font(.system(size: 10, weight: .semibold))
+            .tracking(0.6)
+            .foregroundStyle(HBActivityPalette.inkMuted)
+    }
+
+    private func statusRow(_ s: HouseGlanceSnapshot) -> some View {
+        HStack(spacing: 5) {
+            Circle().fill(statusColor(s.statusRaw)).frame(width: 7, height: 7)
+            Text(statusWord(s.statusRaw))
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(statusColor(s.statusRaw))
+        }
+    }
+
+    private var emptyBody: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            header
+            Text("Open Hummingbird to sync")
+                .font(.system(size: 12))
+                .foregroundStyle(HBActivityPalette.ink)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func signed(_ n: Int) -> String { n > 0 ? "+\(n)" : "\(n)" }
 
     private func statusColor(_ raw: String) -> Color {
         switch raw {

--- a/hummingbird/iosApp/HummingbirdWidgets/JobLiveActivity.swift
+++ b/hummingbird/iosApp/HummingbirdWidgets/JobLiveActivity.swift
@@ -32,11 +32,14 @@ struct JobLiveActivity: Widget {
                     }
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    Text(context.state.statusLabel)
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(tint(context))
-                        .lineLimit(1)
-                        .padding(.trailing, 4)
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text(context.state.statusLabel)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(tint(context))
+                            .lineLimit(1)
+                        SLACountdown(deadline: context.state.slaDeadline, compact: true)
+                    }
+                    .padding(.trailing, 4)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     JobProgressTrack(context: context)
@@ -96,9 +99,35 @@ private struct LockScreenJobView: View {
                     .background(Capsule().fill(tint.opacity(0.16)))
                     .lineLimit(1)
             }
-            JobProgressTrack(context: context)
+            HStack(spacing: 10) {
+                JobProgressTrack(context: context)
+                SLACountdown(deadline: context.state.slaDeadline)
+            }
         }
         .padding(14)
+    }
+}
+
+/// Live SLA countdown, shown only while the deadline is still ahead. `Text(timerInterval:)`
+/// ticks on its own — the app never has to push an update just to move the clock. Rendered
+/// calm (muted ink, not coral): a running countdown is urgency, not yet a breach.
+private struct SLACountdown: View {
+    let deadline: Date?
+    var compact: Bool = false
+
+    var body: some View {
+        if let deadline, deadline > .now {
+            HStack(spacing: 3) {
+                Image(systemName: "timer")
+                    .font(.system(size: compact ? 10 : 11, weight: .semibold))
+                Text(timerInterval: Date.now...deadline, countsDown: true)
+                    .font(.system(size: compact ? 11 : 12, weight: .semibold))
+                    .monospacedDigit()
+                    .multilineTextAlignment(.trailing)
+                    .frame(maxWidth: compact ? 46 : 54)
+            }
+            .foregroundStyle(HBActivityPalette.inkMuted)
+        }
     }
 }
 

--- a/hummingbird/iosApp/scripts/decode-shared-fixtures.swift
+++ b/hummingbird/iosApp/scripts/decode-shared-fixtures.swift
@@ -45,23 +45,37 @@ enum DecodeSharedFixtures {
         try require(flowWindow.data.lens.patientDots == "full", "Flow window lens patient_dots drifted.")
         try require(flowWindow.data.scope.type == "house", "Flow window fixture scope drifted.")
         try require(flowWindow.data.spaces?.floors.count == 11, "Flow window floor rollup count drifted.")
-        try require(flowWindow.data.events.count == 2, "Flow window event count drifted.")
+        try require(flowWindow.data.events.count == 5, "Flow window event count drifted.")
         try require(flowWindow.data.events.first?.kind == "admit", "Flow window first event kind drifted.")
-        try require(flowWindow.data.projections.first?.kind == "surge_probability", "Flow window first projection kind drifted.")
+        try require(flowWindow.data.events.contains { $0.kind == "transport_status" && $0.fromSpace == "ED" },
+                    "Flow window transport_status event route drifted.")
+        try require(flowWindow.data.events.contains { $0.kind == "evs_status" },
+                    "Flow window evs_status event missing.")
+        try require(flowWindow.data.projections.first?.kind == "scheduled_or_case", "Flow window first projection kind drifted.")
+        try require(flowWindow.data.projections.contains { $0.kind == "scheduled_or_case" && $0.room != nil },
+                    "Flow window scheduled_or_case lost its room.")
         try require(flowWindow.data.projections.contains { $0.derived == true && $0.kind == "transport_due" },
                     "Flow window derived transport ghost missing.")
         try require(flowWindow.data.projections.allSatisfy { ["definite", "probable", "possible"].contains($0.confidence) },
                     "Flow window projection confidence vocabulary drifted.")
+        try require(flowWindow.data.bedStatuses.isEmpty, "Flow window house scope must not carry bed_statuses.")
         try require(FlowTime.parse(flowWindow.data.window.now) != nil, "Flow window `now` timestamp failed ISO-8601 parse.")
 
+        let evsWindow = try decode("mobile-flow-window-evs.json", as: Envelope<FlowWindowData>.self, root: root, decoder: decoder)
+        try require(evsWindow.data.lens.roleId == "evs", "EVS flow window fixture decoded the wrong lens role.")
+        try require(evsWindow.data.scope.type == "floor", "EVS flow window fixture scope drifted.")
+        try require(!evsWindow.data.bedStatuses.isEmpty, "EVS flow window bed_statuses missing or empty.")
+        try require(evsWindow.data.bedStatuses.allSatisfy { ["available", "occupied", "blocked", "dirty"].contains($0.status) },
+                    "EVS flow window bed status vocabulary drifted.")
+
         let flowFloors = try decode("mobile-flow-floors.json", as: Envelope<FlowFloorsDocument>.self, root: root, decoder: decoder)
-        try require(flowFloors.data.version == "v1-346c77a48494", "Flow floors plates version drifted.")
+        try require(flowFloors.data.version == "v1-2b3e9f90ad5d", "Flow floors plates version drifted.")
         try require(flowFloors.data.floors.first?.spaces.count == 4, "Flow floors plate count drifted.")
         try require(flowFloors.data.floors.first?.bounds.count == 4, "Flow floors bounds shape drifted.")
         try require(flowFloors.data.floors.contains { floor in floor.spaces.contains { $0.bedId == 693 && $0.rect.count == 4 } },
                     "Flow floors bed plate bridge (bed_id + rect) drifted.")
 
-        print("Decoded 6 shared Hummingbird DTO fixtures.")
+        print("Decoded 7 shared Hummingbird DTO fixtures.")
     }
 
     private static func decode<T: Decodable>(

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,6 +29,9 @@
         </include>
     </source>
     <php>
+        <!-- The full suite (incl. the flow-window fixtures) exceeds PHP's 128M CLI
+             default in a single-process run; raise it so `php artisan test` doesn't OOM. -->
+        <ini name="memory_limit" value="512M"/>
         <env name="APP_ENV" value="testing"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>

--- a/resources/js/Components/PatientFlowNavigator/NavigatorChronobar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorChronobar.tsx
@@ -1,0 +1,162 @@
+import React, { useMemo } from 'react';
+import type { ForecastAggregates } from '@/features/patientFlowNavigator/projections';
+
+interface NavigatorChronobarProps {
+  windowStart: number;
+  windowEnd: number;
+  nowMs: number;
+  currentTime: number;
+  /** Coverage of loaded flow events; null when no events are in the window. */
+  dataStart: number | null;
+  dataEnd: number | null;
+  forecast: ForecastAggregates | null;
+  onScrub: (timeMs: number) => void;
+}
+
+const SLIDER_STEPS = 10000;
+
+function fmtTime(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '--';
+  return new Date(ms).toLocaleString([], {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function relativeLabel(ms: number, nowMs: number): string {
+  const deltaHours = (ms - nowMs) / 3_600_000;
+  if (Math.abs(deltaHours) < 0.05) return 'now';
+  const rounded = Math.abs(deltaHours) >= 10 ? Math.round(Math.abs(deltaHours)) : Math.round(Math.abs(deltaHours) * 10) / 10;
+  return deltaHours > 0 ? `now +${rounded}h` : `now −${rounded}h`;
+}
+
+/** Shift-change detents (07:00 / 19:00 local) inside the window. */
+function shiftDetents(windowStart: number, windowEnd: number): number[] {
+  const detents: number[] = [];
+  const cursor = new Date(windowStart);
+  cursor.setMinutes(0, 0, 0);
+  while (cursor.getTime() <= windowEnd) {
+    if (cursor.getHours() === 7 || cursor.getHours() === 19) {
+      const t = cursor.getTime();
+      if (t >= windowStart) detents.push(t);
+    }
+    cursor.setHours(cursor.getHours() + 1);
+  }
+  return detents;
+}
+
+/**
+ * The 48h Chronobar (FLOW-WINDOW-PLAN §5): [now−24h, now+24h], solid past,
+ * dashed future, gold now-marker, 07:00/19:00 shift detents, dimmed track for
+ * data-sparse regions. The native range input stays for interaction and
+ * accessibility; the annotated strip above it carries the time grammar.
+ */
+export default function NavigatorChronobar({
+  windowStart,
+  windowEnd,
+  nowMs,
+  currentTime,
+  dataStart,
+  dataEnd,
+  forecast,
+  onScrub,
+}: NavigatorChronobarProps) {
+  const span = Math.max(1, windowEnd - windowStart);
+  const pct = (ms: number): number => Math.min(100, Math.max(0, ((ms - windowStart) / span) * 100));
+
+  const detents = useMemo(() => shiftDetents(windowStart, windowEnd), [windowStart, windowEnd]);
+
+  const coverage = useMemo(() => {
+    if (dataStart === null || dataEnd === null) return null;
+    const start = Math.max(dataStart, windowStart);
+    const end = Math.min(dataEnd, nowMs);
+    return end > start ? { start, end } : null;
+  }, [dataStart, dataEnd, windowStart, nowMs]);
+
+  const sliderValue = Math.round(((currentTime - windowStart) / span) * SLIDER_STEPS);
+  const inFuture = currentTime > nowMs;
+
+  return (
+    <div className="patient-flow-chronobar">
+      <output>
+        <span>{fmtTime(currentTime)}</span>
+        <span className={`patient-flow-chronobar-rel ${inFuture ? 'future' : ''}`}>
+          {inFuture ? 'Projected · ' : ''}
+          {relativeLabel(currentTime, nowMs)}
+        </span>
+      </output>
+
+      <div className="patient-flow-chronobar-track" aria-hidden="true">
+        <div className="patient-flow-chronobar-past" style={{ width: `${pct(nowMs)}%` }} />
+        <div
+          className="patient-flow-chronobar-future"
+          style={{ left: `${pct(nowMs)}%`, width: `${100 - pct(nowMs)}%` }}
+        />
+        {coverage && (
+          <div
+            className="patient-flow-chronobar-coverage"
+            style={{ left: `${pct(coverage.start)}%`, width: `${pct(coverage.end) - pct(coverage.start)}%` }}
+          />
+        )}
+        {detents.map((detent) => (
+          <span
+            key={detent}
+            className="patient-flow-chronobar-detent"
+            style={{ left: `${pct(detent)}%` }}
+            title={new Date(detent).toLocaleString([], { weekday: 'short', hour: '2-digit', minute: '2-digit' })}
+          />
+        ))}
+        <span className="patient-flow-chronobar-now" style={{ left: `${pct(nowMs)}%` }} title="Now" />
+      </div>
+
+      <input
+        type="range"
+        min="0"
+        max={SLIDER_STEPS}
+        value={Number.isFinite(sliderValue) ? Math.min(SLIDER_STEPS, Math.max(0, sliderValue)) : 0}
+        aria-label="48-hour time scrubber (24h review, 24h projection)"
+        onChange={(event) => onScrub(windowStart + (Number(event.target.value) / SLIDER_STEPS) * span)}
+      />
+
+      {coverage === null && (
+        <p className="patient-flow-chronobar-empty">No replay events inside the 48h window</p>
+      )}
+
+      {inFuture && forecast && (
+        <dl className="patient-flow-forecast-hud">
+          {forecast.censusTotal !== null && (
+            <div>
+              <dt>Census</dt>
+              <dd>{forecast.censusTotal}</dd>
+            </div>
+          )}
+          {forecast.arrivals && forecast.arrivals.value !== null && (
+            <div>
+              <dt>Arrivals/h</dt>
+              <dd>
+                {forecast.arrivals.value}
+                {forecast.arrivals.band && (
+                  <small> {forecast.arrivals.band.lower}–{forecast.arrivals.band.upper}</small>
+                )}
+              </dd>
+            </div>
+          )}
+          {forecast.surge && forecast.surge.value !== null && (
+            <div>
+              <dt>Surge</dt>
+              <dd>{forecast.surge.value}%</dd>
+            </div>
+          )}
+          {forecast.staffingGaps > 0 && (
+            <div>
+              <dt>Shift gaps</dt>
+              <dd>{forecast.staffingGaps}</dd>
+            </div>
+          )}
+        </dl>
+      )}
+    </div>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorFeed.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorFeed.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { PatientFlowEvent } from '@/features/patientFlowNavigator/types';
+
+interface NavigatorFeedProps {
+  feed: PatientFlowEvent[];
+  /** When true the lens hides patient identity — show the event, not the person. */
+  redactIdentity: boolean;
+}
+
+export default function NavigatorFeed({ feed, redactIdentity }: NavigatorFeedProps) {
+  return (
+    <aside className="patient-flow-feed" aria-label="Live event feed">
+      <strong>Stream</strong>
+      <ol>
+        {feed.map((event) => (
+          <li key={event.event_id}>
+            <span>{new Date(event.occurred_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+            <span>
+              {redactIdentity ? '' : `${event.patient_display_id} `}
+              {event.event_type} {event.to_location}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </aside>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorInspector.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorInspector.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface NavigatorInspectorProps {
+  title: string;
+  rows: Array<[string, string]>;
+}
+
+export default function NavigatorInspector({ title, rows }: NavigatorInspectorProps) {
+  return (
+    <aside className="patient-flow-inspector" aria-live="polite">
+      <strong>{title}</strong>
+      <dl>
+        {rows.map(([key, value]) => (
+          <React.Fragment key={key}>
+            <dt>{key}</dt>
+            <dd>{value}</dd>
+          </React.Fragment>
+        ))}
+      </dl>
+    </aside>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -1,0 +1,547 @@
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { parseTime, positionFor } from '@/features/patientFlowNavigator/stateProjection';
+import { confidenceOpacity } from '@/features/patientFlowNavigator/projections';
+import type { ProjectionAnchor } from '@/features/patientFlowNavigator/projections';
+import type {
+  PatientFlowEvent,
+  PatientFlowLocations,
+  PatientVisibleState,
+  ProjectionItem,
+} from '@/features/patientFlowNavigator/types';
+
+/**
+ * Three.js scene lifecycle for the 4D Navigator — no React in here.
+ *
+ * This module is the ONLY importer of `three`, and the orchestrator loads it
+ * via dynamic import so the whole 3D stack lands in its own lazy chunk.
+ *
+ * Perf contract (FLOW-WINDOW-PLAN §7.3): token positions may be updated every
+ * frame; trails / census heat / ghosts are REBUILT only when the orchestrator
+ * says the time bucket, filters, or layers changed. Geometries and materials
+ * are cached and reused across rebuilds.
+ */
+
+export interface NavigatorSceneCallbacks {
+  onSelect: (data: Record<string, unknown>) => void;
+  onCameraMove: (text: string) => void;
+  onFrame: (deltaSeconds: number) => void;
+}
+
+export interface GhostRenderItem {
+  item: ProjectionItem;
+  anchor: ProjectionAnchor;
+}
+
+export interface ForecastHeatCell {
+  anchor: ProjectionAnchor;
+  value: number;
+  opacity: number;
+}
+
+/** Future-half palette — cool operational tones only, never coral (§5). */
+const GHOST_COLORS: Record<string, number> = {
+  expected_discharge: 0x2dd4bf, // teal
+  transport_due: 0x38bdf8, // sky
+  evs_due: 0x7dd3fc, // light sky
+  scheduled_or_case: 0x60a5fa, // blue
+};
+
+const HOME_POSITION = new THREE.Vector3(88, 104, 162);
+const HOME_TARGET = new THREE.Vector3(0, 48, 0);
+
+export class NavigatorScene {
+  private renderer: THREE.WebGLRenderer;
+
+  private scene: THREE.Scene;
+
+  private camera: THREE.PerspectiveCamera;
+
+  private orbit: OrbitControls;
+
+  private patientLayer = new THREE.Group();
+
+  private trailLayer = new THREE.Group();
+
+  private heatLayer = new THREE.Group();
+
+  private ghostLayer = new THREE.Group();
+
+  private forecastLayer = new THREE.Group();
+
+  private baseObjects: THREE.Object3D[] = [];
+
+  private tokenByPatient = new Map<string, THREE.Mesh>();
+
+  private patientMaterials = new Map<string, THREE.MeshStandardMaterial>();
+
+  private trailMaterials = new Map<string, THREE.LineBasicMaterial>();
+
+  private ghostMaterials = new Map<string, THREE.MeshStandardMaterial>();
+
+  private forecastMaterials = new Map<string, THREE.MeshStandardMaterial>();
+
+  private heatSingleMaterial: THREE.MeshStandardMaterial;
+
+  private heatMultiMaterial: THREE.MeshStandardMaterial;
+
+  private tokenGeometry = new THREE.SphereGeometry(1.65, 18, 12);
+
+  private ghostGeometry = new THREE.SphereGeometry(1.45, 14, 10);
+
+  private heatGeometry = new THREE.CylinderGeometry(1.9, 1.9, 1, 18, 1);
+
+  private forecastGeometry = new THREE.CylinderGeometry(2.6, 2.6, 1, 18, 1);
+
+  private raycaster = new THREE.Raycaster();
+
+  private clock = new THREE.Clock();
+
+  private animationId = 0;
+
+  private lastCameraText = '';
+
+  private lastCameraEmit = 0;
+
+  private disposed = false;
+
+  private readonly container: HTMLElement;
+
+  private readonly callbacks: NavigatorSceneCallbacks;
+
+  private readonly onResize = (): void => {
+    const width = this.container.clientWidth;
+    const height = this.container.clientHeight;
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+    this.renderer.setSize(width, height);
+  };
+
+  private readonly onPointerDown = (event: PointerEvent): void => {
+    if (event.target !== this.renderer.domElement) return;
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    const pointer = new THREE.Vector2(
+      ((event.clientX - rect.left) / rect.width) * 2 - 1,
+      -((event.clientY - rect.top) / rect.height) * 2 + 1,
+    );
+    this.raycaster.setFromCamera(pointer, this.camera);
+    const hits = this.raycaster.intersectObjects(
+      [
+        ...this.patientLayer.children,
+        ...this.ghostLayer.children,
+        ...this.heatLayer.children,
+        ...this.baseObjects,
+      ].filter((object) => object.visible),
+      false,
+    );
+    if (!hits.length) return;
+    this.callbacks.onSelect({ ...(hits[0].object.userData ?? {}) });
+  };
+
+  constructor(canvas: HTMLCanvasElement, container: HTMLElement, callbacks: NavigatorSceneCallbacks) {
+    this.container = container;
+    this.callbacks = callbacks;
+
+    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: false, preserveDrawingBuffer: true });
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    this.renderer.setSize(width, height);
+    this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+
+    this.scene = new THREE.Scene();
+    this.scene.background = new THREE.Color(0x121514);
+    this.scene.fog = new THREE.Fog(0x121514, 150, 470);
+
+    this.camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 1400);
+    this.camera.position.copy(HOME_POSITION);
+
+    this.orbit = new OrbitControls(this.camera, this.renderer.domElement);
+    this.orbit.target.copy(HOME_TARGET);
+    this.orbit.enableDamping = true;
+    this.orbit.maxPolarAngle = Math.PI * 0.49;
+    this.orbit.minDistance = 18;
+    this.orbit.maxDistance = 380;
+
+    this.scene.add(new THREE.HemisphereLight(0xf6f0e4, 0x343a36, 2.2));
+    const sun = new THREE.DirectionalLight(0xfff5df, 2);
+    sun.position.set(-85, 170, 80);
+    this.scene.add(sun);
+    const grid = new THREE.GridHelper(190, 19, 0x796e59, 0x333834);
+    grid.position.y = -0.12;
+    this.scene.add(grid);
+
+    this.scene.add(this.forecastLayer, this.heatLayer, this.trailLayer, this.ghostLayer, this.patientLayer);
+
+    this.heatSingleMaterial = new THREE.MeshStandardMaterial({
+      color: 0x77c06f,
+      emissive: 0x143d17,
+      transparent: true,
+      opacity: 0.62,
+    });
+    this.heatMultiMaterial = new THREE.MeshStandardMaterial({
+      color: 0xf06755,
+      emissive: 0x5a140d,
+      transparent: true,
+      opacity: 0.62,
+    });
+
+    window.addEventListener('resize', this.onResize);
+    this.renderer.domElement.addEventListener('pointerdown', this.onPointerDown);
+    this.animationId = requestAnimationFrame(this.animate);
+  }
+
+  loadModel(url: string, onLoaded: () => void, onError: () => void): void {
+    new GLTFLoader().load(
+      url,
+      (gltf) => {
+        if (this.disposed) return;
+        this.scene.add(gltf.scene);
+        gltf.scene.traverse((object) => {
+          const mesh = object as THREE.Mesh;
+          if (!mesh.isMesh) return;
+          this.baseObjects.push(mesh);
+          const material = mesh.material;
+          if (Array.isArray(material)) {
+            mesh.material = material.map((item) => item.clone());
+            mesh.material.forEach((item) => {
+              item.transparent = true;
+              item.opacity = mesh.userData?.category === 'floor' ? 0.56 : 0.72;
+            });
+          } else if (material) {
+            mesh.material = material.clone();
+            mesh.material.transparent = true;
+            mesh.material.opacity = mesh.userData?.category === 'floor' ? 0.56 : 0.72;
+          }
+        });
+        onLoaded();
+      },
+      undefined,
+      (loadError) => {
+        console.error(loadError);
+        onError();
+      },
+    );
+  }
+
+  setBaseVisibility(floor: string, layerVisible: boolean): void {
+    for (const object of this.baseObjects) {
+      const data = object.userData ?? {};
+      const floorOk = floor === 'all' || String(data.floor) === floor || data.category === 'elevator';
+      object.visible = layerVisible && floorOk;
+    }
+  }
+
+  /** Cheap per-frame path: token creation/positioning only. */
+  updateTokens(states: PatientVisibleState[], layerVisible: boolean, redactIdentity: boolean): void {
+    const visible = new Set<string>();
+    for (const state of states) {
+      let token = this.tokenByPatient.get(state.patientId);
+      if (!token) {
+        token = new THREE.Mesh(this.tokenGeometry, this.materialForPatient(state.patientId));
+        this.tokenByPatient.set(state.patientId, token);
+        this.patientLayer.add(token);
+      }
+      token.position.set(state.position.x, state.position.y, state.position.z);
+      token.scale.setScalar(state.event.event_category === 'movement' ? 1 : 0.82);
+      token.visible = layerVisible;
+      token.userData = {
+        kind: 'patient-token',
+        ...(redactIdentity
+          ? {}
+          : {
+              patient_id: state.patientId,
+              patient_display_id: state.event.patient_display_id,
+              encounter_id: state.event.encounter_id,
+            }),
+        current_location: state.event.to_location,
+        service_line: state.event.service_line,
+        event_type: state.event.event_type,
+        event_category: state.event.event_category,
+        last_event_at: state.event.occurred_at,
+        recent_event_count: state.recent.length,
+      };
+      visible.add(state.patientId);
+    }
+
+    for (const [patientId, token] of this.tokenByPatient.entries()) {
+      if (!visible.has(patientId)) token.visible = false;
+    }
+  }
+
+  /** Bucketed rebuild: trail polylines up to timeMs for the active patients. */
+  rebuildTrails(
+    tracks: Map<string, PatientFlowEvent[]>,
+    locations: PatientFlowLocations,
+    states: PatientVisibleState[],
+    timeMs: number,
+    layerVisible: boolean,
+  ): void {
+    this.clearGroup(this.trailLayer);
+    if (!layerVisible) return;
+
+    const activePatients = new Set(states.map((state) => state.patientId));
+    for (const [patientId, track] of tracks.entries()) {
+      if (!activePatients.has(patientId)) continue;
+      const points: THREE.Vector3[] = [];
+      for (const event of track) {
+        if (parseTime(event.occurred_at) > timeMs) break;
+        const position = positionFor(locations, event.to_location);
+        if (!position) continue;
+        const vector = new THREE.Vector3(position.x, position.y, position.z);
+        if (!points.length || !points[points.length - 1].equals(vector)) points.push(vector);
+      }
+      if (points.length < 2) continue;
+      const geometry = new THREE.BufferGeometry().setFromPoints(points);
+      const line = new THREE.Line(geometry, this.trailMaterialForPatient(patientId));
+      line.userData = { kind: 'patient-trail', patient_id: patientId };
+      this.trailLayer.add(line);
+    }
+  }
+
+  /** Bucketed rebuild: census-heat pillars. Returns occupied-location count. */
+  rebuildHeat(states: PatientVisibleState[], locations: PatientFlowLocations, layerVisible: boolean): number {
+    this.clearGroup(this.heatLayer);
+    if (!layerVisible) return 0;
+
+    const occupancy = new Map<string, number>();
+    for (const state of states) {
+      const loc = state.event.to_location;
+      if (loc) occupancy.set(loc, (occupancy.get(loc) ?? 0) + 1);
+    }
+
+    for (const [loc, count] of occupancy.entries()) {
+      const position = positionFor(locations, loc);
+      if (!position) continue;
+      const marker = new THREE.Mesh(this.heatGeometry, count > 1 ? this.heatMultiMaterial : this.heatSingleMaterial);
+      marker.position.set(position.x, position.y + 2 + count * 0.42, position.z);
+      marker.scale.set(1 + count * 0.12, Math.max(1, count * 1.2), 1 + count * 0.12);
+      marker.userData = {
+        kind: 'occupancy-marker',
+        location: loc,
+        active_patient_count: count,
+        location_name: locations[loc]?.name,
+      };
+      this.heatLayer.add(marker);
+    }
+
+    return occupancy.size;
+  }
+
+  /**
+   * Bucketed rebuild: projection ghost tokens (future half). Translucent
+   * spheres, confidence-mapped opacity, provenance in userData for the
+   * inspector — never a patient identity (D3).
+   */
+  rebuildGhosts(ghosts: GhostRenderItem[], layerVisible: boolean): void {
+    this.clearGroup(this.ghostLayer);
+    if (!layerVisible) return;
+
+    const stackByAnchor = new Map<string, number>();
+    for (const ghost of ghosts) {
+      const { item, anchor } = ghost;
+      const anchorKey = `${anchor.x.toFixed(1)}|${anchor.z.toFixed(1)}`;
+      const stack = stackByAnchor.get(anchorKey) ?? 0;
+      stackByAnchor.set(anchorKey, stack + 1);
+
+      const mesh = new THREE.Mesh(this.ghostGeometry, this.ghostMaterialFor(item.kind, item.confidence));
+      mesh.position.set(anchor.x, anchor.y + 1.2 + stack * 2.4, anchor.z);
+      mesh.userData = {
+        kind: 'projection-ghost',
+        projection_kind: item.kind,
+        label: item.label,
+        confidence: item.confidence,
+        projected_at: item.t,
+        ...(item.ends_at ? { ends_at: item.ends_at } : {}),
+        ...(item.room ? { room: item.room } : {}),
+        ...(item.unit_id !== null ? { unit_id: item.unit_id } : {}),
+        ...(item.bed_id !== null ? { bed_id: item.bed_id } : {}),
+        ...(item.value !== null ? { value: item.value } : {}),
+        ...(item.patient_context_ref ? { patient_context_ref: item.patient_context_ref } : {}),
+        ...(item.entity ? { entity: `${item.entity.type} ${item.entity.ref}` } : {}),
+        ...(item.derived ? { derived: 'Derived · expected discharge' } : {}),
+        source: item.provenance.service,
+        reliability: item.provenance.reliability !== null ? String(item.provenance.reliability) : 'n/a',
+      };
+      this.ghostLayer.add(mesh);
+    }
+  }
+
+  /** Bucketed rebuild: aggregate forecast heat (predicted census per unit). */
+  rebuildForecastHeat(cells: ForecastHeatCell[], layerVisible: boolean): void {
+    this.clearGroup(this.forecastLayer);
+    if (!layerVisible) return;
+
+    for (const cell of cells) {
+      const height = Math.max(1.5, cell.value * 0.3);
+      const mesh = new THREE.Mesh(this.forecastGeometry, this.forecastMaterialFor(cell.opacity));
+      mesh.position.set(cell.anchor.x, cell.anchor.y + 2 + height / 2, cell.anchor.z);
+      mesh.scale.set(1, height, 1);
+      mesh.userData = { kind: 'forecast-heat', predicted_census: cell.value };
+      this.forecastLayer.add(mesh);
+    }
+  }
+
+  focusOn(points: Array<{ x: number; y: number; z: number }>): void {
+    if (!points.length) return;
+    const box = new THREE.Box3();
+    points.forEach((point) => box.expandByPoint(new THREE.Vector3(point.x, point.y, point.z)));
+    const center = box.getCenter(new THREE.Vector3());
+    const size = box.getSize(new THREE.Vector3());
+    const radius = Math.max(size.x, size.y, size.z, 24);
+    this.orbit.target.copy(center);
+    this.camera.position.set(center.x + radius * 1.35, center.y + radius * 1.05, center.z + radius * 1.35);
+    this.orbit.update();
+  }
+
+  resetCamera(): void {
+    this.camera.position.copy(HOME_POSITION);
+    this.orbit.target.copy(HOME_TARGET);
+    this.orbit.update();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    cancelAnimationFrame(this.animationId);
+    window.removeEventListener('resize', this.onResize);
+    this.renderer.domElement.removeEventListener('pointerdown', this.onPointerDown);
+    this.baseObjects.forEach((object) => this.disposeObject(object));
+    this.clearGroup(this.patientLayer);
+    this.clearGroup(this.trailLayer);
+    this.clearGroup(this.heatLayer);
+    this.clearGroup(this.ghostLayer);
+    this.clearGroup(this.forecastLayer);
+    this.patientMaterials.forEach((material) => material.dispose());
+    this.trailMaterials.forEach((material) => material.dispose());
+    this.ghostMaterials.forEach((material) => material.dispose());
+    this.forecastMaterials.forEach((material) => material.dispose());
+    this.heatSingleMaterial.dispose();
+    this.heatMultiMaterial.dispose();
+    this.tokenGeometry.dispose();
+    this.ghostGeometry.dispose();
+    this.heatGeometry.dispose();
+    this.forecastGeometry.dispose();
+    this.orbit.dispose();
+    this.renderer.dispose();
+  }
+
+  private readonly animate = (): void => {
+    if (this.disposed) return;
+    const delta = Math.min(this.clock.getDelta(), 0.05);
+    this.callbacks.onFrame(delta);
+    this.orbit.update();
+    this.emitCameraText();
+    this.renderer.render(this.scene, this.camera);
+    this.animationId = requestAnimationFrame(this.animate);
+  };
+
+  /** Throttled — a React state write per frame is exactly the churn we removed. */
+  private emitCameraText(): void {
+    const now = performance.now();
+    if (now - this.lastCameraEmit < 150) return;
+    const text = `x ${this.camera.position.x.toFixed(0)} y ${this.camera.position.y.toFixed(0)} z ${this.camera.position.z.toFixed(0)}`;
+    if (text === this.lastCameraText) return;
+    this.lastCameraText = text;
+    this.lastCameraEmit = now;
+    this.callbacks.onCameraMove(text);
+  }
+
+  private materialForPatient(patientId: string): THREE.MeshStandardMaterial {
+    let material = this.patientMaterials.get(patientId);
+    if (!material) {
+      const color = hashColor(patientId);
+      material = new THREE.MeshStandardMaterial({
+        color,
+        emissive: color.clone().multiplyScalar(0.22),
+        roughness: 0.42,
+        metalness: 0,
+      });
+      this.patientMaterials.set(patientId, material);
+    }
+    return material;
+  }
+
+  private trailMaterialForPatient(patientId: string): THREE.LineBasicMaterial {
+    let material = this.trailMaterials.get(patientId);
+    if (!material) {
+      material = new THREE.LineBasicMaterial({ color: hashColor(patientId), transparent: true, opacity: 0.55 });
+      this.trailMaterials.set(patientId, material);
+    }
+    return material;
+  }
+
+  private ghostMaterialFor(kind: string, confidence: string): THREE.MeshStandardMaterial {
+    const key = `${kind}|${confidence}`;
+    let material = this.ghostMaterials.get(key);
+    if (!material) {
+      const color = new THREE.Color(GHOST_COLORS[kind] ?? 0x94a3b8);
+      material = new THREE.MeshStandardMaterial({
+        color,
+        emissive: color.clone().multiplyScalar(0.3),
+        transparent: true,
+        opacity: confidenceOpacity(confidence),
+        roughness: 0.6,
+        metalness: 0,
+        depthWrite: false,
+      });
+      this.ghostMaterials.set(key, material);
+    }
+    return material;
+  }
+
+  private forecastMaterialFor(opacity: number): THREE.MeshStandardMaterial {
+    const key = opacity.toFixed(2);
+    let material = this.forecastMaterials.get(key);
+    if (!material) {
+      material = new THREE.MeshStandardMaterial({
+        color: 0x64bfd0,
+        emissive: 0x0f2f36,
+        transparent: true,
+        opacity,
+        depthWrite: false,
+      });
+      this.forecastMaterials.set(key, material);
+    }
+    return material;
+  }
+
+  /**
+   * Remove children of a group, disposing only per-mesh geometries (trail
+   * lines). Shared geometries and all materials are cached (patientMaterials /
+   * trailMaterials / ghostMaterials / heat materials) and reused across
+   * rebuilds — they are disposed once, in dispose().
+   */
+  private clearGroup(group: THREE.Group): void {
+    while (group.children.length) {
+      const child = group.children.pop() as THREE.Mesh | undefined;
+      if (!child) continue;
+      if (child.geometry && child.geometry !== this.tokenGeometry
+        && child.geometry !== this.ghostGeometry
+        && child.geometry !== this.heatGeometry
+        && child.geometry !== this.forecastGeometry) {
+        child.geometry.dispose();
+      }
+    }
+    if (group === this.patientLayer) this.tokenByPatient.clear();
+  }
+
+  private disposeObject(object: THREE.Object3D): void {
+    const mesh = object as THREE.Mesh;
+    mesh.geometry?.dispose?.();
+    const material = mesh.material;
+    if (Array.isArray(material)) {
+      material.forEach((item) => item.dispose());
+    } else {
+      material?.dispose?.();
+    }
+  }
+}
+
+function hashColor(value: string): THREE.Color {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = ((hash << 5) - hash) + value.charCodeAt(index);
+  }
+  return new THREE.Color(`hsl(${Math.abs(hash) % 360}, 70%, 58%)`);
+}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -170,6 +170,7 @@ export default function NavigatorToolbar({
             <input
               id={id}
               type="checkbox"
+              role="switch"
               checked={layers[key]}
               onChange={(event) => onLayerChange(key, event.target.checked)}
             />

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import { Home, Pause, Play, Radio, ScanSearch } from 'lucide-react';
+import type {
+  PatientFlowAmbient,
+  PatientFlowFilters,
+  PatientFlowSummary,
+  PatientLayerState,
+} from '@/features/patientFlowNavigator/types';
+
+export interface NavigatorMetrics {
+  active: number;
+  events: number;
+  occupiedLocations: number;
+}
+
+export interface LayerControl {
+  key: keyof PatientLayerState;
+  label: string;
+  id: string;
+}
+
+interface NavigatorToolbarProps {
+  summary: PatientFlowSummary | null;
+  ambient: PatientFlowAmbient | null;
+  lensTitle: string | null;
+  chronobar: React.ReactNode;
+  playing: boolean;
+  live: boolean;
+  speed: number;
+  filters: PatientFlowFilters;
+  floors: string[];
+  services: string[];
+  categories: string[];
+  layers: PatientLayerState;
+  layerControls: LayerControl[];
+  metrics: NavigatorMetrics;
+  onTogglePlay: () => void;
+  onToggleLive: () => void;
+  onResetCamera: () => void;
+  onFocusPatients: () => void;
+  onSpeedChange: (speed: number) => void;
+  onFiltersChange: (patch: Partial<PatientFlowFilters>) => void;
+  onLayerChange: (key: keyof PatientLayerState, value: boolean) => void;
+}
+
+export default function NavigatorToolbar({
+  summary,
+  ambient,
+  lensTitle,
+  chronobar,
+  playing,
+  live,
+  speed,
+  filters,
+  floors,
+  services,
+  categories,
+  layers,
+  layerControls,
+  metrics,
+  onTogglePlay,
+  onToggleLive,
+  onResetCamera,
+  onFocusPatients,
+  onSpeedChange,
+  onFiltersChange,
+  onLayerChange,
+}: NavigatorToolbarProps) {
+  return (
+    <aside className="patient-flow-toolbar" aria-label="Navigator controls">
+      <div className="patient-flow-brand">
+        <strong>Patient Flow 4D</strong>
+        <span>
+          {summary ? `${summary.patients} pts / ${summary.normalized_events} events` : 'Loading'}
+          {lensTitle ? ` · ${lensTitle}` : ''}
+        </span>
+      </div>
+
+      {chronobar}
+
+      <div className="patient-flow-buttons">
+        <button
+          className={`patient-flow-icon-button ${playing ? 'active' : ''}`}
+          type="button"
+          title={playing ? 'Pause replay' : 'Play replay (loops the past 24h)'}
+          onClick={onTogglePlay}
+        >
+          {playing ? <Pause /> : <Play />}
+        </button>
+        <button
+          className={`patient-flow-icon-button ${live ? 'active' : ''}`}
+          type="button"
+          title="Live stream"
+          onClick={onToggleLive}
+        >
+          <Radio />
+        </button>
+        <button className="patient-flow-icon-button" type="button" title="Reset view" onClick={onResetCamera}>
+          <Home />
+        </button>
+        <button
+          className="patient-flow-icon-button"
+          type="button"
+          title="Focus active patients"
+          onClick={onFocusPatients}
+        >
+          <ScanSearch />
+        </button>
+      </div>
+
+      <div className="patient-flow-control-grid">
+        <label htmlFor="flow-floor">Floor</label>
+        <select
+          id="flow-floor"
+          value={filters.floor}
+          onChange={(event) => onFiltersChange({ floor: event.target.value })}
+        >
+          <option value="all">All</option>
+          {floors.map((floor) => (
+            <option key={floor} value={floor}>Floor {floor}</option>
+          ))}
+        </select>
+
+        <label htmlFor="flow-service">Service</label>
+        <select
+          id="flow-service"
+          value={filters.serviceLine}
+          onChange={(event) => onFiltersChange({ serviceLine: event.target.value })}
+        >
+          <option value="all">All</option>
+          {services.map((service) => (
+            <option key={service} value={service}>{service.replaceAll('_', ' ')}</option>
+          ))}
+        </select>
+
+        <label htmlFor="flow-category">Event</label>
+        <select
+          id="flow-category"
+          value={filters.category}
+          onChange={(event) => onFiltersChange({ category: event.target.value })}
+        >
+          <option value="all">All</option>
+          {categories.map((category) => (
+            <option key={category} value={category}>{category.replaceAll('_', ' ')}</option>
+          ))}
+        </select>
+
+        <label htmlFor="flow-speed">Speed</label>
+        <select id="flow-speed" value={speed} onChange={(event) => onSpeedChange(Number(event.target.value))}>
+          <option value={15}>15m/s</option>
+          <option value={60}>1h/s</option>
+          <option value={240}>4h/s</option>
+          <option value={720}>12h/s</option>
+        </select>
+
+        <label htmlFor="flow-search">Find</label>
+        <input
+          id="flow-search"
+          type="search"
+          placeholder="PT, bed, service"
+          value={filters.search}
+          onChange={(event) => onFiltersChange({ search: event.target.value })}
+        />
+      </div>
+
+      <fieldset className="patient-flow-layer-grid">
+        <legend>Layers</legend>
+        {layerControls.map(({ key, label, id }) => (
+          <div className="patient-flow-checkbox-row" key={key}>
+            <input
+              id={id}
+              type="checkbox"
+              checked={layers[key]}
+              onChange={(event) => onLayerChange(key, event.target.checked)}
+            />
+            <label htmlFor={id}>{label}</label>
+          </div>
+        ))}
+      </fieldset>
+
+      <div className="patient-flow-metrics">
+        <div><span>{metrics.active}</span><small>Active</small></div>
+        <div><span>{metrics.events}</span><small>Events</small></div>
+        <div><span>{metrics.occupiedLocations}</span><small>Locations</small></div>
+        <div><span>{ambient?.summary.eventCount ?? summary?.ambient_signals ?? 0}</span><small>Ambient</small></div>
+      </div>
+    </aside>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -75,6 +75,127 @@
   accent-color: #e0a33f;
 }
 
+/* --- 48h Chronobar (now−24h … now+24h) ---------------------------------- */
+
+.patient-flow-chronobar {
+  display: grid;
+  gap: 6px;
+}
+
+.patient-flow-chronobar output {
+  min-height: 20px;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  color: #ddd4c5;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+}
+
+.patient-flow-chronobar-rel {
+  color: #b9b2a6;
+}
+
+.patient-flow-chronobar-rel.future {
+  color: #7dd3fc;
+}
+
+.patient-flow-chronobar-track {
+  position: relative;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* Past half: solid but dimmed until event coverage brightens it. */
+.patient-flow-chronobar-past {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: rgba(221, 212, 197, 0.14);
+}
+
+/* Future half: dashed ghost region. */
+.patient-flow-chronobar-future {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(125, 211, 252, 0.28) 0 5px,
+    transparent 5px 10px
+  );
+}
+
+/* Replay-event coverage inside the past half. */
+.patient-flow-chronobar-coverage {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: rgba(224, 163, 63, 0.45);
+}
+
+.patient-flow-chronobar-detent {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: rgba(239, 234, 220, 0.4);
+}
+
+.patient-flow-chronobar-now {
+  position: absolute;
+  top: -1px;
+  bottom: -1px;
+  width: 2px;
+  margin-left: -1px;
+  background: #e0a33f;
+}
+
+.patient-flow-chronobar input[type='range'] {
+  width: 100%;
+  accent-color: #e0a33f;
+}
+
+.patient-flow-chronobar input[type='range']:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
+}
+
+.patient-flow-chronobar-empty {
+  margin: 0;
+  color: #b9b2a6;
+  font-size: 12px;
+}
+
+/* Forecast HUD strip — aggregate projections at the scrubbed future time. */
+.patient-flow-forecast-hud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  margin: 0;
+  font-size: 12px;
+  color: #b9b2a6;
+}
+
+.patient-flow-forecast-hud div {
+  display: flex;
+  gap: 5px;
+  align-items: baseline;
+}
+
+.patient-flow-forecast-hud dt {
+  color: #b9b2a6;
+}
+
+.patient-flow-forecast-hud dd {
+  margin: 0;
+  color: #7dd3fc;
+  font-variant-numeric: tabular-nums;
+}
+
+.patient-flow-forecast-hud small {
+  color: #b9b2a6;
+}
+
 .patient-flow-buttons {
   display: grid;
   grid-template-columns: repeat(4, 42px);

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -284,19 +284,64 @@
   min-height: 26px;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
 }
 
 .patient-flow-checkbox-row label {
   min-width: 0;
   overflow-wrap: anywhere;
+  cursor: pointer;
+  user-select: none;
 }
 
+/* Layer visibility toggles — standard switch controls (gold track = on).
+   !important overrides the app's global form-input resets (height/background)
+   so the switch renders consistently inside this scoped viewer overlay. */
 .patient-flow-checkbox-row input[type='checkbox'] {
-  width: 16px;
-  height: 16px;
+  appearance: none !important;
+  -webkit-appearance: none !important;
+  box-sizing: border-box !important;
+  position: relative;
   flex: 0 0 auto;
-  accent-color: #e0a33f;
+  width: 34px !important;
+  height: 20px !important;
+  min-height: 0 !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  border-radius: 999px !important;
+  background: rgba(255, 255, 255, 0.14) !important;
+  border: 1px solid rgba(255, 255, 255, 0.2) !important;
+  box-shadow: none !important;
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease;
+}
+
+.patient-flow-checkbox-row input[type='checkbox']::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #f4f5f7;
+  transform: translateY(-50%);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+  transition: left 0.18s ease;
+}
+
+.patient-flow-checkbox-row input[type='checkbox']:checked {
+  background: #e0a33f !important;
+  border-color: #e0a33f !important;
+}
+
+.patient-flow-checkbox-row input[type='checkbox']:checked::after {
+  left: calc(100% - 16px);
+}
+
+.patient-flow-checkbox-row input[type='checkbox']:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
 }
 
 .patient-flow-metrics {

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -1,110 +1,136 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import * as THREE from 'three';
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import { Home, Pause, Play, Radio, ScanSearch } from 'lucide-react';
 import {
   createPatientFlowEventSource,
   fetchPatientFlowAmbient,
   fetchPatientFlowEvents,
   fetchPatientFlowLocations,
+  fetchPatientFlowProjections,
   fetchPatientFlowSummary,
 } from '@/features/patientFlowNavigator/api';
 import {
   parseTime,
   patientStatesAt,
-  positionFor,
   rebuildTracks,
 } from '@/features/patientFlowNavigator/stateProjection';
+import {
+  ENTITY_PROJECTION_KINDS,
+  aggregatesAt,
+  anchorForProjection,
+  buildProjectionPlacementIndex,
+  confidenceOpacity,
+  floorForProjection,
+  ghostsAt,
+} from '@/features/patientFlowNavigator/projections';
+import type { ForecastAggregates } from '@/features/patientFlowNavigator/projections';
 import type {
-  PatientFlowEvent,
+  FlowLens,
+  FlowPatientDots,
+  FlowUnitSummary,
   PatientFlowAmbient,
+  PatientFlowEvent,
   PatientFlowFilters,
   PatientFlowLocations,
   PatientFlowSummary,
   PatientLayerState,
   PatientVisibleState,
+  ProjectionItem,
 } from '@/features/patientFlowNavigator/types';
+import type { NavigatorScene } from './NavigatorScene';
+import NavigatorChronobar from './NavigatorChronobar';
+import NavigatorFeed from './NavigatorFeed';
+import NavigatorInspector from './NavigatorInspector';
+import NavigatorToolbar from './NavigatorToolbar';
+import type { LayerControl, NavigatorMetrics } from './NavigatorToolbar';
 import './PatientFlowNavigator.css';
+
+/**
+ * Patient Flow 4D Navigator — thin orchestrator (FLOW-WINDOW-PLAN §7.3).
+ *
+ * three.js lives entirely in ./NavigatorScene, loaded via dynamic import so
+ * the 3D stack is its own lazy chunk. This component owns data fetching, the
+ * 48h Chronobar time model, the persona lens, playback/live modes, and wires
+ * the presentational pieces (Toolbar / Chronobar / Inspector / Feed).
+ */
 
 interface PatientFlowNavigatorProps {
   initialFloor?: string;
   initialCategory?: string;
   initialServiceLine?: string;
+  /** Resolved persona lens (Inertia prop); null → full house view. */
+  lens?: FlowLens | null;
+  /** unit_id ↔ unit_code ↔ floor bridge for the projection ghost layer. */
+  units?: FlowUnitSummary[];
 }
 
-interface SceneHandles {
-  renderer: THREE.WebGLRenderer;
-  scene: THREE.Scene;
-  camera: THREE.PerspectiveCamera;
-  orbit: OrbitControls;
-  patientLayer: THREE.Group;
-  trailLayer: THREE.Group;
-  heatLayer: THREE.Group;
-  baseObjects: THREE.Object3D[];
-  tokenByPatient: Map<string, THREE.Mesh>;
-  patientMaterials: Map<string, THREE.MeshStandardMaterial>;
-  animationId: number;
-  clock: THREE.Clock;
-  tokenGeometry: THREE.SphereGeometry;
-  heatGeometry: THREE.CylinderGeometry;
-  raycaster: THREE.Raycaster;
+const WINDOW_HALF_MS = 24 * 60 * 60 * 1000;
+
+const IDENTITY_KEYS = ['patient_display_id', 'patient_id', 'encounter_id'] as const;
+
+interface HandoffParams {
+  floor: string | null;
+  unitRef: string | null;
+  t: number | null;
 }
 
-interface Metrics {
-  active: number;
-  events: number;
-  occupiedLocations: number;
-}
+/** Mobile→web A3 handoff: ?persona=&scope=&t= (persona is resolved server-side). */
+function parseHandoff(nowMs: number): HandoffParams {
+  const empty: HandoffParams = { floor: null, unitRef: null, t: null };
+  if (typeof window === 'undefined') return empty;
+  const params = new URLSearchParams(window.location.search);
 
-const defaultLayers: PatientLayerState = {
-  base: true,
-  tokens: true,
-  trails: true,
-  heat: true,
-};
-
-const layerControls: Array<{ key: keyof PatientLayerState; label: string; id: string }> = [
-  { key: 'base', label: 'Model', id: 'flow-layer-model' },
-  { key: 'tokens', label: 'Patients', id: 'flow-layer-patients' },
-  { key: 'trails', label: 'Trails', id: 'flow-layer-trails' },
-  { key: 'heat', label: 'Census', id: 'flow-layer-census' },
-];
-
-function fmtTime(ms: number): string {
-  if (!Number.isFinite(ms) || ms <= 0) return '--';
-  return new Date(ms).toLocaleString([], {
-    month: 'short',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
-
-function hashColor(value: string): THREE.Color {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = ((hash << 5) - hash) + value.charCodeAt(index);
+  const scope = params.get('scope');
+  let floor: string | null = null;
+  let unitRef: string | null = null;
+  if (scope) {
+    const [type, arg] = scope.split(':', 2);
+    if (type === 'floor' && arg && /^\d+$/.test(arg)) floor = arg;
+    if (type === 'unit' && arg) unitRef = arg;
   }
-  return new THREE.Color(`hsl(${Math.abs(hash) % 360}, 70%, 58%)`);
+
+  let t: number | null = null;
+  const rawT = params.get('t');
+  if (rawT) {
+    const parsed = Date.parse(rawT);
+    if (Number.isFinite(parsed)) {
+      t = Math.min(nowMs + WINDOW_HALF_MS, Math.max(nowMs - WINDOW_HALF_MS, parsed));
+    }
+  }
+
+  return { floor, unitRef, t };
 }
 
-function disposeObject(object: THREE.Object3D): void {
-  const mesh = object as THREE.Mesh;
-  mesh.geometry?.dispose?.();
-  const material = mesh.material;
-  if (Array.isArray(material)) {
-    material.forEach((item) => item.dispose());
-  } else {
-    material?.dispose?.();
+function defaultLayersForLens(lens: FlowLens | null | undefined): PatientLayerState {
+  if (!lens) {
+    return { base: true, tokens: true, trails: true, heat: true, ghosts: true };
   }
+  const has = (layer: string): boolean => lens.layers.includes(layer);
+  const dots = lens.patient_dots !== 'none';
+  return {
+    base: true,
+    tokens: has('events') && dots,
+    trails: has('events') && dots,
+    heat: has('snapshots'),
+    ghosts: has('projections') && lens.projection_kinds.length > 0,
+  };
 }
 
-function clearGroup(group: THREE.Group): void {
-  while (group.children.length) {
-    const child = group.children.pop();
-    if (child) disposeObject(child);
+/**
+ * Lens redaction for the inspector (G7 on web): `none` → aggregate fields
+ * only; `unit`/`task` → identity only when the item carries an opaque
+ * patient_context_ref (flow replay events never do; some projections may).
+ */
+function redactSelection(
+  data: Record<string, unknown>,
+  dots: FlowPatientDots | null,
+): Record<string, unknown> {
+  if (!dots || dots === 'full') return data;
+  const clone: Record<string, unknown> = { ...data };
+  if (dots === 'none') {
+    for (const key of [...IDENTITY_KEYS, 'patient_context_ref', 'entity']) delete clone[key];
+  } else if (!clone.patient_context_ref) {
+    for (const key of IDENTITY_KEYS) delete clone[key];
   }
+  return clone;
 }
 
 function flattenInspector(data: Record<string, unknown>): Array<[string, string]> {
@@ -121,43 +147,75 @@ export default function PatientFlowNavigator({
   initialFloor = 'all',
   initialCategory = 'all',
   initialServiceLine = 'all',
+  lens = null,
+  units = [],
 }: PatientFlowNavigatorProps) {
+  // ---- 48h time window (fixed at load; §5) --------------------------------
+  const nowMs = useMemo(() => Date.now(), []);
+  const windowStart = nowMs - WINDOW_HALF_MS;
+  const windowEnd = nowMs + WINDOW_HALF_MS;
+  const handoff = useMemo(() => parseHandoff(nowMs), [nowMs]);
+
+  const dotsPolicy: FlowPatientDots | null = lens?.patient_dots ?? null;
+  const patientDotsVisible = dotsPolicy !== 'none';
+
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const sceneRef = useRef<SceneHandles | null>(null);
+  const sceneRef = useRef<NavigatorScene | null>(null);
   const tracksRef = useRef<Map<string, PatientFlowEvent[]>>(new Map());
   const eventsRef = useRef<PatientFlowEvent[]>([]);
   const locationsRef = useRef<PatientFlowLocations>({});
-  const filtersRef = useRef<PatientFlowFilters>({ floor: initialFloor, serviceLine: initialServiceLine, category: initialCategory, search: '' });
-  const layersRef = useRef<PatientLayerState>(defaultLayers);
-  const currentTimeRef = useRef(0);
-  const minTimeRef = useRef(0);
-  const maxTimeRef = useRef(0);
+  const filtersRef = useRef<PatientFlowFilters>({
+    floor: handoff.floor ?? initialFloor,
+    serviceLine: initialServiceLine,
+    category: initialCategory,
+    search: '',
+  });
+  const layersRef = useRef<PatientLayerState>(defaultLayersForLens(lens));
+  const projectionsRef = useRef<ProjectionItem[]>([]);
+  const currentTimeRef = useRef(handoff.t ?? nowMs);
   const speedRef = useRef(60);
   const playingRef = useRef(false);
   const liveRef = useRef(false);
   const eventSourceRef = useRef<EventSource | null>(null);
   const lastVisibleStatesRef = useRef<PatientVisibleState[]>([]);
+  const lastBucketKeyRef = useRef('');
+  const lastTimeEmitRef = useRef(0);
+  const scopeAppliedRef = useRef(false);
 
   const [summary, setSummary] = useState<PatientFlowSummary | null>(null);
   const [ambient, setAmbient] = useState<PatientFlowAmbient | null>(null);
   const [locations, setLocations] = useState<PatientFlowLocations>({});
   const [events, setEvents] = useState<PatientFlowEvent[]>([]);
+  const [projections, setProjections] = useState<ProjectionItem[]>([]);
   const [filters, setFilters] = useState<PatientFlowFilters>(filtersRef.current);
-  const [layers, setLayers] = useState<PatientLayerState>(defaultLayers);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [minTime, setMinTime] = useState(0);
-  const [maxTime, setMaxTime] = useState(0);
+  const [layers, setLayers] = useState<PatientLayerState>(layersRef.current);
+  const [currentTime, setCurrentTime] = useState(currentTimeRef.current);
   const [speed, setSpeed] = useState(60);
   const [playing, setPlaying] = useState(false);
   const [live, setLive] = useState(false);
   const [status, setStatus] = useState('Loading');
   const [cameraText, setCameraText] = useState('');
-  const [metrics, setMetrics] = useState<Metrics>({ active: 0, events: 0, occupiedLocations: 0 });
+  const [metrics, setMetrics] = useState<NavigatorMetrics>({ active: 0, events: 0, occupiedLocations: 0 });
+  const [forecast, setForecast] = useState<ForecastAggregates | null>(null);
   const [inspectorTitle, setInspectorTitle] = useState('Select a patient or location');
   const [inspectorRows, setInspectorRows] = useState<Array<[string, string]>>([]);
   const [feed, setFeed] = useState<PatientFlowEvent[]>([]);
   const [error, setError] = useState<string | null>(null);
+
+  const tracks = useMemo(() => rebuildTracks(events), [events]);
+
+  const dataStart = useMemo(() => (events.length ? parseTime(events[0].occurred_at) : null), [events]);
+  const dataEnd = useMemo(
+    () => (events.length ? parseTime(events[events.length - 1].occurred_at) : null),
+    [events],
+  );
+
+  const placementIndex = useMemo(
+    () => buildProjectionPlacementIndex(locations, units),
+    [locations, units],
+  );
+  const placementIndexRef = useRef(placementIndex);
 
   const floors = useMemo(() => {
     return [...new Set(Object.values(locations).map((loc) => loc.floor).filter((value): value is number => value !== null && value !== undefined))]
@@ -173,156 +231,133 @@ export default function PatientFlowNavigator({
     return [...new Set(events.map((event) => event.event_category).filter(Boolean))].sort();
   }, [events]);
 
-  const syncRefs = useCallback(() => {
+  const layerControls = useMemo<LayerControl[]>(() => {
+    const controls: LayerControl[] = [{ key: 'base', label: 'Model', id: 'flow-layer-model' }];
+    if (patientDotsVisible) {
+      controls.push(
+        { key: 'tokens', label: 'Patients', id: 'flow-layer-patients' },
+        { key: 'trails', label: 'Trails', id: 'flow-layer-trails' },
+      );
+    }
+    controls.push({ key: 'heat', label: 'Census', id: 'flow-layer-census' });
+    if (!lens || (lens.layers.includes('projections') && lens.projection_kinds.length > 0)) {
+      controls.push({ key: 'ghosts', label: 'Forecast', id: 'flow-layer-forecast' });
+    }
+    return controls;
+  }, [lens, patientDotsVisible]);
+
+  // ---- scene refresh: cheap per-frame tokens, bucketed heavy layers -------
+  const refreshScene = useCallback(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+
+    const timeMs = currentTimeRef.current;
+    const states = patientStatesAt(tracksRef.current, locationsRef.current, timeMs, filtersRef.current);
+    lastVisibleStatesRef.current = states;
+    scene.updateTokens(
+      states,
+      layersRef.current.tokens && dotsPolicy !== 'none',
+      dotsPolicy !== null && dotsPolicy !== 'full',
+    );
+
+    // Heavy layers rebuild only when the sim-time minute bucket, filters,
+    // layers, or datasets change — not every animation frame.
+    const bucketKey = [
+      Math.floor(timeMs / 60_000),
+      JSON.stringify(filtersRef.current),
+      JSON.stringify(layersRef.current),
+      eventsRef.current.length,
+      projectionsRef.current.length,
+      Object.keys(locationsRef.current).length,
+    ].join('|');
+    if (bucketKey === lastBucketKeyRef.current) return;
+    lastBucketKeyRef.current = bucketKey;
+
+    scene.setBaseVisibility(filtersRef.current.floor, layersRef.current.base);
+    scene.rebuildTrails(
+      tracksRef.current,
+      locationsRef.current,
+      states,
+      timeMs,
+      layersRef.current.trails && patientDotsVisible,
+    );
+    const occupied = scene.rebuildHeat(states, locationsRef.current, layersRef.current.heat);
+
+    // Projection ghosts + forecast heat (the future half; §5 ghost grammar).
+    const index = placementIndexRef.current;
+    const floorFilter = filtersRef.current.floor;
+    const ghostItems = layersRef.current.ghosts
+      ? ghostsAt(projectionsRef.current, nowMs, timeMs).filter((item) => {
+          if (floorFilter === 'all') return true;
+          const floor = floorForProjection(item, index);
+          return floor !== null && String(floor) === floorFilter;
+        })
+      : [];
+
+    const ghostTokens = ghostItems
+      .filter((item) => ENTITY_PROJECTION_KINDS.includes(item.kind))
+      .map((item) => {
+        const anchor = anchorForProjection(item, index);
+        return anchor ? { item, anchor } : null;
+      })
+      .filter((ghost): ghost is NonNullable<typeof ghost> => ghost !== null);
+    scene.rebuildGhosts(ghostTokens, layersRef.current.ghosts);
+
+    const aggregates = layersRef.current.ghosts
+      ? aggregatesAt(projectionsRef.current, nowMs, timeMs)
+      : null;
+    const heatCells = aggregates
+      ? [...aggregates.censusByUnit.entries()]
+          .filter(([unitId]) => {
+            if (floorFilter === 'all') return true;
+            const floor = index.unitFloors.get(unitId);
+            return floor !== undefined && String(floor) === floorFilter;
+          })
+          .map(([unitId, item]) => {
+            const anchor = index.unitAnchors.get(unitId);
+            return anchor && item.value !== null
+              ? { anchor, value: item.value, opacity: Math.min(0.3, confidenceOpacity(item.confidence) * 0.45) }
+              : null;
+          })
+          .filter((cell): cell is NonNullable<typeof cell> => cell !== null)
+      : [];
+    scene.rebuildForecastHeat(heatCells, layersRef.current.ghosts && timeMs > nowMs);
+    setForecast(aggregates && timeMs > nowMs ? aggregates : null);
+
+    setMetrics({
+      active: states.length,
+      events: eventsRef.current.filter((event) => parseTime(event.occurred_at) <= timeMs).length,
+      occupiedLocations: occupied || new Set(states.map((state) => state.event.to_location).filter(Boolean)).size,
+    });
+  }, [dotsPolicy, nowMs, patientDotsVisible]);
+
+  // Keep refs in sync with state, then repaint.
+  useEffect(() => {
     eventsRef.current = events;
     locationsRef.current = locations;
     filtersRef.current = filters;
     layersRef.current = layers;
-    currentTimeRef.current = currentTime;
-    minTimeRef.current = minTime;
-    maxTimeRef.current = maxTime;
+    projectionsRef.current = projections;
     speedRef.current = speed;
     playingRef.current = playing;
     liveRef.current = live;
-    tracksRef.current = rebuildTracks(events);
-  }, [currentTime, events, filters, layers, live, locations, maxTime, minTime, playing, speed]);
+    tracksRef.current = tracks;
+    placementIndexRef.current = placementIndex;
+    refreshScene();
+  }, [events, locations, filters, layers, projections, speed, playing, live, tracks, placementIndex, refreshScene]);
 
+  // Repaint when the displayed time changes. The ref is the source of truth
+  // (playback advances it per frame); scrub/live paths write it via applyTime.
   useEffect(() => {
-    syncRefs();
-  }, [syncRefs]);
+    refreshScene();
+  }, [currentTime, refreshScene]);
 
-  const materialForPatient = useCallback((handles: SceneHandles, patientId: string): THREE.MeshStandardMaterial => {
-    let material = handles.patientMaterials.get(patientId);
-    if (!material) {
-      const color = hashColor(patientId);
-      material = new THREE.MeshStandardMaterial({
-        color,
-        emissive: color.clone().multiplyScalar(0.22),
-        roughness: 0.42,
-        metalness: 0,
-      });
-      handles.patientMaterials.set(patientId, material);
-    }
-
-    return material;
+  const applyTime = useCallback((timeMs: number): void => {
+    currentTimeRef.current = timeMs;
+    setCurrentTime(timeMs);
   }, []);
 
-  const updateBaseVisibility = useCallback((handles: SceneHandles) => {
-    const floor = filtersRef.current.floor;
-    for (const object of handles.baseObjects) {
-      const data = object.userData ?? {};
-      const floorOk = floor === 'all' || String(data.floor) === floor || data.category === 'elevator';
-      object.visible = layersRef.current.base && floorOk;
-    }
-  }, []);
-
-  const updateTokens = useCallback((handles: SceneHandles, states: PatientVisibleState[]) => {
-    const visible = new Set<string>();
-    for (const state of states) {
-      let token = handles.tokenByPatient.get(state.patientId);
-      if (!token) {
-        token = new THREE.Mesh(handles.tokenGeometry, materialForPatient(handles, state.patientId));
-        handles.tokenByPatient.set(state.patientId, token);
-        handles.patientLayer.add(token);
-      }
-      token.position.set(state.position.x, state.position.y, state.position.z);
-      token.scale.setScalar(state.event.event_category === 'movement' ? 1 : 0.82);
-      token.visible = layersRef.current.tokens;
-      token.userData = {
-        kind: 'patient-token',
-        patient_id: state.patientId,
-        patient_display_id: state.event.patient_display_id,
-        current_location: state.event.to_location,
-        service_line: state.event.service_line,
-        event_type: state.event.event_type,
-        event_category: state.event.event_category,
-        last_event_at: state.event.occurred_at,
-        recent_event_count: state.recent.length,
-        encounter_id: state.event.encounter_id,
-      };
-      visible.add(state.patientId);
-    }
-
-    for (const [patientId, token] of handles.tokenByPatient.entries()) {
-      if (!visible.has(patientId)) token.visible = false;
-    }
-  }, [materialForPatient]);
-
-  const updateTrails = useCallback((handles: SceneHandles, states: PatientVisibleState[], timeMs: number) => {
-    clearGroup(handles.trailLayer);
-    if (!layersRef.current.trails) return;
-
-    const activePatients = new Set(states.map((state) => state.patientId));
-    for (const [patientId, track] of tracksRef.current.entries()) {
-      if (!activePatients.has(patientId)) continue;
-      const points: THREE.Vector3[] = [];
-      for (const event of track) {
-        if (parseTime(event.occurred_at) > timeMs) break;
-        const position = positionFor(locationsRef.current, event.to_location);
-        if (!position) continue;
-        const vector = new THREE.Vector3(position.x, position.y, position.z);
-        if (!points.length || !points[points.length - 1].equals(vector)) points.push(vector);
-      }
-      if (points.length < 2) continue;
-      const geometry = new THREE.BufferGeometry().setFromPoints(points);
-      const material = new THREE.LineBasicMaterial({ color: hashColor(patientId), transparent: true, opacity: 0.55 });
-      const line = new THREE.Line(geometry, material);
-      line.userData = { kind: 'patient-trail', patient_id: patientId };
-      handles.trailLayer.add(line);
-    }
-  }, []);
-
-  const updateHeat = useCallback((handles: SceneHandles, states: PatientVisibleState[]) => {
-    clearGroup(handles.heatLayer);
-    if (!layersRef.current.heat) {
-      setMetrics((prev) => ({ ...prev, occupiedLocations: 0 }));
-      return;
-    }
-
-    const occupancy = new Map<string, number>();
-    for (const state of states) {
-      const loc = state.event.to_location;
-      if (loc) occupancy.set(loc, (occupancy.get(loc) ?? 0) + 1);
-    }
-
-    for (const [loc, count] of occupancy.entries()) {
-      const position = positionFor(locationsRef.current, loc);
-      if (!position) continue;
-      const material = new THREE.MeshStandardMaterial({
-        color: count > 1 ? 0xf06755 : 0x77c06f,
-        emissive: count > 1 ? 0x5a140d : 0x143d17,
-        transparent: true,
-        opacity: 0.62,
-      });
-      const marker = new THREE.Mesh(handles.heatGeometry, material);
-      marker.position.set(position.x, position.y + 2 + count * 0.42, position.z);
-      marker.scale.set(1 + count * 0.12, Math.max(1, count * 1.2), 1 + count * 0.12);
-      marker.userData = {
-        kind: 'occupancy-marker',
-        location: loc,
-        active_patient_count: count,
-        location_name: locationsRef.current[loc]?.name,
-      };
-      handles.heatLayer.add(marker);
-    }
-  }, []);
-
-  const updateScene = useCallback(() => {
-    const handles = sceneRef.current;
-    if (!handles || !eventsRef.current.length) return;
-    const states = patientStatesAt(tracksRef.current, locationsRef.current, currentTimeRef.current, filtersRef.current);
-    lastVisibleStatesRef.current = states;
-    updateBaseVisibility(handles);
-    updateTokens(handles, states);
-    updateTrails(handles, states, currentTimeRef.current);
-    updateHeat(handles, states);
-    setMetrics({
-      active: states.length,
-      events: eventsRef.current.filter((event) => parseTime(event.occurred_at) <= currentTimeRef.current).length,
-      occupiedLocations: new Set(states.map((state) => state.event.to_location).filter(Boolean)).size,
-    });
-  }, [updateBaseVisibility, updateHeat, updateTokens, updateTrails]);
-
+  // ---- data bootstrap ------------------------------------------------------
   useEffect(() => {
     let cancelled = false;
 
@@ -338,16 +373,17 @@ export default function PatientFlowNavigator({
         if (cancelled) return;
 
         const sortedEvents = [...eventData].sort((a, b) => parseTime(a.occurred_at) - parseTime(b.occurred_at));
-        const nextMin = sortedEvents.length ? parseTime(sortedEvents[0].occurred_at) : 0;
-        const nextMax = sortedEvents.length ? parseTime(sortedEvents[sortedEvents.length - 1].occurred_at) : 0;
         setSummary(summaryData);
         setAmbient(ambientData);
         setLocations(locationData);
         setEvents(sortedEvents);
-        setMinTime(nextMin);
-        setMaxTime(nextMax);
-        setCurrentTime(nextMax);
-        setStatus(sortedEvents.length ? 'Data loaded' : 'No flow events loaded');
+        if (!sortedEvents.length) {
+          setStatus('No flow events loaded');
+        } else if (parseTime(sortedEvents[sortedEvents.length - 1].occurred_at) < windowStart) {
+          setStatus('Events precede the 48h window — rebase the synthetic fixture');
+        } else {
+          setStatus('Data loaded');
+        }
       } catch (caught) {
         const message = caught instanceof Error ? caught.message : 'Unable to load patient flow data';
         setError(message);
@@ -360,170 +396,112 @@ export default function PatientFlowNavigator({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [windowStart]);
 
+  // Projection stream (future half) — lens-clamped server-side; a failure
+  // only disables ghosts, never the navigator.
   useEffect(() => {
-    syncRefs();
-    updateScene();
-  }, [syncRefs, updateScene]);
+    let cancelled = false;
+    fetchPatientFlowProjections(lens ? { persona: lens.role_id } : {})
+      .then((payload) => {
+        if (cancelled) return;
+        const allowed = lens ? new Set(lens.projection_kinds) : null;
+        setProjections(payload.projections.filter((item) => !allowed || allowed.has(item.kind)));
+      })
+      .catch(() => {
+        if (!cancelled) setProjections([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [lens]);
 
+  // Handoff scope=unit:{id|abbr} → that unit's floor, once derivable.
+  useEffect(() => {
+    if (scopeAppliedRef.current || !handoff.unitRef) return;
+    if (!Object.keys(locations).length) return;
+    scopeAppliedRef.current = true;
+
+    const ref = handoff.unitRef.toLowerCase();
+    const unit = /^\d+$/.test(ref)
+      ? units.find((candidate) => candidate.unit_id === Number(ref))
+      : units.find((candidate) => candidate.unit_code?.toLowerCase() === ref);
+    const floor = unit
+      ? placementIndex.unitFloors.get(unit.unit_id)
+      : Object.values(locations).find((loc) => loc.unit_code?.toLowerCase() === ref)?.floor;
+    if (floor !== undefined && floor !== null) {
+      setFilters((prev) => ({ ...prev, floor: String(floor) }));
+    }
+  }, [handoff.unitRef, locations, placementIndex, units]);
+
+  // ---- three.js scene (lazy chunk) ----------------------------------------
   useEffect(() => {
     const canvas = canvasRef.current;
     const container = containerRef.current;
     if (!canvas || !container || !summary?.model_url) return;
 
-    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: false, preserveDrawingBuffer: true });
-    const width = container.clientWidth;
-    const height = container.clientHeight;
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-    renderer.setSize(width, height);
-    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    let disposed = false;
+    let scene: NavigatorScene | null = null;
 
-    const scene = new THREE.Scene();
-    scene.background = new THREE.Color(0x121514);
-    scene.fog = new THREE.Fog(0x121514, 150, 470);
-
-    const camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 1400);
-    camera.position.set(88, 104, 162);
-
-    const orbit = new OrbitControls(camera, renderer.domElement);
-    orbit.target.set(0, 48, 0);
-    orbit.enableDamping = true;
-    orbit.maxPolarAngle = Math.PI * 0.49;
-    orbit.minDistance = 18;
-    orbit.maxDistance = 380;
-
-    scene.add(new THREE.HemisphereLight(0xf6f0e4, 0x343a36, 2.2));
-    const sun = new THREE.DirectionalLight(0xfff5df, 2);
-    sun.position.set(-85, 170, 80);
-    scene.add(sun);
-    const grid = new THREE.GridHelper(190, 19, 0x796e59, 0x333834);
-    grid.position.y = -0.12;
-    scene.add(grid);
-
-    const patientLayer = new THREE.Group();
-    const trailLayer = new THREE.Group();
-    const heatLayer = new THREE.Group();
-    scene.add(heatLayer, trailLayer, patientLayer);
-
-    const handles: SceneHandles = {
-      renderer,
-      scene,
-      camera,
-      orbit,
-      patientLayer,
-      trailLayer,
-      heatLayer,
-      baseObjects: [],
-      tokenByPatient: new Map(),
-      patientMaterials: new Map(),
-      animationId: 0,
-      clock: new THREE.Clock(),
-      tokenGeometry: new THREE.SphereGeometry(1.65, 18, 12),
-      heatGeometry: new THREE.CylinderGeometry(1.9, 1.9, 1, 18, 1),
-      raycaster: new THREE.Raycaster(),
-    };
-    sceneRef.current = handles;
-
-    new GLTFLoader().load(summary.model_url, (gltf) => {
-      scene.add(gltf.scene);
-      gltf.scene.traverse((object) => {
-        const mesh = object as THREE.Mesh;
-        if (!mesh.isMesh) return;
-        handles.baseObjects.push(mesh);
-        const material = mesh.material;
-        if (Array.isArray(material)) {
-          mesh.material = material.map((item) => item.clone());
-          mesh.material.forEach((item) => {
-            item.transparent = true;
-            item.opacity = mesh.userData?.category === 'floor' ? 0.56 : 0.72;
-          });
-        } else if (material) {
-          mesh.material = material.clone();
-          mesh.material.transparent = true;
-          mesh.material.opacity = mesh.userData?.category === 'floor' ? 0.56 : 0.72;
-        }
+    void import('./NavigatorScene').then(({ NavigatorScene: SceneClass }) => {
+      if (disposed) return;
+      scene = new SceneClass(canvas, container, {
+        onSelect: (data) => {
+          const redacted = redactSelection(data, dotsPolicy);
+          setInspectorTitle(String(
+            redacted.patient_display_id ?? redacted.label ?? redacted.name ?? redacted.code ?? redacted.kind ?? 'Selected',
+          ));
+          setInspectorRows(flattenInspector(redacted));
+        },
+        onCameraMove: setCameraText,
+        onFrame: (delta) => {
+          if (!playingRef.current || liveRef.current) return;
+          const next = currentTimeRef.current + delta * speedRef.current * 60 * 1000;
+          // Replay loops within the past half only; the future is for scrubbing.
+          const bounded = next > nowMs ? windowStart : next;
+          currentTimeRef.current = bounded;
+          const wallNow = performance.now();
+          if (wallNow - lastTimeEmitRef.current > 150) {
+            lastTimeEmitRef.current = wallNow;
+            setCurrentTime(bounded);
+          }
+          refreshScene();
+        },
       });
-      setStatus('Model loaded');
-      updateScene();
-    }, undefined, (loadError) => {
-      console.error(loadError);
-      setError('Model failed to load');
-      setStatus('Model failed to load');
+      sceneRef.current = scene;
+      lastBucketKeyRef.current = '';
+      scene.loadModel(
+        summary.model_url,
+        () => {
+          setStatus('Model loaded');
+          lastBucketKeyRef.current = '';
+          refreshScene();
+        },
+        () => {
+          setError('Model failed to load');
+          setStatus('Model failed to load');
+        },
+      );
+      refreshScene();
     });
 
-    const onResize = (): void => {
-      const nextWidth = container.clientWidth;
-      const nextHeight = container.clientHeight;
-      camera.aspect = nextWidth / nextHeight;
-      camera.updateProjectionMatrix();
-      renderer.setSize(nextWidth, nextHeight);
-    };
-
-    const onPointerDown = (event: PointerEvent): void => {
-      if (event.target !== renderer.domElement) return;
-      const rect = renderer.domElement.getBoundingClientRect();
-      const pointer = new THREE.Vector2(
-        ((event.clientX - rect.left) / rect.width) * 2 - 1,
-        -((event.clientY - rect.top) / rect.height) * 2 + 1,
-      );
-      handles.raycaster.setFromCamera(pointer, camera);
-      const hits = handles.raycaster.intersectObjects([
-        ...patientLayer.children,
-        ...heatLayer.children,
-        ...handles.baseObjects,
-      ].filter((object) => object.visible), false);
-      if (!hits.length) return;
-      const data = hits[0].object.userData ?? {};
-      setInspectorTitle(String(data.patient_display_id ?? data.name ?? data.code ?? data.kind ?? 'Selected'));
-      setInspectorRows(flattenInspector(data));
-    };
-
-    const animate = (): void => {
-      const delta = Math.min(handles.clock.getDelta(), 0.05);
-      if (playingRef.current && !liveRef.current && maxTimeRef.current > minTimeRef.current) {
-        const next = currentTimeRef.current + delta * speedRef.current * 60 * 1000;
-        const bounded = next > maxTimeRef.current ? minTimeRef.current : next;
-        currentTimeRef.current = bounded;
-        setCurrentTime(bounded);
-        updateScene();
-      }
-      orbit.update();
-      setCameraText(`x ${camera.position.x.toFixed(0)} y ${camera.position.y.toFixed(0)} z ${camera.position.z.toFixed(0)}`);
-      renderer.render(scene, camera);
-      handles.animationId = requestAnimationFrame(animate);
-    };
-
-    window.addEventListener('resize', onResize);
-    renderer.domElement.addEventListener('pointerdown', onPointerDown);
-    handles.animationId = requestAnimationFrame(animate);
-
     return () => {
-      window.removeEventListener('resize', onResize);
-      renderer.domElement.removeEventListener('pointerdown', onPointerDown);
-      cancelAnimationFrame(handles.animationId);
+      disposed = true;
       eventSourceRef.current?.close();
-      handles.baseObjects.forEach(disposeObject);
-      clearGroup(patientLayer);
-      clearGroup(trailLayer);
-      clearGroup(heatLayer);
-      handles.patientMaterials.forEach((material) => material.dispose());
-      handles.tokenGeometry.dispose();
-      handles.heatGeometry.dispose();
-      orbit.dispose();
-      renderer.dispose();
       sceneRef.current = null;
+      scene?.dispose();
     };
-  }, [summary?.model_url]);
+  }, [summary?.model_url, dotsPolicy, nowMs, windowStart, refreshScene]);
 
-  const setTimelineFromSlider = (value: string): void => {
-    const pct = Number(value) / 10000;
-    const next = minTime + pct * (maxTime - minTime);
-    disconnectLive();
-    setCurrentTime(next);
-  };
+  // ---- playback / live -----------------------------------------------------
+  const disconnectLive = useCallback((): void => {
+    eventSourceRef.current?.close();
+    eventSourceRef.current = null;
+    setLive(false);
+    setStatus('Historical replay');
+  }, []);
 
-  const connectLive = (): void => {
+  const connectLive = useCallback((): void => {
     eventSourceRef.current?.close();
     const source = createPatientFlowEventSource({ replay: 180, interval: 0.65 });
     eventSourceRef.current = source;
@@ -531,49 +509,32 @@ export default function PatientFlowNavigator({
       const event = JSON.parse((message as MessageEvent<string>).data) as PatientFlowEvent;
       setEvents((prev) => {
         if (prev.some((item) => item.event_id === event.event_id)) return prev;
-        const next = [...prev, event].sort((a, b) => parseTime(a.occurred_at) - parseTime(b.occurred_at));
-        const nextMax = Math.max(...next.map((item) => parseTime(item.occurred_at)));
-        setMaxTime(nextMax);
-        setCurrentTime(nextMax);
-        return next;
+        return [...prev, event].sort((a, b) => parseTime(a.occurred_at) - parseTime(b.occurred_at));
       });
+      // Follow the stream inside the fixed window — the frame never resets.
+      const eventTime = parseTime(event.occurred_at);
+      applyTime(Math.min(nowMs, Math.max(windowStart, eventTime)));
       setFeed((prev) => [event, ...prev.filter((item) => item.event_id !== event.event_id)].slice(0, 8));
     });
     source.onerror = () => setStatus('Live stream reconnecting');
     setLive(true);
     setStatus('Live stream active');
-  };
+  }, [applyTime, nowMs, windowStart]);
 
-  const disconnectLive = (): void => {
-    eventSourceRef.current?.close();
-    eventSourceRef.current = null;
-    setLive(false);
-    setStatus('Historical replay');
-  };
+  const handleScrub = useCallback((timeMs: number): void => {
+    disconnectLive();
+    applyTime(Math.min(windowEnd, Math.max(windowStart, timeMs)));
+  }, [applyTime, disconnectLive, windowEnd, windowStart]);
 
-  const resetCamera = (): void => {
-    const handles = sceneRef.current;
-    if (!handles) return;
-    handles.camera.position.set(88, 104, 162);
-    handles.orbit.target.set(0, 48, 0);
-    handles.orbit.update();
-  };
+  const resetCamera = useCallback((): void => {
+    sceneRef.current?.resetCamera();
+  }, []);
 
-  const focusActivePatients = (): void => {
-    const handles = sceneRef.current;
-    const states = lastVisibleStatesRef.current;
-    if (!handles || !states.length) return;
-    const box = new THREE.Box3();
-    states.forEach((state) => box.expandByPoint(new THREE.Vector3(state.position.x, state.position.y, state.position.z)));
-    const center = box.getCenter(new THREE.Vector3());
-    const size = box.getSize(new THREE.Vector3());
-    const radius = Math.max(size.x, size.y, size.z, 24);
-    handles.orbit.target.copy(center);
-    handles.camera.position.set(center.x + radius * 1.35, center.y + radius * 1.05, center.z + radius * 1.35);
-    handles.orbit.update();
-  };
-
-  const sliderValue = maxTime === minTime ? 10000 : Math.round(((currentTime - minTime) / (maxTime - minTime)) * 10000);
+  const focusActivePatients = useCallback((): void => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    scene.focusOn(lastVisibleStatesRef.current.map((state) => state.position));
+  }, []);
 
   return (
     <section ref={containerRef} className="patient-flow-shell" aria-label="Patient Flow 4D Navigator">
@@ -581,134 +542,47 @@ export default function PatientFlowNavigator({
 
       {error && <div className="patient-flow-error">{error}</div>}
 
-      <aside className="patient-flow-toolbar" aria-label="Navigator controls">
-        <div className="patient-flow-brand">
-          <strong>Patient Flow 4D</strong>
-          <span>{summary ? `${summary.patients} pts / ${summary.normalized_events} events` : 'Loading'}</span>
-        </div>
-
-        <div className="patient-flow-time">
-          <output>{fmtTime(currentTime)}</output>
-          <input
-            type="range"
-            min="0"
-            max="10000"
-            value={Number.isFinite(sliderValue) ? sliderValue : 0}
-            onChange={(event) => setTimelineFromSlider(event.target.value)}
+      <NavigatorToolbar
+        summary={summary}
+        ambient={ambient}
+        lensTitle={lens ? lens.role_id.replaceAll('_', ' ') : null}
+        chronobar={(
+          <NavigatorChronobar
+            windowStart={windowStart}
+            windowEnd={windowEnd}
+            nowMs={nowMs}
+            currentTime={currentTime}
+            dataStart={dataStart}
+            dataEnd={dataEnd}
+            forecast={forecast}
+            onScrub={handleScrub}
           />
-        </div>
+        )}
+        playing={playing}
+        live={live}
+        speed={speed}
+        filters={filters}
+        floors={floors}
+        services={services}
+        categories={categories}
+        layers={layers}
+        layerControls={layerControls}
+        metrics={metrics}
+        onTogglePlay={() => {
+          if (!playing) disconnectLive();
+          setPlaying((value) => !value);
+        }}
+        onToggleLive={() => (live ? disconnectLive() : connectLive())}
+        onResetCamera={resetCamera}
+        onFocusPatients={focusActivePatients}
+        onSpeedChange={setSpeed}
+        onFiltersChange={(patch) => setFilters((prev) => ({ ...prev, ...patch }))}
+        onLayerChange={(key, value) => setLayers((prev) => ({ ...prev, [key]: value }))}
+      />
 
-        <div className="patient-flow-buttons">
-          <button
-            className={`patient-flow-icon-button ${playing ? 'active' : ''}`}
-            type="button"
-            title={playing ? 'Pause replay' : 'Play replay'}
-            onClick={() => {
-              if (!playing) disconnectLive();
-              setPlaying((value) => !value);
-            }}
-          >
-            {playing ? <Pause /> : <Play />}
-          </button>
-          <button
-            className={`patient-flow-icon-button ${live ? 'active' : ''}`}
-            type="button"
-            title="Live stream"
-            onClick={() => (live ? disconnectLive() : connectLive())}
-          >
-            <Radio />
-          </button>
-          <button className="patient-flow-icon-button" type="button" title="Reset view" onClick={resetCamera}>
-            <Home />
-          </button>
-          <button className="patient-flow-icon-button" type="button" title="Focus active patients" onClick={focusActivePatients}>
-            <ScanSearch />
-          </button>
-        </div>
+      <NavigatorFeed feed={feed} redactIdentity={dotsPolicy !== null && dotsPolicy !== 'full'} />
 
-        <div className="patient-flow-control-grid">
-          <label htmlFor="flow-floor">Floor</label>
-          <select id="flow-floor" value={filters.floor} onChange={(event) => setFilters((prev) => ({ ...prev, floor: event.target.value }))}>
-            <option value="all">All</option>
-            {floors.map((floor) => <option key={floor} value={floor}>Floor {floor}</option>)}
-          </select>
-
-          <label htmlFor="flow-service">Service</label>
-          <select id="flow-service" value={filters.serviceLine} onChange={(event) => setFilters((prev) => ({ ...prev, serviceLine: event.target.value }))}>
-            <option value="all">All</option>
-            {services.map((service) => <option key={service} value={service}>{service.replaceAll('_', ' ')}</option>)}
-          </select>
-
-          <label htmlFor="flow-category">Event</label>
-          <select id="flow-category" value={filters.category} onChange={(event) => setFilters((prev) => ({ ...prev, category: event.target.value }))}>
-            <option value="all">All</option>
-            {categories.map((category) => <option key={category} value={category}>{category.replaceAll('_', ' ')}</option>)}
-          </select>
-
-          <label htmlFor="flow-speed">Speed</label>
-          <select id="flow-speed" value={speed} onChange={(event) => setSpeed(Number(event.target.value))}>
-            <option value={15}>15m/s</option>
-            <option value={60}>1h/s</option>
-            <option value={240}>4h/s</option>
-            <option value={720}>12h/s</option>
-          </select>
-
-          <label htmlFor="flow-search">Find</label>
-          <input
-            id="flow-search"
-            type="search"
-            placeholder="PT, bed, service"
-            value={filters.search}
-            onChange={(event) => setFilters((prev) => ({ ...prev, search: event.target.value }))}
-          />
-        </div>
-
-        <fieldset className="patient-flow-layer-grid">
-          <legend>Layers</legend>
-          {layerControls.map(({ key, label, id }) => (
-            <div className="patient-flow-checkbox-row" key={key}>
-              <input
-                id={id}
-                type="checkbox"
-                checked={layers[key]}
-                onChange={(event) => setLayers((prev) => ({ ...prev, [key]: event.target.checked }))}
-              />
-              <label htmlFor={id}>{label}</label>
-            </div>
-          ))}
-        </fieldset>
-
-        <div className="patient-flow-metrics">
-          <div><span>{metrics.active}</span><small>Active</small></div>
-          <div><span>{metrics.events}</span><small>Events</small></div>
-          <div><span>{metrics.occupiedLocations}</span><small>Locations</small></div>
-          <div><span>{ambient?.summary.eventCount ?? summary?.ambient_signals ?? 0}</span><small>Ambient</small></div>
-        </div>
-      </aside>
-
-      <aside className="patient-flow-feed" aria-label="Live event feed">
-        <strong>Stream</strong>
-        <ol>
-          {feed.map((event) => (
-            <li key={event.event_id}>
-              <span>{new Date(event.occurred_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
-              <span>{event.patient_display_id} {event.event_type} {event.to_location}</span>
-            </li>
-          ))}
-        </ol>
-      </aside>
-
-      <aside className="patient-flow-inspector" aria-live="polite">
-        <strong>{inspectorTitle}</strong>
-        <dl>
-          {inspectorRows.map(([key, value]) => (
-            <React.Fragment key={key}>
-              <dt>{key}</dt>
-              <dd>{value}</dd>
-            </React.Fragment>
-          ))}
-        </dl>
-      </aside>
+      <NavigatorInspector title={inspectorTitle} rows={inspectorRows} />
 
       <div className="patient-flow-statusbar">
         <span>{status}</span>

--- a/resources/js/Pages/ED/Analytics/Flow.jsx
+++ b/resources/js/Pages/ED/Analytics/Flow.jsx
@@ -3,14 +3,15 @@ import { Head } from '@inertiajs/react';
 import DashboardLayout from '@/Components/Dashboard/DashboardLayout';
 import PatientFlowNavigator from '@/Components/PatientFlowNavigator/PatientFlowNavigator';
 
-// P4b: the hand-rolled TopNavbar shell converged onto the unified
-// DashboardLayout (fullBleed — the 4D navigator needs the uncapped width).
-export default function Flow() {
+// P4b: the hand-rolled TopNavbar shell converged onto the unified DashboardLayout
+// (fullBleed — the 4D navigator needs the uncapped width). The Flow Window lens +
+// unit summaries (flow-window Phase 4) pass through to the navigator.
+export default function Flow({ flowLens = null, flowUnits = [] }) {
     return (
         <DashboardLayout fullBleed>
             <Head title="Patient Flow - Emergency" />
             <div className="text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
-                <PatientFlowNavigator initialFloor="1" />
+                <PatientFlowNavigator initialFloor="1" lens={flowLens} units={flowUnits} />
             </div>
         </DashboardLayout>
     );

--- a/resources/js/Pages/RTDC/PatientFlowNavigator.tsx
+++ b/resources/js/Pages/RTDC/PatientFlowNavigator.tsx
@@ -2,15 +2,22 @@ import React from 'react';
 import { Head } from '@inertiajs/react';
 import DashboardLayout from '@/Components/Dashboard/DashboardLayout';
 import PatientFlowNavigatorView from '@/Components/PatientFlowNavigator/PatientFlowNavigator';
+import type { FlowLens, FlowUnitSummary } from '@/features/patientFlowNavigator/types';
 
-// P4b: the hand-rolled TopNavbar shell converged onto the unified
-// DashboardLayout (fullBleed — the 4D navigator needs the uncapped width).
-export default function PatientFlowNavigator() {
+interface PatientFlowNavigatorPageProps {
+  flowLens?: FlowLens | null;
+  flowUnits?: FlowUnitSummary[];
+}
+
+// P4b: the hand-rolled TopNavbar shell converged onto the unified DashboardLayout
+// (fullBleed — the 4D navigator needs the uncapped width). The Flow Window lens +
+// unit summaries (flow-window Phase 4) pass through to the navigator view.
+export default function PatientFlowNavigator({ flowLens = null, flowUnits = [] }: PatientFlowNavigatorPageProps) {
   return (
     <DashboardLayout fullBleed>
       <Head title="Patient Flow 4D Navigator - RTDC" />
       <div className="text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
-        <PatientFlowNavigatorView />
+        <PatientFlowNavigatorView lens={flowLens} units={flowUnits} />
       </div>
     </DashboardLayout>
   );

--- a/resources/js/features/patientFlowNavigator/api.ts
+++ b/resources/js/features/patientFlowNavigator/api.ts
@@ -3,6 +3,7 @@ import type {
   PatientFlowAmbient,
   PatientFlowEvent,
   PatientFlowLocations,
+  PatientFlowProjectionsResponse,
   PatientFlowState,
   PatientFlowSummary,
   PatientFlowTracks,
@@ -47,6 +48,21 @@ export async function fetchPatientFlowState(asOf?: string): Promise<PatientFlowS
 
 export async function fetchPatientFlowAmbient(): Promise<PatientFlowAmbient> {
   const response = await axios.get<PatientFlowAmbient>('/api/patient-flow/ambient');
+  return response.data;
+}
+
+/**
+ * The +24h projection stream for the ghost layer (FLOW-WINDOW-PLAN §7.3).
+ * Persona is optional: when set it is forwarded so EnforceFlowLens resolves
+ * the same lens the page was rendered with; the server clamps kinds and
+ * redacts identity regardless.
+ */
+export async function fetchPatientFlowProjections(
+  options: { persona?: string } = {},
+): Promise<PatientFlowProjectionsResponse> {
+  const response = await axios.get<PatientFlowProjectionsResponse>('/api/patient-flow/projections', {
+    params: options.persona ? { persona: options.persona } : {},
+  });
   return response.data;
 }
 

--- a/resources/js/features/patientFlowNavigator/projections.ts
+++ b/resources/js/features/patientFlowNavigator/projections.ts
@@ -1,0 +1,214 @@
+import type {
+  FlowUnitSummary,
+  PatientFlowLocations,
+  ProjectionConfidence,
+  ProjectionItem,
+} from './types';
+
+/**
+ * Placement + selection helpers for the projection ghost layer
+ * (FLOW-WINDOW-PLAN §5 ghost grammar, §7.3). Pure data — no three.js — so it
+ * stays in the main bundle while the scene chunk is lazy-loaded.
+ */
+
+export interface ProjectionAnchor {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** Kinds rendered as per-entity ghost tokens at a spatial anchor. */
+export const ENTITY_PROJECTION_KINDS: ReadonlyArray<ProjectionItem['kind']> = [
+  'expected_discharge',
+  'transport_due',
+  'evs_due',
+  'scheduled_or_case',
+];
+
+/** Kinds rendered as an aggregate forecast layer / HUD strip, never tokens. */
+export const AGGREGATE_PROJECTION_KINDS: ReadonlyArray<ProjectionItem['kind']> = [
+  'predicted_census',
+  'predicted_arrivals',
+  'surge_probability',
+  'staffing_shift_gap',
+];
+
+/** Confidence → ghost opacity (plan §5: definite 0.8 / probable 0.5 / possible 0.3). */
+export function confidenceOpacity(confidence: ProjectionConfidence | string): number {
+  switch (confidence) {
+    case 'definite':
+      return 0.8;
+    case 'probable':
+      return 0.5;
+    default:
+      return 0.3;
+  }
+}
+
+export interface ProjectionPlacementIndex {
+  unitAnchors: Map<number, ProjectionAnchor>;
+  unitFloors: Map<number, number>;
+  unitCodeById: Map<number, string>;
+  roomAnchors: Map<string, ProjectionAnchor>;
+  roomFloors: Map<string, number>;
+}
+
+/**
+ * Join the /locations payload (unit_code, room names, positions) with the
+ * unit_id ↔ unit_code bridge from the Inertia prop so projections — which
+ * carry unit_id / bed_id / room — resolve to scene positions.
+ */
+export function buildProjectionPlacementIndex(
+  locations: PatientFlowLocations,
+  units: FlowUnitSummary[],
+): ProjectionPlacementIndex {
+  const byUnitCode = new Map<string, { sum: ProjectionAnchor; count: number; floor: number | null }>();
+  const roomAnchors = new Map<string, ProjectionAnchor>();
+  const roomFloors = new Map<string, number>();
+
+  for (const location of Object.values(locations)) {
+    const position = location.position_m;
+    if (!position) continue;
+    const anchor: ProjectionAnchor = { x: position.x, y: (position.y ?? 0) + 1.7, z: position.z };
+
+    const unitCode = location.unit_code?.toLowerCase();
+    if (unitCode) {
+      const entry = byUnitCode.get(unitCode) ?? { sum: { x: 0, y: 0, z: 0 }, count: 0, floor: null };
+      entry.sum.x += anchor.x;
+      entry.sum.y += anchor.y;
+      entry.sum.z += anchor.z;
+      entry.count += 1;
+      if (entry.floor === null && location.floor !== null && location.floor !== undefined) {
+        entry.floor = location.floor;
+      }
+      byUnitCode.set(unitCode, entry);
+    }
+
+    for (const key of [location.name, location.location_code]) {
+      if (!key) continue;
+      const normalized = key.trim().toLowerCase();
+      if (!roomAnchors.has(normalized)) {
+        roomAnchors.set(normalized, anchor);
+        if (location.floor !== null && location.floor !== undefined) {
+          roomFloors.set(normalized, location.floor);
+        }
+      }
+    }
+  }
+
+  const unitAnchors = new Map<number, ProjectionAnchor>();
+  const unitFloors = new Map<number, number>();
+  const unitCodeById = new Map<number, string>();
+
+  for (const unit of units) {
+    const code = unit.unit_code?.toLowerCase();
+    if (!code) continue;
+    unitCodeById.set(unit.unit_id, code);
+    const entry = byUnitCode.get(code);
+    if (entry && entry.count > 0) {
+      unitAnchors.set(unit.unit_id, {
+        x: entry.sum.x / entry.count,
+        y: entry.sum.y / entry.count,
+        z: entry.sum.z / entry.count,
+      });
+    }
+    const floor = unit.floor ?? entry?.floor ?? null;
+    if (floor !== null) unitFloors.set(unit.unit_id, floor);
+  }
+
+  return { unitAnchors, unitFloors, unitCodeById, roomAnchors, roomFloors };
+}
+
+/** Scene anchor for an entity-bearing projection, or null when unplaceable. */
+export function anchorForProjection(
+  item: ProjectionItem,
+  index: ProjectionPlacementIndex,
+): ProjectionAnchor | null {
+  if (item.kind === 'scheduled_or_case') {
+    return item.room ? index.roomAnchors.get(item.room.trim().toLowerCase()) ?? null : null;
+  }
+  if (item.unit_id !== null) {
+    return index.unitAnchors.get(item.unit_id) ?? null;
+  }
+  return null;
+}
+
+/** Floor a projection belongs to (for the floor filter), or null when unknown. */
+export function floorForProjection(
+  item: ProjectionItem,
+  index: ProjectionPlacementIndex,
+): number | null {
+  if (item.kind === 'scheduled_or_case' && item.room) {
+    return index.roomFloors.get(item.room.trim().toLowerCase()) ?? null;
+  }
+  if (item.unit_id !== null) {
+    return index.unitFloors.get(item.unit_id) ?? null;
+  }
+  return null;
+}
+
+/**
+ * Ghosts accumulated by scrubbing into the future half: every projection with
+ * now < t ≤ scrub time — the symmetric grammar to past event accumulation.
+ */
+export function ghostsAt(items: ProjectionItem[], nowMs: number, timeMs: number): ProjectionItem[] {
+  if (timeMs <= nowMs) return [];
+  return items.filter((item) => {
+    const t = Date.parse(item.t);
+    return Number.isFinite(t) && t > nowMs && t <= timeMs;
+  });
+}
+
+export interface ForecastAggregates {
+  /** Per-unit predicted census at the bucket closest to (≤) scrub time. */
+  censusByUnit: Map<number, ProjectionItem>;
+  censusTotal: number | null;
+  arrivals: ProjectionItem | null;
+  surge: ProjectionItem | null;
+  staffingGaps: number;
+}
+
+/** House-level aggregates for the forecast HUD strip + heat layer at scrub t. */
+export function aggregatesAt(
+  items: ProjectionItem[],
+  nowMs: number,
+  timeMs: number,
+): ForecastAggregates {
+  const empty: ForecastAggregates = {
+    censusByUnit: new Map(),
+    censusTotal: null,
+    arrivals: null,
+    surge: null,
+    staffingGaps: 0,
+  };
+  if (timeMs <= nowMs) return empty;
+
+  const censusByUnit = new Map<number, ProjectionItem>();
+  let arrivals: ProjectionItem | null = null;
+  let surge: ProjectionItem | null = null;
+  let staffingGaps = 0;
+
+  for (const item of items) {
+    const t = Date.parse(item.t);
+    if (!Number.isFinite(t) || t > timeMs) continue;
+
+    if (item.kind === 'predicted_census' && item.unit_id !== null) {
+      const existing = censusByUnit.get(item.unit_id);
+      if (!existing || Date.parse(existing.t) < t) censusByUnit.set(item.unit_id, item);
+    } else if (item.kind === 'predicted_arrivals') {
+      if (!arrivals || Date.parse(arrivals.t) < t) arrivals = item;
+    } else if (item.kind === 'surge_probability') {
+      if (!surge || Date.parse(surge.t) < t) surge = item;
+    } else if (item.kind === 'staffing_shift_gap') {
+      const ends = item.ends_at ? Date.parse(item.ends_at) : t;
+      if (timeMs <= ends) staffingGaps += 1;
+    }
+  }
+
+  let censusTotal: number | null = null;
+  for (const item of censusByUnit.values()) {
+    if (item.value !== null) censusTotal = (censusTotal ?? 0) + item.value;
+  }
+
+  return { censusByUnit, censusTotal, arrivals, surge, staffingGaps };
+}

--- a/resources/js/features/patientFlowNavigator/types.ts
+++ b/resources/js/features/patientFlowNavigator/types.ts
@@ -164,6 +164,8 @@ export interface PatientLayerState {
   tokens: boolean;
   trails: boolean;
   heat: boolean;
+  /** Projection ghost layer (future half of the 48h window). */
+  ghosts: boolean;
 }
 
 export interface PatientVisibleState {
@@ -171,4 +173,77 @@ export interface PatientVisibleState {
   event: PatientFlowEvent;
   position: { x: number; y: number; z: number };
   recent: PatientFlowEvent[];
+}
+
+// ---------------------------------------------------------------------------
+// 48h Flow Window — projections + persona lens (FLOW-WINDOW-PLAN §7.3)
+// ---------------------------------------------------------------------------
+
+export type ProjectionKind =
+  | 'expected_discharge'
+  | 'predicted_census'
+  | 'predicted_arrivals'
+  | 'scheduled_or_case'
+  | 'transport_due'
+  | 'evs_due'
+  | 'staffing_shift_gap'
+  | 'surge_probability';
+
+export type ProjectionConfidence = 'definite' | 'probable' | 'possible';
+
+export interface ProjectionProvenance {
+  service: string;
+  reliability: number | null;
+}
+
+export interface ProjectionEntity {
+  type: string;
+  ref: string;
+}
+
+export interface ProjectionItem {
+  t: string;
+  kind: ProjectionKind;
+  confidence: ProjectionConfidence;
+  unit_id: number | null;
+  bed_id: number | null;
+  room: string | null;
+  entity: ProjectionEntity | null;
+  patient_context_ref: string | null;
+  label: string;
+  value: number | null;
+  band: { lower: number; upper: number } | null;
+  ends_at: string | null;
+  derived: boolean;
+  provenance: ProjectionProvenance;
+}
+
+export interface PatientFlowProjectionsResponse {
+  window: { from: string; to: string };
+  lens: { role_id: string; projection_kinds: string[]; patient_dots: string };
+  projections: ProjectionItem[];
+  generated_at: string;
+}
+
+export type FlowPatientDots = 'full' | 'unit' | 'task' | 'none';
+
+/** Resolved persona lens (config/hummingbird/flow_lens.php), passed as an Inertia prop. */
+export interface FlowLens {
+  role_id: string;
+  scope_default: string;
+  scopes_allowed: string[];
+  layers: string[];
+  event_kinds: string[];
+  projection_kinds: string[];
+  patient_dots: FlowPatientDots;
+  actions: string[];
+  default_zoom_hours: number;
+}
+
+/** unit_id ↔ unit_code ↔ floor bridge for joining projections to /locations. */
+export interface FlowUnitSummary {
+  unit_id: number;
+  unit_code: string | null;
+  name: string | null;
+  floor: number | null;
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -512,6 +512,7 @@ Route::middleware(['auth:sanctum', CheckForAnyAbility::class.':mobile:read', 'th
     // patient identity never exceeds the caller's A2P matrix depth.
     Route::prefix('flow')->group(function () {
         Route::get('/floors', [MobileFlowController::class, 'floors']);
+        Route::get('/spaces3d', [MobileFlowController::class, 'spaces3d']);
         Route::get('/window', [MobileFlowController::class, 'window']);
     });
 

--- a/tests/Feature/Mobile/FlowFixtureRegenerationTest.php
+++ b/tests/Feature/Mobile/FlowFixtureRegenerationTest.php
@@ -56,7 +56,22 @@ class FlowFixtureRegenerationTest extends TestCase
             ->assertOk()
             ->json();
 
-        foreach (['mobile-flow-window.json' => $window, 'mobile-flow-floors.json' => $floors] as $name => $payload) {
+        // The turn map: an EVS tech at floor scope is the one lens/scope combo
+        // that exercises bed_statuses (+ task-depth redaction) in a fixture.
+        $evsUser = User::factory()->create(['role' => 'evs', 'must_change_password' => false, 'is_active' => true]);
+        Sanctum::actingAs($evsUser, ['mobile:read']);
+        $micuFloor = (int) app(\App\Support\Hospital\HospitalManifest::class)->unit('MICU')['floor'];
+        $evsWindow = $this->getJson('/api/mobile/v1/flow/window?persona=evs&scope=floor:'.$micuFloor)
+            ->assertOk()
+            ->json();
+        $this->assertArrayHasKey('bed_statuses', $evsWindow['data'], 'the EVS floor capture must include the turn map');
+
+        $fixtures = [
+            'mobile-flow-window.json' => $window,
+            'mobile-flow-floors.json' => $floors,
+            'mobile-flow-window-evs.json' => $evsWindow,
+        ];
+        foreach ($fixtures as $name => $payload) {
             file_put_contents(
                 base_path(self::FIXTURE_DIR.'/'.$name),
                 json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n",

--- a/tests/Feature/Mobile/FlowWindowTest.php
+++ b/tests/Feature/Mobile/FlowWindowTest.php
@@ -181,6 +181,166 @@ class FlowWindowTest extends TestCase
         $this->assertStringContainsString($eddPtok, $body);
     }
 
+    public function test_or_milestones_and_scheduled_cases_carry_the_room_identity(): void
+    {
+        $this->actingAsRole('periop_manager');
+
+        $response = $this->getJson('/api/mobile/v1/flow/window?persona=periop_manager&scope=house')
+            ->assertOk();
+
+        // The four OR-side milestones land in the named room, not generic 'OR'.
+        $milestones = collect($response->json('data.events'))->where('kind', 'or_milestone');
+        $this->assertNotEmpty($milestones, 'seeded orlog milestones should be on the timeline');
+        $this->assertSame(['OR 3'], $milestones->pluck('to_space')->unique()->values()->all());
+
+        $cases = collect($response->json('data.projections'))->where('kind', 'scheduled_or_case');
+        $this->assertNotEmpty($cases, 'seeded OR case should project onto the schedule lane');
+        $this->assertSame('OR 3', $cases->first()['room']);
+
+        // Non-OR projections carry the field as null — additive, never absent.
+        $this->actingAsRole('bed_manager');
+        $discharge = collect($this->getJson('/api/mobile/v1/flow/window?persona=bed_manager')->json('data.projections'))
+            ->firstWhere('kind', 'expected_discharge');
+        $this->assertArrayHasKey('room', $discharge);
+        $this->assertNull($discharge['room']);
+    }
+
+    public function test_bed_statuses_are_served_only_to_bed_status_lenses_at_floor_or_unit_scope(): void
+    {
+        $micu = Unit::where('abbreviation', 'MICU')->firstOrFail();
+        $floor = (int) app(\App\Support\Hospital\HospitalManifest::class)->unit('MICU')['floor'];
+
+        // EVS (event_kinds includes bed_status) at floor scope → the turn map.
+        $this->actingAsRole('evs');
+        $data = $this->getJson('/api/mobile/v1/flow/window?persona=evs&scope=floor:'.$floor)
+            ->assertOk()
+            ->json('data');
+        $this->assertArrayHasKey('bed_statuses', $data);
+        $occupied = collect($data['bed_statuses'])->firstWhere('unit_id', $micu->unit_id);
+        $this->assertNotNull($occupied, 'floor scope must include the scoped floor\'s beds');
+        foreach ($data['bed_statuses'] as $bed) {
+            $this->assertContains($bed['status'], ['available', 'occupied', 'blocked', 'dirty']);
+            $this->assertIsInt($bed['bed_id']);
+            $this->assertIsInt($bed['unit_id']);
+            $this->assertNotSame('', (string) $bed['label']);
+        }
+        $this->assertContains('occupied', collect($data['bed_statuses'])->pluck('status')->all());
+
+        // …but never at house scope (current-state bed detail is floor/unit only).
+        $this->assertArrayNotHasKey(
+            'bed_statuses',
+            $this->getJson('/api/mobile/v1/flow/window?persona=evs')->assertOk()->json('data'),
+        );
+
+        // Transport's lens has no bed_status kind → same floor, no key.
+        $this->actingAsRole('transport');
+        $this->assertArrayNotHasKey(
+            'bed_statuses',
+            $this->getJson('/api/mobile/v1/flow/window?persona=transport&scope=floor:'.$floor)->assertOk()->json('data'),
+        );
+
+        // Executive is house-only and dotless — unaffected either way.
+        $this->actingAsRole('executive');
+        $this->assertArrayNotHasKey(
+            'bed_statuses',
+            $this->getJson('/api/mobile/v1/flow/window?persona=executive')->assertOk()->json('data'),
+        );
+    }
+
+    public function test_transport_status_and_evs_status_events_ride_the_timeline(): void
+    {
+        $this->actingAsRole('bed_manager');
+
+        $events = collect($this->getJson('/api/mobile/v1/flow/window?persona=bed_manager')
+            ->assertOk()
+            ->json('data.events'));
+
+        $transport = $events->where('kind', 'transport_status');
+        $this->assertCount(2, $transport, 'both seeded transport transitions should be on the timeline');
+        $this->assertSame('ED', $transport->first()['from_space']);
+        $this->assertSame('MICU-01', $transport->first()['to_space']);
+
+        $evs = $events->where('kind', 'evs_status');
+        $this->assertNotEmpty($evs, 'seeded EVS transition should be on the timeline');
+        $this->assertSame('MICU-01', $evs->first()['to_space']);
+    }
+
+    public function test_delta_refresh_narrows_the_append_only_halves_and_serves_projections_in_full(): void
+    {
+        Artisan::call('flow:snapshot', ['--backfill' => '24h']);
+        $this->actingAsRole('bed_manager');
+
+        $full = $this->getJson('/api/mobile/v1/flow/window?persona=bed_manager')->assertOk()->json('data');
+        $events = collect($full['events']);
+        $this->assertNotEmpty($events, 'the seeded story should put events on the timeline');
+
+        // A `since` at the earliest event drops at least that event (t > since is strict).
+        $earliest = $events->map(fn (array $e): string => $e['t'])->sort()->first();
+        $since = (new \DateTimeImmutable($earliest))->format(\DateTimeInterface::ATOM);
+
+        $delta = $this->getJson('/api/mobile/v1/flow/window?persona=bed_manager&since='.urlencode($since))
+            ->assertOk()->json('data');
+
+        // The cursor is echoed (compared as instants — the server re-serializes it).
+        $this->assertNotNull($delta['window']['since']);
+        $this->assertEquals(new \DateTimeImmutable($since), new \DateTimeImmutable($delta['window']['since']));
+
+        // Append-only halves are strictly narrowed; nothing at/at-or-before the cursor survives.
+        $this->assertLessThan(count($full['events']), count($delta['events']));
+        foreach ($delta['events'] as $event) {
+            $this->assertGreaterThan(new \DateTimeImmutable($since), new \DateTimeImmutable($event['t']));
+        }
+        $this->assertLessThanOrEqual(count($full['snapshots']), count($delta['snapshots']));
+
+        // Projections and spaces are recomputed in full on every request.
+        $this->assertCount(count($full['projections']), $delta['projections']);
+        $this->assertSame($full['spaces']['plates_version'], $delta['spaces']['plates_version']);
+    }
+
+    public function test_delta_with_out_of_range_or_malformed_since_is_a_422(): void
+    {
+        $this->actingAsRole('bed_manager');
+
+        foreach (['2000-01-01T00:00:00Z', '2100-01-01T00:00:00Z', 'not-a-timestamp'] as $bad) {
+            $this->getJson('/api/mobile/v1/flow/window?persona=bed_manager&since='.urlencode($bad))
+                ->assertStatus(422)
+                ->assertJsonPath('error.code', 'invalid_since');
+        }
+    }
+
+    public function test_delta_responses_still_enforce_lens_redaction(): void
+    {
+        // Executive is patient_dots:none — a delta request must be as redacted as a full one.
+        $this->actingAsRole('executive');
+        $now = $this->getJson('/api/mobile/v1/flow/window?persona=executive')->assertOk()->json('data.window.now');
+
+        $body = $this->getJson('/api/mobile/v1/flow/window?persona=executive&since='.urlencode($now))
+            ->assertOk()
+            ->getContent();
+
+        $this->assertStringNotContainsString('ptok_', $body, 'a dotless role must not gain a token on a delta refresh');
+        foreach (self::RAW_PATIENT_REFS as $rawRef) {
+            $this->assertStringNotContainsString($rawRef, $body);
+        }
+    }
+
+    public function test_bed_statuses_survive_a_qualifying_evs_floor_scope_delta(): void
+    {
+        $floor = (int) app(\App\Support\Hospital\HospitalManifest::class)->unit('MICU')['floor'];
+        $this->actingAsRole('evs');
+
+        $now = $this->getJson('/api/mobile/v1/flow/window?persona=evs&scope=floor:'.$floor)
+            ->assertOk()->json('data.window.now');
+
+        $data = $this->getJson('/api/mobile/v1/flow/window?persona=evs&scope=floor:'.$floor.'&since='.urlencode($now))
+            ->assertOk()->json('data');
+
+        // bed_statuses is "now" state, always full — a delta never strips it.
+        $this->assertArrayHasKey('bed_statuses', $data);
+        $this->assertNotEmpty($data['bed_statuses']);
+        $this->assertEquals(new \DateTimeImmutable($now), new \DateTimeImmutable($data['window']['since']));
+    }
+
     public function test_floors_asset_is_versioned_and_supports_conditional_requests(): void
     {
         $this->actingAsRole('bed_manager');
@@ -224,5 +384,4 @@ class FlowWindowTest extends TestCase
 
         return $user;
     }
-
 }

--- a/tests/Feature/Mobile/FlowWindowTest.php
+++ b/tests/Feature/Mobile/FlowWindowTest.php
@@ -341,6 +341,106 @@ class FlowWindowTest extends TestCase
         $this->assertEquals(new \DateTimeImmutable($now), new \DateTimeImmutable($data['window']['since']));
     }
 
+    public function test_duties_are_clamped_to_each_personas_lens_duty_kinds(): void
+    {
+        foreach (MobilePersonaCatalog::ROLE_IDS as $roleId) {
+            $this->actingAsRole($roleId);
+            $allowed = config("hummingbird.flow_lens.{$roleId}.duty_kinds");
+
+            $duties = collect($this->getJson('/api/mobile/v1/flow/window?persona='.$roleId.'&layers=duties')
+                ->assertOk()->json('data.duties'));
+
+            foreach ($duties as $duty) {
+                $this->assertContains($duty['kind'], $allowed, "{$roleId} received an out-of-lens duty kind: {$duty['kind']}");
+            }
+            if ($allowed === []) {
+                $this->assertCount(0, $duties, "{$roleId} has no duty_kinds but its payload carried duties");
+            }
+        }
+    }
+
+    public function test_frontline_duties_carry_temporal_status_provenance_and_an_action(): void
+    {
+        $this->actingAsRole('transport');
+
+        $run = collect($this->getJson('/api/mobile/v1/flow/window?persona=transport')->assertOk()->json('data.duties'))
+            ->firstWhere('kind', 'transport_run');
+
+        $this->assertNotNull($run, 'the seeded trip should surface as a transport_run duty');
+        $this->assertContains($run['window_status'], ['overdue', 'due', 'upcoming', null]);
+        $this->assertContains($run['tier'], ['critical', 'warning', 'info']);
+        $this->assertSame('duty_projection', $run['provenance']['service']);
+        $this->assertArrayHasKey('centroid_m', $run); // present (a 3D anchor or null when unmapped)
+        $this->assertNotNull($run['action'], 'a transport_run is actionable');
+        $this->assertStringContainsString('/transport/requests/', $run['action']['endpoint']);
+        $this->assertSame('POST', $run['action']['method']);
+
+        // The EVS turn and the EDD both surface as duties for their personas.
+        $this->actingAsRole('evs');
+        $this->assertNotNull(
+            collect($this->getJson('/api/mobile/v1/flow/window?persona=evs')->assertOk()->json('data.duties'))
+                ->firstWhere('kind', 'bed_turn'),
+            'the seeded isolation turn should surface as a bed_turn duty',
+        );
+    }
+
+    public function test_duties_honour_the_redaction_matrix(): void
+    {
+        foreach (MobilePersonaCatalog::ROLE_IDS as $roleId) {
+            $this->actingAsRole($roleId);
+            $duties = $this->getJson('/api/mobile/v1/flow/window?persona='.$roleId.'&layers=duties')
+                ->assertOk()->json('data.duties');
+            $json = json_encode($duties);
+
+            foreach (self::RAW_PATIENT_REFS as $raw) {
+                $this->assertStringNotContainsString($raw, $json, "{$roleId} duties leaked a raw patient ref");
+            }
+            $this->assertStringNotContainsString('_patient_ref', $json, "{$roleId} duties leaked the internal ref field");
+
+            if (config("hummingbird.flow_lens.{$roleId}.patient_dots") === 'none') {
+                foreach ($duties as $duty) {
+                    $this->assertNull($duty['patient_context_ref'] ?? null, "{$roleId} is patient_dots:none but a duty carried a token");
+                }
+            }
+        }
+    }
+
+    public function test_duties_survive_a_since_delta_in_full(): void
+    {
+        $this->actingAsRole('transport');
+        $now = $this->getJson('/api/mobile/v1/flow/window?persona=transport')->assertOk()->json('data.window.now');
+
+        $full = $this->getJson('/api/mobile/v1/flow/window?persona=transport')->assertOk()->json('data.duties');
+        $delta = $this->getJson('/api/mobile/v1/flow/window?persona=transport&since='.urlencode($now))
+            ->assertOk()->json('data.duties');
+
+        $this->assertNotEmpty($full);
+        $this->assertCount(count($full), $delta, 'duties are current worklist — always full, never narrowed by a delta');
+    }
+
+    public function test_spaces3d_asset_is_versioned_and_carries_3d_centroids(): void
+    {
+        $this->actingAsRole('bed_manager');
+
+        $res = $this->getJson('/api/mobile/v1/flow/spaces3d')->assertOk();
+        $etag = $res->headers->get('ETag');
+        $this->assertNotEmpty($etag);
+        $this->assertSame(trim($etag, '"'), $res->json('data.version'));
+
+        // The bare test DB has no CAD catalog imported (facility:import-catalog
+        // is a demo/deploy step), so `spaces` may be empty here; against a
+        // catalog-loaded DB every entry carries a {x, y, z} metre centroid.
+        $spaces = $res->json('data.spaces');
+        $this->assertIsArray($spaces);
+        foreach ($spaces as $space) {
+            $this->assertEqualsCanonicalizing(['x', 'y', 'z'], array_keys($space['centroid_m']));
+        }
+
+        $this->withHeaders(['If-None-Match' => $etag])
+            ->getJson('/api/mobile/v1/flow/spaces3d')
+            ->assertStatus(304);
+    }
+
     public function test_floors_asset_is_versioned_and_supports_conditional_requests(): void
     {
         $this->actingAsRole('bed_manager');

--- a/tests/Feature/MobileBffTest.php
+++ b/tests/Feature/MobileBffTest.php
@@ -321,6 +321,7 @@ class MobileBffTest extends TestCase
             '/eddy/conversations/{uuid}' => "/api/mobile/v1/eddy/conversations/{$conversation->eddy_conversation_uuid}",
             '/evs/queue' => '/api/mobile/v1/evs/queue',
             '/flow/floors' => '/api/mobile/v1/flow/floors',
+            '/flow/spaces3d' => '/api/mobile/v1/flow/spaces3d',
             '/flow/window' => '/api/mobile/v1/flow/window?persona=bed_manager',
             '/for-you' => '/api/mobile/v1/for-you?persona=bed_manager',
             '/improvement/opportunities' => '/api/mobile/v1/improvement/opportunities',

--- a/tests/Feature/MobileSharedDtoFixtureTest.php
+++ b/tests/Feature/MobileSharedDtoFixtureTest.php
@@ -18,6 +18,7 @@ class MobileSharedDtoFixtureTest extends TestCase
         'mobile-activity-feed.json',
         'mobile-patient-operational-context.json',
         'mobile-flow-window.json',
+        'mobile-flow-window-evs.json',
         'mobile-flow-floors.json',
     ];
 

--- a/tests/Support/SeedsFlowStory.php
+++ b/tests/Support/SeedsFlowStory.php
@@ -5,17 +5,26 @@ namespace Tests\Support;
 use App\Models\Barrier;
 use App\Models\Bed;
 use App\Models\Encounter;
+use App\Models\Evs\EvsEvent;
 use App\Models\Evs\EvsRequest;
 use App\Models\OperationalEvent;
 use App\Models\RtdcPrediction;
+use App\Models\Transport\TransportEvent;
 use App\Models\Transport\TransportRequest;
 use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 /**
  * One coherent operational story across both halves of the Flow Window,
  * shared by the window feature tests and the shared-fixture regenerator
  * (FLOW_FIXTURE_DUMP=1) so the contract fixtures are captured, not typed.
+ *
+ * The story: FLOWTEST-PAT-EDD discharges from MICU bed 1 today; EVS turns
+ * that bed (isolation); FLOWTEST-PAT-TRIP is inbound from the ED to the
+ * same bed label. In periop, one case runs in "OR 3" with in-room /
+ * procedure-start milestones already on the clock.
  */
 trait SeedsFlowStory
 {
@@ -74,19 +83,41 @@ trait SeedsFlowStory
             'status' => 'open',
         ]);
 
-        // Prediction half: a trip due in 2h and a turn due in 1h.
-        TransportRequest::create([
+        // Prediction half: a trip due in 2h — origin/destination drawn from
+        // vocabularies the mobile plates asset can resolve (unit abbreviation
+        // and bed label), never free text.
+        $trip = TransportRequest::create([
             'request_uuid' => (string) Str::uuid(),
             'request_type' => 'inpatient',
             'priority' => 'routine',
             'status' => 'queued',
             'patient_ref' => 'FLOWTEST-PAT-TRIP',
-            'origin' => 'MICU',
-            'destination' => 'Imaging',
+            'origin' => 'ED',
+            'destination' => $bed->label,
             'transport_mode' => 'wheelchair',
             'needed_at' => now()->addHours(2),
         ]);
-        EvsRequest::create([
+
+        // Review half: the trip's status transitions inside the past window.
+        TransportEvent::create([
+            'event_uuid' => (string) Str::uuid(),
+            'transport_request_id' => $trip->transport_request_id,
+            'event_type' => 'transport.requested',
+            'from_status' => null,
+            'to_status' => 'requested',
+            'occurred_at' => now()->subHours(2),
+        ]);
+        TransportEvent::create([
+            'event_uuid' => (string) Str::uuid(),
+            'transport_request_id' => $trip->transport_request_id,
+            'event_type' => 'transport.queued',
+            'from_status' => 'requested',
+            'to_status' => 'queued',
+            'occurred_at' => now()->subHour(),
+        ]);
+
+        // A turn due in 1h on a real bed (isolation — the flag EVS pre-positions on).
+        $turn = EvsRequest::create([
             'request_uuid' => (string) Str::uuid(),
             'request_type' => 'bed_clean',
             'priority' => 'routine',
@@ -95,8 +126,126 @@ trait SeedsFlowStory
             'bed_id' => $bed->bed_id,
             'patient_ref' => 'FLOWTEST-PAT-TURN',
             'location_label' => $bed->label,
-            'turn_type' => 'standard',
+            'turn_type' => 'isolation',
+            'isolation_required' => true,
             'needed_at' => now()->addHour(),
         ]);
+        EvsEvent::create([
+            'event_uuid' => (string) Str::uuid(),
+            'evs_request_id' => $turn->evs_request_id,
+            'event_type' => 'evs.queued',
+            'from_status' => 'requested',
+            'to_status' => 'queued',
+            'occurred_at' => now()->subMinutes(45),
+        ]);
+
+        $this->seedPeriopFlowStory();
+    }
+
+    /**
+     * One case in "OR 3" today: scheduled an hour ago (so the projection
+     * still runs +3h ahead) with in-room / procedure-start milestones inside
+     * the past window. Guarded like the flow services — the suite still
+     * passes when the optional periop tables are absent.
+     */
+    private function seedPeriopFlowStory(): void
+    {
+        // Same dual-name resolution OperationalTimelineService uses (legacy
+        // ETL: prod.orlog; migration path: prod.or_logs).
+        $orlogTable = collect(['prod.orlog', 'prod.or_logs'])
+            ->first(fn (string $table): bool => Schema::hasTable($table));
+
+        if ($orlogTable === null || ! Schema::hasTable('prod.or_cases')) {
+            return;
+        }
+
+        $locationId = DB::table('prod.locations')->where('abbreviation', 'MOR')->value('location_id')
+            ?? DB::table('prod.locations')->insertGetId($this->referenceRow([
+                'name' => 'Main OR Suite', 'abbreviation' => 'MOR',
+                'type' => 'surgical', 'pos_type' => 'inpatient',
+            ]), 'location_id');
+
+        $roomId = DB::table('prod.rooms')->where('name', 'OR 3')->value('room_id')
+            ?? DB::table('prod.rooms')->insertGetId($this->referenceRow([
+                'location_id' => $locationId, 'name' => 'OR 3', 'type' => 'OR',
+            ]), 'room_id');
+
+        $specialtyId = DB::table('prod.specialties')->where('code', 'GENSUR')->value('specialty_id')
+            ?? DB::table('prod.specialties')->insertGetId($this->referenceRow([
+                'name' => 'General Surgery', 'code' => 'GENSUR',
+            ]), 'specialty_id');
+
+        $surgeonId = DB::table('prod.providers')->where('npi', '9990001111')->value('provider_id')
+            ?? DB::table('prod.providers')->insertGetId($this->referenceRow([
+                'npi' => '9990001111', 'name' => 'Flow Story Surgeon',
+                'specialty_id' => $specialtyId, 'type' => 'surgeon',
+            ]), 'provider_id');
+
+        $serviceId = DB::table('prod.services')->where('code', 'GENSUR')->value('service_id')
+            ?? DB::table('prod.services')->insertGetId($this->referenceRow([
+                'name' => 'General Surgery', 'code' => 'GENSUR',
+            ]), 'service_id');
+
+        $statusId = DB::table('prod.case_statuses')->where('code', 'SCHED')->value('status_id')
+            ?? DB::table('prod.case_statuses')->insertGetId($this->referenceRow([
+                'name' => 'Scheduled', 'code' => 'SCHED',
+            ]), 'status_id');
+
+        $caseTypeId = DB::table('prod.case_types')->where('code', 'ELEC')->value('case_type_id')
+            ?? DB::table('prod.case_types')->insertGetId($this->referenceRow([
+                'name' => 'Elective', 'code' => 'ELEC',
+            ]), 'case_type_id');
+
+        $caseClassId = DB::table('prod.case_classes')->where('code', 'INP')->value('case_class_id')
+            ?? DB::table('prod.case_classes')->insertGetId($this->referenceRow([
+                'name' => 'Inpatient', 'code' => 'INP',
+            ]), 'case_class_id');
+
+        $patientClassId = DB::table('prod.patient_classes')->where('code', 'INP')->value('patient_class_id')
+            ?? DB::table('prod.patient_classes')->insertGetId($this->referenceRow([
+                'name' => 'Inpatient', 'code' => 'INP',
+            ]), 'patient_class_id');
+
+        $asaId = DB::table('prod.asa_ratings')->where('code', 'ASA2')->value('asa_id')
+            ?? DB::table('prod.asa_ratings')->insertGetId($this->referenceRow([
+                'name' => 'ASA II', 'code' => 'ASA2',
+            ]), 'asa_id');
+
+        $caseId = DB::table('prod.or_cases')->insertGetId($this->referenceRow([
+            'patient_id' => 'FLOWTEST-OR-CASE',
+            'surgery_date' => now()->toDateString(),
+            'room_id' => $roomId,
+            'location_id' => $locationId,
+            'primary_surgeon_id' => $surgeonId,
+            'case_service_id' => $serviceId,
+            'scheduled_start_time' => now()->subHour(),
+            'scheduled_duration' => 240,
+            'record_create_date' => now()->subDays(3),
+            'status_id' => $statusId,
+            'asa_rating_id' => $asaId,
+            'case_type_id' => $caseTypeId,
+            'case_class_id' => $caseClassId,
+            'patient_class_id' => $patientClassId,
+        ]), 'case_id');
+
+        DB::table($orlogTable)->insert($this->referenceRow([
+            'case_id' => $caseId,
+            'tracking_date' => now()->toDateString(),
+            'or_in_time' => now()->subHours(2),
+            'procedure_start_time' => now()->subMinutes(90),
+            'primary_procedure' => 'Laparoscopic Cholecystectomy',
+        ]));
+    }
+
+    /** @return array<string, mixed> the row plus the audit boilerplate every prod.* table shares */
+    private function referenceRow(array $attributes): array
+    {
+        return $attributes + [
+            'created_by' => 'flow-story',
+            'modified_by' => 'flow-story',
+            'created_at' => now(),
+            'updated_at' => now(),
+            'is_deleted' => false,
+        ];
     }
 }


### PR DESCRIPTION
Integrates the **hummingbird flow-window / native 4D-viewer** workstream into `main`, completing the follow-up tracked in #11.

The deployment taxonomy that shared the original `codex/hummingbird-login` branch already landed on `main` (`0af1924`) and is intentionally **not** re-included here — this branch is the hummingbird work only, cherry-picked cleanly on top of today's `main`.

## Commits (cherry-picked from `codex/hummingbird-login`, oldest first)

- `feat(flow-window)` Phases 2–5 backend contract — OR room identity, bed statuses, since-deltas
- `feat(flow-window)` Phase 4 — web 4D Navigator parity (decompose, ghosts, lens, handoff)
- `feat(flow-window)` Phases 2–5 iOS — task/aggregate lenses + stickiness
- `feat(flow-window)` Phases 2–5 Android — task/aggregate lenses + stickiness
- `feat(native-4d-viewer)` Phase A duties layer + Phase B iOS SceneKit 3D foundation
- `fix(flow-navigator)` standard toggle switches for the 3D layer controls
- `test:` raise phpunit `memory_limit` to 512M for the flow-window fixtures (see below)

## Conflict resolution

Two web page wrappers conflicted with main's **P4b `DashboardLayout` convergence** — resolved per the #11 strategy: keep main's unified `DashboardLayout` (drop the re-introduced hand-rolled `TopNavbar` shell) **and** graft the hummingbird `flowLens` / `flowUnits` props through to the navigator. The underlying view component + `features/patientFlowNavigator/types` already accept those props (they merged without conflict), so both intents are preserved.

- `resources/js/Pages/ED/Analytics/Flow.jsx`
- `resources/js/Pages/RTDC/PatientFlowNavigator.tsx`

## Why the phpunit memory bump

Including the flow-window fixtures pushes the full single-process suite past PHP's 128M CLI default, so `php artisan test` OOM'd (the individual flow tests pass fine). Set `memory_limit=512M` explicitly in `phpunit.xml` so the standard command runs clean.

## Verification

- `npm run build` ✓
- `npx tsc --noEmit` — no new errors (baseline: 7 pre-existing — 6 legacy `.jsx` + 1 `TopNavbar` TS1261 casing, both on `main`)
- `php artisan test` — **628 passed**, 1 skipped, **0 memory errors**; the only failure is the pre-existing `EddyKnowledgeRagTest` (pgvector, environmental)
- `npx vitest run` — **271 passed** (60 files)

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
