### PR TITLE
feat(patient-flow): 4D barrier + occupancy insights (auto-login gated to non-prod)

### DIFF
--- a/app/Http/Controllers/Api/PatientFlow/PatientFlowController.php
+++ b/app/Http/Controllers/Api/PatientFlow/PatientFlowController.php
@@ -8,7 +8,10 @@ use App\Services\PatientFlow\AmbientSignalService;
 use App\Services\PatientFlow\FacilitySpaceLocationResolver;
 use App\Services\PatientFlow\FhirBundleFactory;
 use App\Services\PatientFlow\FlowEventRepository;
+use App\Services\PatientFlow\OccupancyInsightProjector;
+use App\Services\PatientFlow\PatientFlowDemoBarrierScenario;
 use App\Services\PatientFlow\PatientStateProjector;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -22,6 +25,8 @@ class PatientFlowController extends Controller
         private readonly PatientStateProjector $stateProjector,
         private readonly FhirBundleFactory $fhir,
         private readonly AmbientSignalService $ambientSignals,
+        private readonly OccupancyInsightProjector $occupancyInsights,
+        private readonly PatientFlowDemoBarrierScenario $demoBarriers,
     ) {}
 
     public function summary(): JsonResponse
@@ -101,6 +106,85 @@ class PatientFlowController extends Controller
     }
 
     /**
+     * Disk-ready occupancy detail contract for the 4D viewer.
+     *
+     * Unlike /events and /state, this endpoint is aggregate-safe: it computes
+     * from patient-flow replay internally, then applies the active persona lens
+     * to omit patient identity for roles whose `patient_dots` policy does not
+     * allow it. It is the backend home for duration, origin, next move, timer,
+     * delay, service-line compounding, and persona roll-up details.
+     */
+    public function occupancy(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $lens */
+        $lens = $request->attributes->get('flow_lens');
+        $roleId = (string) $request->attributes->get('flow_role_id');
+        $asOf = is_string($request->query('asOf')) ? $request->query('asOf') : null;
+        $time = $asOf ? CarbonImmutable::parse($asOf) : CarbonImmutable::now();
+
+        $filters = $this->filters($request) + ['limit' => 20000];
+        unset($filters['from']);
+        $filters['to'] = $time->toIso8601String();
+
+        $events = $this->events->serializeEvents($this->events->filteredEvents($filters));
+        $locations = $this->locations->allNavigatorLocations($this->facilityCode());
+
+        $scope = ['type' => 'house', 'floor' => null, 'unit_id' => null, 'patient_ref' => null];
+        $rawProjections = app(\App\Services\Flow\ForwardProjectionService::class)
+            ->projections($time, $time->addHours(24), $scope, $lens['projection_kinds']);
+        $depth = $lens['patient_dots'] === 'full' ? 'full' : 'none';
+        $lensService = app(\App\Services\Flow\FlowLensService::class);
+        $projections = array_map(
+            fn (array $item): array => $lensService->redactRow($item, $depth, $scope),
+            $rawProjections,
+        );
+
+        $demoScenario = null;
+        $demoEnabled = $this->demoBarriersEnabled($request);
+        $staleReplay = $demoEnabled && $this->replayIsStale($events, $time);
+        $demoReplacesReplay = $demoEnabled && (
+            $this->demoBarriersReplaceReplay($request)
+            || $staleReplay
+        );
+        if ($demoReplacesReplay) {
+            $events = [];
+            $projections = [];
+        }
+
+        if ($demoEnabled) {
+            $demo = $this->demoBarriers->build($locations, $time, $filters);
+            $events = [...$events, ...$demo['events']];
+            $projections = [...$projections, ...$demo['projections']];
+            $demoScenario = $demo['scenario'] + [
+                'replaces_replay' => $demoReplacesReplay,
+                'replaces_stale_replay' => $staleReplay,
+            ];
+        }
+
+        $payload = $this->occupancyInsights->project(
+            events: $events,
+            locations: $locations,
+            projections: $projections,
+            asOf: $time->toIso8601String(),
+            lens: $lens,
+        );
+
+        return response()->json($payload + [
+            'lens' => [
+                'role_id' => $roleId,
+                'patient_dots' => $lens['patient_dots'],
+                'projection_kinds' => $lens['projection_kinds'],
+            ],
+            'projection_window' => [
+                'from' => $time->toIso8601String(),
+                'to' => $time->addHours(24)->toIso8601String(),
+            ],
+            'demo_scenario' => $demoScenario,
+            'generated_at' => now()->toJSON(),
+        ]);
+    }
+
+    /**
      * The +24h projection stream for the web Navigator's ghost layer —
      * FLOW-WINDOW-PLAN §6.4/§7.3. Same ForwardProjectionService and the same
      * persona lens as the mobile window (EnforceFlowLens attaches both), so
@@ -175,6 +259,48 @@ class PatientFlowController extends Controller
     private function facilityCode(): string
     {
         return (string) config('facility_models.zep_500.facility_code', 'ZEPHYRUS-500');
+    }
+
+    private function demoBarriersEnabled(Request $request): bool
+    {
+        $value = $request->query('demo');
+        if ($value !== null) {
+            $normalized = strtolower((string) $value);
+
+            return in_array($normalized, ['1', 'true', 'yes', 'on', 'barriers', 'rtdc'], true);
+        }
+
+        return (bool) config('patient_flow.demo_barriers_enabled', false);
+    }
+
+    private function demoBarriersReplaceReplay(Request $request): bool
+    {
+        $value = $request->query('demo');
+        if ($value !== null) {
+            $normalized = strtolower((string) $value);
+
+            return in_array($normalized, ['1', 'true', 'yes', 'on', 'barriers', 'rtdc', 'replace'], true);
+        }
+
+        return (bool) config('patient_flow.demo_barriers_replace_replay', false);
+    }
+
+    /** @param list<array<string, mixed>> $events */
+    private function replayIsStale(array $events, CarbonImmutable $time): bool
+    {
+        $latest = null;
+        foreach ($events as $event) {
+            if (empty($event['occurred_at'])) {
+                continue;
+            }
+
+            $occurred = CarbonImmutable::parse((string) $event['occurred_at']);
+            if (! $latest || $occurred->greaterThan($latest)) {
+                $latest = $occurred;
+            }
+        }
+
+        return ! $latest || $latest->lessThan($time->subHours(48));
     }
 
     /** @param array<string,array<string,mixed>> $locations */

--- a/app/Http/Middleware/SessionAuthMiddleware.php
+++ b/app/Http/Middleware/SessionAuthMiddleware.php
@@ -23,7 +23,17 @@ class SessionAuthMiddleware
             return $next($request);
         }
 
-        // Auto-login as admin user
+        // The admin auto-login below is a LOCAL/DEMO convenience ONLY. In any other
+        // environment (production, staging) this middleware must behave like real `auth`
+        // — never mint an admin session for an anonymous visitor. See
+        // .claude/rules/auth-system.md (the temp-password + must_change_password flow).
+        if (! app()->environment(['local', 'testing'])) {
+            return $request->expectsJson()
+                ? abort(401, 'Unauthenticated.')
+                : redirect()->guest(route('login'));
+        }
+
+        // Auto-login as admin user (local/demo only)
         $user = User::firstOrCreate(
             ['username' => 'admin'],
             [
@@ -31,8 +41,20 @@ class SessionAuthMiddleware
                 'email' => 'admin@example.com',
                 'password' => bcrypt('password'),
                 'workflow_preference' => 'superuser',
+                'must_change_password' => false,
+                'role' => 'admin',
+                'is_active' => true,
             ]
         );
+
+        if ($user->must_change_password || ! in_array($user->role, ['admin', 'bed_manager'], true)) {
+            $user->forceFill([
+                'workflow_preference' => $user->workflow_preference ?: 'superuser',
+                'must_change_password' => false,
+                'role' => 'admin',
+                'is_active' => true,
+            ])->save();
+        }
 
         // Log the user in
         Auth::login($user);

--- a/app/Models/PatientFlow/OccupancySnapshot.php
+++ b/app/Models/PatientFlow/OccupancySnapshot.php
@@ -19,6 +19,12 @@ class OccupancySnapshot extends Model
         'active_patient_count' => 'integer',
         'service_line_counts' => 'array',
         'acuity_counts' => 'array',
+        'occupancy_details' => 'array',
+        'timer_status_counts' => 'array',
+        'service_line_timer_counts' => 'array',
+        'persona_timer_counts' => 'array',
+        'active_blocker_counts' => 'array',
+        'projection_window' => 'array',
     ];
 
     public function facilitySpace(): BelongsTo

--- a/app/Services/Flow/TimelineSnapshotService.php
+++ b/app/Services/Flow/TimelineSnapshotService.php
@@ -221,6 +221,12 @@ class TimelineSnapshotService
                     'active_patient_count' => $occupied,
                     'service_line_counts' => [],
                     'acuity_counts' => $acuityCounts,
+                    'occupancy_details' => [],
+                    'timer_status_counts' => ['ok' => $occupied, 'watch' => 0, 'delayed' => 0],
+                    'service_line_timer_counts' => [],
+                    'persona_timer_counts' => ['transport' => 0, 'evs' => 0, 'bed_manager' => 0, 'capacity' => 0],
+                    'active_blocker_counts' => [],
+                    'projection_window' => [],
                 ],
             );
         }

--- a/app/Services/PatientFlow/OccupancyInsightProjector.php
+++ b/app/Services/PatientFlow/OccupancyInsightProjector.php
@@ -1,0 +1,441 @@
+<?php
+
+namespace App\Services\PatientFlow;
+
+use Carbon\CarbonImmutable;
+
+class OccupancyInsightProjector
+{
+    private const LONG_STAY_WARN_MINUTES = 8 * 60;
+
+    private const LONG_STAY_DELAY_MINUTES = 18 * 60;
+
+    private const READY_MOVE_WINDOW_MINUTES = 30;
+
+    private const OVERDUE_TIMER_WINDOW_MINUTES = 4 * 60;
+
+    /**
+     * @param  list<array<string, mixed>>  $events
+     * @param  array<string, array<string, mixed>>  $locations
+     * @param  list<array<string, mixed>>  $projections
+     * @param  array<string, mixed>  $lens
+     * @return array{asOf: string, occupancy: list<array<string, mixed>>, summary: array<string, mixed>}
+     */
+    public function project(array $events, array $locations, array $projections, ?string $asOf, array $lens): array
+    {
+        $time = $asOf ? CarbonImmutable::parse($asOf) : CarbonImmutable::now();
+        $tracks = $this->tracks($events);
+        $identityVisible = ($lens['patient_dots'] ?? null) === 'full';
+
+        $items = [];
+        foreach ($tracks as $patientRef => $track) {
+            $state = $this->stateAt($patientRef, $track, $time);
+            if (! $state) {
+                continue;
+            }
+
+            $event = $state['event'];
+            $locationCode = (string) ($event['to_location'] ?? '');
+            if ($locationCode === '' || ! isset($locations[$locationCode])) {
+                continue;
+            }
+
+            $loc = $locations[$locationCode];
+            $arrivedAt = CarbonImmutable::parse((string) $event['occurred_at']);
+            $stayMinutes = max(0, $arrivedAt->diffInMinutes($time, false));
+            $projectionTimers = array_map(
+                fn (array $projection): array => $this->projectionTimer($projection, $time),
+                $this->nearbyProjections($event, $projections, $time),
+            );
+            $knownNext = $state['next_event'] ? $this->eventTimer($state['next_event'], $time) : null;
+            $timers = array_values(array_filter([
+                $this->stayTimer($stayMinutes),
+                $knownNext,
+                ...$projectionTimers,
+            ]));
+            usort($timers, fn (array $a, array $b): int => $this->rank($b['status']) <=> $this->rank($a['status']));
+
+            $blockers = array_values(array_unique(array_map(
+                fn (array $timer): string => (string) $timer['label'],
+                array_filter($timers, fn (array $timer): bool => $timer['status'] !== 'ok'),
+            )));
+            $blockingTimers = array_values(array_filter($timers, fn (array $timer): bool => $timer['status'] !== 'ok'));
+
+            $item = [
+                'key' => $patientRef.':'.$locationCode,
+                'location' => $locationCode,
+                'location_name' => $event['location_name'] ?? $loc['name'] ?? null,
+                'unit_code' => $event['unit_code'] ?? $loc['unit_code'] ?? null,
+                'service_line' => $event['service_line'] ?? $event['location_service_line'] ?? $loc['service_line'] ?? null,
+                'position_m' => $event['position_m'] ?? $loc['position_m'] ?? null,
+                'stay_minutes' => $stayMinutes,
+                'arrived_at' => $arrivedAt->toJSON(),
+                'came_from' => $state['came_from'],
+                'next_move' => $state['next_event']['to_location'] ?? ($projectionTimers[0]['label'] ?? null),
+                'next_move_at' => $state['next_event']['occurred_at'] ?? ($projectionTimers[0]['due_at'] ?? null),
+                'primary_status' => $this->strongestStatus(array_column($timers, 'status')),
+                'timers' => $timers,
+                'blockers' => $blockers,
+                'barrier_reasons' => $this->uniqueTimerValues($blockingTimers, 'reason'),
+                'owner_roles' => $this->uniqueTimerValues($blockingTimers, 'owner_role'),
+                'delay_impacts' => $this->uniqueTimerValues($blockingTimers, 'impact'),
+            ];
+
+            if ($identityVisible) {
+                $item += [
+                    'patient_id' => $event['patient_id'] ?? null,
+                    'patient_display_id' => $event['patient_display_id'] ?? null,
+                    'encounter_id' => $event['encounter_id'] ?? null,
+                ];
+            }
+
+            $items[] = $item;
+        }
+
+        return [
+            'asOf' => $time->toJSON(),
+            'occupancy' => $items,
+            'summary' => $this->summary($items),
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $events
+     * @return array<string, list<array<string, mixed>>>
+     */
+    private function tracks(array $events): array
+    {
+        usort($events, fn (array $a, array $b): int => strcmp((string) $a['occurred_at'], (string) $b['occurred_at']));
+        $tracks = [];
+        foreach ($events as $event) {
+            $patientRef = (string) ($event['patient_id'] ?? '');
+            if ($patientRef === '') {
+                continue;
+            }
+            $tracks[$patientRef][] = $event;
+        }
+
+        return $tracks;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $track
+     * @return array{event: array<string, mixed>, next_event: ?array<string, mixed>, came_from: ?string}|null
+     */
+    private function stateAt(string $patientRef, array $track, CarbonImmutable $time): ?array
+    {
+        $current = null;
+        $currentIndex = null;
+        foreach ($track as $index => $event) {
+            $occurred = CarbonImmutable::parse((string) $event['occurred_at']);
+            if ($occurred->greaterThan($time)) {
+                break;
+            }
+
+            if (in_array($event['event_type'] ?? null, ['discharge', 'cancel_admit'], true)) {
+                $current = null;
+                $currentIndex = null;
+
+                continue;
+            }
+
+            if (! empty($event['to_location'])) {
+                $current = $event;
+                $currentIndex = $index;
+            }
+        }
+
+        if (! $current || $currentIndex === null) {
+            return null;
+        }
+
+        $previousMovement = null;
+        for ($index = $currentIndex - 1; $index >= 0; $index--) {
+            if (($track[$index]['event_category'] ?? null) === 'movement' && ! empty($track[$index]['to_location'])) {
+                $previousMovement = $track[$index];
+                break;
+            }
+        }
+
+        $next = null;
+        for ($index = $currentIndex + 1; $index < count($track); $index++) {
+            if (CarbonImmutable::parse((string) $track[$index]['occurred_at'])->greaterThan($time)) {
+                $next = $track[$index];
+                break;
+            }
+        }
+
+        return [
+            'event' => $current,
+            'next_event' => $next,
+            'came_from' => $current['from_location'] ?? $previousMovement['to_location'] ?? null,
+        ];
+    }
+
+    /** @param list<array<string, mixed>> $projections */
+    private function nearbyProjections(array $event, array $projections, CarbonImmutable $time): array
+    {
+        $items = array_filter($projections, function (array $item) use ($event, $time): bool {
+            if (! in_array($item['kind'] ?? null, ['expected_discharge', 'transport_due', 'evs_due', 'scheduled_or_case'], true)) {
+                return false;
+            }
+
+            $t = CarbonImmutable::parse((string) $item['t']);
+            if ($t->lessThan($time->subMinutes(self::OVERDUE_TIMER_WINDOW_MINUTES))) {
+                return false;
+            }
+
+            $entityRef = isset($item['entity']['ref']) ? (string) $item['entity']['ref'] : null;
+            if ($entityRef && in_array($entityRef, [$event['encounter_id'] ?? null, $event['patient_id'] ?? null, $event['patient_display_id'] ?? null], true)) {
+                return true;
+            }
+
+            if (($item['bed_id'] ?? null) !== null && ! empty($event['bed']) && (string) $item['bed_id'] === (string) $event['bed']) {
+                return true;
+            }
+
+            if (! empty($item['room']) && ! empty($event['room']) && strtolower((string) $item['room']) === strtolower((string) $event['room'])) {
+                return true;
+            }
+
+            return false;
+        });
+
+        usort($items, fn (array $a, array $b): int => strcmp((string) $a['t'], (string) $b['t']));
+
+        return array_slice(array_values($items), 0, 4);
+    }
+
+    private function eventTimer(array $event, CarbonImmutable $time): array
+    {
+        $minutes = $this->minutesUntil($time, (string) $event['occurred_at']);
+        $movement = ($event['event_category'] ?? null) === 'movement';
+        $metadata = is_array($event['metadata'] ?? null) ? $event['metadata'] : [];
+
+        return [
+            'kind' => $movement ? 'next_transport' : 'readiness',
+            'label' => $movement && ! empty($event['to_location'])
+                ? 'Next '.$event['to_location']
+                : str_replace('_', ' ', (string) ($event['event_type'] ?? 'readiness')),
+            'due_at' => $event['occurred_at'],
+            'minutes_remaining' => $minutes,
+            'status' => $this->timerStatus($minutes),
+            'source' => $movement ? 'movement' : (string) ($event['event_category'] ?? 'event'),
+            'reason' => $this->nullableString($metadata['reason'] ?? $metadata['barrier_reason'] ?? $metadata['delay_reason'] ?? null),
+            'owner_role' => $this->nullableString($metadata['owner_role'] ?? null),
+            'blocks' => $this->nullableString($metadata['blocks'] ?? null),
+            'impact' => $this->nullableString($metadata['impact'] ?? null),
+        ];
+    }
+
+    private function projectionTimer(array $item, CarbonImmutable $time): array
+    {
+        $minutes = $this->minutesUntil($time, (string) $item['t']);
+        $explicitKind = $this->nullableString($item['timer_kind'] ?? null);
+        $kind = in_array($explicitKind, ['stay', 'arrival_transport', 'next_transport', 'evs', 'readiness'], true)
+            ? $explicitKind
+            : match ($item['kind']) {
+                'evs_due' => 'evs',
+                'transport_due' => 'next_transport',
+                default => 'readiness',
+            };
+
+        return [
+            'kind' => $kind,
+            'label' => $this->nullableString($item['label'] ?? null) ?? match ($item['kind']) {
+                'expected_discharge' => 'Discharge',
+                'transport_due' => 'Transport',
+                'evs_due' => 'EVS turn',
+                'scheduled_or_case' => 'OR',
+                default => $item['label'] ?? 'Timer',
+            },
+            'due_at' => $item['t'],
+            'minutes_remaining' => $minutes,
+            'status' => $this->timerStatus($minutes),
+            'source' => (string) ($item['provenance']['service'] ?? 'projection'),
+            'reason' => $this->nullableString($item['reason'] ?? $item['barrier']['reason'] ?? null),
+            'owner_role' => $this->nullableString($item['owner_role'] ?? $item['barrier']['owner_role'] ?? null),
+            'blocks' => $this->nullableString($item['blocks'] ?? $item['barrier']['blocks'] ?? null),
+            'impact' => $this->nullableString($item['impact'] ?? $item['barrier']['impact'] ?? null),
+        ];
+    }
+
+    private function stayTimer(int $stayMinutes): array
+    {
+        $status = $stayMinutes >= self::LONG_STAY_DELAY_MINUTES
+            ? 'delayed'
+            : ($stayMinutes >= self::LONG_STAY_WARN_MINUTES ? 'watch' : 'ok');
+
+        return [
+            'kind' => 'stay',
+            'label' => 'Stay',
+            'due_at' => null,
+            'minutes_remaining' => null,
+            'status' => $status,
+            'source' => 'elapsed occupancy',
+            'reason' => $status === 'ok' ? null : 'Elapsed occupancy has crossed the RTDC stay-duration threshold.',
+            'owner_role' => $status === 'ok' ? null : 'bed_manager',
+            'blocks' => $status === 'ok' ? null : 'Capacity release',
+            'impact' => $status === 'ok' ? null : 'Long-stay occupancy compounds bed availability risk.',
+        ];
+    }
+
+    private function minutesUntil(CarbonImmutable $from, string $iso): ?int
+    {
+        return CarbonImmutable::parse($iso)->diffInMinutes($from, false) * -1;
+    }
+
+    private function timerStatus(?int $minutesRemaining): string
+    {
+        if ($minutesRemaining === null) {
+            return 'ok';
+        }
+
+        if ($minutesRemaining < 0) {
+            return 'delayed';
+        }
+
+        return $minutesRemaining <= self::READY_MOVE_WINDOW_MINUTES ? 'watch' : 'ok';
+    }
+
+    /** @param list<string> $statuses */
+    private function strongestStatus(array $statuses): string
+    {
+        return array_reduce(
+            $statuses,
+            fn (string $best, string $status): string => $this->rank($status) > $this->rank($best) ? $status : $best,
+            'ok',
+        );
+    }
+
+    private function rank(string $status): int
+    {
+        return match ($status) {
+            'delayed' => 2,
+            'watch' => 1,
+            default => 0,
+        };
+    }
+
+    /** @param list<array<string, mixed>> $items */
+    private function summary(array $items): array
+    {
+        $summary = [
+            'active' => count($items),
+            'delayed' => 0,
+            'watch' => 0,
+            'transport_delays' => 0,
+            'evs_delays' => 0,
+            'ready_to_move' => 0,
+            'avg_stay_minutes' => 0,
+            'service_lines' => [],
+            'persona' => ['transport' => 0, 'evs' => 0, 'bed_manager' => 0, 'capacity' => 0],
+            'timer_status_counts' => ['ok' => 0, 'watch' => 0, 'delayed' => 0],
+            'top_barriers' => [],
+        ];
+
+        $service = [];
+        $barriers = [];
+        $stayTotal = 0;
+        foreach ($items as $item) {
+            $stayTotal += (int) $item['stay_minutes'];
+            $status = (string) $item['primary_status'];
+            if ($status === 'delayed') {
+                $summary['delayed']++;
+            } elseif ($status === 'watch') {
+                $summary['watch']++;
+            }
+
+            foreach ($item['timers'] as $timer) {
+                $summary['timer_status_counts'][$timer['status']]++;
+                if ($timer['status'] !== 'ok' && ($timer['kind'] ?? null) !== 'stay') {
+                    $barrierKey = implode('|', [
+                        (string) ($timer['label'] ?? 'Barrier'),
+                        (string) ($timer['reason'] ?? ''),
+                        (string) ($timer['owner_role'] ?? ''),
+                    ]);
+                    $barriers[$barrierKey] ??= [
+                        'label' => (string) ($timer['label'] ?? 'Barrier'),
+                        'reason' => $this->nullableString($timer['reason'] ?? null),
+                        'owner_role' => $this->nullableString($timer['owner_role'] ?? null),
+                        'count' => 0,
+                        'service_lines' => [],
+                    ];
+                    $barriers[$barrierKey]['count']++;
+                    if (! empty($item['service_line'])) {
+                        $barriers[$barrierKey]['service_lines'][] = str_replace('_', ' ', (string) $item['service_line']);
+                    }
+                }
+            }
+
+            $transport = collect($item['timers'])->contains(fn (array $timer): bool => in_array($timer['kind'], ['arrival_transport', 'next_transport'], true) && $timer['status'] !== 'ok');
+            $evs = collect($item['timers'])->contains(fn (array $timer): bool => $timer['kind'] === 'evs' && $timer['status'] !== 'ok');
+            $ready = collect($item['timers'])->contains(fn (array $timer): bool => $timer['minutes_remaining'] !== null && $timer['minutes_remaining'] <= self::READY_MOVE_WINDOW_MINUTES);
+
+            if ($transport) {
+                $summary['transport_delays']++;
+            }
+            if ($evs) {
+                $summary['evs_delays']++;
+            }
+            if ($ready) {
+                $summary['ready_to_move']++;
+            }
+
+            $key = (string) ($item['service_line'] ?: 'unassigned');
+            $service[$key] ??= ['service_line' => str_replace('_', ' ', $key), 'occupied' => 0, 'delayed' => 0, 'watch' => 0, 'avg_stay_minutes' => 0, '_stay' => 0];
+            $service[$key]['occupied']++;
+            $service[$key]['_stay'] += (int) $item['stay_minutes'];
+            if ($status === 'delayed') {
+                $service[$key]['delayed']++;
+            } elseif ($status === 'watch') {
+                $service[$key]['watch']++;
+            }
+        }
+
+        foreach ($service as $row) {
+            $row['avg_stay_minutes'] = $row['occupied'] > 0 ? (int) round($row['_stay'] / $row['occupied']) : 0;
+            unset($row['_stay']);
+            $summary['service_lines'][] = $row;
+        }
+
+        usort($summary['service_lines'], fn (array $a, array $b): int => ($b['delayed'] + $b['watch']) <=> ($a['delayed'] + $a['watch']) ?: $b['occupied'] <=> $a['occupied']);
+        $summary['service_lines'] = array_slice($summary['service_lines'], 0, 8);
+        $summary['top_barriers'] = array_values(array_map(function (array $row): array {
+            $row['service_lines'] = array_values(array_unique($row['service_lines']));
+
+            return $row;
+        }, $barriers));
+        usort($summary['top_barriers'], fn (array $a, array $b): int => $b['count'] <=> $a['count'] ?: strcmp($a['label'], $b['label']));
+        $summary['top_barriers'] = array_slice($summary['top_barriers'], 0, 5);
+        $summary['avg_stay_minutes'] = count($items) > 0 ? (int) round($stayTotal / count($items)) : 0;
+        $summary['persona'] = [
+            'transport' => $summary['transport_delays'],
+            'evs' => $summary['evs_delays'],
+            'bed_manager' => $summary['ready_to_move'] + $summary['delayed'],
+            'capacity' => $summary['delayed'] + $summary['watch'],
+        ];
+
+        return $summary;
+    }
+
+    /** @param list<array<string, mixed>> $timers */
+    private function uniqueTimerValues(array $timers, string $key): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            fn (array $timer): ?string => $this->nullableString($timer[$key] ?? null),
+            $timers,
+        ))));
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/app/Services/PatientFlow/PatientFlowDemoBarrierScenario.php
+++ b/app/Services/PatientFlow/PatientFlowDemoBarrierScenario.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace App\Services\PatientFlow;
+
+use Carbon\CarbonImmutable;
+
+class PatientFlowDemoBarrierScenario
+{
+    /**
+     * @param  array<string, array<string, mixed>>  $locations
+     * @param  array<string, mixed>  $filters
+     * @return array{
+     *     events: list<array<string, mixed>>,
+     *     projections: list<array<string, mixed>>,
+     *     scenario: array<string, mixed>
+     * }
+     */
+    public function build(array $locations, CarbonImmutable $time, array $filters): array
+    {
+        $used = [];
+        $events = [];
+        $projections = [];
+        $templates = $this->templates();
+
+        foreach ($templates as $index => $template) {
+            $picked = $this->pickLocation($locations, $template['criteria'], $used);
+            if (! $picked) {
+                continue;
+            }
+
+            $locationCode = $picked['code'];
+            $location = $picked['location'];
+            $serviceLine = (string) ($template['service_line'] ?? $location['service_line'] ?? 'capacity');
+
+            if (! $this->passesFilters($location, $serviceLine, $filters)) {
+                continue;
+            }
+
+            $patientRef = 'DEMO-FLOW-'.str_pad((string) ($index + 1), 3, '0', STR_PAD_LEFT);
+            $encounterRef = 'DEMO-VISIT-'.str_pad((string) ($index + 1), 3, '0', STR_PAD_LEFT);
+            $arrivedAt = $time->subMinutes((int) $template['stay_minutes']);
+
+            $events[] = [
+                'event_id' => 'demo-flow-current-'.$index,
+                'event_category' => 'movement',
+                'event_type' => (string) ($template['event_type'] ?? 'transfer'),
+                'message_type' => 'ADT',
+                'trigger_event' => 'A02',
+                'patient_id' => $patientRef,
+                'patient_display_id' => 'Demo '.$patientRef,
+                'encounter_id' => $encounterRef,
+                'occurred_at' => $arrivedAt->toJSON(),
+                'recorded_at' => $arrivedAt->toJSON(),
+                'from_location' => $template['came_from'] ?? null,
+                'to_location' => $locationCode,
+                'point_of_care' => $location['unit_code'] ?? null,
+                'room' => $locationCode,
+                'bed' => $locationCode,
+                'patient_class' => 'I',
+                'fhir_encounter_status' => 'in-progress',
+                'fhir_encounter_class' => 'inpatient',
+                'service_line' => $serviceLine,
+                'priority' => $template['priority'] ?? 'routine',
+                'diagnosis_codes' => [],
+                'order_codes' => [],
+                'observation_codes' => [],
+                'medication_codes' => [],
+                'facility_space_id' => $location['facility_space_id'] ?? null,
+                'location_name' => $location['name'] ?? $locationCode,
+                'location_category' => $location['category'] ?? null,
+                'location_floor' => $location['floor'] ?? null,
+                'location_service_line' => $location['service_line'] ?? $serviceLine,
+                'position_ft' => $location['position_ft'] ?? null,
+                'position_m' => $location['position_m'] ?? null,
+                'unit_code' => $location['unit_code'] ?? null,
+                'metadata' => [
+                    'demo_scenario' => 'rtdc_barriers',
+                    'scenario_label' => $template['label'],
+                    'rtdc_factor' => $template['rtdc_factor'],
+                ],
+            ];
+
+            foreach ($template['timers'] as $timerIndex => $timer) {
+                $projections[] = [
+                    't' => $time->addMinutes((int) $timer['minutes'])->toJSON(),
+                    'kind' => (string) $timer['projection_kind'],
+                    'timer_kind' => $timer['timer_kind'] ?? null,
+                    'confidence' => $timer['confidence'] ?? 'probable',
+                    'unit_id' => null,
+                    'bed_id' => null,
+                    'room' => $locationCode,
+                    'entity' => ['type' => 'patient', 'ref' => $encounterRef],
+                    'patient_context_ref' => 'ptok_demo_'.$index,
+                    'label' => (string) $timer['label'],
+                    'value' => null,
+                    'band' => null,
+                    'ends_at' => null,
+                    'derived' => true,
+                    'reason' => (string) $timer['reason'],
+                    'owner_role' => (string) $timer['owner_role'],
+                    'blocks' => (string) $timer['blocks'],
+                    'impact' => (string) $timer['impact'],
+                    'provenance' => [
+                        'service' => (string) ($timer['source'] ?? 'RTDC demo barrier model'),
+                        'reliability' => 0.84,
+                    ],
+                    '_patient_ref' => $patientRef,
+                    '_demo_timer_id' => 'demo-flow-timer-'.$index.'-'.$timerIndex,
+                ];
+            }
+        }
+
+        return [
+            'events' => $events,
+            'projections' => $projections,
+            'scenario' => [
+                'key' => 'rtdc_barriers',
+                'label' => 'RTDC barrier demonstration',
+                'enabled' => true,
+                'patients' => count($events),
+                'barrier_timers' => count($projections),
+                'generated_at' => $time->toJSON(),
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function templates(): array
+    {
+        return [
+            [
+                'label' => 'ED boarded ICU admit',
+                'criteria' => ['acuity' => 'emergency', 'category' => 'bay', 'code_prefix' => 'ED-'],
+                'service_line' => 'emergency_medicine',
+                'came_from' => 'ED-WAITING',
+                'stay_minutes' => 780,
+                'priority' => 'urgent',
+                'rtdc_factor' => 'ED boarding compounds ICU and transport capacity.',
+                'timers' => [
+                    [
+                        'projection_kind' => 'transport_due',
+                        'timer_kind' => 'arrival_transport',
+                        'label' => 'ICU arrival transport',
+                        'minutes' => -35,
+                        'reason' => 'ICU bed is assigned but the oxygen-capable transport team is still tied up on CT and ED runs.',
+                        'owner_role' => 'transport',
+                        'blocks' => 'ED treatment room release and ICU admission start',
+                        'impact' => 'ED boarding persists and one monitored ED room stays unavailable.',
+                        'source' => 'Transport command queue',
+                    ],
+                    [
+                        'projection_kind' => 'expected_discharge',
+                        'timer_kind' => 'readiness',
+                        'label' => 'ICU acceptance',
+                        'minutes' => -18,
+                        'reason' => 'Receiving ICU nurse-to-nurse handoff is waiting on staffing confirmation.',
+                        'owner_role' => 'charge_nurse',
+                        'blocks' => 'Critical-care admit finalization',
+                        'impact' => 'Critical-care demand cannot be absorbed on plan.',
+                        'source' => 'Bed placement huddle',
+                    ],
+                ],
+            ],
+            [
+                'label' => 'PACU hold for dirty inpatient bed',
+                'criteria' => ['category' => 'bay', 'code_prefix' => 'PACU-'],
+                'service_line' => 'perioperative',
+                'came_from' => 'OR-12',
+                'stay_minutes' => 255,
+                'priority' => 'urgent',
+                'rtdc_factor' => 'OR recovery capacity is constrained by downstream EVS readiness.',
+                'timers' => [
+                    [
+                        'projection_kind' => 'evs_due',
+                        'timer_kind' => 'evs',
+                        'label' => 'Receiving bed EVS turn',
+                        'minutes' => -28,
+                        'reason' => 'Isolation clean on the assigned surgical bed exceeded target after discharge transport arrived late.',
+                        'owner_role' => 'evs',
+                        'blocks' => 'PACU discharge and next OR recovery slot',
+                        'impact' => 'PACU hold risks OR room recovery delay.',
+                        'source' => 'EVS bed board',
+                    ],
+                    [
+                        'projection_kind' => 'transport_due',
+                        'timer_kind' => 'next_transport',
+                        'label' => 'PACU to floor move',
+                        'minutes' => 22,
+                        'reason' => 'Transport can move as soon as EVS releases the bed.',
+                        'owner_role' => 'transport',
+                        'blocks' => 'Surgical floor placement',
+                        'impact' => 'If EVS slips again, the transport slot is lost.',
+                        'source' => 'Transport command queue',
+                    ],
+                ],
+            ],
+            [
+                'label' => 'Medicine discharge barrier',
+                'criteria' => ['service_line' => 'adult_med_surg', 'unit_prefix' => 'MS'],
+                'service_line' => 'adult_med_surg',
+                'came_from' => 'MS4A-HALL',
+                'stay_minutes' => 2110,
+                'priority' => 'routine',
+                'rtdc_factor' => 'A discharge delay keeps an inpatient bed unavailable for ED demand.',
+                'timers' => [
+                    [
+                        'projection_kind' => 'expected_discharge',
+                        'timer_kind' => 'readiness',
+                        'label' => 'Discharge clearance',
+                        'minutes' => -55,
+                        'reason' => 'Home oxygen authorization and DME delivery confirmation are incomplete after discharge order.',
+                        'owner_role' => 'hospitalist',
+                        'blocks' => 'Bed release for next ED admit',
+                        'impact' => 'One med-surg bed remains occupied beyond plan.',
+                        'source' => 'Discharge barrier tracker',
+                    ],
+                ],
+            ],
+            [
+                'label' => 'Critical-care stepdown hold',
+                'criteria' => ['service_line' => 'critical_care', 'unit_prefix' => 'MICU'],
+                'service_line' => 'critical_care',
+                'came_from' => 'MICU3-RESUS',
+                'stay_minutes' => 1530,
+                'priority' => 'urgent',
+                'rtdc_factor' => 'ICU outflow delay blocks the next high-acuity admission.',
+                'timers' => [
+                    [
+                        'projection_kind' => 'transport_due',
+                        'timer_kind' => 'next_transport',
+                        'label' => 'Stepdown move',
+                        'minutes' => -42,
+                        'reason' => 'Telemetry stepdown room is assigned but the receiving unit is holding for a 1:4 staffing variance.',
+                        'owner_role' => 'bed_manager',
+                        'blocks' => 'ICU bed release for ED admit',
+                        'impact' => 'Critical-care capacity remains constrained.',
+                        'source' => 'RTDC placement queue',
+                    ],
+                ],
+            ],
+            [
+                'label' => 'Cath lab pickup watch',
+                'criteria' => ['service_line' => 'cardiology', 'unit_prefix' => 'TEL7'],
+                'service_line' => 'cardiology',
+                'came_from' => 'TEL7A-HALL',
+                'stay_minutes' => 530,
+                'priority' => 'time_sensitive',
+                'rtdc_factor' => 'Procedure pickup timing competes with transport capacity.',
+                'timers' => [
+                    [
+                        'projection_kind' => 'transport_due',
+                        'timer_kind' => 'next_transport',
+                        'label' => 'Cath lab pickup',
+                        'minutes' => 18,
+                        'reason' => 'Nurse handoff and consent packet are due before the transport window closes.',
+                        'owner_role' => 'transport',
+                        'blocks' => 'Cath lab on-time start',
+                        'impact' => 'A missed pickup shifts the cath schedule and downstream recovery demand.',
+                        'source' => 'Cath lab schedule',
+                    ],
+                ],
+            ],
+            [
+                'label' => 'Rehab placement expiration',
+                'criteria' => ['service_line' => 'rehabilitation', 'unit_prefix' => 'AIR'],
+                'service_line' => 'rehabilitation',
+                'came_from' => 'AIR11-GYM',
+                'stay_minutes' => 95,
+                'priority' => 'routine',
+                'rtdc_factor' => 'Post-acute acceptance timing affects bed release and avoidable days.',
+                'timers' => [
+                    [
+                        'projection_kind' => 'expected_discharge',
+                        'timer_kind' => 'readiness',
+                        'label' => 'Post-acute acceptance',
+                        'minutes' => 14,
+                        'reason' => 'External rehab acceptance expires soon unless the packet is reconciled.',
+                        'owner_role' => 'case_management',
+                        'blocks' => 'Same-day discharge execution',
+                        'impact' => 'Missed acceptance adds another avoidable bed day.',
+                        'source' => 'Post-acute placement queue',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $locations
+     * @param  array<string, mixed>  $criteria
+     * @param  array<string, bool>  $used
+     * @return array{code: string, location: array<string, mixed>}|null
+     */
+    private function pickLocation(array $locations, array $criteria, array &$used): ?array
+    {
+        $candidates = [];
+        foreach ($locations as $code => $location) {
+            if (isset($used[$code]) || empty($location['position_m'])) {
+                continue;
+            }
+
+            $score = $this->scoreLocation($code, $location, $criteria);
+            if ($score <= 0) {
+                continue;
+            }
+
+            $candidates[] = ['code' => $code, 'location' => $location, 'score' => $score];
+        }
+
+        if ($candidates === []) {
+            foreach ($locations as $code => $location) {
+                if (! isset($used[$code]) && ! empty($location['position_m'])) {
+                    $used[$code] = true;
+
+                    return ['code' => $code, 'location' => $location];
+                }
+            }
+
+            return null;
+        }
+
+        usort($candidates, fn (array $a, array $b): int => $b['score'] <=> $a['score'] ?: strcmp($a['code'], $b['code']));
+        $picked = $candidates[0];
+        $used[$picked['code']] = true;
+
+        return ['code' => $picked['code'], 'location' => $picked['location']];
+    }
+
+    /**
+     * @param  array<string, mixed>  $location
+     * @param  array<string, mixed>  $criteria
+     */
+    private function scoreLocation(string $code, array $location, array $criteria): int
+    {
+        $score = 0;
+        $metadata = is_array($location['metadata'] ?? null) ? $location['metadata'] : [];
+
+        if (($criteria['service_line'] ?? null) && ($location['service_line'] ?? null) === $criteria['service_line']) {
+            $score += 80;
+        }
+        if (($criteria['category'] ?? null) && ($location['category'] ?? null) === $criteria['category']) {
+            $score += 40;
+        }
+        if (($criteria['acuity'] ?? null) && (($location['acuity'] ?? null) === $criteria['acuity'] || ($metadata['acuity'] ?? null) === $criteria['acuity'])) {
+            $score += 35;
+        }
+        if (($criteria['unit_prefix'] ?? null) && str_starts_with((string) ($location['unit_code'] ?? ''), (string) $criteria['unit_prefix'])) {
+            $score += 30;
+        }
+        if (($criteria['code_prefix'] ?? null) && str_starts_with($code, (string) $criteria['code_prefix'])) {
+            $score += 30;
+        }
+
+        return $score;
+    }
+
+    /**
+     * @param  array<string, mixed>  $location
+     * @param  array<string, mixed>  $filters
+     */
+    private function passesFilters(array $location, string $serviceLine, array $filters): bool
+    {
+        if (isset($filters['floor']) && $filters['floor'] !== '' && $filters['floor'] !== 'all'
+            && (string) ($location['floor'] ?? '') !== (string) $filters['floor']) {
+            return false;
+        }
+
+        if (isset($filters['service_line']) && $filters['service_line'] !== '' && $filters['service_line'] !== 'all'
+            && $serviceLine !== $filters['service_line']) {
+            return false;
+        }
+
+        if (isset($filters['category']) && $filters['category'] !== '' && $filters['category'] !== 'all'
+            && $filters['category'] !== 'movement') {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/config/patient_flow.php
+++ b/config/patient_flow.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Patient Flow 4D Demo Barriers
+    |--------------------------------------------------------------------------
+    |
+    | Local demo environments need a rich RTDC pressure picture even when the
+    | replay tables are sparse. Production keeps this off unless explicitly
+    | enabled. Request query demo=0 disables it for an individual call.
+    |
+    */
+    'demo_barriers_enabled' => env(
+        'PATIENT_FLOW_DEMO_BARRIERS',
+        env('APP_ENV') !== 'production' && env('APP_ENV') !== 'testing',
+    ),
+
+    'demo_barriers_replace_replay' => env(
+        'PATIENT_FLOW_DEMO_BARRIERS_REPLACE_REPLAY',
+        env('APP_ENV') !== 'production' && env('APP_ENV') !== 'testing',
+    ),
+];

--- a/database/migrations/2026_07_05_000400_extend_patient_flow_occupancy_snapshots_for_disk_details.php
+++ b/database/migrations/2026_07_05_000400_extend_patient_flow_occupancy_snapshots_for_disk_details.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Traits\SafeMigration;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    use SafeMigration;
+
+    public function up(): void
+    {
+        DB::unprepared(<<<'SQL'
+            ALTER TABLE flow_core.occupancy_snapshots
+                ADD COLUMN IF NOT EXISTS occupancy_details jsonb NOT NULL DEFAULT '[]'::jsonb,
+                ADD COLUMN IF NOT EXISTS timer_status_counts jsonb NOT NULL DEFAULT '{}'::jsonb,
+                ADD COLUMN IF NOT EXISTS service_line_timer_counts jsonb NOT NULL DEFAULT '{}'::jsonb,
+                ADD COLUMN IF NOT EXISTS persona_timer_counts jsonb NOT NULL DEFAULT '{}'::jsonb,
+                ADD COLUMN IF NOT EXISTS active_blocker_counts jsonb NOT NULL DEFAULT '{}'::jsonb,
+                ADD COLUMN IF NOT EXISTS projection_window jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+            CREATE INDEX IF NOT EXISTS idx_flow_occupancy_details_gin
+                ON flow_core.occupancy_snapshots USING gin(occupancy_details);
+
+            CREATE INDEX IF NOT EXISTS idx_flow_occupancy_service_line_timers_gin
+                ON flow_core.occupancy_snapshots USING gin(service_line_timer_counts);
+
+            COMMENT ON COLUMN flow_core.occupancy_snapshots.occupancy_details IS
+                'Disk-ready occupancy detail payloads for the 4D viewer: stay duration, origin, anticipated move, and timers.';
+
+            COMMENT ON COLUMN flow_core.occupancy_snapshots.timer_status_counts IS
+                'Roll-up of ok/watch/delayed timer states at this snapshot.';
+
+            COMMENT ON COLUMN flow_core.occupancy_snapshots.service_line_timer_counts IS
+                'Service-line compounded occupancy pressure counts for RTDC demand-capacity views.';
+
+            COMMENT ON COLUMN flow_core.occupancy_snapshots.persona_timer_counts IS
+                'Persona-facing counts for transport, EVS, bed management, and capacity leadership.';
+        SQL);
+    }
+
+    public function down(): void
+    {
+        if (! $this->isLocalEnvironment()) {
+            return;
+        }
+
+        DB::unprepared(<<<'SQL'
+            ALTER TABLE flow_core.occupancy_snapshots
+                DROP COLUMN IF EXISTS projection_window,
+                DROP COLUMN IF EXISTS active_blocker_counts,
+                DROP COLUMN IF EXISTS persona_timer_counts,
+                DROP COLUMN IF EXISTS service_line_timer_counts,
+                DROP COLUMN IF EXISTS timer_status_counts,
+                DROP COLUMN IF EXISTS occupancy_details;
+        SQL);
+    }
+};

--- a/docs/superpowers/plans/2026-07-05-patient-flow-4d-barrier-eddy-implementation-plan.md
+++ b/docs/superpowers/plans/2026-07-05-patient-flow-4d-barrier-eddy-implementation-plan.md
@@ -1,0 +1,1030 @@
+# Patient Flow 4D Barrier And Eddy Enablement Implementation Plan
+
+Date: 2026-07-05
+Status: Detailed execution plan
+Target repo: `/Users/sudoshi/Github/Zephyrus`
+Primary surface: `/rtdc/patient-flow-navigator`
+Primary API: `/api/patient-flow/occupancy`
+Related docs:
+
+- `docs/superpowers/plans/2026-06-25-patient-flow-4d-navigator-integration.md`
+- `docs/superpowers/plans/2026-06-25-patient-flow-4d-navigator-todo.md`
+- `docs/hummingbird/FLOW-WINDOW-PLAN.md`
+- `docs/EDDY-AI-AGENT-PLAN.md`
+
+## 1. Objective
+
+Advance the Patient Flow 4D viewer from a compelling visual demo into an
+RTDC operating instrument where every bed/position occupancy disk can explain:
+
+- how long the position has been occupied,
+- where the patient came from,
+- where the patient is expected to move next,
+- which timer is driving action,
+- whether arrival, movement, EVS readiness, discharge readiness, staffing, or
+  another dependency is delayed,
+- which service line and persona are affected,
+- why the barrier exists,
+- who owns the next step,
+- what RTDC demand-capacity metric is being affected,
+- what Eddy can safely summarize or recommend for human review.
+
+The implementation is complete when the 4D viewer, backend contract, snapshot
+storage, persona lenses, and Eddy context all share the same barrier semantics.
+
+## 2. Current Baseline
+
+The current working implementation already provides the first demonstration
+slice:
+
+- `GET /api/patient-flow/occupancy` returns disk-ready occupancy details.
+- `flow_core.occupancy_snapshots` has JSONB places for occupancy details,
+  timer rollups, service-line rollups, persona rollups, blockers, and projection
+  windows.
+- Occupancy disks render above patient positions in `NavigatorScene.ts`.
+- Disk radius reflects duration of stay.
+- Disk color reflects `ok`, `watch`, or `delayed`.
+- Timer pips show the first few active timers.
+- Clicking a disk exposes a flat inspector payload with timers and barrier
+  metadata.
+- The toolbar includes RTDC occupancy/timer rollups.
+- A `Barriers` switch finds/focuses all barriers and delays.
+- A local demo scenario can show six focused RTDC barriers instead of noisy
+  stale replay data.
+- Eddy can be opened with a prefilled prompt containing occupancy, service-line
+  compounding, and barrier reasons.
+
+This plan assumes that baseline exists and focuses on hardening it into a
+production-grade capability.
+
+## 3. Guiding Principles
+
+- One barrier vocabulary must serve backend storage, 4D disks, persona rollups,
+  mobile lenses, and Eddy context.
+- The viewer must show source lineage and confidence for every timer or barrier.
+- Patient identity must remain persona-lensed. Aggregate personas can see
+  pressure and reasons without patient detail.
+- Demo data must be deterministic, explainable, and switchable. It must not
+  pollute production behavior.
+- Eddy should receive structured context, not only prose. Text prompts are a
+  useful UI affordance, not the system of record.
+- UI controls should help operators act: find, rank, filter, focus, inspect,
+  and hand off.
+- Every visual claim must map back to a backend field that can be tested.
+
+## 4. Scope
+
+### In Scope
+
+- Barrier taxonomy and metadata model.
+- Occupancy detail contract expansion.
+- Snapshot persistence and rollup jobs.
+- 4D viewer finder controls, inspector grouping, legends, and camera focus.
+- Named demo scenarios.
+- Eddy structured context endpoint or payload.
+- Persona-specific lens handling for barrier visibility and actions.
+- Backend, frontend, and browser smoke tests.
+- Documentation and operator demo scripts.
+
+### Out Of Scope For This Plan
+
+- Replacing the full RTDC planning engine.
+- Building autonomous action execution for Eddy.
+- Production integrations with real transport, EVS, staffing, or discharge
+  systems beyond existing source hooks.
+- Native mobile implementation beyond contract alignment notes.
+- Reworking the Three.js renderer into React Three Fiber.
+
+## 5. Target Architecture
+
+### 5.1 Data Flow
+
+```text
+source systems / demo scenario
+  -> normalized flow events and projections
+  -> barrier/timer enrichment
+  -> occupancy insight projector
+  -> occupancy API response
+  -> snapshot persistence
+  -> 4D disks, toolbar rollups, inspector, Eddy context
+```
+
+### 5.2 Backend Components
+
+- `PatientFlowController::occupancy`
+    - request validation,
+    - persona lens resolution,
+    - replay/projection loading,
+    - demo scenario routing,
+    - response assembly.
+
+- `OccupancyInsightProjector`
+    - patient/current-position reconstruction,
+    - stay duration,
+    - origin and next move,
+    - timer status,
+    - barrier reason extraction,
+    - service-line and persona rollups.
+
+- `PatientFlowDemoBarrierScenario`
+    - deterministic demo barriers,
+    - real facility location selection,
+    - scenario metadata.
+
+- New `BarrierTaxonomyService`
+    - canonical barrier codes,
+    - SLA thresholds,
+    - owner roles,
+    - RTDC metric mapping,
+    - Eddy-safe summaries.
+
+- New `OccupancySnapshotWriter` or extension of `TimelineSnapshotService`
+    - periodic persistence of detail and rollup JSON,
+    - retention and replay-friendly projection windows.
+
+### 5.3 Frontend Components
+
+- `PatientFlowNavigator.tsx`
+    - fetch orchestration,
+    - barrier finder state,
+    - Eddy prompt/context handoff,
+    - camera focus behavior.
+
+- `NavigatorToolbar.tsx`
+    - barrier finder toggle,
+    - ranked barrier list,
+    - persona/service-line rollups,
+    - legend affordance.
+
+- `NavigatorScene.ts`
+    - disk/pip rendering,
+    - disk metadata,
+    - finder highlighting,
+    - click/focus behavior.
+
+- `NavigatorInspector`
+    - grouped detail layout,
+    - timer and barrier cards,
+    - source lineage,
+    - persona-safe fields.
+
+- `features/patientFlowNavigator/*`
+    - API mappers,
+    - fallback occupancy derivation,
+    - typed barrier/timer contracts.
+
+## 6. Data Contract
+
+### 6.1 Occupancy Insight Shape
+
+Each disk should have the following canonical fields:
+
+```json
+{
+    "key": "patient-or-context:location",
+    "location": "MS4A-B001",
+    "location_name": "4 - Med Surg bed 001",
+    "unit_code": "MS4A",
+    "service_line": "adult_med_surg",
+    "position_m": { "x": 0, "y": 0, "z": 0 },
+    "stay_minutes": 2110,
+    "arrived_at": "2026-07-05T00:50:00Z",
+    "came_from": "MS4A-HALL",
+    "next_move": "Discharge",
+    "next_move_at": "2026-07-05T11:05:00Z",
+    "primary_status": "delayed",
+    "timers": [],
+    "blockers": [],
+    "barrier_reasons": [],
+    "owner_roles": [],
+    "delay_impacts": [],
+    "source_lineage": [],
+    "patient_id": "only when lens allows",
+    "patient_display_id": "only when lens allows",
+    "encounter_id": "only when lens allows"
+}
+```
+
+### 6.2 Timer Shape
+
+Every timer should include:
+
+```json
+{
+    "kind": "arrival_transport | next_transport | evs | readiness | stay",
+    "label": "Receiving bed EVS turn",
+    "due_at": "2026-07-05T11:32:00Z",
+    "minutes_remaining": -28,
+    "status": "ok | watch | delayed",
+    "source": "EVS bed board",
+    "barrier_code": "evs_isolation_clean_delayed",
+    "reason": "Isolation clean exceeded target after discharge transport arrived late.",
+    "owner_role": "evs",
+    "blocks": "PACU discharge and next OR recovery slot",
+    "impact": "PACU hold risks OR room recovery delay.",
+    "confidence": "definite | probable | possible",
+    "source_lineage": []
+}
+```
+
+### 6.3 Summary Shape
+
+The summary should include:
+
+- active occupancy count,
+- delayed count,
+- watch count,
+- ready-to-move count,
+- transport delay count,
+- EVS delay count,
+- average stay minutes,
+- service-line rollups,
+- persona rollups,
+- timer status counts,
+- top barriers,
+- top impacted units,
+- top impacted service lines,
+- current scenario metadata when demo mode is on.
+
+### 6.4 Persona Visibility Rules
+
+- `patient_dots=full`
+    - can see patient identifiers,
+    - can see disk-level timer and barrier detail,
+    - can open patient context links.
+
+- `patient_dots=unit`
+    - can see patient identifiers only within shared unit scope,
+    - can see aggregate barriers outside that scope.
+
+- `patient_dots=task`
+    - can see patient identifiers only for task-linked transport/EVS duties,
+    - can see non-PHI task details.
+
+- `patient_dots=none`
+    - cannot see patient identifiers,
+    - can see aggregate disk heat, barrier counts, service-line pressure, and
+      source-safe reasons.
+
+## 7. Barrier Taxonomy
+
+### 7.1 Canonical Barrier Codes
+
+Create a canonical taxonomy, preferably in config first and DB-backed later:
+
+```text
+transport_arrival_delay
+transport_next_move_delay
+transport_equipment_constraint
+evs_turn_delay
+evs_isolation_clean_delayed
+receiving_unit_staffing
+receiving_unit_handoff
+discharge_authorization
+post_acute_packet_pending
+home_dme_pending
+clinical_clearance_pending
+or_pacu_hold
+procedure_pickup_watch
+stepdown_capacity_delay
+staffing_variance
+bed_assignment_pending
+```
+
+### 7.2 Barrier Metadata
+
+Each barrier code should define:
+
+- display name,
+- owner role,
+- affected personas,
+- default timer kind,
+- status thresholds,
+- source system,
+- source confidence,
+- RTDC metric impact,
+- escalation path,
+- Eddy-safe summary,
+- allowed actions,
+- whether patient identity may be shown by lens.
+
+### 7.3 Suggested Config Shape
+
+```php
+return [
+    'evs_isolation_clean_delayed' => [
+        'display_name' => 'Isolation clean delayed',
+        'owner_role' => 'evs',
+        'timer_kind' => 'evs',
+        'watch_minutes' => 15,
+        'delayed_minutes' => 0,
+        'rtdc_metrics' => ['dirty_bed_minutes', 'bed_release_delay'],
+        'affected_personas' => ['evs', 'bed_manager', 'charge_nurse'],
+        'eddy_summary' => 'EVS clean is delaying bed release.',
+    ],
+];
+```
+
+## 8. Implementation Phases
+
+## Phase 0: Baseline Audit And Guardrails
+
+### Goals
+
+- Confirm the current barrier demo implementation is the baseline.
+- Document all existing route, API, and frontend touch points.
+- Add a lightweight implementation note if behavior differs from this plan.
+
+### Tasks
+
+- [ ] Run `git status --short` and record unrelated dirty files.
+- [ ] Re-read `routes/api.php` patient-flow group.
+- [ ] Re-read `routes/web.php` demo session auth changes.
+- [ ] Re-read `PatientFlowController::occupancy`.
+- [ ] Re-read `OccupancyInsightProjector`.
+- [ ] Re-read `PatientFlowDemoBarrierScenario`.
+- [ ] Re-read `PatientFlowNavigator.tsx`.
+- [ ] Re-read `NavigatorScene.ts`.
+- [ ] Re-read `NavigatorToolbar.tsx`.
+- [ ] Confirm the current browser route smoke:
+
+```bash
+curl -sS -L http://127.0.0.1:8001/rtdc/patient-flow-navigator
+```
+
+- [ ] Confirm the focused demo API smoke:
+
+```bash
+curl -sS \
+  'http://127.0.0.1:8001/api/patient-flow/occupancy?demo=barriers&persona=bed_manager&asOf=2026-07-05T12:00:00Z'
+```
+
+### Acceptance Criteria
+
+- [ ] The route renders `RTDC/PatientFlowNavigator`.
+- [ ] Occupancy API returns active demo barriers.
+- [ ] API includes `demo_scenario`.
+- [ ] API includes `top_barriers`.
+- [ ] API includes disk-level barrier reasons.
+
+## Phase 1: Canonical Barrier Taxonomy
+
+### Goals
+
+- Move from free-form barrier text to governed barrier codes.
+- Keep display text and source-safe Eddy language derived from backend config.
+
+### Backend Tasks
+
+- [ ] Add `config/patient_flow_barriers.php`.
+- [ ] Add canonical barrier codes and metadata.
+- [ ] Add `BarrierTaxonomyService`.
+- [ ] Add methods:
+    - [ ] `definition(string $code): array`.
+    - [ ] `statusFor(string $code, ?int $minutesRemaining): string`.
+    - [ ] `ownerFor(string $code): string`.
+    - [ ] `eddySummaryFor(string $code): string`.
+    - [ ] `rtdcMetricsFor(string $code): array`.
+- [ ] Update `PatientFlowDemoBarrierScenario` to emit `barrier_code`.
+- [ ] Update `OccupancyInsightProjector` to resolve barrier metadata.
+- [ ] Keep `reason` as narrative detail, but require `barrier_code` for
+      normalized analytics.
+- [ ] Add tests for unknown barrier codes.
+- [ ] Add tests for status thresholds.
+
+### Frontend Tasks
+
+- [ ] Add `barrierCode` to `OccupancyTimer`.
+- [ ] Add `rtdcMetrics` to timer or disk detail types.
+- [ ] Display human labels from backend response, not local enums.
+- [ ] Show barrier code in debug-only inspector rows if useful.
+
+### Acceptance Criteria
+
+- [ ] Top-barrier rollups group by `barrier_code`, not just label/reason.
+- [ ] Demo scenario returns at least five distinct barrier codes.
+- [ ] Backend tests prove taxonomy fields are present.
+- [ ] Frontend build passes.
+
+## Phase 2: Backend Snapshot Persistence
+
+### Goals
+
+- Persist the full occupancy/timer/barrier picture over time.
+- Enable RTDC trend analysis instead of current-state-only rendering.
+
+### Backend Tasks
+
+- [ ] Decide whether to extend `TimelineSnapshotService` or add
+      `OccupancySnapshotWriter`.
+- [ ] Ensure `flow_core.occupancy_snapshots` stores:
+    - [ ] `occupancy_details`,
+    - [ ] `timer_status_counts`,
+    - [ ] `service_line_timer_counts`,
+    - [ ] `persona_timer_counts`,
+    - [ ] `active_blocker_counts`,
+    - [ ] `projection_window`.
+- [ ] Add `barrier_code_counts` if not covered by existing JSON fields.
+- [ ] Add `source_lineage_counts` if source transparency is needed in RTDC
+      dashboards.
+- [ ] Add scheduled write path from current snapshot job.
+- [ ] Add idempotent upsert keyed by facility, snapshot time, and scenario/live
+      mode.
+- [ ] Add pruning/retention rules.
+- [ ] Add fixture tests with demo scenario and real replay fallback.
+
+### API Tasks
+
+- [ ] Add `GET /api/patient-flow/occupancy/history`.
+- [ ] Support query params:
+    - [ ] `from`,
+    - [ ] `to`,
+    - [ ] `interval`,
+    - [ ] `persona`,
+    - [ ] `service_line`,
+    - [ ] `floor`,
+    - [ ] `barrier_code`.
+- [ ] Return time-series rollups for:
+    - [ ] delayed occupancy,
+    - [ ] watch occupancy,
+    - [ ] transport blockers,
+    - [ ] EVS blockers,
+    - [ ] discharge blockers,
+    - [ ] service-line pressure.
+
+### Acceptance Criteria
+
+- [ ] Snapshot job writes detail JSON.
+- [ ] History endpoint returns at least a 24-hour trend.
+- [ ] Tests verify snapshot persistence and filtering.
+- [ ] Existing current occupancy endpoint remains backward compatible.
+
+## Phase 3: Barrier Finder Panel
+
+### Goals
+
+- Expand the `Barriers` toggle into an operational finder.
+- Let users find all barriers and delays without hunting through the 3D scene.
+
+### Frontend Tasks
+
+- [ ] Add a ranked barrier finder panel under the toolbar rollup.
+- [ ] Include rows with:
+    - [ ] barrier label,
+    - [ ] location,
+    - [ ] service line,
+    - [ ] owner role,
+    - [ ] elapsed delay,
+    - [ ] next expected move,
+    - [ ] impact summary.
+- [ ] Add filter chips or segmented controls:
+    - [ ] all,
+    - [ ] transport,
+    - [ ] EVS,
+    - [ ] discharge/readiness,
+    - [ ] staffing,
+    - [ ] long stay.
+- [ ] Add sort modes:
+    - [ ] severity,
+    - [ ] oldest delay,
+    - [ ] service-line impact,
+    - [ ] owner role,
+    - [ ] next due.
+- [ ] Clicking a row should:
+    - [ ] turn on barrier finder mode,
+    - [ ] focus camera on the disk,
+    - [ ] open the inspector,
+    - [ ] optionally pulse the disk for one second.
+- [ ] Add empty states for aggregate personas and no-barrier filters.
+
+### Scene Tasks
+
+- [ ] Add stable scene object keys by occupancy `key`.
+- [ ] Add `focusOccupancy(key: string)` to `NavigatorScene`.
+- [ ] Add barrier/delay highlight material or outline.
+- [ ] Keep non-barrier disks dimmed, not hidden, if the user needs spatial
+      context.
+- [ ] Add keyboard-accessible focus path from panel row to scene.
+
+### Acceptance Criteria
+
+- [ ] Operator can toggle `Barriers`.
+- [ ] Operator can filter to EVS or transport delays.
+- [ ] Operator can click a barrier row and land on the correct disk.
+- [ ] Inspector opens with barrier fields.
+- [ ] Browser smoke verifies the toggle and at least one row click.
+
+## Phase 4: Grouped Disk Inspector
+
+### Goals
+
+- Replace flat key-value rows with an operator-readable detail layout.
+- Make the click path a clear answer to "what is blocked and why?"
+
+### Frontend Tasks
+
+- [ ] Add typed selection model:
+    - [ ] `patient-token`,
+    - [ ] `occupancy-marker`,
+    - [ ] `occupancy-timer`,
+    - [ ] `projection-ghost`,
+    - [ ] `facility-space`.
+- [ ] Build `OccupancyInspectorPanel`.
+- [ ] Group fields into:
+    - [ ] Bed/position,
+    - [ ] Patient/encounter context,
+    - [ ] Duration and origin,
+    - [ ] Next move,
+    - [ ] Active timers,
+    - [ ] Barrier reason,
+    - [ ] Owner/persona,
+    - [ ] RTDC impact,
+    - [ ] Source lineage,
+    - [ ] Eddy handoff.
+- [ ] Add timer cards with status color and due/overdue text.
+- [ ] Add source chips:
+    - [ ] ADT,
+    - [ ] transport queue,
+    - [ ] EVS board,
+    - [ ] discharge tracker,
+    - [ ] OR schedule,
+    - [ ] staffing grid,
+    - [ ] demo scenario.
+- [ ] Add persona redaction labels when patient identity is hidden.
+
+### Backend Tasks
+
+- [ ] Ensure inspector payload does not require parsing display strings.
+- [ ] Include `source_lineage` arrays for timers.
+- [ ] Include `rtdc_metrics` and `metric_impact`.
+- [ ] Include `actions_allowed` by persona if action buttons are shown.
+
+### Acceptance Criteria
+
+- [ ] Clicked occupancy disk shows grouped details.
+- [ ] Timer pips show timer-specific details.
+- [ ] Aggregate personas do not see patient identifiers.
+- [ ] No inspector row contains raw PHI from source payloads.
+
+## Phase 5: Visual Legend And Semantics
+
+### Goals
+
+- Make the disk grammar immediately legible.
+
+### Frontend Tasks
+
+- [ ] Add compact legend component.
+- [ ] Explain with visual samples:
+    - [ ] disk size = duration,
+    - [ ] green = on track,
+    - [ ] amber = watch,
+    - [ ] red = delayed,
+    - [ ] pips = active timers,
+    - [ ] ghost = future projection.
+- [ ] Add hover tooltips for icon-only controls.
+- [ ] Add a `What am I seeing?` disclosure if needed, but avoid heavy in-app
+      instructional copy.
+- [ ] Confirm mobile viewport does not overlap toolbar, status bar, feed, and
+      inspector.
+
+### Acceptance Criteria
+
+- [ ] New users can decode disk size/color/pips from the legend.
+- [ ] Legend does not cover important scene content.
+- [ ] Build and browser smoke pass at desktop and mobile widths.
+
+## Phase 6: Named Demo Scenarios
+
+### Goals
+
+- Make demos repeatable and credible across service lines and personas.
+
+### Scenario Catalog
+
+- [ ] `rtdc_barriers`
+    - ED boarding, PACU hold, discharge barrier, ICU stepdown, cath pickup, rehab
+      acceptance.
+- [ ] `ed_boarding_surge`
+    - ED admits waiting on ICU/med-surg beds and transport.
+- [ ] `evs_backlog`
+    - Dirty beds, isolation cleans, discharge transport slippage.
+- [ ] `or_pacu_hold`
+    - OR recovery capacity constrained by inpatient bed turns.
+- [ ] `weekend_staffing_gap`
+    - receiving unit staffing variance delays moves.
+- [ ] `post_acute_discharge_gridlock`
+    - authorizations, DME, packet completion, transport timing.
+- [ ] `critical_care_outflow`
+    - ICU stepdown blockers and high-acuity arrivals.
+
+### Backend Tasks
+
+- [ ] Add scenario parameter:
+
+```text
+GET /api/patient-flow/occupancy?demo=or_pacu_hold
+```
+
+- [ ] Add scenario registry:
+    - [ ] key,
+    - [ ] label,
+    - [ ] description,
+    - [ ] affected service lines,
+    - [ ] affected personas,
+    - [ ] default as-of time,
+    - [ ] expected top barriers.
+- [ ] Add `GET /api/patient-flow/demo-scenarios`.
+- [ ] Support `demo=0` to disable demo replacement.
+- [ ] Keep production default off unless explicitly enabled.
+
+### Frontend Tasks
+
+- [ ] Add scenario picker in dev/demo mode.
+- [ ] Show current scenario label in toolbar.
+- [ ] Trigger occupancy refetch on scenario change.
+- [ ] Keep scenario picker hidden or disabled in production unless configured.
+
+### Acceptance Criteria
+
+- [ ] Each named scenario returns deterministic counts.
+- [ ] Browser smoke can switch scenarios.
+- [ ] Tests assert expected top barriers for at least three scenarios.
+
+## Phase 7: Eddy Structured Context
+
+### Goals
+
+- Give Eddy structured, governed context for barrier reasoning and action
+  drafting.
+- Avoid making Eddy infer facts from display strings.
+
+### Backend Tasks
+
+- [ ] Add `GET /api/patient-flow/eddy-context`.
+- [ ] Or add `eddy_context` object to occupancy response when requested:
+
+```text
+GET /api/patient-flow/occupancy?include=eddy_context
+```
+
+- [ ] Include:
+    - [ ] role/persona,
+    - [ ] scope,
+    - [ ] as-of time,
+    - [ ] current metrics,
+    - [ ] top barriers,
+    - [ ] barrier-to-owner map,
+    - [ ] affected service lines,
+    - [ ] recommended focus areas,
+    - [ ] source lineage,
+    - [ ] redaction state,
+    - [ ] action allowlist.
+- [ ] Add policy filters so Eddy never receives patient identifiers for
+      aggregate personas.
+- [ ] Add tests for bed manager vs executive context.
+
+### Frontend Tasks
+
+- [ ] Replace prose-only prefill with structured context plus concise prompt.
+- [ ] Keep a readable prompt for the user to inspect.
+- [ ] Add "Ask Eddy about selected barrier" from inspector.
+- [ ] Add "Ask Eddy about all barriers" from toolbar.
+- [ ] Add "Draft huddle summary" action for bed manager/house supervisor.
+
+### Eddy Behavior Requirements
+
+- [ ] Rank barriers by RTDC impact.
+- [ ] Separate facts from recommendations.
+- [ ] Call out uncertainty and source lineage.
+- [ ] Respect persona scope.
+- [ ] Recommend human-reviewed actions only.
+- [ ] Avoid clinical advice and avoid autonomous execution.
+
+### Acceptance Criteria
+
+- [ ] Eddy can summarize the barrier picture.
+- [ ] Eddy can explain why each top barrier matters.
+- [ ] Eddy output differs appropriately by persona.
+- [ ] Tests verify structured context redaction.
+
+## Phase 8: Persona Comparison Mode
+
+### Goals
+
+- Demonstrate how the same operational picture compounds across service lines
+  and personas.
+
+### Frontend Tasks
+
+- [ ] Add a persona lens control for broad-access users:
+    - [ ] Bed Manager,
+    - [ ] Transport,
+    - [ ] EVS,
+    - [ ] Charge Nurse,
+    - [ ] Hospitalist,
+    - [ ] Capacity Lead,
+    - [ ] Executive,
+    - [ ] PI Lead.
+- [ ] Display lens summary:
+    - [ ] what this persona can see,
+    - [ ] what this persona owns,
+    - [ ] what this persona can act on.
+- [ ] Update disk labels/inspector by lens.
+- [ ] Add comparison panel:
+    - [ ] total barriers,
+    - [ ] owned by current persona,
+    - [ ] visible but not owned,
+    - [ ] hidden due to policy.
+
+### Backend Tasks
+
+- [ ] Ensure `persona` query param remains server-authorized.
+- [ ] Add `persona_timer_counts` by taxonomy code.
+- [ ] Add `owned_by_current_persona` booleans per barrier/timer.
+- [ ] Add `visible_detail_level` per disk.
+
+### Acceptance Criteria
+
+- [ ] Bed manager sees patient-level operational detail.
+- [ ] Executive sees aggregate pressure and no patient identity.
+- [ ] Transport sees transport-owned work.
+- [ ] EVS sees EVS-owned work.
+- [ ] Browser smoke checks at least bed manager and executive.
+
+## Phase 9: Service-Line Compounding Analytics
+
+### Goals
+
+- Show how a barrier in one domain cascades across service lines.
+
+### Backend Tasks
+
+- [ ] Add service-line dependency mapping:
+    - [ ] ED -> inpatient bed assignment,
+    - [ ] OR/PACU -> inpatient bed release,
+    - [ ] ICU -> stepdown capacity,
+    - [ ] med-surg -> discharge/post-acute,
+    - [ ] cardiology -> procedure schedule,
+    - [ ] rehab -> post-acute placement.
+- [ ] Add `compound_pressure_score` per service line.
+- [ ] Add `downstream_impacts` to timer/barrier payloads.
+- [ ] Add rollups:
+    - [ ] delayed by service line,
+    - [ ] watch by service line,
+    - [ ] owner-role blockers by service line,
+    - [ ] net bed capacity impact by service line.
+
+### Frontend Tasks
+
+- [ ] Add service-line compounding strip or panel.
+- [ ] Allow clicking a service line to filter/focus disks.
+- [ ] Show cross-service-line barrier relationships in inspector.
+
+### Acceptance Criteria
+
+- [ ] ED boarding barrier shows ICU/transport impact.
+- [ ] PACU hold shows EVS/surgical floor impact.
+- [ ] Discharge barrier shows med-surg/ED bed-release impact.
+- [ ] Eddy prompt includes service-line compounding.
+
+## Phase 10: Source Lineage And Confidence
+
+### Goals
+
+- Make each barrier defensible.
+
+### Backend Tasks
+
+- [ ] Add lineage fields to timers:
+    - [ ] source system,
+    - [ ] source table or service,
+    - [ ] source record ID when safe,
+    - [ ] generated at,
+    - [ ] reliability/confidence,
+    - [ ] derived vs direct.
+- [ ] Add confidence mapping for demo and real sources.
+- [ ] Add lineage tests.
+
+### Frontend Tasks
+
+- [ ] Show lineage chips in inspector.
+- [ ] Show confidence in projection ghosts and timers.
+- [ ] Avoid alarm styling for possible-confidence projections.
+
+### Acceptance Criteria
+
+- [ ] Every non-stay timer has source lineage.
+- [ ] Demo lineage is clearly marked as demo.
+- [ ] Real source lineage is shown when available.
+
+## Phase 11: Testing And Verification
+
+### Backend Tests
+
+- [ ] `PatientFlowApiTest` covers:
+    - [ ] occupancy contract,
+    - [ ] barrier reasons,
+    - [ ] taxonomy codes,
+    - [ ] demo scenario metadata,
+    - [ ] executive redaction,
+    - [ ] bed manager identity visibility.
+- [ ] Add `BarrierTaxonomyServiceTest`.
+- [ ] Add `OccupancySnapshotWriterTest`.
+- [ ] Add history endpoint tests.
+- [ ] Add Eddy context redaction tests.
+
+### Frontend Tests
+
+- [ ] Add unit tests for occupancy API mapping.
+- [ ] Add tests for local fallback barrier rollups.
+- [ ] Add tests for barrier finder filtering and sorting.
+- [ ] Add tests for grouped inspector rendering.
+
+### Browser Smoke Tests
+
+- [ ] Route loads 4D navigator.
+- [ ] Canvas is nonblank.
+- [ ] Toolbar metrics show expected demo counts.
+- [ ] `Barriers` switch toggles on.
+- [ ] Barrier panel rows render.
+- [ ] Row click opens inspector.
+- [ ] Eddy button prefill includes top barriers.
+- [ ] Executive persona hides patient identifiers.
+
+### Commands
+
+```bash
+php artisan test --filter=PatientFlowApiTest
+php artisan test --filter=FlowWindowTest
+./vendor/bin/pint
+npm run build
+```
+
+## Phase 12: Rollout
+
+### Local Demo Rollout
+
+- [ ] Keep demo mode enabled by default in local.
+- [ ] Keep demo replacement enabled by default in local.
+- [ ] Provide demo script with exact route and expected counts.
+- [ ] Store screenshots after smoke verification.
+
+### Staging Rollout
+
+- [ ] Set `PATIENT_FLOW_DEMO_BARRIERS=true` only if staging demos need it.
+- [ ] Set `PATIENT_FLOW_DEMO_BARRIERS_REPLACE_REPLAY=false` if staging has
+      real replay data.
+- [ ] Verify persona redaction.
+- [ ] Verify no raw PHI appears in inspector or Eddy context.
+
+### Production Rollout
+
+- [ ] Keep demo mode disabled by default.
+- [ ] Enable current occupancy endpoint only after source lineage and redaction
+      tests are green.
+- [ ] Enable snapshot writes behind a feature flag.
+- [ ] Enable Eddy context after governance review.
+- [ ] Monitor API latency and snapshot job duration.
+
+## 9. Detailed TODO Checklist
+
+### Backend Contract
+
+- [ ] Add barrier taxonomy config.
+- [ ] Add taxonomy service.
+- [ ] Add `barrier_code` to demo timers.
+- [ ] Add `barrier_code` to occupancy timers.
+- [ ] Add `rtdc_metrics` to occupancy timers.
+- [ ] Add `source_lineage` to occupancy timers.
+- [ ] Add `owned_by_current_persona` to timers.
+- [ ] Add `visible_detail_level` to occupancy disks.
+- [ ] Add top impacted units to summary.
+- [ ] Add top impacted service lines to summary.
+- [ ] Add source-lineage rollups to summary.
+
+### Snapshot Storage
+
+- [ ] Add `barrier_code_counts` JSONB if needed.
+- [ ] Add `source_lineage_counts` JSONB if needed.
+- [ ] Write periodic occupancy snapshots.
+- [ ] Add snapshot history endpoint.
+- [ ] Add retention/pruning logic.
+- [ ] Add tests for snapshot write/read.
+
+### Demo Scenarios
+
+- [ ] Add scenario registry.
+- [ ] Add scenario list endpoint.
+- [ ] Add `ed_boarding_surge`.
+- [ ] Add `evs_backlog`.
+- [ ] Add `or_pacu_hold`.
+- [ ] Add `weekend_staffing_gap`.
+- [ ] Add `post_acute_discharge_gridlock`.
+- [ ] Add `critical_care_outflow`.
+- [ ] Add deterministic count tests.
+
+### Frontend Controls
+
+- [ ] Convert `Barriers` toggle into a finder panel.
+- [ ] Add owner-role filter.
+- [ ] Add service-line filter from barrier panel.
+- [ ] Add severity sort.
+- [ ] Add oldest-delay sort.
+- [ ] Add owner-role sort.
+- [ ] Add click-to-focus disk.
+- [ ] Add row-to-inspector path.
+- [ ] Add selected barrier pulse.
+
+### Inspector
+
+- [ ] Add typed selection model.
+- [ ] Build grouped occupancy inspector.
+- [ ] Add timer cards.
+- [ ] Add source chips.
+- [ ] Add RTDC metric impact block.
+- [ ] Add Eddy selected-barrier action.
+- [ ] Add redaction state display.
+
+### Eddy
+
+- [ ] Add structured Eddy context payload.
+- [ ] Add all-barriers Eddy action.
+- [ ] Add selected-barrier Eddy action.
+- [ ] Add huddle-summary Eddy action.
+- [ ] Add persona redaction tests.
+- [ ] Add source-lineage requirements to prompt.
+
+### Visual Semantics
+
+- [ ] Add disk legend.
+- [ ] Add timer pip legend.
+- [ ] Add projection ghost legend.
+- [ ] Add confidence styling.
+- [ ] Add accessible labels for icon controls.
+- [ ] Verify desktop and mobile layout.
+
+### Personas
+
+- [ ] Bed manager lens smoke.
+- [ ] Transport lens smoke.
+- [ ] EVS lens smoke.
+- [ ] Charge nurse lens smoke.
+- [ ] Hospitalist lens smoke.
+- [ ] Capacity lead lens smoke.
+- [ ] Executive lens smoke.
+- [ ] PI lead lens smoke.
+
+### Quality Gates
+
+- [ ] `php artisan test --filter=PatientFlowApiTest`.
+- [ ] Add taxonomy tests.
+- [ ] Add snapshot tests.
+- [ ] Add Eddy context tests.
+- [ ] Add frontend unit tests.
+- [ ] Add browser smoke script.
+- [ ] `npm run build`.
+- [ ] `./vendor/bin/pint`.
+
+## 10. Open Decisions
+
+- [ ] Should barrier taxonomy start as config-only, DB-backed, or both?
+- [ ] Should demo scenarios be API-only or also seed database rows?
+- [ ] Should the barrier finder hide non-barrier disks or dim them?
+- [ ] Should service-line compounding score be simple weighted count first, or
+      tied to RTDC net bed need immediately?
+- [ ] Should Eddy context be embedded in occupancy response or separate?
+- [ ] Which roles should get action buttons in the first production slice?
+- [ ] How long should occupancy detail snapshots be retained?
+- [ ] Should production ever allow demo replacement mode, or only additive
+      demo overlays?
+
+## 11. Recommended Sequence
+
+1. Barrier taxonomy.
+2. Barrier finder panel with click-to-focus.
+3. Grouped inspector.
+4. Named demo scenarios.
+5. Structured Eddy context.
+6. Snapshot persistence and history.
+7. Persona comparison mode.
+8. Service-line compounding analytics.
+9. Source lineage hardening.
+10. Full browser/persona smoke suite.
+
+This sequence keeps the next visible product improvement close to the current
+demo while moving the underlying contract toward production use.
+
+## 12. Definition Of Done
+
+- [ ] The backend has a canonical, tested place for every timer, barrier, owner,
+      reason, source, and RTDC impact.
+- [ ] The 4D viewer can find, rank, focus, and inspect all barriers and delays.
+- [ ] Each disk answers duration, origin, next move, active timers, delay reason,
+      owner, and impact.
+- [ ] Service-line and persona rollups show compounding pressure.
+- [ ] Eddy receives structured governed context.
+- [ ] Aggregate personas receive useful pressure context without patient identity.
+- [ ] Demo scenarios are deterministic and repeatable.
+- [ ] Snapshot persistence supports trend and history views.
+- [ ] Automated tests cover contracts, redaction, taxonomy, snapshots, and build.

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -5,6 +5,8 @@ import { parseTime, positionFor } from '@/features/patientFlowNavigator/statePro
 import { confidenceOpacity } from '@/features/patientFlowNavigator/projections';
 import type { ProjectionAnchor } from '@/features/patientFlowNavigator/projections';
 import type {
+  OccupancyInsight,
+  OccupancyTimerStatus,
   PatientFlowEvent,
   PatientFlowLocations,
   PatientVisibleState,
@@ -86,11 +88,17 @@ export class NavigatorScene {
 
   private heatMultiMaterial: THREE.MeshStandardMaterial;
 
+  private occupancyMaterials = new Map<OccupancyTimerStatus, THREE.MeshStandardMaterial>();
+
+  private timerPipMaterials = new Map<OccupancyTimerStatus, THREE.MeshStandardMaterial>();
+
   private tokenGeometry = new THREE.SphereGeometry(1.65, 18, 12);
 
   private ghostGeometry = new THREE.SphereGeometry(1.45, 14, 10);
 
-  private heatGeometry = new THREE.CylinderGeometry(1.9, 1.9, 1, 18, 1);
+  private heatGeometry = new THREE.CylinderGeometry(2.7, 2.7, 0.18, 40, 1);
+
+  private timerPipGeometry = new THREE.CylinderGeometry(0.28, 0.28, 0.42, 12, 1);
 
   private forecastGeometry = new THREE.CylinderGeometry(2.6, 2.6, 1, 18, 1);
 
@@ -300,33 +308,79 @@ export class NavigatorScene {
     }
   }
 
-  /** Bucketed rebuild: census-heat pillars. Returns occupied-location count. */
-  rebuildHeat(states: PatientVisibleState[], locations: PatientFlowLocations, layerVisible: boolean): number {
+  /** Bucketed rebuild: overhead occupancy disks with stay/timer state. */
+  rebuildHeat(insights: OccupancyInsight[], layerVisible: boolean): number {
     this.clearGroup(this.heatLayer);
     if (!layerVisible) return 0;
 
-    const occupancy = new Map<string, number>();
-    for (const state of states) {
-      const loc = state.event.to_location;
-      if (loc) occupancy.set(loc, (occupancy.get(loc) ?? 0) + 1);
-    }
+    const stackByLocation = new Map<string, number>();
 
-    for (const [loc, count] of occupancy.entries()) {
-      const position = positionFor(locations, loc);
-      if (!position) continue;
-      const marker = new THREE.Mesh(this.heatGeometry, count > 1 ? this.heatMultiMaterial : this.heatSingleMaterial);
-      marker.position.set(position.x, position.y + 2 + count * 0.42, position.z);
-      marker.scale.set(1 + count * 0.12, Math.max(1, count * 1.2), 1 + count * 0.12);
+    for (const insight of insights) {
+      const stack = stackByLocation.get(insight.location) ?? 0;
+      stackByLocation.set(insight.location, stack + 1);
+      const stayHours = insight.stayMinutes / 60;
+      const radiusScale = Math.min(2.25, 0.78 + Math.sqrt(Math.max(0.25, stayHours)) * 0.2);
+      const marker = new THREE.Mesh(this.heatGeometry, this.occupancyMaterialFor(insight.primaryStatus));
+      marker.position.set(insight.position.x, insight.position.y + 3.5 + stack * 0.34, insight.position.z);
+      marker.scale.set(radiusScale, 1, radiusScale);
       marker.userData = {
         kind: 'occupancy-marker',
-        location: loc,
-        active_patient_count: count,
-        location_name: locations[loc]?.name,
+        location: insight.location,
+        location_name: insight.locationName,
+        service_line: insight.serviceLine,
+        unit: insight.unitCode,
+        stay_minutes: insight.stayMinutes,
+        arrived_at: insight.arrivedAt,
+        came_from: insight.cameFrom,
+        next_move: insight.nextMove,
+        next_move_at: insight.nextMoveAt,
+        status: insight.primaryStatus,
+        blockers: insight.blockers.join(', '),
+        barrier_reasons: insight.barrierReasons?.join(' | '),
+        owner_roles: insight.ownerRoles?.join(', '),
+        delay_impacts: insight.delayImpacts?.join(' | '),
+        timers: insight.timers.map((timer) => `${timer.label}: ${timer.minutesRemaining ?? 'n/a'}m ${timer.status}${timer.reason ? ` because ${timer.reason}` : ''}`).join(' | '),
+        ...Object.fromEntries(
+          insight.timers.slice(0, 6).map((timer, index) => [
+            `timer_${index + 1}`,
+            `${timer.label}${timer.dueAt ? ` due ${timer.dueAt}` : ''}${timer.minutesRemaining !== null ? ` (${timer.minutesRemaining}m)` : ''} · ${timer.status} · ${timer.source}${timer.reason ? ` · ${timer.reason}` : ''}`,
+          ]),
+        ),
+        ...(insight.patientDisplayId ? { patient_display_id: insight.patientDisplayId } : {}),
+        ...(insight.patientId ? { patient_id: insight.patientId } : {}),
+        ...(insight.encounterId ? { encounter_id: insight.encounterId } : {}),
+        ...(insight.patientContextRef ? { patient_context_ref: insight.patientContextRef } : {}),
       };
       this.heatLayer.add(marker);
+
+      insight.timers.slice(0, 4).forEach((timer, index) => {
+        const angle = (index / 4) * Math.PI * 2 + Math.PI / 4;
+        const distance = 3.25 * radiusScale;
+        const pip = new THREE.Mesh(this.timerPipGeometry, this.timerPipMaterialFor(timer.status));
+        pip.position.set(
+          insight.position.x + Math.cos(angle) * distance,
+          insight.position.y + 3.92 + stack * 0.34,
+          insight.position.z + Math.sin(angle) * distance,
+        );
+        pip.userData = {
+          kind: 'occupancy-timer',
+          location: insight.location,
+          timer: timer.label,
+          due_at: timer.dueAt,
+          minutes_remaining: timer.minutesRemaining,
+          status: timer.status,
+          source: timer.source,
+          reason: timer.reason,
+          owner_role: timer.ownerRole,
+          blocks: timer.blocks,
+          impact: timer.impact,
+          ...(insight.patientDisplayId ? { patient_display_id: insight.patientDisplayId } : {}),
+        };
+        this.heatLayer.add(pip);
+      });
     }
 
-    return occupancy.size;
+    return stackByLocation.size;
   }
 
   /**
@@ -416,11 +470,14 @@ export class NavigatorScene {
     this.trailMaterials.forEach((material) => material.dispose());
     this.ghostMaterials.forEach((material) => material.dispose());
     this.forecastMaterials.forEach((material) => material.dispose());
+    this.occupancyMaterials.forEach((material) => material.dispose());
+    this.timerPipMaterials.forEach((material) => material.dispose());
     this.heatSingleMaterial.dispose();
     this.heatMultiMaterial.dispose();
     this.tokenGeometry.dispose();
     this.ghostGeometry.dispose();
     this.heatGeometry.dispose();
+    this.timerPipGeometry.dispose();
     this.forecastGeometry.dispose();
     this.orbit.dispose();
     this.renderer.dispose();
@@ -506,6 +563,41 @@ export class NavigatorScene {
     return material;
   }
 
+  private occupancyMaterialFor(status: OccupancyTimerStatus): THREE.MeshStandardMaterial {
+    let material = this.occupancyMaterials.get(status);
+    if (!material) {
+      const color = status === 'delayed' ? 0xf06755 : status === 'watch' ? 0xe0a33f : 0x77c06f;
+      material = new THREE.MeshStandardMaterial({
+        color,
+        emissive: status === 'delayed' ? 0x5a140d : status === 'watch' ? 0x4a3210 : 0x143d17,
+        transparent: true,
+        opacity: status === 'ok' ? 0.58 : 0.74,
+        roughness: 0.52,
+        metalness: 0,
+        depthWrite: false,
+      });
+      this.occupancyMaterials.set(status, material);
+    }
+    return material;
+  }
+
+  private timerPipMaterialFor(status: OccupancyTimerStatus): THREE.MeshStandardMaterial {
+    let material = this.timerPipMaterials.get(status);
+    if (!material) {
+      const color = status === 'delayed' ? 0xff8a75 : status === 'watch' ? 0xffd166 : 0x93e088;
+      material = new THREE.MeshStandardMaterial({
+        color,
+        emissive: color,
+        emissiveIntensity: status === 'ok' ? 0.18 : 0.42,
+        transparent: true,
+        opacity: 0.88,
+        depthWrite: false,
+      });
+      this.timerPipMaterials.set(status, material);
+    }
+    return material;
+  }
+
   /**
    * Remove children of a group, disposing only per-mesh geometries (trail
    * lines). Shared geometries and all materials are cached (patientMaterials /
@@ -519,6 +611,7 @@ export class NavigatorScene {
       if (child.geometry && child.geometry !== this.tokenGeometry
         && child.geometry !== this.ghostGeometry
         && child.geometry !== this.heatGeometry
+        && child.geometry !== this.timerPipGeometry
         && child.geometry !== this.forecastGeometry) {
         child.geometry.dispose();
       }

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Home, Pause, Play, Radio, ScanSearch } from 'lucide-react';
+import { Bot, Home, Pause, Play, Radio, ScanSearch } from 'lucide-react';
 import type {
+  OccupancySummary,
   PatientFlowAmbient,
   PatientFlowFilters,
   PatientFlowSummary,
@@ -33,14 +34,19 @@ interface NavigatorToolbarProps {
   categories: string[];
   layers: PatientLayerState;
   layerControls: LayerControl[];
+  barrierFinder: boolean;
   metrics: NavigatorMetrics;
+  occupancy: OccupancySummary;
+  eddyEnabled: boolean;
   onTogglePlay: () => void;
   onToggleLive: () => void;
   onResetCamera: () => void;
   onFocusPatients: () => void;
+  onAskEddy: () => void;
   onSpeedChange: (speed: number) => void;
   onFiltersChange: (patch: Partial<PatientFlowFilters>) => void;
   onLayerChange: (key: keyof PatientLayerState, value: boolean) => void;
+  onBarrierFinderChange: (value: boolean) => void;
 }
 
 export default function NavigatorToolbar({
@@ -57,14 +63,19 @@ export default function NavigatorToolbar({
   categories,
   layers,
   layerControls,
+  barrierFinder,
   metrics,
+  occupancy,
+  eddyEnabled,
   onTogglePlay,
   onToggleLive,
   onResetCamera,
   onFocusPatients,
+  onAskEddy,
   onSpeedChange,
   onFiltersChange,
   onLayerChange,
+  onBarrierFinderChange,
 }: NavigatorToolbarProps) {
   return (
     <aside className="patient-flow-toolbar" aria-label="Navigator controls">
@@ -106,6 +117,16 @@ export default function NavigatorToolbar({
         >
           <ScanSearch />
         </button>
+        {eddyEnabled && (
+          <button
+            className="patient-flow-icon-button"
+            type="button"
+            title="Ask Eddy about timer and service-line pressure"
+            onClick={onAskEddy}
+          >
+            <Bot />
+          </button>
+        )}
       </div>
 
       <div className="patient-flow-control-grid">
@@ -177,6 +198,16 @@ export default function NavigatorToolbar({
             <label htmlFor={id}>{label}</label>
           </div>
         ))}
+        <div className="patient-flow-checkbox-row">
+          <input
+            id="flow-barrier-finder"
+            type="checkbox"
+            role="switch"
+            checked={barrierFinder}
+            onChange={(event) => onBarrierFinderChange(event.target.checked)}
+          />
+          <label htmlFor="flow-barrier-finder" title="Find all barriers and delays">Barriers</label>
+        </div>
       </fieldset>
 
       <div className="patient-flow-metrics">
@@ -185,6 +216,39 @@ export default function NavigatorToolbar({
         <div><span>{metrics.occupiedLocations}</span><small>Locations</small></div>
         <div><span>{ambient?.summary.eventCount ?? summary?.ambient_signals ?? 0}</span><small>Ambient</small></div>
       </div>
+
+      <section className="patient-flow-occupancy-rollup" aria-label="Occupancy timer rollup">
+        <div className="patient-flow-rollup-grid">
+          <div><span>{occupancy.delayed}</span><small>Delayed</small></div>
+          <div><span>{occupancy.readyToMove}</span><small>Ready</small></div>
+          <div><span>{occupancy.transportDelays}</span><small>Transport</small></div>
+          <div><span>{occupancy.evsDelays}</span><small>EVS</small></div>
+        </div>
+
+        {occupancy.serviceLines.length > 0 && (
+          <ol className="patient-flow-service-rollup">
+            {occupancy.serviceLines.slice(0, 3).map((item) => (
+              <li key={item.serviceLine}>
+                <span>{item.serviceLine}</span>
+                <strong>{item.occupied}</strong>
+                <small>{item.delayed} delayed / {item.watch} watch</small>
+              </li>
+            ))}
+          </ol>
+        )}
+
+        {Boolean(occupancy.topBarriers?.length) && (
+          <ol className="patient-flow-barrier-rollup">
+            {occupancy.topBarriers?.slice(0, 3).map((item) => (
+              <li key={`${item.label}-${item.reason ?? 'none'}`}>
+                <span>{item.label}</span>
+                <strong>{item.count}</strong>
+                <small>{item.reason ?? item.ownerRole ?? 'Barrier active'}</small>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
     </aside>
   );
 }

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -198,7 +198,7 @@
 
 .patient-flow-buttons {
   display: grid;
-  grid-template-columns: repeat(4, 42px);
+  grid-template-columns: repeat(5, 42px);
   gap: 8px;
   margin: 12px 0;
 }
@@ -370,6 +370,90 @@
   font-size: 12px;
 }
 
+.patient-flow-occupancy-rollup {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.patient-flow-rollup-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.patient-flow-rollup-grid div {
+  min-height: 48px;
+  border: 1px solid rgba(239, 234, 220, 0.16);
+  border-radius: 6px;
+  padding: 7px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.patient-flow-rollup-grid span {
+  display: block;
+  color: #f3efe5;
+  font-size: 18px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.patient-flow-rollup-grid small,
+.patient-flow-service-rollup small,
+.patient-flow-barrier-rollup small {
+  color: #b9b2a6;
+  font-size: 11px;
+}
+
+.patient-flow-service-rollup,
+.patient-flow-barrier-rollup {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  color: #b9b2a6;
+  font-size: 12px;
+}
+
+.patient-flow-service-rollup li,
+.patient-flow-barrier-rollup li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 26px minmax(112px, auto);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  padding-top: 5px;
+}
+
+.patient-flow-service-rollup span,
+.patient-flow-barrier-rollup span {
+  min-width: 0;
+  overflow: hidden;
+  color: #ddd6c7;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.patient-flow-service-rollup strong,
+.patient-flow-barrier-rollup strong {
+  color: #f3efe5;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.patient-flow-barrier-rollup li {
+  grid-template-columns: minmax(0, 0.8fr) 22px minmax(0, 1.2fr);
+}
+
+.patient-flow-barrier-rollup small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .patient-flow-inspector {
   right: 16px;
   bottom: 48px;
@@ -478,7 +562,7 @@
   }
 
   .patient-flow-buttons {
-    grid-template-columns: repeat(4, 38px);
+    grid-template-columns: repeat(5, 38px);
     margin: 10px 0;
   }
 
@@ -492,6 +576,10 @@
   }
 
   .patient-flow-metrics {
+    display: none;
+  }
+
+  .patient-flow-occupancy-rollup {
     display: none;
   }
 

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -1,9 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { usePage } from '@inertiajs/react';
 import {
   createPatientFlowEventSource,
   fetchPatientFlowAmbient,
   fetchPatientFlowEvents,
   fetchPatientFlowLocations,
+  fetchPatientFlowOccupancy,
   fetchPatientFlowProjections,
   fetchPatientFlowSummary,
 } from '@/features/patientFlowNavigator/api';
@@ -22,10 +24,14 @@ import {
   ghostsAt,
 } from '@/features/patientFlowNavigator/projections';
 import type { ForecastAggregates } from '@/features/patientFlowNavigator/projections';
+import { buildOccupancyInsights } from '@/features/patientFlowNavigator/occupancyInsights';
+import { useEddyStore } from '@/stores/eddyStore';
 import type {
   FlowLens,
   FlowPatientDots,
   FlowUnitSummary,
+  OccupancyInsight,
+  OccupancySummary,
   PatientFlowAmbient,
   PatientFlowEvent,
   PatientFlowFilters,
@@ -35,6 +41,7 @@ import type {
   PatientVisibleState,
   ProjectionItem,
 } from '@/features/patientFlowNavigator/types';
+import type { PageProps } from '@/types';
 import type { NavigatorScene } from './NavigatorScene';
 import NavigatorChronobar from './NavigatorChronobar';
 import NavigatorFeed from './NavigatorFeed';
@@ -65,6 +72,24 @@ interface PatientFlowNavigatorProps {
 const WINDOW_HALF_MS = 24 * 60 * 60 * 1000;
 
 const IDENTITY_KEYS = ['patient_display_id', 'patient_id', 'encounter_id'] as const;
+
+const EMPTY_OCCUPANCY_SUMMARY: OccupancySummary = {
+  active: 0,
+  delayed: 0,
+  watch: 0,
+  transportDelays: 0,
+  evsDelays: 0,
+  readyToMove: 0,
+  avgStayMinutes: 0,
+  serviceLines: [],
+  persona: {
+    transport: 0,
+    evs: 0,
+    bedManager: 0,
+    capacity: 0,
+  },
+  topBarriers: [],
+};
 
 interface HandoffParams {
   floor: string | null;
@@ -136,11 +161,26 @@ function redactSelection(
 function flattenInspector(data: Record<string, unknown>): Array<[string, string]> {
   return Object.entries(data)
     .filter(([, value]) => value !== undefined && value !== null && value !== '')
-    .slice(0, 18)
+    .slice(0, 32)
     .map(([key, value]) => [
       key.replaceAll('_', ' '),
       typeof value === 'object' ? JSON.stringify(value) : String(value),
     ]);
+}
+
+function occupancyFilterKey(filters: PatientFlowFilters): string {
+  return JSON.stringify({
+    floor: filters.floor,
+    serviceLine: filters.serviceLine,
+    category: filters.category,
+    search: filters.search.trim() ? 'local-search' : '',
+  });
+}
+
+function isBarrierOrDelay(insight: OccupancyInsight): boolean {
+  return insight.primaryStatus !== 'ok'
+    || insight.blockers.length > 0
+    || insight.timers.some((timer) => timer.status !== 'ok');
 }
 
 export default function PatientFlowNavigator({
@@ -158,6 +198,9 @@ export default function PatientFlowNavigator({
 
   const dotsPolicy: FlowPatientDots | null = lens?.patient_dots ?? null;
   const patientDotsVisible = dotsPolicy !== 'none';
+  const page = usePage<PageProps>();
+  const eddyEnabled = Boolean(page.props.eddy?.enabled);
+  const openEddyWithPrefill = useEddyStore((state) => state.openWithPrefill);
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -172,13 +215,21 @@ export default function PatientFlowNavigator({
     search: '',
   });
   const layersRef = useRef<PatientLayerState>(defaultLayersForLens(lens));
+  const barrierFinderRef = useRef(false);
   const projectionsRef = useRef<ProjectionItem[]>([]);
+  const serverOccupancyRef = useRef<{
+    asOfMs: number;
+    filterKey: string;
+    occupancy: OccupancyInsight[];
+    summary: OccupancySummary;
+  } | null>(null);
   const currentTimeRef = useRef(handoff.t ?? nowMs);
   const speedRef = useRef(60);
   const playingRef = useRef(false);
   const liveRef = useRef(false);
   const eventSourceRef = useRef<EventSource | null>(null);
   const lastVisibleStatesRef = useRef<PatientVisibleState[]>([]);
+  const lastOccupancyInsightsRef = useRef<OccupancyInsight[]>([]);
   const lastBucketKeyRef = useRef('');
   const lastTimeEmitRef = useRef(0);
   const scopeAppliedRef = useRef(false);
@@ -190,6 +241,7 @@ export default function PatientFlowNavigator({
   const [projections, setProjections] = useState<ProjectionItem[]>([]);
   const [filters, setFilters] = useState<PatientFlowFilters>(filtersRef.current);
   const [layers, setLayers] = useState<PatientLayerState>(layersRef.current);
+  const [barrierFinder, setBarrierFinder] = useState(false);
   const [currentTime, setCurrentTime] = useState(currentTimeRef.current);
   const [speed, setSpeed] = useState(60);
   const [playing, setPlaying] = useState(false);
@@ -197,6 +249,7 @@ export default function PatientFlowNavigator({
   const [status, setStatus] = useState('Loading');
   const [cameraText, setCameraText] = useState('');
   const [metrics, setMetrics] = useState<NavigatorMetrics>({ active: 0, events: 0, occupiedLocations: 0 });
+  const [occupancy, setOccupancy] = useState<OccupancySummary>(EMPTY_OCCUPANCY_SUMMARY);
   const [forecast, setForecast] = useState<ForecastAggregates | null>(null);
   const [inspectorTitle, setInspectorTitle] = useState('Select a patient or location');
   const [inspectorRows, setInspectorRows] = useState<Array<[string, string]>>([]);
@@ -253,7 +306,27 @@ export default function PatientFlowNavigator({
 
     const timeMs = currentTimeRef.current;
     const states = patientStatesAt(tracksRef.current, locationsRef.current, timeMs, filtersRef.current);
+    const localOccupancy = buildOccupancyInsights(
+      states,
+      locationsRef.current,
+      projectionsRef.current,
+      timeMs,
+      lens,
+    );
+    const serverOccupancy = serverOccupancyRef.current;
+    const useServerOccupancy = Boolean(
+      serverOccupancy
+        && Math.abs(serverOccupancy.asOfMs - timeMs) < 60_000
+        && serverOccupancy.filterKey === occupancyFilterKey(filtersRef.current)
+        && filtersRef.current.search.trim() === '',
+    );
+    const occupancyInsights = useServerOccupancy ? serverOccupancy!.occupancy : localOccupancy.insights;
+    const occupancySummary = useServerOccupancy ? serverOccupancy!.summary : localOccupancy.summary;
+    const visibleOccupancyInsights = barrierFinderRef.current
+      ? occupancyInsights.filter(isBarrierOrDelay)
+      : occupancyInsights;
     lastVisibleStatesRef.current = states;
+    lastOccupancyInsightsRef.current = occupancyInsights;
     scene.updateTokens(
       states,
       layersRef.current.tokens && dotsPolicy !== 'none',
@@ -266,6 +339,7 @@ export default function PatientFlowNavigator({
       Math.floor(timeMs / 60_000),
       JSON.stringify(filtersRef.current),
       JSON.stringify(layersRef.current),
+      barrierFinderRef.current ? 'barriers' : 'all',
       eventsRef.current.length,
       projectionsRef.current.length,
       Object.keys(locationsRef.current).length,
@@ -281,7 +355,7 @@ export default function PatientFlowNavigator({
       timeMs,
       layersRef.current.trails && patientDotsVisible,
     );
-    const occupied = scene.rebuildHeat(states, locationsRef.current, layersRef.current.heat);
+    const occupied = scene.rebuildHeat(visibleOccupancyInsights, layersRef.current.heat);
 
     // Projection ghosts + forecast heat (the future half; §5 ghost grammar).
     const index = placementIndexRef.current;
@@ -323,13 +397,15 @@ export default function PatientFlowNavigator({
       : [];
     scene.rebuildForecastHeat(heatCells, layersRef.current.ghosts && timeMs > nowMs);
     setForecast(aggregates && timeMs > nowMs ? aggregates : null);
+    setOccupancy(occupancySummary);
 
     setMetrics({
-      active: states.length,
+      active: barrierFinderRef.current ? visibleOccupancyInsights.length : (useServerOccupancy ? occupancySummary.active : states.length),
       events: eventsRef.current.filter((event) => parseTime(event.occurred_at) <= timeMs).length,
-      occupiedLocations: occupied || new Set(states.map((state) => state.event.to_location).filter(Boolean)).size,
+      occupiedLocations: occupied
+        || new Set((barrierFinderRef.current || useServerOccupancy ? visibleOccupancyInsights.map((item) => item.location) : states.map((state) => state.event.to_location)).filter(Boolean)).size,
     });
-  }, [dotsPolicy, nowMs, patientDotsVisible]);
+  }, [dotsPolicy, lens, nowMs, patientDotsVisible]);
 
   // Keep refs in sync with state, then repaint.
   useEffect(() => {
@@ -337,6 +413,7 @@ export default function PatientFlowNavigator({
     locationsRef.current = locations;
     filtersRef.current = filters;
     layersRef.current = layers;
+    barrierFinderRef.current = barrierFinder;
     projectionsRef.current = projections;
     speedRef.current = speed;
     playingRef.current = playing;
@@ -344,13 +421,56 @@ export default function PatientFlowNavigator({
     tracksRef.current = tracks;
     placementIndexRef.current = placementIndex;
     refreshScene();
-  }, [events, locations, filters, layers, projections, speed, playing, live, tracks, placementIndex, refreshScene]);
+  }, [events, locations, filters, layers, barrierFinder, projections, speed, playing, live, tracks, placementIndex, refreshScene]);
+
+  useEffect(() => {
+    barrierFinderRef.current = barrierFinder;
+    lastBucketKeyRef.current = '';
+    refreshScene();
+    if (barrierFinder) {
+      const points = lastOccupancyInsightsRef.current
+        .filter(isBarrierOrDelay)
+        .map((item) => item.position);
+      sceneRef.current?.focusOn(points);
+    }
+  }, [barrierFinder, refreshScene]);
 
   // Repaint when the displayed time changes. The ref is the source of truth
   // (playback advances it per frame); scrub/live paths write it via applyTime.
   useEffect(() => {
     refreshScene();
   }, [currentTime, refreshScene]);
+
+  useEffect(() => {
+    if (!lens || filters.search.trim() !== '') return;
+    const asOf = new Date(currentTime).toISOString();
+    const filterKey = occupancyFilterKey(filters);
+    const timer = window.setTimeout(() => {
+      fetchPatientFlowOccupancy({
+        asOf,
+        floor: filters.floor !== 'all' ? filters.floor : undefined,
+        service_line: filters.serviceLine !== 'all' ? filters.serviceLine : undefined,
+        category: filters.category !== 'all' ? filters.category : undefined,
+        limit: 20000,
+      })
+        .then((payload) => {
+          serverOccupancyRef.current = {
+            asOfMs: Date.parse(payload.asOf),
+            filterKey,
+            occupancy: payload.occupancy,
+            summary: payload.summary,
+          };
+          lastBucketKeyRef.current = '';
+          setOccupancy(payload.summary);
+          refreshScene();
+        })
+        .catch(() => {
+          serverOccupancyRef.current = null;
+        });
+    }, playing ? 900 : 220);
+
+    return () => window.clearTimeout(timer);
+  }, [currentTime, filters, lens, playing, refreshScene]);
 
   const applyTime = useCallback((timeMs: number): void => {
     currentTimeRef.current = timeMs;
@@ -367,20 +487,23 @@ export default function PatientFlowNavigator({
         const [summaryData, locationData, eventData, ambientData] = await Promise.all([
           fetchPatientFlowSummary(),
           fetchPatientFlowLocations(),
-          fetchPatientFlowEvents({ limit: 20000 }),
+          patientDotsVisible ? fetchPatientFlowEvents({ limit: 20000 }) : Promise.resolve([]),
           fetchPatientFlowAmbient(),
         ]);
         if (cancelled) return;
 
         const sortedEvents = [...eventData].sort((a, b) => parseTime(a.occurred_at) - parseTime(b.occurred_at));
+        const replayIsStale = sortedEvents.length > 0 && parseTime(sortedEvents[sortedEvents.length - 1].occurred_at) < windowStart;
         setSummary(summaryData);
         setAmbient(ambientData);
         setLocations(locationData);
-        setEvents(sortedEvents);
-        if (!sortedEvents.length) {
+        setEvents(replayIsStale ? [] : sortedEvents);
+        if (!patientDotsVisible) {
+          setStatus('Aggregate persona lens');
+        } else if (!sortedEvents.length) {
           setStatus('No flow events loaded');
-        } else if (parseTime(sortedEvents[sortedEvents.length - 1].occurred_at) < windowStart) {
-          setStatus('Events precede the 48h window — rebase the synthetic fixture');
+        } else if (replayIsStale) {
+          setStatus('Demo barriers loaded');
         } else {
           setStatus('Data loaded');
         }
@@ -396,7 +519,7 @@ export default function PatientFlowNavigator({
     return () => {
       cancelled = true;
     };
-  }, [windowStart]);
+  }, [patientDotsVisible, windowStart]);
 
   // Projection stream (future half) — lens-clamped server-side; a failure
   // only disables ghosts, never the navigator.
@@ -502,6 +625,10 @@ export default function PatientFlowNavigator({
   }, []);
 
   const connectLive = useCallback((): void => {
+    if (!patientDotsVisible) {
+      setStatus('Live patient stream unavailable for this persona');
+      return;
+    }
     eventSourceRef.current?.close();
     const source = createPatientFlowEventSource({ replay: 180, interval: 0.65 });
     eventSourceRef.current = source;
@@ -519,7 +646,7 @@ export default function PatientFlowNavigator({
     source.onerror = () => setStatus('Live stream reconnecting');
     setLive(true);
     setStatus('Live stream active');
-  }, [applyTime, nowMs, windowStart]);
+  }, [applyTime, nowMs, patientDotsVisible, windowStart]);
 
   const handleScrub = useCallback((timeMs: number): void => {
     disconnectLive();
@@ -535,6 +662,42 @@ export default function PatientFlowNavigator({
     if (!scene) return;
     scene.focusOn(lastVisibleStatesRef.current.map((state) => state.position));
   }, []);
+
+  const askEddy = useCallback((): void => {
+    const serviceLines = occupancy.serviceLines.length > 0
+      ? occupancy.serviceLines
+          .map((item) => `${item.serviceLine}: ${item.occupied} occupied, ${item.delayed} delayed, ${item.watch} watch`)
+          .join('; ')
+      : 'No active service-line occupancy in the current lens.';
+    const topBarriers = occupancy.topBarriers?.length
+      ? occupancy.topBarriers
+          .slice(0, 5)
+          .map((item) => `${item.label} (${item.count}): ${item.reason ?? item.ownerRole ?? 'active barrier'}`)
+          .join('; ')
+      : 'No active barrier reasons in the current lens.';
+    const sampleDiskDetails = lastOccupancyInsightsRef.current
+      .filter((item) => item.primaryStatus !== 'ok')
+      .slice(0, 4)
+      .map((item) => {
+        const reasons = item.barrierReasons?.length ? item.barrierReasons.join(' / ') : item.blockers.join(', ');
+        return `${item.locationName ?? item.location}: ${item.serviceLine ?? 'unassigned'}; ${Math.round(item.stayMinutes / 60)}h stay; ${reasons}`;
+      })
+      .join('; ') || 'No delayed disk details selected.';
+
+    openEddyWithPrefill(
+      [
+        'Review this Patient Flow 4D timer picture for RTDC demand-capacity risk.',
+        `Persona lens: ${lens?.role_id ?? 'house'}. Floor filter: ${filtersRef.current.floor}. Service filter: ${filtersRef.current.serviceLine}.`,
+        `Occupancy: ${occupancy.active} active, ${occupancy.delayed} delayed, ${occupancy.watch} watch, ${occupancy.readyToMove} ready inside 30 minutes.`,
+        `Timer blockers: ${occupancy.transportDelays} transport, ${occupancy.evsDelays} EVS, average stay ${Math.round(occupancy.avgStayMinutes / 60)}h.`,
+        `Service-line compounding: ${serviceLines}`,
+        `Barrier reasons: ${topBarriers}`,
+        `Disk examples: ${sampleDiskDetails}`,
+        'Prioritize what the current persona can influence, call out cross-service-line compounding, and draft only governed recommendations for human review.',
+      ].join('\n'),
+      'patient-flow-4d-timers',
+    );
+  }, [lens?.role_id, occupancy, openEddyWithPrefill]);
 
   return (
     <section ref={containerRef} className="patient-flow-shell" aria-label="Patient Flow 4D Navigator">
@@ -567,7 +730,10 @@ export default function PatientFlowNavigator({
         categories={categories}
         layers={layers}
         layerControls={layerControls}
+        barrierFinder={barrierFinder}
         metrics={metrics}
+        occupancy={occupancy}
+        eddyEnabled={eddyEnabled}
         onTogglePlay={() => {
           if (!playing) disconnectLive();
           setPlaying((value) => !value);
@@ -578,6 +744,8 @@ export default function PatientFlowNavigator({
         onSpeedChange={setSpeed}
         onFiltersChange={(patch) => setFilters((prev) => ({ ...prev, ...patch }))}
         onLayerChange={(key, value) => setLayers((prev) => ({ ...prev, [key]: value }))}
+        onBarrierFinderChange={setBarrierFinder}
+        onAskEddy={askEddy}
       />
 
       <NavigatorFeed feed={feed} redactIdentity={dotsPolicy !== null && dotsPolicy !== 'full'} />

--- a/resources/js/features/patientFlowNavigator/api.ts
+++ b/resources/js/features/patientFlowNavigator/api.ts
@@ -3,6 +3,9 @@ import type {
   PatientFlowAmbient,
   PatientFlowEvent,
   PatientFlowLocations,
+  OccupancyInsight,
+  OccupancySummary,
+  OccupancyTimer,
   PatientFlowProjectionsResponse,
   PatientFlowState,
   PatientFlowSummary,
@@ -49,6 +52,166 @@ export async function fetchPatientFlowState(asOf?: string): Promise<PatientFlowS
 export async function fetchPatientFlowAmbient(): Promise<PatientFlowAmbient> {
   const response = await axios.get<PatientFlowAmbient>('/api/patient-flow/ambient');
   return response.data;
+}
+
+interface RawOccupancyTimer {
+  kind: OccupancyTimer['kind'];
+  label: string;
+  due_at: string | null;
+  minutes_remaining: number | null;
+  status: OccupancyTimer['status'];
+  source: string;
+  reason?: string | null;
+  owner_role?: string | null;
+  blocks?: string | null;
+  impact?: string | null;
+}
+
+interface RawOccupancyInsight {
+  key: string;
+  location: string;
+  location_name?: string | null;
+  unit_code?: string | null;
+  service_line?: string | null;
+  patient_display_id?: string | null;
+  patient_id?: string | null;
+  encounter_id?: string | null;
+  patient_context_ref?: string | null;
+  position_m?: { x: number; y?: number; z: number } | null;
+  stay_minutes: number;
+  arrived_at?: string | null;
+  came_from?: string | null;
+  next_move?: string | null;
+  next_move_at?: string | null;
+  primary_status: OccupancyInsight['primaryStatus'];
+  timers: RawOccupancyTimer[];
+  blockers: string[];
+  barrier_reasons?: string[];
+  owner_roles?: string[];
+  delay_impacts?: string[];
+}
+
+interface RawOccupancySummary {
+  active: number;
+  delayed: number;
+  watch: number;
+  transport_delays: number;
+  evs_delays: number;
+  ready_to_move: number;
+  avg_stay_minutes: number;
+  service_lines: Array<{
+    service_line: string;
+    occupied: number;
+    delayed: number;
+    watch: number;
+    avg_stay_minutes: number;
+  }>;
+  persona: {
+    transport: number;
+    evs: number;
+    bed_manager: number;
+    capacity: number;
+  };
+  top_barriers?: Array<{
+    label: string;
+    reason?: string | null;
+    owner_role?: string | null;
+    count: number;
+    service_lines: string[];
+  }>;
+}
+
+interface RawOccupancyResponse {
+  asOf: string;
+  occupancy: RawOccupancyInsight[];
+  summary: RawOccupancySummary;
+}
+
+function mapTimer(timer: RawOccupancyTimer): OccupancyTimer {
+  return {
+    kind: timer.kind,
+    label: timer.label,
+    dueAt: timer.due_at,
+    minutesRemaining: timer.minutes_remaining,
+    status: timer.status,
+    source: timer.source,
+    reason: timer.reason,
+    ownerRole: timer.owner_role,
+    blocks: timer.blocks,
+    impact: timer.impact,
+  };
+}
+
+function mapOccupancy(item: RawOccupancyInsight): OccupancyInsight | null {
+  if (!item.position_m) return null;
+  return {
+    key: item.key,
+    location: item.location,
+    locationName: item.location_name,
+    unitCode: item.unit_code,
+    serviceLine: item.service_line,
+    patientDisplayId: item.patient_display_id,
+    patientId: item.patient_id,
+    encounterId: item.encounter_id,
+    patientContextRef: item.patient_context_ref,
+    position: { x: item.position_m.x, y: (item.position_m.y ?? 0) + 1.7, z: item.position_m.z },
+    stayMinutes: item.stay_minutes,
+    arrivedAt: item.arrived_at,
+    cameFrom: item.came_from,
+    nextMove: item.next_move,
+    nextMoveAt: item.next_move_at,
+    primaryStatus: item.primary_status,
+    timers: item.timers.map(mapTimer),
+    blockers: item.blockers,
+    barrierReasons: item.barrier_reasons ?? [],
+    ownerRoles: item.owner_roles ?? [],
+    delayImpacts: item.delay_impacts ?? [],
+  };
+}
+
+function mapSummary(summary: RawOccupancySummary): OccupancySummary {
+  return {
+    active: summary.active,
+    delayed: summary.delayed,
+    watch: summary.watch,
+    transportDelays: summary.transport_delays,
+    evsDelays: summary.evs_delays,
+    readyToMove: summary.ready_to_move,
+    avgStayMinutes: summary.avg_stay_minutes,
+    serviceLines: summary.service_lines.map((item) => ({
+      serviceLine: item.service_line,
+      occupied: item.occupied,
+      delayed: item.delayed,
+      watch: item.watch,
+      avgStayMinutes: item.avg_stay_minutes,
+    })),
+    persona: {
+      transport: summary.persona.transport,
+      evs: summary.persona.evs,
+      bedManager: summary.persona.bed_manager,
+      capacity: summary.persona.capacity,
+    },
+    topBarriers: (summary.top_barriers ?? []).map((item) => ({
+      label: item.label,
+      reason: item.reason,
+      ownerRole: item.owner_role,
+      count: item.count,
+      serviceLines: item.service_lines,
+    })),
+  };
+}
+
+export async function fetchPatientFlowOccupancy(query: PatientFlowEventQuery & { asOf?: string } = {}): Promise<{
+  asOf: string;
+  occupancy: OccupancyInsight[];
+  summary: OccupancySummary;
+}> {
+  const response = await axios.get<RawOccupancyResponse>('/api/patient-flow/occupancy', { params: query });
+  return {
+    asOf: response.data.asOf,
+    occupancy: response.data.occupancy.map(mapOccupancy).filter((item): item is OccupancyInsight => item !== null),
+    summary: mapSummary(response.data.summary),
+  };
 }
 
 /**

--- a/resources/js/features/patientFlowNavigator/occupancyInsights.ts
+++ b/resources/js/features/patientFlowNavigator/occupancyInsights.ts
@@ -1,0 +1,292 @@
+import type {
+  FlowLens,
+  OccupancyInsight,
+  OccupancyServiceLineSummary,
+  OccupancySummary,
+  OccupancyTimer,
+  OccupancyTimerStatus,
+  PatientFlowLocations,
+  PatientVisibleState,
+  ProjectionItem,
+} from './types';
+
+const LONG_STAY_WARN_MINUTES = 8 * 60;
+const LONG_STAY_DELAY_MINUTES = 18 * 60;
+const READY_MOVE_WINDOW_MINUTES = 30;
+const OVERDUE_TIMER_WINDOW_MINUTES = 4 * 60;
+
+const TIMER_LABELS: Record<string, string> = {
+  expected_discharge: 'Discharge',
+  transport_due: 'Transport',
+  evs_due: 'EVS turn',
+  scheduled_or_case: 'OR',
+};
+
+function minutesBetween(fromMs: number, toIso: string): number | null {
+  const target = Date.parse(toIso);
+  if (!Number.isFinite(target)) return null;
+  return Math.round((target - fromMs) / 60_000);
+}
+
+function timerStatus(minutesRemaining: number | null): OccupancyTimerStatus {
+  if (minutesRemaining === null) return 'ok';
+  if (minutesRemaining < 0) return 'delayed';
+  if (minutesRemaining <= READY_MOVE_WINDOW_MINUTES) return 'watch';
+  return 'ok';
+}
+
+function statusRank(status: OccupancyTimerStatus): number {
+  if (status === 'delayed') return 2;
+  if (status === 'watch') return 1;
+  return 0;
+}
+
+function strongestStatus(statuses: OccupancyTimerStatus[]): OccupancyTimerStatus {
+  return statuses.reduce(
+    (best, status) => (statusRank(status) > statusRank(best) ? status : best),
+    'ok' as OccupancyTimerStatus,
+  );
+}
+
+function humanServiceLine(value?: string | null): string {
+  return value ? value.replaceAll('_', ' ') : 'Unassigned';
+}
+
+function projectionMatchesState(item: ProjectionItem, state: PatientVisibleState): boolean {
+  const entityRef = item.entity?.ref ? String(item.entity.ref) : null;
+  if (item.patient_context_ref && state.event.metadata?.patient_context_ref === item.patient_context_ref) return true;
+  if (entityRef && [state.event.encounter_id, state.event.patient_id, state.event.patient_display_id].includes(entityRef)) return true;
+  if (item.bed_id !== null && state.event.bed && String(item.bed_id) === String(state.event.bed)) return true;
+  if (item.room && state.event.room && item.room.toLowerCase() === state.event.room.toLowerCase()) return true;
+  return false;
+}
+
+function nearbyProjections(
+  state: PatientVisibleState,
+  projections: ProjectionItem[],
+  timeMs: number,
+): ProjectionItem[] {
+  const currentUnit = state.event.unit_code;
+  const eventLocation = state.event.to_location;
+  const future = projections
+    .filter((item) => {
+      const t = Date.parse(item.t);
+      if (!Number.isFinite(t) || t < timeMs - OVERDUE_TIMER_WINDOW_MINUTES * 60_000) return false;
+      if (projectionMatchesState(item, state)) return true;
+      if (item.room && [state.event.room, eventLocation].filter(Boolean).some((value) => item.room?.toLowerCase() === String(value).toLowerCase())) return true;
+      if (item.unit_id !== null && currentUnit && item.label.toLowerCase().includes(currentUnit.toLowerCase())) return true;
+      return false;
+    })
+    .sort((a, b) => Date.parse(a.t) - Date.parse(b.t));
+
+  return future.slice(0, 4);
+}
+
+function eventTimer(state: PatientVisibleState, timeMs: number): OccupancyTimer | null {
+  const next = state.nextEvent;
+  if (!next?.occurred_at) return null;
+  const minutesRemaining = minutesBetween(timeMs, next.occurred_at);
+  if (minutesRemaining === null) return null;
+  const movement = next.event_category === 'movement';
+  const label = movement && next.to_location
+    ? `Next ${next.to_location}`
+    : next.event_type.replaceAll('_', ' ');
+  const metadata = next.metadata ?? {};
+
+  return {
+    kind: movement ? 'next_transport' : 'readiness',
+    label,
+    dueAt: next.occurred_at,
+    minutesRemaining,
+    status: timerStatus(minutesRemaining),
+    source: movement ? 'movement' : next.event_category,
+    reason: typeof metadata.reason === 'string' ? metadata.reason : typeof metadata.barrier_reason === 'string' ? metadata.barrier_reason : typeof metadata.delay_reason === 'string' ? metadata.delay_reason : null,
+    ownerRole: typeof metadata.owner_role === 'string' ? metadata.owner_role : null,
+    blocks: typeof metadata.blocks === 'string' ? metadata.blocks : null,
+    impact: typeof metadata.impact === 'string' ? metadata.impact : null,
+  };
+}
+
+function projectionTimer(item: ProjectionItem, timeMs: number): OccupancyTimer {
+  const minutesRemaining = minutesBetween(timeMs, item.t);
+  const source = item.derived ? `${item.provenance.service} · derived` : item.provenance.service;
+  const explicitKind = item.timer_kind && ['stay', 'arrival_transport', 'next_transport', 'evs', 'readiness'].includes(item.timer_kind)
+    ? item.timer_kind
+    : null;
+
+  return {
+    kind: explicitKind ?? (item.kind === 'evs_due' ? 'evs' : item.kind === 'transport_due' ? 'next_transport' : 'readiness'),
+    label: item.label || TIMER_LABELS[item.kind] || item.kind.replaceAll('_', ' '),
+    dueAt: item.t,
+    minutesRemaining,
+    status: timerStatus(minutesRemaining),
+    source,
+    reason: item.reason ?? null,
+    ownerRole: item.owner_role ?? null,
+    blocks: item.blocks ?? null,
+    impact: item.impact ?? null,
+  };
+}
+
+function stayTimer(stayMinutes: number): OccupancyTimer {
+  const status: OccupancyTimerStatus = stayMinutes >= LONG_STAY_DELAY_MINUTES
+    ? 'delayed'
+    : stayMinutes >= LONG_STAY_WARN_MINUTES ? 'watch' : 'ok';
+
+  return {
+    kind: 'stay',
+    label: 'Stay',
+    dueAt: null,
+    minutesRemaining: null,
+    status,
+    source: 'elapsed occupancy',
+    reason: status === 'ok' ? null : 'Elapsed occupancy has crossed the RTDC stay-duration threshold.',
+    ownerRole: status === 'ok' ? null : 'bed_manager',
+    blocks: status === 'ok' ? null : 'Capacity release',
+    impact: status === 'ok' ? null : 'Long-stay occupancy compounds bed availability risk.',
+  };
+}
+
+function blockerLabels(timers: OccupancyTimer[]): string[] {
+  return timers
+    .filter((timer) => timer.status !== 'ok')
+    .map((timer) => timer.label)
+    .filter((value, index, values) => values.indexOf(value) === index);
+}
+
+function summarize(insights: OccupancyInsight[]): OccupancySummary {
+  const serviceMap = new Map<string, { occupied: number; delayed: number; watch: number; stay: number }>();
+  let delayed = 0;
+  let watch = 0;
+  let transportDelays = 0;
+  let evsDelays = 0;
+  let readyToMove = 0;
+  let stayTotal = 0;
+  const barrierMap = new Map<string, { label: string; reason: string | null; ownerRole: string | null; count: number; serviceLines: Set<string> }>();
+
+  for (const insight of insights) {
+    stayTotal += insight.stayMinutes;
+    if (insight.primaryStatus === 'delayed') delayed += 1;
+    if (insight.primaryStatus === 'watch') watch += 1;
+    if (insight.timers.some((timer) => ['arrival_transport', 'next_transport'].includes(timer.kind) && timer.status !== 'ok')) transportDelays += 1;
+    if (insight.timers.some((timer) => timer.kind === 'evs' && timer.status !== 'ok')) evsDelays += 1;
+    if (insight.timers.some((timer) => timer.minutesRemaining !== null && timer.minutesRemaining <= READY_MOVE_WINDOW_MINUTES)) readyToMove += 1;
+
+    const serviceLine = humanServiceLine(insight.serviceLine);
+    const entry = serviceMap.get(serviceLine) ?? { occupied: 0, delayed: 0, watch: 0, stay: 0 };
+    entry.occupied += 1;
+    entry.stay += insight.stayMinutes;
+    if (insight.primaryStatus === 'delayed') entry.delayed += 1;
+    if (insight.primaryStatus === 'watch') entry.watch += 1;
+    serviceMap.set(serviceLine, entry);
+
+    for (const timer of insight.timers) {
+      if (timer.status === 'ok') continue;
+      if (timer.kind === 'stay') continue;
+      const key = `${timer.label}|${timer.reason ?? ''}|${timer.ownerRole ?? ''}`;
+      const barrier = barrierMap.get(key) ?? {
+        label: timer.label,
+        reason: timer.reason ?? null,
+        ownerRole: timer.ownerRole ?? null,
+        count: 0,
+        serviceLines: new Set<string>(),
+      };
+      barrier.count += 1;
+      barrier.serviceLines.add(serviceLine);
+      barrierMap.set(key, barrier);
+    }
+  }
+
+  const serviceLines: OccupancyServiceLineSummary[] = [...serviceMap.entries()]
+    .map(([serviceLine, entry]) => ({
+      serviceLine,
+      occupied: entry.occupied,
+      delayed: entry.delayed,
+      watch: entry.watch,
+      avgStayMinutes: entry.occupied > 0 ? Math.round(entry.stay / entry.occupied) : 0,
+    }))
+    .sort((a, b) => (b.delayed + b.watch) - (a.delayed + a.watch) || b.occupied - a.occupied)
+    .slice(0, 4);
+
+  return {
+    active: insights.length,
+    delayed,
+    watch,
+    transportDelays,
+    evsDelays,
+    readyToMove,
+    avgStayMinutes: insights.length > 0 ? Math.round(stayTotal / insights.length) : 0,
+    serviceLines,
+    persona: {
+      transport: transportDelays,
+      evs: evsDelays,
+      bedManager: readyToMove + delayed,
+      capacity: delayed + watch,
+    },
+    topBarriers: [...barrierMap.values()]
+      .map((item) => ({
+        label: item.label,
+        reason: item.reason,
+        ownerRole: item.ownerRole,
+        count: item.count,
+        serviceLines: [...item.serviceLines],
+      }))
+      .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+      .slice(0, 5),
+  };
+}
+
+export function buildOccupancyInsights(
+  states: PatientVisibleState[],
+  locations: PatientFlowLocations,
+  projections: ProjectionItem[],
+  timeMs: number,
+  lens: FlowLens | null | undefined,
+): { insights: OccupancyInsight[]; summary: OccupancySummary } {
+  const identityVisible = !lens || lens.patient_dots === 'full';
+
+  const insights = states.map((state): OccupancyInsight => {
+    const stayMinutes = Math.max(0, Math.round((timeMs - Date.parse(state.arrivedAt)) / 60_000));
+    const projectionTimers = nearbyProjections(state, projections, timeMs).map((item) => projectionTimer(item, timeMs));
+    const knownNext = eventTimer(state, timeMs);
+    const timers = [
+      stayTimer(stayMinutes),
+      ...(knownNext ? [knownNext] : []),
+      ...projectionTimers,
+    ].sort((a, b) => statusRank(b.status) - statusRank(a.status));
+    const location = state.event.to_location ?? 'unknown';
+    const loc = locations[location];
+    const blockers = blockerLabels(timers);
+    const blockingTimers = timers.filter((timer) => timer.status !== 'ok');
+    const statuses = timers.map((timer) => timer.status);
+
+    return {
+      key: `${state.patientId}:${location}`,
+      location,
+      locationName: state.event.location_name ?? loc?.name ?? null,
+      unitCode: state.event.unit_code ?? loc?.unit_code ?? null,
+      serviceLine: state.event.service_line ?? state.event.location_service_line ?? loc?.service_line ?? null,
+      ...(identityVisible
+        ? {
+            patientDisplayId: state.event.patient_display_id,
+            patientId: state.event.patient_id,
+            encounterId: state.event.encounter_id,
+          }
+        : {}),
+      position: state.position,
+      stayMinutes,
+      arrivedAt: state.arrivedAt,
+      cameFrom: state.cameFrom ?? state.event.from_location ?? null,
+      nextMove: state.nextEvent?.to_location ?? projectionTimers[0]?.label ?? null,
+      nextMoveAt: state.nextEvent?.occurred_at ?? projectionTimers[0]?.dueAt ?? null,
+      primaryStatus: strongestStatus(statuses),
+      timers,
+      blockers,
+      barrierReasons: [...new Set(blockingTimers.map((timer) => timer.reason).filter((value): value is string => Boolean(value)))],
+      ownerRoles: [...new Set(blockingTimers.map((timer) => timer.ownerRole).filter((value): value is string => Boolean(value)))],
+      delayImpacts: [...new Set(blockingTimers.map((timer) => timer.impact).filter((value): value is string => Boolean(value)))],
+    };
+  });
+
+  return { insights, summary: summarize(insights) };
+}

--- a/resources/js/features/patientFlowNavigator/stateProjection.ts
+++ b/resources/js/features/patientFlowNavigator/stateProjection.ts
@@ -98,7 +98,24 @@ export function patientStatesAt(
       return occurred <= timeMs && occurred >= timeMs - 2 * 60 * 60 * 1000;
     });
 
-    states.push({ patientId, event: current, position, recent });
+    const currentIndex = track.findIndex((event) => event.event_id === current?.event_id);
+    const previousMovement = track
+      .slice(0, Math.max(0, currentIndex))
+      .reverse()
+      .find((event) => event.event_category === 'movement' && Boolean(event.to_location));
+    const nextEvent = track
+      .slice(Math.max(0, currentIndex + 1))
+      .find((event) => parseTime(event.occurred_at) > timeMs);
+
+    states.push({
+      patientId,
+      event: current,
+      position,
+      recent,
+      arrivedAt: current.occurred_at,
+      cameFrom: current.from_location ?? previousMovement?.to_location ?? null,
+      nextEvent: nextEvent ?? null,
+    });
   }
 
   return states;

--- a/resources/js/features/patientFlowNavigator/types.ts
+++ b/resources/js/features/patientFlowNavigator/types.ts
@@ -173,6 +173,83 @@ export interface PatientVisibleState {
   event: PatientFlowEvent;
   position: { x: number; y: number; z: number };
   recent: PatientFlowEvent[];
+  arrivedAt: string;
+  cameFrom?: string | null;
+  nextEvent?: PatientFlowEvent | null;
+}
+
+export type OccupancyTimerKind = 'stay' | 'arrival_transport' | 'next_transport' | 'evs' | 'readiness';
+export type OccupancyTimerStatus = 'ok' | 'watch' | 'delayed';
+
+export interface OccupancyTimer {
+  kind: OccupancyTimerKind;
+  label: string;
+  dueAt: string | null;
+  minutesRemaining: number | null;
+  status: OccupancyTimerStatus;
+  source: string;
+  reason?: string | null;
+  ownerRole?: string | null;
+  blocks?: string | null;
+  impact?: string | null;
+}
+
+export interface OccupancyInsight {
+  key: string;
+  location: string;
+  locationName?: string | null;
+  unitCode?: string | null;
+  serviceLine?: string | null;
+  patientDisplayId?: string | null;
+  patientId?: string | null;
+  encounterId?: string | null;
+  patientContextRef?: string | null;
+  position: { x: number; y: number; z: number };
+  stayMinutes: number;
+  arrivedAt?: string | null;
+  cameFrom?: string | null;
+  nextMove?: string | null;
+  nextMoveAt?: string | null;
+  primaryStatus: OccupancyTimerStatus;
+  timers: OccupancyTimer[];
+  blockers: string[];
+  barrierReasons?: string[];
+  ownerRoles?: string[];
+  delayImpacts?: string[];
+}
+
+export interface OccupancyServiceLineSummary {
+  serviceLine: string;
+  occupied: number;
+  delayed: number;
+  watch: number;
+  avgStayMinutes: number;
+}
+
+export interface OccupancyPersonaSummary {
+  transport: number;
+  evs: number;
+  bedManager: number;
+  capacity: number;
+}
+
+export interface OccupancySummary {
+  active: number;
+  delayed: number;
+  watch: number;
+  transportDelays: number;
+  evsDelays: number;
+  readyToMove: number;
+  avgStayMinutes: number;
+  serviceLines: OccupancyServiceLineSummary[];
+  persona: OccupancyPersonaSummary;
+  topBarriers?: Array<{
+    label: string;
+    reason?: string | null;
+    ownerRole?: string | null;
+    count: number;
+    serviceLines: string[];
+  }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -204,6 +281,7 @@ export interface ProjectionEntity {
 export interface ProjectionItem {
   t: string;
   kind: ProjectionKind;
+  timer_kind?: OccupancyTimerKind | null;
   confidence: ProjectionConfidence;
   unit_id: number | null;
   bed_id: number | null;
@@ -216,6 +294,10 @@ export interface ProjectionItem {
   ends_at: string | null;
   derived: boolean;
   provenance: ProjectionProvenance;
+  reason?: string | null;
+  owner_role?: string | null;
+  blocks?: string | null;
+  impact?: string | null;
 }
 
 export interface PatientFlowProjectionsResponse {

--- a/routes/api.php
+++ b/routes/api.php
@@ -165,6 +165,8 @@ Route::middleware(['web', 'auth', 'throttle:60,1'])->prefix('patient-flow')->gro
     // the same lens the mobile window uses.
     Route::get('/projections', [PatientFlowController::class, 'projections'])
         ->middleware(\App\Http\Middleware\EnforceFlowLens::class);
+    Route::get('/occupancy', [PatientFlowController::class, 'occupancy'])
+        ->middleware(\App\Http\Middleware\EnforceFlowLens::class);
 
     Route::post('/ingest/hl7v2', [PatientFlowIngestController::class, 'hl7v2']);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,8 +31,12 @@ Route::get('/', function (Request $request) {
     return redirect()->route('login');
 });
 
-// Authenticated routes
-Route::middleware(['auth'])
+// Authenticated demo routes.
+//
+// SessionAuthMiddleware is the existing local/demo auto-login gate. Keeping it
+// Direct viewer URLs create a valid session here, while API routes retain their
+// normal web-session authentication.
+Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
     ->group(function () {
         // RTDC Routes
         Route::prefix('rtdc')->group(function () {

--- a/tests/Feature/PatientFlow/PatientFlowApiTest.php
+++ b/tests/Feature/PatientFlow/PatientFlowApiTest.php
@@ -89,6 +89,62 @@ class PatientFlowApiTest extends TestCase
             ->assertJsonPath('activePatients', 1)
             ->assertJsonPath('patients.0.location', 'TICU-B001');
 
+        $occupancy = $this->actingAs($user)
+            ->getJson('/api/patient-flow/occupancy?asOf=2026-06-25T02:00:00Z')
+            ->assertOk()
+            ->assertJsonPath('summary.active', 1)
+            ->assertJsonPath('summary.service_lines.0.occupied', 1)
+            ->assertJsonPath('occupancy.0.location', 'TICU-B001')
+            ->assertJsonPath('occupancy.0.came_from', null)
+            ->assertJsonStructure([
+                'occupancy' => [
+                    [
+                        'location',
+                        'location_name',
+                        'service_line',
+                        'stay_minutes',
+                        'arrived_at',
+                        'primary_status',
+                        'timers' => [['kind', 'label', 'status', 'source']],
+                    ],
+                ],
+                'summary' => ['persona', 'service_lines', 'timer_status_counts'],
+            ])
+            ->json('occupancy.0');
+
+        $this->assertArrayHasKey('patient_id', $occupancy);
+
+        $redacted = $this->actingAs(User::factory()->create(['role' => 'executive']))
+            ->getJson('/api/patient-flow/occupancy?asOf=2026-06-25T02:00:00Z')
+            ->assertOk()
+            ->assertJsonPath('lens.patient_dots', 'none')
+            ->json('occupancy.0');
+
+        $this->assertArrayNotHasKey('patient_id', $redacted);
+        $this->assertArrayNotHasKey('patient_display_id', $redacted);
+
+        $demo = $this->actingAs($user)
+            ->getJson('/api/patient-flow/occupancy?asOf=2026-06-25T02:00:00Z&demo=barriers')
+            ->assertOk()
+            ->assertJsonPath('demo_scenario.key', 'rtdc_barriers')
+            ->assertJsonStructure([
+                'occupancy' => [
+                    [
+                        'barrier_reasons',
+                        'owner_roles',
+                        'delay_impacts',
+                        'timers' => [['reason', 'owner_role', 'blocks', 'impact']],
+                    ],
+                ],
+                'summary' => [
+                    'top_barriers' => [['label', 'reason', 'owner_role', 'count', 'service_lines']],
+                ],
+            ])
+            ->json();
+
+        $this->assertNotEmpty($demo['summary']['top_barriers']);
+        $this->assertNotEmpty(collect($demo['occupancy'])->first(fn (array $item): bool => ! empty($item['barrier_reasons'])));
+
         $ambient = $this->actingAs($user)
             ->getJson('/api/patient-flow/ambient')
             ->assertOk()


### PR DESCRIPTION
## Summary
Advances the **Patient Flow 4D Navigator** from a visual demo toward an RTDC operating instrument — occupancy disks carry dwell / origin / next-move / timer / barrier detail, service-line + persona timer counts, and Eddy-summarizable context. (This is the concurrent `patient-flow-4d-barrier-eddy` workstream — **its owner should review**; the plan doc's validation checklist is not yet ticked.)

## 🔒 Security fix included (the reason this is a PR, not a push to main)
The workstream swapped the authenticated web route group from `['auth']` to `SessionAuthMiddleware`, which had **no environment gating** — it auto-logs-in a hardcoded `admin@example.com` superuser for any anonymous request. Left as-is, deploying to `zephyrus.acumenus.net` would be a full auth bypass (violates `.claude/rules/auth-system.md`).

**Fix on this branch:** `SessionAuthMiddleware`'s admin auto-login is now gated to `app()->environment(['local','testing'])`. In production/staging it behaves like real `auth` (redirect to `login` / 401). Local demo convenience is preserved; public exposure is closed.

## Changes
- Backend: `PatientFlowController` occupancy insights, `OccupancyInsightProjector`, `PatientFlowDemoBarrierScenario`, `TimelineSnapshotService`, `OccupancySnapshot`, `config/patient_flow.php`
- Migration `2026_07_05_000400`: **additive** jsonb columns + GIN indexes on `flow_core.occupancy_snapshots`; guarded `down()`
- Frontend: `PatientFlowNavigator` + `NavigatorScene`/`Toolbar` + `features/patientFlowNavigator/*`
- `routes/api.php`, `routes/web.php`

## Verification
- ✅ `PatientFlowApiTest` — 3 passed / 100 assertions (exercises migration 000400 + controller + insights + API auth-required)
- ✅ Auth flow — `AuthenticationTest` + `RegistrationTest` + `PasswordUpdateTest` = 8 passed / 24 assertions (gating did **not** break real auth)
- ✅ `npm run build` (vite) — built clean (Navigator chunks bundled)
- ⚠️ Pre-existing (on `main`, not this PR): `tests/Feature/Auth/AuthenticationFlowTest.php` uses Pest `describe()` but Pest isn't installed → unloadable; `.husky/pre-commit` references a missing `build:check` script.

## Not included
- `.env.local` deletion (local shadowing-trap workaround) and the Hummingbird 4D/Eddy work (already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)