### PR TITLE
fix(patient-flow): enforce authorization and machine ingress

### DIFF
--- a/app/Exceptions/PatientFlowIngestException.php
+++ b/app/Exceptions/PatientFlowIngestException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class PatientFlowIngestException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $errorCode,
+        string $message,
+        public readonly int $status,
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/app/Http/Controllers/Api/Mobile/FlowController.php
+++ b/app/Http/Controllers/Api/Mobile/FlowController.php
@@ -6,8 +6,6 @@ use App\Http\Concerns\RendersMobileEnvelope;
 use App\Http\Controllers\Controller;
 use App\Models\Bed;
 use App\Models\CensusSnapshot;
-use App\Models\Evs\EvsRequest;
-use App\Models\Transport\TransportRequest;
 use App\Services\Flow\DutyProjectionService;
 use App\Services\Flow\FloorPlateAssetService;
 use App\Services\Flow\FloorRollupService;
@@ -170,7 +168,8 @@ class FlowController extends Controller
 
         $layers = $this->lens->clampLayers($lens, $request->query('layers'));
         $depth = $this->lens->effectivePatientDepth($lens, $scope, $request->user());
-        $taskRefs = $depth === 'task' ? $this->taskPatientRefs($roleId) : [];
+        $taskRefs = $depth === 'task' ? $this->lens->taskPatientRefs($roleId) : [];
+        $visibleUnitIds = $depth === 'unit' ? $this->lens->visibleUnitIds($request->user()) : [];
 
         $payload = [
             'window' => [
@@ -219,14 +218,14 @@ class FlowController extends Controller
                 ));
             }
             $payload['events'] = array_map(
-                fn (array $event): array => $this->lens->redactRow($event, $depth, $scope, $taskRefs),
+                fn (array $event): array => $this->lens->redactRow($event, $depth, $scope, $taskRefs, $visibleUnitIds),
                 $events,
             );
         }
 
         if (in_array('projections', $layers, true)) {
             $payload['projections'] = array_map(
-                fn (array $item): array => $this->lens->redactRow($item, $depth, $scope, $taskRefs),
+                fn (array $item): array => $this->lens->redactRow($item, $depth, $scope, $taskRefs, $visibleUnitIds),
                 $this->projections->projections($from->max($now), $to, $scope, $lens['projection_kinds']),
             );
         }
@@ -237,7 +236,7 @@ class FlowController extends Controller
         // even on a `?since=` delta (it is current worklist, not append-only).
         if (in_array('duties', $layers, true)) {
             $payload['duties'] = array_map(
-                fn (array $item): array => $this->lens->redactRow($item, $depth, $scope, $taskRefs),
+                fn (array $item): array => $this->lens->redactRow($item, $depth, $scope, $taskRefs, $visibleUnitIds),
                 $this->dutyProjections->duties($now, $lens['duty_kinds'] ?? [], $this->scopeUnitIds($scope)),
             );
         }
@@ -400,20 +399,6 @@ class FlowController extends Controller
     private function floorRollup(): array
     {
         return $this->floorRollup ??= $this->floors->floors();
-    }
-
-    /** @return list<string> patient refs visible to a task-scoped role */
-    private function taskPatientRefs(string $roleId): array
-    {
-        return match ($roleId) {
-            'transport' => TransportRequest::query()
-                ->where('is_deleted', false)->whereNotNull('patient_ref')
-                ->distinct()->pluck('patient_ref')->all(),
-            'evs' => EvsRequest::query()
-                ->where('is_deleted', false)->whereNotNull('patient_ref')
-                ->distinct()->pluck('patient_ref')->all(),
-            default => [],
-        };
     }
 
     private function invalidSince(CarbonImmutable $from, CarbonImmutable $to): JsonResponse

--- a/app/Http/Controllers/Api/PatientFlow/PatientFlowController.php
+++ b/app/Http/Controllers/Api/PatientFlow/PatientFlowController.php
@@ -4,10 +4,11 @@ namespace App\Http\Controllers\Api\PatientFlow;
 
 use App\Http\Controllers\Controller;
 use App\Models\PatientFlow\FlowEvent;
+use App\Services\Flow\FlowLensService;
 use App\Services\PatientFlow\AmbientSignalService;
 use App\Services\PatientFlow\FacilitySpaceLocationResolver;
 use App\Services\PatientFlow\FhirBundleFactory;
-use App\Services\PatientFlow\FlowEventRepository;
+use App\Services\PatientFlow\PatientFlowEventAccessService;
 use App\Services\PatientFlow\PatientFlowOccupancyContextService;
 use App\Services\PatientFlow\PatientFlowOccupancyHistoryService;
 use App\Services\PatientFlow\PatientFlowScenarioRegistry;
@@ -22,7 +23,8 @@ use InvalidArgumentException;
 class PatientFlowController extends Controller
 {
     public function __construct(
-        private readonly FlowEventRepository $events,
+        private readonly PatientFlowEventAccessService $eventAccess,
+        private readonly FlowLensService $flowLens,
         private readonly FacilitySpaceLocationResolver $locations,
         private readonly PatientStateProjector $stateProjector,
         private readonly FhirBundleFactory $fhir,
@@ -87,19 +89,27 @@ class PatientFlowController extends Controller
 
     public function events(Request $request): JsonResponse
     {
-        return response()->json($this->events->serializeEvents(
-            $this->events->filteredEvents($this->filters($request)),
-        ));
+        try {
+            return $this->patientJson($this->eventAccess->rows($request, $this->filters($request)));
+        } catch (InvalidArgumentException $exception) {
+            return $this->invalidPatientFilter($exception);
+        }
     }
 
     public function tracks(Request $request): JsonResponse
     {
+        try {
+            $events = $this->eventAccess->rows($request, $this->filters($request));
+        } catch (InvalidArgumentException $exception) {
+            return $this->invalidPatientFilter($exception);
+        }
+
         $tracks = [];
-        foreach ($this->events->serializeEvents($this->events->filteredEvents($this->filters($request))) as $event) {
+        foreach ($events as $event) {
             $tracks[$event['patient_id']][] = $event;
         }
 
-        return response()->json($tracks);
+        return $this->patientJson($tracks);
     }
 
     public function state(Request $request): JsonResponse
@@ -110,10 +120,14 @@ class PatientFlowController extends Controller
             $filters['to'] = $request->query('asOf');
         }
 
-        $events = $this->events->serializeEvents($this->events->filteredEvents($filters));
+        try {
+            $events = $this->eventAccess->rows($request, $filters);
+        } catch (InvalidArgumentException $exception) {
+            return $this->invalidPatientFilter($exception);
+        }
         $state = $this->stateProjector->reconstruct($events, $request->query('asOf'));
 
-        return response()->json([
+        return $this->patientJson([
             'asOf' => $request->query('asOf'),
             'activePatients' => count($state),
             'patients' => array_values($state),
@@ -154,13 +168,18 @@ class PatientFlowController extends Controller
         $roleId = (string) $request->attributes->get('flow_role_id');
         $asOf = is_string($request->query('asOf')) ? $request->query('asOf') : null;
         $time = $asOf ? CarbonImmutable::parse($asOf) : CarbonImmutable::now();
+        $context = $this->eventAccess->context($request);
 
-        return response()->json($this->occupancyContext->build(
+        return $this->patientJson($this->occupancyContext->build(
             $lens,
             $roleId,
             $time,
             $this->filters($request),
             $this->includes($request, 'eddy_context'),
+            $context['scope'],
+            $context['depth'],
+            $context['task_refs'],
+            $context['visible_unit_ids'],
         ));
     }
 
@@ -169,11 +188,21 @@ class PatientFlowController extends Controller
         /** @var array<string, mixed> $lens */
         $lens = $request->attributes->get('flow_lens');
         $roleId = (string) $request->attributes->get('flow_role_id');
+        $context = $this->eventAccess->context($request);
 
         try {
-            return response()->json($this->occupancyHistory->history($lens, $roleId, $this->filters($request), $request->user()));
+            return $this->patientJson($this->occupancyHistory->history(
+                $lens,
+                $roleId,
+                $this->filters($request),
+                $request->user(),
+                $context['scope'],
+                $context['depth'],
+                $context['task_refs'],
+                $context['visible_unit_ids'],
+            ));
         } catch (InvalidArgumentException $exception) {
-            return response()->json([
+            return $this->patientJson([
                 'error' => [
                     'code' => 'invalid_occupancy_history_window',
                     'message' => $exception->getMessage(),
@@ -196,24 +225,34 @@ class PatientFlowController extends Controller
 
         $now = \Carbon\CarbonImmutable::now();
         $to = $now->addHours(24);
-        $scope = ['type' => 'house', 'floor' => null, 'unit_id' => null, 'patient_ref' => null];
+        $context = $this->eventAccess->context($request);
+        $scope = $context['scope'];
+        $depth = $context['depth'];
 
         $items = app(\App\Services\Flow\ForwardProjectionService::class)
             ->projections($now, $to, $scope, $lens['projection_kinds']);
 
-        // Same redaction implementation as the mobile window. At house scope
-        // only `full` keeps identity — unit/task depths collapse to none here
-        // (the web ghost layer is aggregate for those roles).
-        $depth = $lens['patient_dots'] === 'full' ? 'full' : 'none';
-        $lensService = app(\App\Services\Flow\FlowLensService::class);
         $items = array_map(
-            fn (array $item): array => $lensService->redactRow($item, $depth, $scope),
+            fn (array $item): array => $this->flowLens->redactRow(
+                $item,
+                $depth,
+                $scope,
+                $context['task_refs'],
+                $context['visible_unit_ids'],
+            ),
             $items,
         );
 
-        return response()->json([
+        return $this->patientJson([
             'window' => ['from' => $now->toIso8601String(), 'to' => $to->toIso8601String()],
-            'lens' => ['role_id' => $roleId, 'projection_kinds' => $lens['projection_kinds'], 'patient_dots' => $lens['patient_dots']],
+            'lens' => ['role_id' => $roleId, 'projection_kinds' => $lens['projection_kinds'], 'patient_dots' => $depth],
+            'scope' => [
+                'type' => $scope['type'],
+                'floor' => $scope['floor'],
+                'unit_id' => $scope['unit_id'],
+                'patient_context_ref' => $scope['patient_context_ref'],
+                'label' => $scope['label'],
+            ],
             'projections' => $items,
             'generated_at' => now()->toJSON(),
         ]);
@@ -223,7 +262,7 @@ class PatientFlowController extends Controller
     {
         $eventId = $request->query('event_id');
         if (! is_string($eventId) || $eventId === '') {
-            return response()->json(['error' => 'event_id is required'], 422);
+            return $this->patientJson(['error' => 'event_id is required'], 422);
         }
 
         $event = FlowEvent::query()
@@ -231,11 +270,11 @@ class PatientFlowController extends Controller
             ->whereKey($eventId)
             ->first();
 
-        if (! $event) {
-            return response()->json(['error' => 'event_id not found'], 404);
+        if (! $event || ! ($payload = $this->eventAccess->event($request, $event))) {
+            return $this->patientJson(['error' => 'event_id not found'], 404);
         }
 
-        return response()->json($this->fhir->make($event));
+        return $this->patientJson($this->fhir->makeFromPayload($payload));
     }
 
     /**
@@ -308,6 +347,25 @@ class PatientFlowController extends Controller
             fn (string $value): string => strtolower(trim($value)),
             explode(',', (string) $request->query('include', '')),
         )), true);
+    }
+
+    /** @param array<string, mixed>|list<mixed> $payload */
+    private function patientJson(array $payload, int $status = 200): JsonResponse
+    {
+        return response()->json($payload, $status)->withHeaders([
+            'Cache-Control' => 'private, no-store, max-age=0',
+            'Pragma' => 'no-cache',
+        ]);
+    }
+
+    private function invalidPatientFilter(InvalidArgumentException $exception): JsonResponse
+    {
+        return $this->patientJson([
+            'error' => [
+                'code' => 'invalid_patient_context_ref',
+                'message' => $exception->getMessage(),
+            ],
+        ], 422);
     }
 
     /** @param array<string,array<string,mixed>> $locations */

--- a/app/Http/Controllers/Api/PatientFlow/PatientFlowIngestController.php
+++ b/app/Http/Controllers/Api/PatientFlow/PatientFlowIngestController.php
@@ -2,17 +2,16 @@
 
 namespace App\Http\Controllers\Api\PatientFlow;
 
+use App\Exceptions\PatientFlowIngestException;
 use App\Http\Controllers\Controller;
-use App\Services\PatientFlow\FlowEventNormalizer;
-use App\Services\PatientFlow\FlowEventRepository;
+use App\Services\PatientFlow\PatientFlowHl7IngestPipeline;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class PatientFlowIngestController extends Controller
 {
     public function __construct(
-        private readonly FlowEventNormalizer $normalizer,
-        private readonly FlowEventRepository $events,
+        private readonly PatientFlowHl7IngestPipeline $pipeline,
     ) {}
 
     public function hl7v2(Request $request): JsonResponse
@@ -22,21 +21,58 @@ class PatientFlowIngestController extends Controller
             : (string) $request->getContent();
 
         if (trim($body) === '') {
-            return response()->json(['error' => 'raw_hl7 body is required'], 400);
+            return $this->error('raw_hl7_required', 'raw_hl7 body is required.', 400);
         }
 
-        $event = $this->normalizer->normalize($body, 'hl7v2-post');
-        $stored = $this->events->upsertNormalizedEvent(
-            $event,
-            null,
-            null,
-            null,
-            (string) config('facility_models.zep_500.facility_code', 'ZEPHYRUS-500'),
-        );
+        $maxBytes = max(1024, (int) config('patient_flow.hl7_ingest_max_bytes', 1_048_576));
+        if (strlen($body) > $maxBytes) {
+            return $this->error(
+                'hl7_payload_too_large',
+                "The HL7 payload exceeds the {$maxBytes}-byte limit.",
+                413,
+            );
+        }
 
+        $sourceKey = $request->header('X-Integration-Source');
+        if (! is_string($sourceKey) || trim($sourceKey) === '') {
+            return $this->error(
+                'integration_source_required',
+                'X-Integration-Source is required.',
+                422,
+            );
+        }
+
+        try {
+            $receipt = $this->pipeline->ingest(
+                trim($sourceKey),
+                $body,
+                $request->header('Idempotency-Key'),
+                [
+                    'request_id' => $request->header('X-Request-ID'),
+                    'machine_token_id' => $request->user()?->currentAccessToken()?->getKey(),
+                    'authenticated_user_id' => $request->user()?->getAuthIdentifier(),
+                ],
+            );
+        } catch (PatientFlowIngestException $exception) {
+            return $this->error($exception->errorCode, $exception->getMessage(), $exception->status);
+        }
+
+        return response()->json($receipt, $receipt['duplicate'] ? 200 : 202)->withHeaders([
+            'Cache-Control' => 'private, no-store, max-age=0',
+            'Pragma' => 'no-cache',
+        ]);
+    }
+
+    private function error(string $code, string $message, int $status): JsonResponse
+    {
         return response()->json([
-            'accepted' => true,
-            'event' => $this->events->serializeEvent($stored->load(['toFacilitySpace', 'fromFacilitySpace'])),
-        ], 202);
+            'error' => [
+                'code' => $code,
+                'message' => $message,
+            ],
+        ], $status)->withHeaders([
+            'Cache-Control' => 'private, no-store, max-age=0',
+            'Pragma' => 'no-cache',
+        ]);
     }
 }

--- a/app/Http/Controllers/Api/PatientFlow/PatientFlowStreamController.php
+++ b/app/Http/Controllers/Api/PatientFlow/PatientFlowStreamController.php
@@ -3,27 +3,41 @@
 namespace App\Http\Controllers\Api\PatientFlow;
 
 use App\Http\Controllers\Controller;
-use App\Services\PatientFlow\FlowEventRepository;
+use App\Services\PatientFlow\PatientFlowEventAccessService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class PatientFlowStreamController extends Controller
 {
-    public function __construct(private readonly FlowEventRepository $events) {}
+    public function __construct(private readonly PatientFlowEventAccessService $eventAccess) {}
 
-    public function __invoke(Request $request): StreamedResponse
+    public function __invoke(Request $request): StreamedResponse|JsonResponse
     {
         $replay = min(max((int) $request->query('replay', 160), 1), 500);
         $interval = max((float) $request->query('interval', 1.0), 0.05);
-        $events = $this->events->serializeEvents($this->events->filteredEvents([
-            'limit' => $replay,
-            'from' => $request->query('from'),
-            'to' => $request->query('to'),
-            'patient' => $request->query('patient'),
-            'category' => $request->query('category'),
-            'service_line' => $request->query('service_line'),
-            'floor' => $request->query('floor'),
-        ]));
+        try {
+            $events = $this->eventAccess->rows($request, [
+                'limit' => $replay,
+                'from' => $request->query('from'),
+                'to' => $request->query('to'),
+                'patient' => $request->query('patient'),
+                'category' => $request->query('category'),
+                'service_line' => $request->query('service_line'),
+                'floor' => $request->query('floor'),
+            ]);
+        } catch (InvalidArgumentException $exception) {
+            return response()->json([
+                'error' => [
+                    'code' => 'invalid_patient_context_ref',
+                    'message' => $exception->getMessage(),
+                ],
+            ], 422)->withHeaders([
+                'Cache-Control' => 'private, no-store, max-age=0',
+                'Pragma' => 'no-cache',
+            ]);
+        }
 
         return response()->stream(function () use ($events, $interval) {
             echo ": connected\n\n";
@@ -47,7 +61,8 @@ class PatientFlowStreamController extends Controller
             }
         }, 200, [
             'Content-Type' => 'text/event-stream',
-            'Cache-Control' => 'no-cache',
+            'Cache-Control' => 'private, no-store, max-age=0',
+            'Pragma' => 'no-cache',
             'Connection' => 'keep-alive',
             'X-Accel-Buffering' => 'no',
         ]);

--- a/app/Http/Middleware/EnforceFlowLens.php
+++ b/app/Http/Middleware/EnforceFlowLens.php
@@ -21,8 +21,9 @@ use Symfony\Component\HttpFoundation\Response;
  * — and users with no Hummingbird persona at all — get an explicit 403,
  * exactly mirroring their A2P matrix.
  *
- * The resolved lens is attached to the request (`flow_lens`, `flow_role_id`)
- * so downstream controllers can reuse it without re-resolving.
+ * `scoped` and `scoped-patients` additionally resolve the canonical Flow
+ * Window scope and attach the effective depth plus unit/task grants. This is
+ * the web API equivalent of Mobile FlowController's server-side clamp.
  */
 class EnforceFlowLens
 {
@@ -40,12 +41,41 @@ class EnforceFlowLens
             return $this->forbidden($exception->getMessage());
         }
 
-        if ($requirement === 'patients' && $lens['patient_dots'] === 'none') {
+        if (in_array($requirement, ['patients', 'scoped-patients'], true) && $lens['patient_dots'] === 'none') {
             return $this->forbidden('This persona has no patient-level flow access.');
         }
 
         $request->attributes->set('flow_lens', $lens);
         $request->attributes->set('flow_role_id', $roleId);
+
+        if (in_array($requirement, ['scoped', 'scoped-patients'], true)) {
+            $requestedScope = $request->query('scope');
+            if ($requestedScope !== null && ! is_string($requestedScope)) {
+                return $this->forbidden('Flow scope must be a string.');
+            }
+
+            try {
+                $scope = $this->lens->resolveScope($lens, $requestedScope, $request->user());
+                $depth = $this->lens->effectivePatientDepth($lens, $scope, $request->user());
+            } catch (AuthorizationException $exception) {
+                return $this->forbidden($exception->getMessage());
+            }
+
+            if ($requirement === 'scoped-patients' && $depth === 'none') {
+                return $this->forbidden('The resolved flow scope grants no patient-level access.');
+            }
+
+            $request->attributes->set('flow_scope', $scope);
+            $request->attributes->set('flow_patient_depth', $depth);
+            $request->attributes->set(
+                'flow_task_patient_refs',
+                $depth === 'task' ? $this->lens->taskPatientRefs($roleId) : [],
+            );
+            $request->attributes->set(
+                'flow_visible_unit_ids',
+                $depth === 'unit' ? $this->lens->visibleUnitIds($request->user()) : [],
+            );
+        }
 
         return $next($request);
     }

--- a/app/Http/Middleware/RequireMachineToken.php
+++ b/app/Http/Middleware/RequireMachineToken.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Reject Sanctum's first-party/session shortcut at machine integration routes.
+ *
+ * `auth:sanctum` runs first and authenticates the bearer. This second boundary
+ * proves that authentication came from a persisted PAT and that the requested
+ * machine ability was granted explicitly (a wildcard human token is not enough).
+ */
+class RequireMachineToken
+{
+    public function handle(Request $request, Closure $next, string $ability): Response
+    {
+        $authorization = (string) $request->header('Authorization', '');
+        $token = $request->user()?->currentAccessToken();
+
+        if (! preg_match('/^Bearer\s+\S+$/i', $authorization)
+            || ! $token instanceof PersonalAccessToken) {
+            return $this->forbidden(
+                'machine_token_required',
+                'This integration route requires a dedicated bearer token.',
+            );
+        }
+
+        if ($request->user()?->is_active !== true) {
+            return $this->forbidden(
+                'machine_identity_inactive',
+                'The machine identity is inactive.',
+            );
+        }
+
+        $abilities = is_array($token->abilities) ? $token->abilities : [];
+        if (! in_array($ability, $abilities, true)) {
+            return $this->forbidden(
+                'machine_ability_required',
+                "The machine token must explicitly grant {$ability}.",
+            );
+        }
+
+        return $next($request);
+    }
+
+    private function forbidden(string $code, string $message): Response
+    {
+        return response()->json([
+            'error' => [
+                'code' => $code,
+                'message' => $message,
+            ],
+        ], 403);
+    }
+}

--- a/app/Services/Flow/FlowLensService.php
+++ b/app/Services/Flow/FlowLensService.php
@@ -2,9 +2,12 @@
 
 namespace App\Services\Flow;
 
+use App\Models\Evs\EvsRequest;
+use App\Models\Transport\TransportRequest;
 use App\Models\Unit;
 use App\Models\User;
 use App\Services\Mobile\MobilePatientContextService;
+use App\Services\Mobile\MobilePersonaCatalog;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Schema;
 
@@ -23,8 +26,27 @@ use Illuminate\Support\Facades\Schema;
  */
 class FlowLensService
 {
+    private const IDENTIFIER_KEYS = [
+        '_patient_ref',
+        'patient_ref',
+        'patient_id',
+        'patient_display_id',
+        'patient_name',
+        'patient_ids',
+        'patient_refs',
+        'downstream_patient_refs',
+        'encounter_id',
+        'encounter_ref',
+        'raw_message_hash',
+        'mrn',
+        'medical_record_number',
+        'message_control_id',
+        'attending_provider_hash',
+    ];
+
     public function __construct(
         private readonly MobilePatientContextService $patientContext,
+        private readonly MobilePersonaCatalog $personas,
     ) {}
 
     /** @return array<string, mixed> */
@@ -104,16 +126,112 @@ class FlowLensService
             return $policy;
         }
 
-        // unit policy: depth only inside a unit the user shares.
-        if ($scope['type'] !== 'unit' && $scope['type'] !== 'patient') {
-            return 'none';
-        }
-
         if ($scope['type'] === 'patient') {
             return 'unit'; // patientScope() already authorized the specific patient
         }
 
-        return $this->userSharesUnit($user, (int) $scope['unit_id']) ? 'unit' : 'none';
+        // Broad-access operators may assume any persona. In an empty/bootstrap
+        // facility there is no unit row to resolve, but the request must remain
+        // safely usable (it will contain no patient rows because the visible
+        // unit set is empty).
+        if ($this->personas->isBroadAccessUser($user)) {
+            return 'unit';
+        }
+
+        $visibleUnitIds = $this->visibleUnitIds($user);
+        if ($scope['type'] === 'unit' && ! in_array((int) $scope['unit_id'], $visibleUnitIds, true)) {
+            return 'none';
+        }
+
+        // At house/floor scope a unit-depth persona receives patient rows only
+        // for their assigned units. The row filter applies that intersection.
+        return $visibleUnitIds === [] ? 'none' : 'unit';
+    }
+
+    /** @return list<int> */
+    public function visibleUnitIds(?User $user): array
+    {
+        if (! $user || ! Schema::hasTable('prod.units')) {
+            return [];
+        }
+
+        $query = $this->personas->isBroadAccessUser($user)
+            ? Unit::query()->where('is_deleted', false)
+            : $user->units()->where('prod.units.is_deleted', false);
+
+        return $query
+            ->pluck('prod.units.unit_id')
+            ->map(fn ($id): int => (int) $id)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /** @return list<string> patient refs visible to an active task-depth role */
+    public function taskPatientRefs(string $roleId): array
+    {
+        $query = match ($roleId) {
+            'transport' => TransportRequest::query()->active(),
+            'evs' => EvsRequest::query()->active(),
+            default => null,
+        };
+
+        if ($query === null) {
+            return [];
+        }
+
+        return $query
+            ->whereNotNull('patient_ref')
+            ->pluck('patient_ref')
+            ->map(fn ($ref): string => (string) $ref)
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Whether a raw patient row is inside the requested spatial/patient scope.
+     *
+     * @param  array{type: string, floor: ?int, unit_id: ?int, patient_ref?: ?string}  $scope
+     */
+    public function rowInScope(array $row, array $scope): bool
+    {
+        return match ($scope['type']) {
+            'patient' => $this->patientRefForRow($row) !== null
+                && hash_equals((string) ($scope['patient_ref'] ?? ''), (string) $this->patientRefForRow($row)),
+            'unit' => isset($row['unit_id']) && (int) $row['unit_id'] === (int) $scope['unit_id'],
+            'floor' => $this->floorForRow($row) !== null
+                && $this->floorForRow($row) === (int) $scope['floor'],
+            default => true,
+        };
+    }
+
+    /**
+     * Whether a scoped row may carry patient context for the effective depth.
+     *
+     * @param  array{type: string, floor: ?int, unit_id: ?int, patient_ref?: ?string}  $scope
+     * @param  list<int>  $visibleUnitIds
+     * @param  list<string>  $taskRefs
+     */
+    public function canViewPatientRow(
+        array $row,
+        string $depth,
+        array $scope,
+        array $visibleUnitIds = [],
+        array $taskRefs = [],
+    ): bool {
+        $patientRef = $this->patientRefForRow($row);
+        if ($patientRef === null || ! $this->rowInScope($row, $scope)) {
+            return false;
+        }
+
+        return match ($depth) {
+            'full' => true,
+            'task' => in_array($patientRef, $taskRefs, true),
+            'unit' => $scope['type'] === 'patient'
+                || (isset($row['unit_id']) && in_array((int) $row['unit_id'], $visibleUnitIds, true)),
+            default => false,
+        };
     }
 
     /**
@@ -124,25 +242,62 @@ class FlowLensService
      *
      * @param  array{type: string, floor: ?int, unit_id: ?int}  $scope
      * @param  list<string>  $taskRefs  patient refs visible to a task-depth role
+     * @param  list<int>  $visibleUnitIds  unit ids visible to a unit-depth role
      * @return array<string, mixed>
      */
-    public function redactRow(array $row, string $depth, array $scope, array $taskRefs = []): array
-    {
-        $patientRef = $row['_patient_ref'] ?? null;
-        unset($row['_patient_ref']);
+    public function redactRow(
+        array $row,
+        string $depth,
+        array $scope,
+        array $taskRefs = [],
+        array $visibleUnitIds = [],
+    ): array {
+        $patientRef = $this->patientRefForRow($row);
+        $hadPatientId = array_key_exists('patient_id', $row);
+        $hadPatientDisplay = array_key_exists('patient_display_id', $row);
+        $encounterRef = isset($row['encounter_id']) && is_scalar($row['encounter_id'])
+            ? (string) $row['encounter_id']
+            : null;
+        $originalKey = isset($row['key']) && is_scalar($row['key']) ? (string) $row['key'] : null;
 
         $allowed = match (true) {
             $patientRef === null => false,
             $depth === 'none' => false,
             $depth === 'full' => true,
             $depth === 'task' => in_array($patientRef, $taskRefs, true),
-            // unit depth: the shared-unit check happened in
-            // effectivePatientDepth(); keep identity only inside the scoped unit.
-            default => ($row['unit_id'] ?? null) !== null
-                && (($scope['unit_id'] ?? null) === null || $row['unit_id'] === $scope['unit_id']),
+            $depth === 'unit' && $scope['type'] === 'patient' => true,
+            $depth === 'unit' => ($row['unit_id'] ?? null) !== null
+                && in_array((int) $row['unit_id'], $visibleUnitIds, true),
+            default => false,
         };
 
-        if (! $allowed) {
+        $row = $this->stripIdentifierKeys($row);
+
+        if ($patientRef !== null && $originalKey !== null) {
+            $row['key'] = $this->opaqueRef('flow-row', $patientRef, 'flow_')
+                .(($row['location'] ?? null) ? ':'.$row['location'] : '');
+        }
+
+        if ($allowed && $patientRef !== null) {
+            $patientContextRef = $this->patientContext->contextRefFor($patientRef);
+            $row['patient_context_ref'] = $patientContextRef;
+
+            if ($hadPatientId) {
+                $row['patient_id'] = $patientContextRef;
+            }
+
+            if ($hadPatientDisplay) {
+                $row['patient_display_id'] = 'Patient '.strtoupper(substr((string) $patientContextRef, -6));
+            }
+
+            if ($encounterRef !== null && $encounterRef !== '') {
+                $row['encounter_id'] = $this->opaqueRef('encounter', $encounterRef, 'etok_');
+            }
+
+            if (($row['entity']['type'] ?? null) === 'patient') {
+                $row['entity']['ref'] = $patientContextRef;
+            }
+        } else {
             $row['patient_context_ref'] = null;
             if (($row['entity']['type'] ?? null) === 'patient') {
                 $row['entity'] = null;
@@ -150,6 +305,15 @@ class FlowLensService
         }
 
         return $row;
+    }
+
+    public function opaqueRef(string $kind, string $value, string $prefix): string
+    {
+        return $prefix.substr(hash_hmac(
+            'sha256',
+            $kind.'|'.$value,
+            (string) config('app.key', 'zephyrus'),
+        ), 0, 24);
     }
 
     /**
@@ -209,6 +373,17 @@ class FlowLensService
         }
 
         if (! $unit) {
+            if ($user && $arg === null && $this->personas->isBroadAccessUser($user)) {
+                return [
+                    'type' => 'house',
+                    'floor' => null,
+                    'unit_id' => null,
+                    'patient_ref' => null,
+                    'patient_context_ref' => null,
+                    'label' => 'House',
+                ];
+            }
+
             throw new AuthorizationException('Unit scope requires a known unit (unit:{id} or unit:{abbr}), or an assigned unit for this user.');
         }
 
@@ -263,13 +438,43 @@ class FlowLensService
         return $user->units()->where('prod.units.is_deleted', false)->first();
     }
 
-    private function userSharesUnit(?User $user, int $unitId): bool
+    private function patientRefForRow(array $row): ?string
     {
-        if (! $user || ! Schema::hasTable('prod.user_unit')) {
-            return false;
+        foreach (['_patient_ref', 'patient_ref', 'patient_id'] as $key) {
+            $value = $row[$key] ?? null;
+            if (is_scalar($value) && trim((string) $value) !== '' && ! str_starts_with((string) $value, 'ptok_')) {
+                return (string) $value;
+            }
         }
 
-        return $user->units()->wherePivot('unit_id', $unitId)->exists();
+        return null;
+    }
+
+    private function floorForRow(array $row): ?int
+    {
+        foreach (['location_floor', 'floor'] as $key) {
+            if (isset($row[$key]) && is_numeric($row[$key])) {
+                return (int) $row[$key];
+            }
+        }
+
+        return null;
+    }
+
+    /** @param array<array-key, mixed> $value */
+    private function stripIdentifierKeys(array $value): array
+    {
+        $redacted = [];
+
+        foreach ($value as $key => $item) {
+            if (is_string($key) && in_array(strtolower($key), self::IDENTIFIER_KEYS, true)) {
+                continue;
+            }
+
+            $redacted[$key] = is_array($item) ? $this->stripIdentifierKeys($item) : $item;
+        }
+
+        return $redacted;
     }
 
     private function floorForUnit(Unit $unit): ?int

--- a/app/Services/Mobile/MobilePatientContextService.php
+++ b/app/Services/Mobile/MobilePatientContextService.php
@@ -171,14 +171,14 @@ class MobilePatientContextService
         if ($roleId === 'transport') {
             return TransportRequest::query()
                 ->where('patient_ref', $patientRef)
-                ->where('is_deleted', false)
+                ->active()
                 ->exists();
         }
 
         if ($roleId === 'evs') {
             return EvsRequest::query()
                 ->where('patient_ref', $patientRef)
-                ->where('is_deleted', false)
+                ->active()
                 ->exists();
         }
 

--- a/app/Services/PatientFlow/FhirBundleFactory.php
+++ b/app/Services/PatientFlow/FhirBundleFactory.php
@@ -2,18 +2,17 @@
 
 namespace App\Services\PatientFlow;
 
-use App\Models\PatientFlow\FlowEvent;
-
 class FhirBundleFactory
 {
-    public function __construct(private readonly FlowEventRepository $events) {}
-
     /**
+     * Build only from a payload that has already crossed its authorization and
+     * redaction boundary. Patient Flow web callers must use this method.
+     *
+     * @param  array<string, mixed>  $payload
      * @return array<string, mixed>
      */
-    public function make(FlowEvent $event): array
+    public function makeFromPayload(array $payload): array
     {
-        $payload = $this->events->serializeEvent($event);
         $locationId = $payload['to_location'] ?: 'unknown';
 
         $encounter = [

--- a/app/Services/PatientFlow/FlowEventRepository.php
+++ b/app/Services/PatientFlow/FlowEventRepository.php
@@ -2,15 +2,23 @@
 
 namespace App\Services\PatientFlow;
 
+use App\Models\Bed;
 use App\Models\PatientFlow\FlowEncounter;
 use App\Models\PatientFlow\FlowEvent;
 use App\Models\PatientFlow\PatientIdentity;
+use App\Models\Unit;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 class FlowEventRepository
 {
+    /** @var array<string, int>|null */
+    private ?array $unitIdsByCode = null;
+
+    /** @var array<int, int>|null */
+    private ?array $unitIdsBySpace = null;
+
     public function __construct(private readonly FacilitySpaceLocationResolver $locations) {}
 
     /**
@@ -145,6 +153,7 @@ class FlowEventRepository
     public function serializeEvent(FlowEvent $event): array
     {
         $location = $this->locations->spaceToPayload($event->toFacilitySpace);
+        $unitId = $this->unitIdForEvent($event, $location);
 
         return [
             'event_id' => $event->flow_event_id,
@@ -184,7 +193,49 @@ class FlowEventRepository
             'position_ft' => $location['position_ft'] ?? null,
             'position_m' => $location['position_m'] ?? null,
             'unit_code' => $location['unit_code'] ?? null,
+            'unit_id' => $unitId,
         ];
+    }
+
+    /** @param array<string, mixed>|null $location */
+    private function unitIdForEvent(FlowEvent $event, ?array $location): ?int
+    {
+        $this->loadUnitMaps();
+
+        $unitCode = isset($location['unit_code']) && is_scalar($location['unit_code'])
+            ? strtoupper(trim((string) $location['unit_code']))
+            : null;
+        if ($unitCode && isset($this->unitIdsByCode[$unitCode])) {
+            return $this->unitIdsByCode[$unitCode];
+        }
+
+        $spaceId = $event->to_facility_space_id !== null ? (int) $event->to_facility_space_id : null;
+
+        return $spaceId !== null ? ($this->unitIdsBySpace[$spaceId] ?? null) : null;
+    }
+
+    private function loadUnitMaps(): void
+    {
+        if ($this->unitIdsByCode !== null && $this->unitIdsBySpace !== null) {
+            return;
+        }
+
+        $this->unitIdsByCode = [];
+        $this->unitIdsBySpace = [];
+
+        foreach (Unit::query()->where('is_deleted', false)->get(['unit_id', 'abbreviation', 'facility_space_id']) as $unit) {
+            if ($unit->abbreviation) {
+                $this->unitIdsByCode[strtoupper(trim((string) $unit->abbreviation))] = (int) $unit->unit_id;
+            }
+
+            if ($unit->facility_space_id !== null) {
+                $this->unitIdsBySpace[(int) $unit->facility_space_id] = (int) $unit->unit_id;
+            }
+        }
+
+        foreach (Bed::query()->where('is_deleted', false)->whereNotNull('facility_space_id')->get(['facility_space_id', 'unit_id']) as $bed) {
+            $this->unitIdsBySpace[(int) $bed->facility_space_id] = (int) $bed->unit_id;
+        }
     }
 
     /**

--- a/app/Services/PatientFlow/OccupancyInsightProjector.php
+++ b/app/Services/PatientFlow/OccupancyInsightProjector.php
@@ -94,6 +94,11 @@ class OccupancyInsightProjector
 
             $item = [
                 'key' => $patientRef.':'.$locationCode,
+                // Internal authorization bridge. PatientFlowOccupancyContextService
+                // always passes the projected row through FlowLensService before
+                // it leaves the process.
+                '_patient_ref' => $event['patient_id'] ?? null,
+                'unit_id' => $event['unit_id'] ?? null,
                 'location' => $locationCode,
                 'location_name' => $event['location_name'] ?? $loc['name'] ?? null,
                 'unit_code' => $event['unit_code'] ?? $loc['unit_code'] ?? null,

--- a/app/Services/PatientFlow/PatientFlowEventAccessService.php
+++ b/app/Services/PatientFlow/PatientFlowEventAccessService.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Services\PatientFlow;
+
+use App\Models\PatientFlow\FlowEvent;
+use App\Services\Flow\FlowLensService;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+
+/**
+ * One authorization/redaction path for web Patient Flow event surfaces.
+ *
+ * Raw flow identifiers are used only long enough to enforce the resolved
+ * scope/depth. Every surviving row is then passed through FlowLensService,
+ * which emits opaque patient/encounter context refs.
+ */
+class PatientFlowEventAccessService
+{
+    public function __construct(
+        private readonly FlowEventRepository $events,
+        private readonly FlowLensService $lens,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $filters
+     * @return list<array<string, mixed>>
+     */
+    public function rows(Request $request, array $filters = []): array
+    {
+        $patientContextRef = $this->patientFilter($request);
+        unset($filters['patient']);
+
+        $context = $this->context($request);
+        $rows = $this->events->serializeEvents($this->events->filteredEvents($filters));
+        $authorized = [];
+
+        foreach ($rows as $row) {
+            if (! $this->eventKindAllowed($row, $context['lens'])
+                || ! $this->lens->canViewPatientRow(
+                    $row,
+                    $context['depth'],
+                    $context['scope'],
+                    $context['visible_unit_ids'],
+                    $context['task_refs'],
+                )) {
+                continue;
+            }
+
+            $redacted = $this->lens->redactRow(
+                $row,
+                $context['depth'],
+                $context['scope'],
+                $context['task_refs'],
+                $context['visible_unit_ids'],
+            );
+
+            if ($patientContextRef !== null && ($redacted['patient_context_ref'] ?? null) !== $patientContextRef) {
+                continue;
+            }
+
+            $authorized[] = $redacted;
+        }
+
+        return $authorized;
+    }
+
+    /** @return array<string, mixed>|null */
+    public function event(Request $request, FlowEvent $event): ?array
+    {
+        $context = $this->context($request);
+        $row = $this->events->serializeEvent($event);
+
+        if (! $this->eventKindAllowed($row, $context['lens'])
+            || ! $this->lens->canViewPatientRow(
+                $row,
+                $context['depth'],
+                $context['scope'],
+                $context['visible_unit_ids'],
+                $context['task_refs'],
+            )) {
+            return null;
+        }
+
+        return $this->lens->redactRow(
+            $row,
+            $context['depth'],
+            $context['scope'],
+            $context['task_refs'],
+            $context['visible_unit_ids'],
+        );
+    }
+
+    /**
+     * @return array{
+     *   lens: array<string, mixed>,
+     *   scope: array<string, mixed>,
+     *   depth: string,
+     *   task_refs: list<string>,
+     *   visible_unit_ids: list<int>
+     * }
+     */
+    public function context(Request $request): array
+    {
+        $lens = $request->attributes->get('flow_lens');
+        $scope = $request->attributes->get('flow_scope');
+        $depth = $request->attributes->get('flow_patient_depth');
+
+        if (! is_array($lens) || ! is_array($scope) || ! is_string($depth)) {
+            throw new \LogicException('Patient Flow scope was not resolved before controller execution.');
+        }
+
+        return [
+            'lens' => $lens,
+            'scope' => $scope,
+            'depth' => $depth,
+            'task_refs' => array_values(array_filter(
+                (array) $request->attributes->get('flow_task_patient_refs', []),
+                'is_string',
+            )),
+            'visible_unit_ids' => array_values(array_map(
+                'intval',
+                (array) $request->attributes->get('flow_visible_unit_ids', []),
+            )),
+        ];
+    }
+
+    /** @param array<string, mixed> $row */
+    private function eventKindAllowed(array $row, array $lens): bool
+    {
+        $allowed = is_array($lens['event_kinds'] ?? null) ? $lens['event_kinds'] : [];
+
+        return $allowed === [] || in_array((string) ($row['event_type'] ?? ''), $allowed, true);
+    }
+
+    private function patientFilter(Request $request): ?string
+    {
+        $value = $request->query('patient');
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (! is_string($value) || ! preg_match('/^ptok_[A-Za-z0-9]{24}$/', $value)) {
+            throw new InvalidArgumentException('patient must be an opaque ptok_ context ref.');
+        }
+
+        return $value;
+    }
+}

--- a/app/Services/PatientFlow/PatientFlowHl7IngestPipeline.php
+++ b/app/Services/PatientFlow/PatientFlowHl7IngestPipeline.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace App\Services\PatientFlow;
+
+use App\Exceptions\PatientFlowIngestException;
+use App\Integrations\Healthcare\DTO\CanonicalOperationalEvent;
+use App\Integrations\Healthcare\Services\CanonicalEventWriter;
+use App\Models\Integration\CanonicalEventRecord;
+use App\Models\Integration\ProvenanceRecord;
+use App\Models\Integration\Source;
+use App\Models\Raw\DeadLetter;
+use App\Models\Raw\InboundMessage;
+use App\Models\Raw\IngestRun;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Throwable;
+
+/** Raw -> canonical -> Patient Flow projection pipeline for machine-delivered ADT. */
+class PatientFlowHl7IngestPipeline
+{
+    private const CONNECTOR_KEY = 'patient-flow.hl7v2.adt';
+
+    public function __construct(
+        private readonly FlowEventNormalizer $normalizer,
+        private readonly FlowEventRepository $events,
+        private readonly CanonicalEventWriter $canonicalEvents,
+    ) {}
+
+    /**
+     * @return array{accepted: true, duplicate: bool, status: string, run_id: string, message_id: string, canonical_event_id: string}
+     */
+    public function ingest(
+        string $sourceKey,
+        string $rawHl7,
+        ?string $requestedIdempotencyKey = null,
+        array $requestMetadata = [],
+    ): array {
+        $source = $this->authorizedSource($sourceKey);
+        $payloadHash = hash('sha256', $rawHl7);
+        $idempotencyKey = $this->idempotencyKey($requestedIdempotencyKey, $payloadHash);
+        $run = $this->startRun($source, $requestMetadata);
+        $message = null;
+        $messageCreated = false;
+
+        try {
+            $message = InboundMessage::firstOrCreate(
+                [
+                    'source_id' => $source->source_id,
+                    'idempotency_key' => $idempotencyKey,
+                ],
+                [
+                    'message_uuid' => (string) Str::uuid(),
+                    'ingest_run_id' => $run->ingest_run_id,
+                    'message_type' => 'HL7V2_ADT',
+                    'external_id' => null,
+                    'payload_hash' => $payloadHash,
+                    'payload' => ['raw_hl7' => $rawHl7],
+                    'received_at' => now(),
+                    'parse_status' => 'received',
+                    'metadata' => ['connector_key' => self::CONNECTOR_KEY],
+                ],
+            );
+            $messageCreated = $message->wasRecentlyCreated;
+
+            if (! hash_equals((string) $message->payload_hash, $payloadHash)) {
+                throw new PatientFlowIngestException(
+                    'idempotency_key_conflict',
+                    'The idempotency key was already used with a different payload.',
+                    409,
+                );
+            }
+
+            $existingCanonical = CanonicalEventRecord::query()
+                ->where('inbound_message_id', $message->inbound_message_id)
+                ->first();
+            if (! $messageCreated && $existingCanonical?->projection_status === 'projected') {
+                $this->completeRun($run, skipped: true);
+
+                return $this->receipt($run, $message, $existingCanonical, true);
+            }
+
+            $parsed = Hl7V2Message::parse($rawHl7);
+            if ($parsed->messageType() !== 'ADT') {
+                throw new PatientFlowIngestException(
+                    'unsupported_hl7_message',
+                    'This ingress accepts HL7 v2 ADT messages only.',
+                    422,
+                );
+            }
+
+            $required = [
+                'MSH-10 message control id' => $parsed->field('MSH', 10),
+                'MSH-9 trigger event' => $parsed->triggerEvent(),
+                'PID-3 patient identifier' => $parsed->field('PID', 3, 1),
+                'PV1-19 visit identifier' => $parsed->field('PV1', 19, 1),
+            ];
+            $missing = array_keys(array_filter($required, fn (?string $value): bool => trim((string) $value) === ''));
+            if ($missing !== []) {
+                throw new PatientFlowIngestException(
+                    'invalid_hl7_adt',
+                    'The ADT message is missing required flow fields: '.implode(', ', $missing).'.',
+                    422,
+                );
+            }
+
+            $normalized = $this->normalizer->normalize($rawHl7, 'hl7v2');
+
+            $message->update([
+                'message_type' => 'ADT^'.($normalized['trigger_event'] ?? 'UNKNOWN'),
+                'external_id' => $normalized['message_control_id'] ?? null,
+                'normalized_payload' => $normalized,
+                'parse_status' => 'normalized',
+            ]);
+
+            [$record] = DB::transaction(function () use ($source, $run, $message, $normalized, $idempotencyKey): array {
+                $canonical = new CanonicalOperationalEvent(
+                    eventId: (string) Str::uuid(),
+                    eventType: 'patient_flow.adt.'.(string) $normalized['event_type'],
+                    entityType: 'patient',
+                    entityRef: (string) $normalized['patient_id'],
+                    payload: $normalized,
+                    occurredAt: CarbonImmutable::parse((string) $normalized['occurred_at']),
+                    idempotencyKey: self::CONNECTOR_KEY.':'.$source->source_id.':'.$idempotencyKey,
+                    correlationId: isset($normalized['message_control_id']) ? (string) $normalized['message_control_id'] : null,
+                    sequenceKey: isset($normalized['encounter_id']) ? (string) $normalized['encounter_id'] : null,
+                    metadata: [
+                        'connector_key' => self::CONNECTOR_KEY,
+                        'source_protocol' => 'hl7v2',
+                    ],
+                );
+
+                $record = $this->canonicalEvents->write($canonical, $source, $run, $message);
+                $flowEvent = $this->events->upsertNormalizedEvent(
+                    $normalized,
+                    (int) $source->source_id,
+                    (int) $message->inbound_message_id,
+                    (int) $record->canonical_event_id,
+                    (string) config('facility_models.zep_500.facility_code', 'ZEPHYRUS-500'),
+                );
+
+                ProvenanceRecord::firstOrCreate(
+                    [
+                        'source_id' => $source->source_id,
+                        'inbound_message_id' => $message->inbound_message_id,
+                        'canonical_event_id' => $record->canonical_event_id,
+                        'target_schema' => 'flow_core',
+                        'target_table' => 'flow_events',
+                        'target_pk' => $flowEvent->flow_event_id,
+                    ],
+                    [
+                        'lineage' => [
+                            'raw_message' => "raw.inbound_messages:{$message->inbound_message_id}",
+                            'canonical_event' => "integration.canonical_events:{$record->canonical_event_id}",
+                            'projection' => "flow_core.flow_events:{$flowEvent->flow_event_id}",
+                        ],
+                    ],
+                );
+
+                $record->update([
+                    'projection_status' => 'projected',
+                    'projected_at' => now(),
+                ]);
+                $message->update(['parse_status' => 'projected']);
+
+                return [$record->fresh(), $flowEvent];
+            });
+
+            $this->completeRun($run);
+
+            return $this->receipt($run, $message, $record, ! $messageCreated);
+        } catch (PatientFlowIngestException $exception) {
+            $this->fail($run, $message, $messageCreated, $exception);
+
+            throw $exception;
+        } catch (Throwable $exception) {
+            $this->fail($run, $message, $messageCreated, $exception);
+
+            throw new PatientFlowIngestException(
+                'hl7_ingest_failed',
+                'The HL7 message could not be accepted into the canonical pipeline.',
+                422,
+            );
+        }
+    }
+
+    private function authorizedSource(string $sourceKey): Source
+    {
+        if (! preg_match('/^[a-z0-9][a-z0-9._-]{0,159}$/', $sourceKey)) {
+            throw new PatientFlowIngestException('integration_source_forbidden', 'The integration source is not authorized.', 403);
+        }
+
+        $source = Source::query()->where('source_key', $sourceKey)->first();
+        $valid = $source
+            && $source->interface_type === 'hl7v2'
+            && $source->active_status === 'active'
+            && $source->phi_allowed;
+
+        if ($valid && app()->environment('production')) {
+            $valid = $source->environment === 'production' && $source->go_live_status === 'live';
+        }
+
+        if (! $valid) {
+            throw new PatientFlowIngestException('integration_source_forbidden', 'The integration source is not authorized.', 403);
+        }
+
+        return $source;
+    }
+
+    private function idempotencyKey(?string $requested, string $payloadHash): string
+    {
+        $requested = trim((string) $requested);
+        if ($requested === '') {
+            return 'sha256:'.$payloadHash;
+        }
+
+        if (strlen($requested) > 190 || ! preg_match('/^[A-Za-z0-9._:-]+$/', $requested)) {
+            throw new PatientFlowIngestException(
+                'invalid_idempotency_key',
+                'Idempotency-Key must be 1-190 URL-safe characters.',
+                422,
+            );
+        }
+
+        return $requested;
+    }
+
+    private function startRun(Source $source, array $metadata): IngestRun
+    {
+        return IngestRun::create([
+            'run_uuid' => (string) Str::uuid(),
+            'source_id' => $source->source_id,
+            'connector_key' => self::CONNECTOR_KEY,
+            'run_type' => 'machine_ingress',
+            'status' => 'running',
+            'started_at' => now(),
+            'metadata' => $metadata,
+        ]);
+    }
+
+    private function completeRun(IngestRun $run, bool $skipped = false): void
+    {
+        $run->update([
+            'status' => 'completed',
+            'completed_at' => now(),
+            'messages_received' => 1,
+            'messages_succeeded' => $skipped ? 0 : 1,
+            'messages_failed' => 0,
+            'messages_skipped' => $skipped ? 1 : 0,
+        ]);
+    }
+
+    private function fail(IngestRun $run, ?InboundMessage $message, bool $messageCreated, Throwable $exception): void
+    {
+        if ($message && $messageCreated) {
+            $message->update(['parse_status' => 'failed']);
+        }
+
+        $run->update([
+            'status' => 'failed',
+            'completed_at' => now(),
+            'messages_received' => $message ? 1 : 0,
+            'messages_succeeded' => 0,
+            'messages_failed' => 1,
+            'error_summary' => $exception instanceof PatientFlowIngestException
+                ? $exception->errorCode
+                : 'pipeline_exception',
+        ]);
+
+        DeadLetter::create([
+            'dead_letter_uuid' => (string) Str::uuid(),
+            'source_id' => $run->source_id,
+            'ingest_run_id' => $run->ingest_run_id,
+            'inbound_message_id' => $message?->inbound_message_id,
+            'failure_stage' => 'patient_flow_ingress',
+            'reason_code' => $exception instanceof PatientFlowIngestException
+                ? $exception->errorCode
+                : 'pipeline_exception',
+            'message' => $exception instanceof PatientFlowIngestException
+                ? $exception->getMessage()
+                : 'Patient Flow canonical ingestion failed.',
+            'exception_class' => $exception::class,
+            'context' => ['connector_key' => self::CONNECTOR_KEY],
+            'status' => 'open',
+            'metadata' => [],
+        ]);
+    }
+
+    /**
+     * @return array{accepted: true, duplicate: bool, status: string, run_id: string, message_id: string, canonical_event_id: string}
+     */
+    private function receipt(
+        IngestRun $run,
+        InboundMessage $message,
+        CanonicalEventRecord $record,
+        bool $duplicate,
+    ): array {
+        $receiptRun = $duplicate
+            ? (IngestRun::query()->find($message->ingest_run_id) ?? $run)
+            : $run;
+
+        return [
+            'accepted' => true,
+            'duplicate' => $duplicate,
+            'status' => 'projected',
+            'run_id' => (string) $receiptRun->run_uuid,
+            'message_id' => (string) $message->message_uuid,
+            'canonical_event_id' => (string) $record->event_id,
+        ];
+    }
+}

--- a/app/Services/PatientFlow/PatientFlowOccupancyContextService.php
+++ b/app/Services/PatientFlow/PatientFlowOccupancyContextService.php
@@ -31,18 +31,21 @@ class PatientFlowOccupancyContextService
         CarbonImmutable $time,
         array $filters = [],
         bool $includeEddyContext = false,
+        ?array $scope = null,
+        ?string $depth = null,
+        array $taskRefs = [],
+        array $visibleUnitIds = [],
     ): array {
         $filters = $this->normalizedFilters($filters, $time);
         $events = $this->events->serializeEvents($this->events->filteredEvents($filters));
         $locations = $this->locations->allNavigatorLocations($this->facilityCode());
 
-        $scope = ['type' => 'house', 'floor' => null, 'unit_id' => null, 'patient_ref' => null];
+        $scope ??= ['type' => 'house', 'floor' => null, 'unit_id' => null, 'patient_ref' => null, 'patient_context_ref' => null, 'label' => 'House'];
+        $depth ??= ($lens['patient_dots'] ?? null) === 'full' ? 'full' : 'none';
+        $effectiveLens = $lens;
+        $effectiveLens['patient_dots'] = $depth;
         $rawProjections = $this->projections->projections($time, $time->addHours(24), $scope, $lens['projection_kinds']);
-        $depth = ($lens['patient_dots'] ?? null) === 'full' ? 'full' : 'none';
-        $projections = array_map(
-            fn (array $item): array => $this->flowLens->redactRow($item, $depth, $scope),
-            $rawProjections,
-        );
+        $projections = $rawProjections;
 
         $demoScenario = null;
         $demoEnabled = $this->demoBarriersEnabled($filters);
@@ -65,6 +68,11 @@ class PatientFlowOccupancyContextService
                 'replaces_stale_replay' => $staleReplay,
             ];
         }
+
+        $events = array_values(array_filter(
+            $events,
+            fn (array $event): bool => $this->flowLens->rowInScope($event, $scope),
+        ));
 
         $operational = $demoEnabled
             ? [
@@ -93,15 +101,33 @@ class PatientFlowOccupancyContextService
             locations: $locations,
             projections: $projections,
             asOf: $time->toIso8601String(),
-            lens: $lens,
+            lens: $effectiveLens,
             operationalBarriers: $operational['records'],
+        );
+
+        $payload['occupancy'] = array_map(
+            fn (array $item): array => $this->flowLens->redactRow(
+                $item,
+                $depth,
+                $scope,
+                $taskRefs,
+                $visibleUnitIds,
+            ),
+            $payload['occupancy'],
         );
 
         $response = $payload + [
             'lens' => [
                 'role_id' => $roleId,
-                'patient_dots' => $lens['patient_dots'],
+                'patient_dots' => $depth,
                 'projection_kinds' => $lens['projection_kinds'],
+            ],
+            'scope' => [
+                'type' => $scope['type'],
+                'floor' => $scope['floor'],
+                'unit_id' => $scope['unit_id'],
+                'patient_context_ref' => $scope['patient_context_ref'] ?? null,
+                'label' => $scope['label'] ?? ucfirst((string) $scope['type']),
             ],
             'operational_barrier_sources' => $operational['sources'],
             'projection_window' => [
@@ -115,12 +141,12 @@ class PatientFlowOccupancyContextService
         if ($includeEddyContext) {
             $response['eddy_context'] = $this->eddyContext->build(
                 $payload,
-                $lens,
+                $effectiveLens,
                 $roleId,
                 $time,
                 $filters,
                 $demoScenario,
-                $this->contextScope($filters),
+                $this->contextScope($filters, $scope),
             );
         }
 
@@ -187,15 +213,21 @@ class PatientFlowOccupancyContextService
     }
 
     /** @param array<string, mixed> $filters */
-    private function contextScope(array $filters): array
+    private function contextScope(array $filters, array $resolvedScope): array
     {
         $scope = [
-            'type' => 'house',
-            'label' => 'House',
+            'type' => $resolvedScope['type'],
+            'label' => $resolvedScope['label'] ?? ucfirst((string) $resolvedScope['type']),
             'filters' => $this->contextFilters($filters),
         ];
 
-        if (isset($filters['floor']) && $filters['floor'] !== '' && $filters['floor'] !== 'all') {
+        foreach (['floor', 'unit_id', 'patient_context_ref'] as $key) {
+            if (($resolvedScope[$key] ?? null) !== null) {
+                $scope[$key] = $resolvedScope[$key];
+            }
+        }
+
+        if ($resolvedScope['type'] === 'house' && isset($filters['floor']) && $filters['floor'] !== '' && $filters['floor'] !== 'all') {
             $floor = (int) $filters['floor'];
             $scope['type'] = 'floor';
             $scope['floor'] = $floor;

--- a/app/Services/PatientFlow/PatientFlowOccupancyHistoryService.php
+++ b/app/Services/PatientFlow/PatientFlowOccupancyHistoryService.php
@@ -2,33 +2,20 @@
 
 namespace App\Services\PatientFlow;
 
-use App\Models\Evs\EvsRequest;
+use App\Models\Bed;
 use App\Models\PatientFlow\OccupancySnapshot;
-use App\Models\Transport\TransportRequest;
+use App\Models\Unit;
 use App\Models\User;
-use App\Services\Mobile\MobilePatientContextService;
+use App\Services\Flow\FlowLensService;
 use Carbon\CarbonImmutable;
 use InvalidArgumentException;
 use Throwable;
 
 class PatientFlowOccupancyHistoryService
 {
-    private const DETAIL_IDENTIFIER_KEYS = [
-        'patient_ref',
-        '_patient_ref',
-        'patient_id',
-        'patient_display_id',
-        'patient_name',
-        'encounter_id',
-        'encounter_ref',
-        'downstream_patient_refs',
-        'mrn',
-        'medical_record_number',
-    ];
-
     public function __construct(
         private readonly PatientFlowScenarioRegistry $scenarios,
-        private readonly MobilePatientContextService $patients,
+        private readonly FlowLensService $flowLens,
     ) {}
 
     /**
@@ -36,8 +23,16 @@ class PatientFlowOccupancyHistoryService
      * @param  array<string, mixed>  $filters
      * @return array<string, mixed>
      */
-    public function history(array $lens, string $roleId, array $filters, ?User $user = null): array
-    {
+    public function history(
+        array $lens,
+        string $roleId,
+        array $filters,
+        ?User $user = null,
+        ?array $scope = null,
+        ?string $effectiveDepth = null,
+        array $taskPatientRefs = [],
+        array $visibleUnitIds = [],
+    ): array {
         $to = $this->time('to', $filters['to'] ?? $filters['asOf'] ?? null, CarbonImmutable::now());
         $from = $this->time('from', $filters['from'] ?? null, $to->subHours(24));
         if ($from->greaterThan($to)) {
@@ -46,9 +41,14 @@ class PatientFlowOccupancyHistoryService
 
         $limit = max(1, min(500, (int) ($filters['limit'] ?? 120)));
         $scenario = $this->scenarioKey($filters);
-        $depth = (string) ($lens['patient_dots'] ?? 'none');
-        $unitIds = $depth === 'unit' ? $this->visibleUnitIds($user) : [];
-        $taskPatientRefs = $depth === 'task' ? $this->taskPatientRefs($roleId) : [];
+        $scope ??= ['type' => 'house', 'floor' => null, 'unit_id' => null, 'patient_ref' => null, 'patient_context_ref' => null, 'label' => 'House'];
+        $depth = $effectiveDepth ?? (string) ($lens['patient_dots'] ?? 'none');
+        $unitIds = $depth === 'unit'
+            ? ($visibleUnitIds ?: $this->flowLens->visibleUnitIds($user))
+            : [];
+        $taskPatientRefs = $depth === 'task'
+            ? ($taskPatientRefs ?: $this->flowLens->taskPatientRefs($roleId))
+            : [];
 
         $query = OccupancySnapshot::query()
             ->with('facilitySpace')
@@ -57,8 +57,20 @@ class PatientFlowOccupancyHistoryService
             ->orderBy('facility_space_id')
             ->limit($limit);
 
-        if (($filters['floor'] ?? null) !== null && $filters['floor'] !== '' && $filters['floor'] !== 'all') {
-            $query->whereHas('facilitySpace', fn ($space) => $space->where('floor_number', (int) $filters['floor']));
+        $floor = $scope['type'] === 'floor'
+            ? $scope['floor']
+            : (($filters['floor'] ?? null) !== null && $filters['floor'] !== '' && $filters['floor'] !== 'all'
+                ? (int) $filters['floor']
+                : null);
+        if ($floor !== null) {
+            $query->whereHas('facilitySpace', fn ($space) => $space->where('floor_number', (int) $floor));
+        }
+
+        if ($scope['type'] === 'unit') {
+            $spaceIds = $this->spaceIdsForUnit((int) $scope['unit_id']);
+            $spaceIds === []
+                ? $query->whereRaw('1 = 0')
+                : $query->whereIn('facility_space_id', $spaceIds);
         }
 
         if (($filters['service_line'] ?? null) !== null && $filters['service_line'] !== '' && $filters['service_line'] !== 'all') {
@@ -66,9 +78,19 @@ class PatientFlowOccupancyHistoryService
             $query->whereHas('facilitySpace', fn ($space) => $space->where('service_line_code', $serviceLine));
         }
 
-        $snapshots = $query->get()->map(function (OccupancySnapshot $snapshot) use ($depth, $scenario, $taskPatientRefs, $unitIds): array {
+        $snapshots = $query->get()->map(function (OccupancySnapshot $snapshot) use ($depth, $scenario, $scope, $taskPatientRefs, $unitIds): array {
             $space = $snapshot->facilitySpace;
             $details = is_array($snapshot->occupancy_details) ? $snapshot->occupancy_details : [];
+
+            $details = array_map(function (mixed $detail) use ($space): mixed {
+                if (! is_array($detail)) {
+                    return $detail;
+                }
+
+                $detail['location_floor'] ??= $space?->floor_number;
+
+                return $detail;
+            }, $details);
 
             return [
                 'snapshot_at' => $snapshot->snapshot_at?->toIso8601String(),
@@ -83,7 +105,7 @@ class PatientFlowOccupancyHistoryService
                 'active_patient_count' => (int) $snapshot->active_patient_count,
                 'service_line_counts' => $snapshot->service_line_counts ?: [],
                 'acuity_counts' => $snapshot->acuity_counts ?: [],
-                'occupancy_details' => $this->detailsForDepth($details, $depth, $unitIds, $taskPatientRefs),
+                'occupancy_details' => $this->detailsForDepth($details, $depth, $scope, $unitIds, $taskPatientRefs),
                 'timer_status_counts' => $snapshot->timer_status_counts ?: [],
                 'service_line_timer_counts' => $snapshot->service_line_timer_counts ?: [],
                 'persona_timer_counts' => $snapshot->persona_timer_counts ?: [],
@@ -108,6 +130,13 @@ class PatientFlowOccupancyHistoryService
                 'role_id' => $roleId,
                 'patient_dots' => $depth,
                 'projection_kinds' => $lens['projection_kinds'] ?? [],
+            ],
+            'scope' => [
+                'type' => $scope['type'],
+                'floor' => $scope['floor'],
+                'unit_id' => $scope['unit_id'],
+                'patient_context_ref' => $scope['patient_context_ref'] ?? null,
+                'label' => $scope['label'] ?? ucfirst((string) $scope['type']),
             ],
             'scenario' => $scenario,
             'history' => $snapshots,
@@ -139,58 +168,35 @@ class PatientFlowOccupancyHistoryService
 
     /**
      * @param  array<int, mixed>  $details
+     * @param  array<string, mixed>  $scope
      * @param  list<int>  $unitIds
      * @param  list<string>  $taskPatientRefs
      * @return list<array<string, mixed>>
      */
-    private function detailsForDepth(array $details, string $depth, array $unitIds, array $taskPatientRefs): array
+    private function detailsForDepth(array $details, string $depth, array $scope, array $unitIds, array $taskPatientRefs): array
     {
-        if ($depth === 'full') {
-            return $this->redactDetails(array_values(array_filter($details, 'is_array')));
+        $redacted = [];
+        foreach ($details as $detail) {
+            if (! is_array($detail)) {
+                continue;
+            }
+
+            $patientRef = $this->patientRefForDetail($detail);
+            if ($patientRef === null) {
+                continue;
+            }
+
+            $detail['_patient_ref'] = $patientRef;
+            unset($detail['patient_ref'], $detail['patient_id'], $detail['patient_display_id'], $detail['encounter_id']);
+
+            if (! $this->flowLens->canViewPatientRow($detail, $depth, $scope, $unitIds, $taskPatientRefs)) {
+                continue;
+            }
+
+            $redacted[] = $this->flowLens->redactRow($detail, $depth, $scope, $taskPatientRefs, $unitIds);
         }
 
-        if ($depth === 'unit') {
-            return $this->redactDetails(array_values(array_filter(
-                $details,
-                fn (mixed $detail): bool => is_array($detail)
-                    && isset($detail['unit_id'])
-                    && in_array((int) $detail['unit_id'], $unitIds, true),
-            )));
-        }
-
-        if ($depth === 'task') {
-            return $this->redactDetails(array_values(array_filter(
-                $details,
-                fn (mixed $detail): bool => is_array($detail)
-                    && isset($detail['patient_ref'])
-                    && in_array((string) $detail['patient_ref'], $taskPatientRefs, true),
-            )));
-        }
-
-        return [];
-    }
-
-    /**
-     * @param  list<array<string, mixed>>  $details
-     * @return list<array<string, mixed>>
-     */
-    private function redactDetails(array $details): array
-    {
-        return array_map(fn (array $detail): array => $this->redactDetail($detail), $details);
-    }
-
-    /** @param array<string, mixed> $detail */
-    private function redactDetail(array $detail): array
-    {
-        $patientRef = $this->patientRefForDetail($detail);
-
-        $detail = $this->stripIdentifierKeys($detail);
-
-        if ($patientRef !== null) {
-            $detail['patient_context_ref'] = $this->patients->contextRefFor($patientRef);
-        }
-
-        return $detail;
+        return $redacted;
     }
 
     /** @param array<string, mixed> $detail */
@@ -204,22 +210,6 @@ class PatientFlowOccupancyHistoryService
         }
 
         return null;
-    }
-
-    /** @param array<array-key, mixed> $value */
-    private function stripIdentifierKeys(array $value): array
-    {
-        $redacted = [];
-
-        foreach ($value as $key => $item) {
-            if (is_string($key) && in_array($key, self::DETAIL_IDENTIFIER_KEYS, true)) {
-                continue;
-            }
-
-            $redacted[$key] = is_array($item) ? $this->stripIdentifierKeys($item) : $item;
-        }
-
-        return $redacted;
     }
 
     /** @param array<string, mixed> $filters */
@@ -236,42 +226,22 @@ class PatientFlowOccupancyHistoryService
     }
 
     /** @return list<int> */
-    private function visibleUnitIds(?User $user): array
+    private function spaceIdsForUnit(int $unitId): array
     {
-        if (! $user) {
-            return [];
+        $spaceIds = Bed::query()
+            ->where('is_deleted', false)
+            ->where('unit_id', $unitId)
+            ->whereNotNull('facility_space_id')
+            ->pluck('facility_space_id');
+
+        $unitSpaceId = Unit::query()
+            ->where('is_deleted', false)
+            ->whereKey($unitId)
+            ->value('facility_space_id');
+        if ($unitSpaceId !== null) {
+            $spaceIds->push($unitSpaceId);
         }
 
-        return $user->units()
-            ->pluck('prod.units.unit_id')
-            ->map(fn ($id): int => (int) $id)
-            ->values()
-            ->all();
-    }
-
-    /** @return list<string> */
-    private function taskPatientRefs(string $roleId): array
-    {
-        $query = match ($roleId) {
-            'transport' => TransportRequest::query()
-                ->where('is_deleted', false)
-                ->whereNotIn('status', ['completed', 'cancelled', 'canceled']),
-            'evs' => EvsRequest::query()
-                ->where('is_deleted', false)
-                ->whereNotIn('status', ['completed', 'cancelled', 'canceled']),
-            default => null,
-        };
-
-        if ($query === null) {
-            return [];
-        }
-
-        return $query
-            ->whereNotNull('patient_ref')
-            ->pluck('patient_ref')
-            ->map(fn ($ref): string => (string) $ref)
-            ->unique()
-            ->values()
-            ->all();
+        return $spaceIds->map(fn ($id): int => (int) $id)->unique()->values()->all();
     }
 }

--- a/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
+++ b/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
@@ -1,0 +1,128 @@
+# Operational Platform Closure Checklist
+
+**Status:** Active execution checklist
+
+**Opened:** 2026-07-10
+
+**Authority:** This checklist tracks the bounded release/security/operations closure tranches requested after the 2026-07-09 remediation review. Product scope and acceptance intent remain governed by `docs/ZEPHYRUS-2.0-BETA-PRD.md` and `docs/ZEPHYRUS-2.0-PLAN.md`.
+
+## Release order and branch discipline
+
+- [x] R0.1 Prove the production application tree came from `feat/hummingbird-4d-service-line-eddy` and record the deployed head.
+- [x] R0.2 Open a normal merge PR from the deployed branch without squashing or rewriting its fourteen commits.
+- [x] R0.3 Repair branch CI so the core and full workflows do not cancel one another.
+- [x] R0.4 Run Laravel/PHPUnit, Pint, Vite/TypeScript/Vitest, and Arena pytest checks to green.
+- [x] R0.5 Merge through GitHub with a merge commit and verify the deployed feature history remains reachable from `main`.
+- [x] R0.6 Deploy only the merged `main` tree through `./deploy.sh`.
+- [x] R0.7 Verify Apache, the forced Zephyrus vhost, the public login boundary, runtime file parity, and current release migrations.
+- [x] R0.8 Restore all pre-existing local worktree changes without including them in the release PR.
+- [ ] R0.9 Keep each remaining tranche on a separate branch and PR; require full CI and a post-merge deployment from `main` before starting the next production tranche.
+
+## Patient Flow authorization and ingress hotfix
+
+### Read boundary
+
+- [x] S1.1 Resolve the canonical Flow Window scope (`house`, `floor`, `unit`, or opaque `patient`) on every lensed web Patient Flow request.
+- [x] S1.2 Compute effective patient depth server-side and reject patient endpoints when the resolved role/scope grants no patient depth.
+- [x] S1.3 Centralize active transport/EVS task-patient references in `FlowLensService`; terminal or deleted work must not confer access.
+- [x] S1.4 Filter event, track, state, and SSE rows by resolved spatial scope and patient access before serialization.
+- [x] S1.5 Replace raw patient/display/encounter references with stable opaque context tokens and strip raw-message hashes plus identifier-bearing metadata.
+- [x] S1.6 Reject raw patient query identifiers; only opaque `ptok_` filters may select a patient.
+- [x] S1.7 Apply effective scope/depth to occupancy, occupancy history, and forward projections while preserving aggregate-safe output.
+- [x] S1.8 Add `private, no-store` response policy to all patient-bearing JSON and event-stream responses.
+
+### FHIR boundary
+
+- [x] S1.9 Authorize the requested flow event against the resolved scope/depth before constructing a FHIR bundle.
+- [x] S1.10 Return a non-enumerating not-found response for an absent or out-of-scope event.
+- [x] S1.11 Construct the bundle from the lensed payload so Patient and Encounter resources never restore internal identifiers.
+
+### HL7 v2 ingress boundary
+
+- [x] S1.12 Remove `/api/patient-flow/ingest/hl7v2` from the browser-session Patient Flow route group.
+- [x] S1.13 Expose ADT ingestion only under the canonical `/api/integrations/v1/...` namespace.
+- [x] S1.14 Require a real Sanctum bearer token with the explicit `integration:patient-flow:ingest` ability; browser sessions and wildcard human tokens must not satisfy the machine boundary.
+- [x] S1.15 Require a configured, active, PHI-approved HL7 v2 source; production also requires a production/live source.
+- [x] S1.16 Persist an ingest run and immutable raw message before normalization.
+- [x] S1.17 Write the canonical event through `CanonicalEventWriter`, then project `flow_core.flow_events` with source/raw/canonical foreign keys.
+- [x] S1.18 Write provenance from raw message through canonical event to the Patient Flow projection.
+- [x] S1.19 Enforce source-scoped idempotency, return the prior opaque receipt for a byte-identical retry, and reject a key reused with a different payload.
+- [x] S1.20 Return only opaque run/message/canonical receipt identifiers; never echo HL7 or patient data.
+
+### Security evidence and release
+
+- [x] S1.21 Test unit-scope allow/deny behavior across sibling units.
+- [x] S1.22 Test task-scope access for active work and denial after terminal status.
+- [x] S1.23 Test that JSON, FHIR, and SSE payloads contain no internal patient/encounter references.
+- [x] S1.24 Test old-route removal plus anonymous, browser-session, missing-ability, wildcard-token, and explicit-machine-token ingress outcomes.
+- [x] S1.25 Test source-state enforcement, canonical lineage, provenance, rejected raw retention, and duplicate delivery.
+- [ ] S1.26 Run focused tests, repository Pint, the full Laravel suite, frontend checks, and full branch CI.
+- [ ] S1.27 Merge the security PR and redeploy the merged `main` commit through `./deploy.sh`.
+
+Pre-PR local evidence on the isolated security branch:
+
+- `./vendor/bin/pint --test`: 874 files passed.
+- `php artisan test`: 718 passed, 7,403 assertions, one intentional fixture-regeneration skip.
+- `PatientFlowSecurityHotfixTest`: nine adversarial tests and 100 assertions passed after the final ingress validation changes.
+- `npx tsc --noEmit`: passed.
+- `npx vitest run --coverage`: 80 files and 330 tests passed.
+- `npm run build`: production build passed.
+- `python -m pytest tests -q` in a clean Arena dependency environment: 17 passed.
+- Exact-head GitHub CI, merge, and post-merge deployment remain open gates.
+
+## Patient Flow 4D wall-display lockdown
+
+- [ ] W1.1 Treat wall mode as a render-only surface: no drill, patient, lens, inbox, alert-engagement, or Eddy controls may mount.
+- [ ] W1.2 Remove interactive semantics, focus targets, hover affordances, and pointer handlers from wall-mode tiles and overlays.
+- [ ] W1.3 Ignore or strip drill/patient URL state when wall mode is active.
+- [ ] W1.4 Do not fetch agent-inbox or patient-detail data in wall mode.
+- [ ] W1.5 Preserve current desk-mode drill, patient, inbox, lens, and Eddy behavior without duplication.
+- [ ] W1.6 Add component tests proving wall mode is chromeless/non-interactive and desk mode remains interactive.
+- [ ] W1.7 Publish as its own bounded PR, run full CI, merge, and deploy from `main`.
+
+## Integrations operational runtime
+
+- [ ] I1.1 Replace the synchronous production queue posture with supervised asynchronous workers, retry/backoff policy, failed-job visibility, and deploy-safe restart behavior.
+- [ ] I1.2 Add protocol-aware health checks for FHIR R4/SMART and HL7 v2 rather than configuration-presence checks.
+- [ ] I1.3 Add audited replay controls with bounded source/time/event scope, dry-run preview, idempotency, and operator authorization.
+- [ ] I1.4 Configure one real Epic FHIR R4/SMART source, endpoint, secret reference, capabilities, and watermark without committing credentials.
+- [ ] I1.5 Prove SMART backend-service authentication, CapabilityStatement compatibility, minimal read scope, polling, canonical mapping, projection, and watermark advancement.
+- [ ] I1.6 Add the first real HL7 v2 ADT source through the machine-authenticated canonical ingress established in S1.
+- [ ] I1.7 Exercise failure, dead-letter, replay, recovery, stale-watermark, secret-rotation, and rollback paths.
+- [ ] I1.8 Publish configuration/runbook evidence while keeping environment-specific secrets outside Git.
+
+## Staffing operations completion
+
+- [ ] ST1.1 Establish the canonical qualification vocabulary and effective-dated staff qualification records.
+- [ ] ST1.2 Model availability, leave, preference, and conflict windows with timezone-safe overlap rules.
+- [ ] ST1.3 Validate each assignment against role, qualification, unit/service-line capability, availability, and overlapping shifts.
+- [ ] ST1.4 Implement shift fulfillment as a governed lifecycle with idempotent accept/fill/release/cancel transitions and an immutable activity trail.
+- [ ] ST1.5 Surface explicit unfilled/unsafe/conflicted states to web and Hummingbird with server-enforced action policies.
+- [ ] ST1.6 Add migration, service, API, policy, concurrency, pagination, and mobile parity tests.
+
+## Transport lifecycle completion
+
+- [ ] T1.1 Define one transition graph for request, assignment, pickup, movement, arrival, handoff, completion, escalation, cancellation, and failure.
+- [ ] T1.2 Reject illegal or actor-inappropriate transitions server-side across web and mobile endpoints.
+- [ ] T1.3 Require idempotency keys on lifecycle writes and make replays return the original result without duplicate events.
+- [ ] T1.4 Enforce transporter/team/vendor capacity and prevent overlapping active assignments.
+- [ ] T1.5 Require structured handoff evidence before completion where the request type demands it.
+- [ ] T1.6 Add deterministic cursor pagination and stable filters to web/mobile queues.
+- [ ] T1.7 Prove transition, concurrency, capacity, idempotency, handoff, pagination, and parity behavior with tests.
+
+## Canonical documentation reconciliation
+
+- [ ] D1.1 Re-audit code, migrations, tests, CI, deployed runtime, and open PR state before changing completion claims.
+- [ ] D1.2 Reconcile `docs/superpowers/plans/2026-07-09-operational-platform-remediation-plan.md` so deployed work is marked shipped rather than gated.
+- [ ] D1.3 Link each remaining gate to this checklist's evidence, owner, branch/PR, test, migration, and deployment result.
+- [ ] D1.4 Remove contradictory status language while preserving historical decision context.
+- [ ] D1.5 Update the canonical PRD/plan only after the corresponding production tranche is verified.
+
+## Definition of done for every production tranche
+
+- [ ] The branch contains only the intended tranche and preserves unrelated local work.
+- [ ] Focused tests and relevant static/build checks pass locally.
+- [ ] Full GitHub branch CI passes on the exact PR head.
+- [ ] Review/merge happens through a normal PR; no history rewrite or direct production pull is used.
+- [ ] `main` contains the PR head, the production deploy comes from that merged `main`, and runtime verification is recorded.
+- [ ] Documentation claims match the code and deployed state after—not before—the verification gate.

--- a/routes/api.php
+++ b/routes/api.php
@@ -157,7 +157,7 @@ Route::middleware(['web', 'auth', 'throttle:60,1'])->prefix('patient-flow')->gro
 
     // Patient-level reads — persona-lensed (FLOW-WINDOW-PLAN §6.4, closes G7):
     // requires a flow lens whose patient_dots policy is not `none`.
-    Route::middleware(\App\Http\Middleware\EnforceFlowLens::class.':patients')->group(function () {
+    Route::middleware(\App\Http\Middleware\EnforceFlowLens::class.':scoped-patients')->group(function () {
         Route::get('/events', [PatientFlowController::class, 'events']);
         Route::get('/tracks', [PatientFlowController::class, 'tracks']);
         Route::get('/state', [PatientFlowController::class, 'state']);
@@ -169,14 +169,22 @@ Route::middleware(['web', 'auth', 'throttle:60,1'])->prefix('patient-flow')->gro
     // aggregate-safe: items are persona-clamped and identity-redacted by
     // the same lens the mobile window uses.
     Route::get('/projections', [PatientFlowController::class, 'projections'])
-        ->middleware(\App\Http\Middleware\EnforceFlowLens::class);
+        ->middleware(\App\Http\Middleware\EnforceFlowLens::class.':scoped');
     Route::get('/occupancy/history', [PatientFlowController::class, 'occupancyHistory'])
-        ->middleware(\App\Http\Middleware\EnforceFlowLens::class);
+        ->middleware(\App\Http\Middleware\EnforceFlowLens::class.':scoped');
     Route::get('/occupancy', [PatientFlowController::class, 'occupancy'])
-        ->middleware(\App\Http\Middleware\EnforceFlowLens::class);
-
-    Route::post('/ingest/hl7v2', [PatientFlowIngestController::class, 'hl7v2']);
+        ->middleware(\App\Http\Middleware\EnforceFlowLens::class.':scoped');
 });
+
+// Machine-to-machine ingress only. This route intentionally lives outside the
+// browser-session Patient Flow group and writes through raw -> canonical ->
+// projection/provenance before acknowledging an ADT message.
+Route::post('/integrations/v1/patient-flow/hl7v2', [PatientFlowIngestController::class, 'hl7v2'])
+    ->middleware([
+        'auth:sanctum',
+        \App\Http\Middleware\RequireMachineToken::class.':integration:patient-flow:ingest',
+        'throttle:120,1',
+    ]);
 
 // RTDC — Real-Time Demand Capacity (web session auth)
 // The `web` group provides StartSession (reads the session cookie) so the Inertia SPA

--- a/tests/Feature/PatientFlow/PatientFlowSecurityHotfixTest.php
+++ b/tests/Feature/PatientFlow/PatientFlowSecurityHotfixTest.php
@@ -1,0 +1,435 @@
+<?php
+
+namespace Tests\Feature\PatientFlow;
+
+use App\Models\Integration\Source;
+use App\Models\Transport\TransportRequest;
+use App\Models\Unit;
+use App\Models\User;
+use App\Services\PatientFlow\FlowEventNormalizer;
+use App\Services\PatientFlow\FlowEventRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class PatientFlowSecurityHotfixTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_unit_scope_filters_and_redacts_every_patient_read_surface(): void
+    {
+        [$unitA, $unitB] = $this->createTwoUnits();
+        $eventA = $this->storeFlowEvent('PATIENT-A-RAW', 'MSG-A', 'UNITA', 'ROOM-A', 'BED-A');
+        $eventB = $this->storeFlowEvent('PATIENT-B-RAW', 'MSG-B', 'UNITB', 'ROOM-B', 'BED-B');
+
+        $user = User::factory()->create(['role' => 'charge_nurse']);
+        $user->units()->attach($unitA->unit_id, ['role' => 'charge_nurse', 'is_primary' => true]);
+
+        $eventsResponse = $this->actingAs($user)
+            ->getJson('/api/patient-flow/events?persona=charge_nurse')
+            ->assertOk()
+            ->assertHeader('Cache-Control', 'max-age=0, no-store, private');
+
+        $events = $eventsResponse->json();
+        $this->assertCount(1, $events);
+        $this->assertSame($eventA['event_id'], $events[0]['event_id']);
+        $this->assertStringStartsWith('ptok_', $events[0]['patient_id']);
+        $this->assertSame($events[0]['patient_id'], $events[0]['patient_context_ref']);
+        $this->assertStringStartsWith('etok_', $events[0]['encounter_id']);
+        $this->assertSame((int) $unitA->unit_id, $events[0]['unit_id']);
+        $this->assertArrayNotHasKey('raw_message_hash', $events[0]);
+
+        $encodedEvents = $eventsResponse->getContent();
+        foreach ([$eventA['patient_id'], $eventA['patient_display_id'], $eventA['encounter_id'], $eventB['patient_id'], $eventB['encounter_id']] as $internalIdentifier) {
+            $this->assertStringNotContainsString($internalIdentifier, $encodedEvents);
+        }
+
+        $tracks = $this->actingAs($user)
+            ->getJson('/api/patient-flow/tracks?persona=charge_nurse')
+            ->assertOk()
+            ->json();
+        $this->assertCount(1, $tracks);
+        $this->assertStringStartsWith('ptok_', (string) array_key_first($tracks));
+
+        $state = $this->actingAs($user)
+            ->getJson('/api/patient-flow/state?persona=charge_nurse')
+            ->assertOk()
+            ->assertJsonPath('activePatients', 1)
+            ->json();
+        $this->assertStringStartsWith('ptok_', $state['patients'][0]['patient_id']);
+        $this->assertStringNotContainsString($eventA['patient_id'], json_encode($state, JSON_THROW_ON_ERROR));
+
+        $this->actingAs($user)
+            ->getJson('/api/patient-flow/events?persona=charge_nurse&scope=unit:'.$unitB->unit_id)
+            ->assertForbidden()
+            ->assertJsonPath('error.code', 'flow_lens_forbidden');
+
+        $this->actingAs($user)
+            ->getJson('/api/patient-flow/events?persona=charge_nurse&patient='.$eventA['patient_id'])
+            ->assertStatus(422)
+            ->assertJsonPath('error.code', 'invalid_patient_context_ref');
+    }
+
+    public function test_fhir_and_sse_share_the_unit_authorization_and_redaction_boundary(): void
+    {
+        [$unitA] = $this->createTwoUnits();
+        $eventA = $this->storeFlowEvent('PATIENT-A-RAW', 'MSG-A', 'UNITA', 'ROOM-A', 'BED-A');
+        $eventB = $this->storeFlowEvent('PATIENT-B-RAW', 'MSG-B', 'UNITB', 'ROOM-B', 'BED-B');
+        $user = User::factory()->create(['role' => 'charge_nurse']);
+        $user->units()->attach($unitA->unit_id, ['role' => 'charge_nurse', 'is_primary' => true]);
+
+        $fhir = $this->actingAs($user)
+            ->getJson('/api/patient-flow/fhir/bundle?persona=charge_nurse&event_id='.urlencode($eventA['event_id']))
+            ->assertOk()
+            ->assertHeader('Cache-Control', 'max-age=0, no-store, private')
+            ->json();
+
+        $fhirJson = json_encode($fhir, JSON_THROW_ON_ERROR);
+        $this->assertStringContainsString('ptok_', $fhirJson);
+        $this->assertStringContainsString('etok_', $fhirJson);
+        $this->assertStringNotContainsString($eventA['patient_id'], $fhirJson);
+        $this->assertStringNotContainsString($eventA['encounter_id'], $fhirJson);
+
+        $this->actingAs($user)
+            ->getJson('/api/patient-flow/fhir/bundle?persona=charge_nurse&event_id='.urlencode($eventB['event_id']))
+            ->assertNotFound()
+            ->assertJsonPath('error', 'event_id not found');
+
+        $stream = $this->actingAs($user)
+            ->get('/api/patient-flow/stream/adt?persona=charge_nurse&replay=10&interval=0.05')
+            ->assertOk()
+            ->assertHeader('Cache-Control', 'max-age=0, no-store, private');
+        $streamed = $stream->streamedContent();
+        $this->assertStringContainsString($eventA['event_id'], $streamed);
+        $this->assertStringContainsString('ptok_', $streamed);
+        $this->assertStringNotContainsString($eventA['patient_id'], $streamed);
+        $this->assertStringNotContainsString($eventB['event_id'], $streamed);
+        $this->assertStringNotContainsString($eventB['patient_id'], $streamed);
+    }
+
+    public function test_task_scope_is_limited_to_active_transport_work(): void
+    {
+        $this->createTwoUnits();
+        $activeEvent = $this->storeFlowEvent('TASK-PATIENT-A', 'TASK-MSG-A', 'UNITA', 'ROOM-A', 'BED-A', 'A03');
+        $terminalEvent = $this->storeFlowEvent('TASK-PATIENT-B', 'TASK-MSG-B', 'UNITB', 'ROOM-B', 'BED-B', 'A03');
+
+        $activeRequest = $this->transportRequest($activeEvent['patient_id'], 'assigned');
+        $this->transportRequest($terminalEvent['patient_id'], 'completed');
+        $user = User::factory()->create(['role' => 'transport']);
+
+        $events = $this->actingAs($user)
+            ->getJson('/api/patient-flow/events?persona=transport')
+            ->assertOk()
+            ->json();
+        $this->assertCount(1, $events);
+        $this->assertSame($activeEvent['event_id'], $events[0]['event_id']);
+        $this->assertStringStartsWith('ptok_', $events[0]['patient_context_ref']);
+
+        $this->actingAs($user)
+            ->getJson('/api/patient-flow/fhir/bundle?persona=transport&event_id='.urlencode($terminalEvent['event_id']))
+            ->assertNotFound();
+
+        $activeRequest->update(['status' => 'completed', 'completed_at' => now()]);
+        $this->actingAs($user)
+            ->getJson('/api/patient-flow/events?persona=transport')
+            ->assertOk()
+            ->assertExactJson([]);
+    }
+
+    public function test_browser_sessions_cannot_reach_the_machine_ingress_route(): void
+    {
+        $raw = $this->rawAdt('MACHINE-PATIENT', 'MACHINE-MSG', 'UNITA', 'ROOM-A', 'BED-A');
+
+        $this->postJson('/api/integrations/v1/patient-flow/hl7v2', ['raw_hl7' => $raw])
+            ->assertUnauthorized();
+
+        $user = User::factory()->create(['role' => 'admin']);
+        $this->actingAs($user)
+            ->postJson('/api/integrations/v1/patient-flow/hl7v2', ['raw_hl7' => $raw])
+            ->assertForbidden()
+            ->assertJsonPath('error.code', 'machine_token_required');
+
+        $this->actingAs($user)
+            ->postJson('/api/patient-flow/ingest/hl7v2', ['raw_hl7' => $raw])
+            ->assertNotFound();
+    }
+
+    public function test_machine_ingress_requires_the_explicit_non_wildcard_ability(): void
+    {
+        $user = User::factory()->create(['role' => 'integration']);
+        $raw = $this->rawAdt('MACHINE-PATIENT', 'MACHINE-MSG', 'UNITA', 'ROOM-A', 'BED-A');
+
+        $wildcard = $user->createToken('human-admin', ['*'])->plainTextToken;
+        $this->withToken($wildcard)
+            ->postJson('/api/integrations/v1/patient-flow/hl7v2', ['raw_hl7' => $raw], [
+                'X-Integration-Source' => 'ehr.hl7v2',
+            ])
+            ->assertForbidden()
+            ->assertJsonPath('error.code', 'machine_ability_required');
+
+        $wrong = $user->createToken('integration-reader', ['integration:read'])->plainTextToken;
+        $this->withToken($wrong)
+            ->postJson('/api/integrations/v1/patient-flow/hl7v2', ['raw_hl7' => $raw], [
+                'X-Integration-Source' => 'ehr.hl7v2',
+            ])
+            ->assertForbidden()
+            ->assertJsonPath('error.code', 'machine_ability_required');
+
+    }
+
+    public function test_machine_ingress_rejects_an_inactive_machine_identity(): void
+    {
+        $inactive = User::factory()->create(['role' => 'integration', 'is_active' => false]);
+        $token = $inactive->createToken(
+            'integration:patient-flow',
+            ['integration:patient-flow:ingest'],
+        )->plainTextToken;
+
+        $this->withToken($token)
+            ->postJson('/api/integrations/v1/patient-flow/hl7v2', [
+                'raw_hl7' => $this->rawAdt('MACHINE-PATIENT', 'MACHINE-MSG', 'UNITA', 'ROOM-A', 'BED-A'),
+            ], [
+                'X-Integration-Source' => 'ehr.hl7v2',
+            ])
+            ->assertForbidden()
+            ->assertJsonPath('error.code', 'machine_identity_inactive');
+    }
+
+    public function test_machine_ingress_writes_canonical_lineage_and_is_idempotent(): void
+    {
+        $this->createTwoUnits();
+        $source = $this->integrationSource();
+        $user = User::factory()->create(['role' => 'integration']);
+        $token = $user->createToken('integration:patient-flow', ['integration:patient-flow:ingest'])->plainTextToken;
+        $raw = $this->rawAdt('MACHINE-PATIENT', 'MACHINE-MSG', 'UNITA', 'ROOM-A', 'BED-A');
+        $headers = [
+            'X-Integration-Source' => $source->source_key,
+            'Idempotency-Key' => 'delivery-123',
+        ];
+
+        $first = $this->withToken($token)
+            ->postJson('/api/integrations/v1/patient-flow/hl7v2', ['raw_hl7' => $raw], $headers)
+            ->assertAccepted()
+            ->assertHeader('Cache-Control', 'max-age=0, no-store, private')
+            ->assertJsonPath('accepted', true)
+            ->assertJsonPath('duplicate', false)
+            ->assertJsonMissingPath('event')
+            ->json();
+
+        foreach (['run_id', 'message_id', 'canonical_event_id'] as $field) {
+            $this->assertTrue(Str::isUuid($first[$field]), "{$field} must be opaque UUID");
+        }
+        $this->assertStringNotContainsString('MACHINE-PATIENT', json_encode($first, JSON_THROW_ON_ERROR));
+
+        $message = DB::table('raw.inbound_messages')->where('message_uuid', $first['message_id'])->first();
+        $canonical = DB::table('integration.canonical_events')->where('event_id', $first['canonical_event_id'])->first();
+        $flowEvent = DB::table('flow_core.flow_events')->where('inbound_message_id', $message->inbound_message_id)->first();
+        $this->assertNotNull($message);
+        $this->assertNotNull($canonical);
+        $this->assertNotNull($flowEvent);
+        $this->assertSame((int) $source->source_id, (int) $flowEvent->source_id);
+        $this->assertSame((int) $message->inbound_message_id, (int) $flowEvent->inbound_message_id);
+        $this->assertSame((int) $canonical->canonical_event_id, (int) $flowEvent->canonical_event_id);
+        $this->assertDatabaseHas('integration.provenance_records', [
+            'source_id' => $source->source_id,
+            'inbound_message_id' => $message->inbound_message_id,
+            'canonical_event_id' => $canonical->canonical_event_id,
+            'target_schema' => 'flow_core',
+            'target_table' => 'flow_events',
+            'target_pk' => $flowEvent->flow_event_id,
+        ]);
+
+        $retry = $this->withToken($token)
+            ->postJson('/api/integrations/v1/patient-flow/hl7v2', ['raw_hl7' => $raw], $headers)
+            ->assertOk()
+            ->assertJsonPath('duplicate', true)
+            ->json();
+        $this->assertSame($first['run_id'], $retry['run_id']);
+        $this->assertSame($first['message_id'], $retry['message_id']);
+        $this->assertSame($first['canonical_event_id'], $retry['canonical_event_id']);
+
+        $this->assertSame(1, DB::table('raw.inbound_messages')->where('source_id', $source->source_id)->count());
+        $this->assertSame(1, DB::table('integration.canonical_events')->where('source_id', $source->source_id)->count());
+        $this->assertSame(1, DB::table('flow_core.flow_events')->where('source_id', $source->source_id)->count());
+        $this->assertSame(1, DB::table('integration.provenance_records')->where('source_id', $source->source_id)->count());
+        $this->assertSame(2, DB::table('raw.ingest_runs')->where('source_id', $source->source_id)->count());
+
+        $this->withToken($token)
+            ->postJson('/api/integrations/v1/patient-flow/hl7v2', [
+                'raw_hl7' => str_replace('MACHINE-PATIENT', 'OTHER-PATIENT', $raw),
+            ], $headers)
+            ->assertStatus(409)
+            ->assertJsonPath('error.code', 'idempotency_key_conflict');
+        $this->assertSame(1, DB::table('raw.inbound_messages')->where('source_id', $source->source_id)->count());
+    }
+
+    public function test_machine_ingress_rejects_sources_that_are_not_active_hl7_and_phi_approved(): void
+    {
+        $source = $this->integrationSource([
+            'source_key' => 'ehr.disabled',
+            'active_status' => 'inactive',
+            'phi_allowed' => false,
+        ]);
+        $user = User::factory()->create(['role' => 'integration']);
+        $token = $user->createToken('integration:patient-flow', ['integration:patient-flow:ingest'])->plainTextToken;
+
+        $this->withToken($token)
+            ->postJson('/api/integrations/v1/patient-flow/hl7v2', [
+                'raw_hl7' => $this->rawAdt('MACHINE-PATIENT', 'MACHINE-MSG', 'UNITA', 'ROOM-A', 'BED-A'),
+            ], [
+                'X-Integration-Source' => $source->source_key,
+            ])
+            ->assertForbidden()
+            ->assertJsonPath('error.code', 'integration_source_forbidden');
+
+        $this->assertSame(0, DB::table('raw.ingest_runs')->where('source_id', $source->source_id)->count());
+    }
+
+    public function test_machine_ingress_retains_rejected_raw_messages_without_projecting_them(): void
+    {
+        $source = $this->integrationSource();
+        $user = User::factory()->create(['role' => 'integration']);
+        $token = $user->createToken('integration:patient-flow', ['integration:patient-flow:ingest'])->plainTextToken;
+        $raw = implode("\r", [
+            'MSH|^~\\&|EHR|AMC|FLOW|AMC|20260710120000||ORU^R01|NOT-ADT|P|2.5.1',
+            'PID|||REJECTED-PATIENT^^^AMC^MR||FLOW^REJECTED',
+            '',
+        ]);
+
+        $response = $this->withToken($token)
+            ->postJson('/api/integrations/v1/patient-flow/hl7v2', ['raw_hl7' => $raw], [
+                'X-Integration-Source' => $source->source_key,
+                'Idempotency-Key' => 'rejected-delivery-1',
+            ])
+            ->assertStatus(422)
+            ->assertJsonPath('error.code', 'unsupported_hl7_message');
+
+        $this->assertStringNotContainsString('REJECTED-PATIENT', $response->getContent());
+        $this->assertDatabaseHas('raw.inbound_messages', [
+            'source_id' => $source->source_id,
+            'idempotency_key' => 'rejected-delivery-1',
+            'parse_status' => 'failed',
+        ]);
+        $this->assertDatabaseHas('raw.dead_letters', [
+            'source_id' => $source->source_id,
+            'reason_code' => 'unsupported_hl7_message',
+            'status' => 'open',
+        ]);
+        $this->assertSame(0, DB::table('integration.canonical_events')->where('source_id', $source->source_id)->count());
+        $this->assertSame(0, DB::table('flow_core.flow_events')->where('source_id', $source->source_id)->count());
+    }
+
+    /** @return array{0: Unit, 1: Unit} */
+    private function createTwoUnits(): array
+    {
+        $spaceA = $this->facilitySpace('BED-A', 'UNITA', 1);
+        $spaceB = $this->facilitySpace('BED-B', 'UNITB', 2);
+
+        $unitA = Unit::create([
+            'name' => 'Unit A',
+            'abbreviation' => 'UNITA',
+            'type' => 'med_surg',
+            'staffed_bed_count' => 1,
+            'facility_space_id' => $spaceA,
+        ]);
+        $unitB = Unit::create([
+            'name' => 'Unit B',
+            'abbreviation' => 'UNITB',
+            'type' => 'med_surg',
+            'staffed_bed_count' => 1,
+            'facility_space_id' => $spaceB,
+        ]);
+
+        return [$unitA, $unitB];
+    }
+
+    private function facilitySpace(string $locationCode, string $unitCode, int $floor): int
+    {
+        return (int) DB::table('hosp_space.facility_spaces')->insertGetId([
+            'space_code' => 'ZEPHYRUS-500:'.$locationCode,
+            'space_name' => $locationCode,
+            'space_category' => 'bed',
+            'floor_label' => 'Floor '.$floor,
+            'floor_number' => $floor,
+            'status' => 'active',
+            'geometry' => json_encode(['position_ft' => ['x' => $floor * 10, 'z' => $floor * 10]], JSON_THROW_ON_ERROR),
+            'attributes' => json_encode(['unit_code' => $unitCode], JSON_THROW_ON_ERROR),
+            'source_system' => 'security-test',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], 'facility_space_id');
+    }
+
+    /** @return array<string, mixed> */
+    private function storeFlowEvent(
+        string $patient,
+        string $messageId,
+        string $unit,
+        string $room,
+        string $bed,
+        string $trigger = 'A01',
+    ): array {
+        $raw = $this->rawAdt($patient, $messageId, $unit, $room, $bed, $trigger);
+        $event = app(FlowEventNormalizer::class)->normalize($raw);
+        app(FlowEventRepository::class)->upsertNormalizedEvent($event);
+
+        return $event;
+    }
+
+    private function rawAdt(
+        string $patient,
+        string $messageId,
+        string $unit,
+        string $room,
+        string $bed,
+        string $trigger = 'A01',
+    ): string {
+        return implode("\r", [
+            "MSH|^~\\&|EHR|AMC|FLOW|AMC|20260710120000||ADT^{$trigger}|{$messageId}|P|2.5.1",
+            "EVN|{$trigger}|20260710120000",
+            "PID|||{$patient}^^^AMC^MR||FLOW^{$patient}",
+            "PV1||I|{$unit}^{$room}^{$bed}^ZEPHYRUS||||99001^ATTENDING^SYNTHETIC|||hospital_medicine|||||||||VIS-{$messageId}^^^AMC^VN",
+            '',
+        ]);
+    }
+
+    private function transportRequest(string $patientRef, string $status): TransportRequest
+    {
+        return TransportRequest::create([
+            'request_uuid' => (string) Str::uuid(),
+            'request_type' => 'inpatient',
+            'priority' => 'routine',
+            'status' => $status,
+            'patient_ref' => $patientRef,
+            'origin' => 'Unit A',
+            'destination' => 'Unit B',
+            'transport_mode' => 'wheelchair',
+            'requested_at' => now(),
+            'completed_at' => $status === 'completed' ? now() : null,
+            'is_deleted' => false,
+        ]);
+    }
+
+    /** @param array<string, mixed> $overrides */
+    private function integrationSource(array $overrides = []): Source
+    {
+        return Source::create(array_merge([
+            'source_uuid' => (string) Str::uuid(),
+            'source_key' => 'ehr.hl7v2',
+            'tenant_key' => 'default',
+            'facility_key' => 'ZEPHYRUS-500',
+            'source_name' => 'Security Test HL7 v2',
+            'vendor' => 'Test EHR',
+            'system_class' => 'ehr',
+            'environment' => 'test',
+            'interface_type' => 'hl7v2',
+            'active_status' => 'active',
+            'contract_status' => 'executed',
+            'baa_status' => 'executed',
+            'phi_allowed' => true,
+            'go_live_status' => 'ready',
+            'metadata' => [],
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
## Summary

- resolve canonical FlowLens scope and effective depth for Patient Flow web reads
- filter events, tracks, state, SSE, occupancy, history, and projections before emitting opaque ptok_/etok_ identifiers
- authorize FHIR event access against the same scope and build bundles only from lensed payloads
- remove browser-session HL7 ingest and expose a machine-only integration route requiring an explicit non-wildcard Sanctum ability
- persist raw receipt, canonical event, Patient Flow projection, and provenance with source-scoped idempotency
- add the operational closure checklist and adversarial security coverage

## Security boundary

The new POST /api/integrations/v1/patient-flow/hl7v2 route fails closed until both exist:

1. a dedicated active machine token explicitly granting integration:patient-flow:ingest
2. a configured active, PHI-approved hl7v2 integration source (production also requires production/live state)

The old POST /api/patient-flow/ingest/hl7v2 browser route no longer exists.

## Local validation

- Laravel Pint: 874 files passed
- Laravel/PHPUnit: 718 passed, 7,403 assertions, one intentional fixture-regeneration skip
- PatientFlowSecurityHotfixTest: 9 passed, 100 assertions after final ingress validation
- TypeScript: npx tsc --noEmit passed
- Vitest coverage: 80 files, 330 tests passed
- Vite production build passed
- Arena sidecar: 17 pytest tests passed in a clean dependency environment

## Release gate

No schema migration is required. Do not deploy this branch directly: merge only after both CI workflows pass, then deploy the merged main commit through ./deploy.sh and verify the runtime boundary.