### PR TITLE
fix(cockpit): make wall display static and chromeless

### DIFF
--- a/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
+++ b/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
@@ -56,8 +56,8 @@
 - [x] S1.23 Test that JSON, FHIR, and SSE payloads contain no internal patient/encounter references.
 - [x] S1.24 Test old-route removal plus anonymous, browser-session, missing-ability, wildcard-token, and explicit-machine-token ingress outcomes.
 - [x] S1.25 Test source-state enforcement, canonical lineage, provenance, rejected raw retention, and duplicate delivery.
-- [ ] S1.26 Run focused tests, repository Pint, the full Laravel suite, frontend checks, and full branch CI.
-- [ ] S1.27 Merge the security PR and redeploy the merged `main` commit through `./deploy.sh`.
+- [x] S1.26 Run focused tests, repository Pint, the full Laravel suite, frontend checks, and full branch CI.
+- [x] S1.27 Merge the security PR and redeploy the merged `main` commit through `./deploy.sh`.
 
 Pre-PR local evidence on the isolated security branch:
 
@@ -68,17 +68,27 @@ Pre-PR local evidence on the isolated security branch:
 - `npx vitest run --coverage`: 80 files and 330 tests passed.
 - `npm run build`: production build passed.
 - `python -m pytest tests -q` in a clean Arena dependency environment: 17 passed.
-- Exact-head GitHub CI, merge, and post-merge deployment remain open gates.
+- Exact-head GitHub CI passed all five required checks on PR #15.
+- PR #15 merged as `2905664a058e7ba15ff9c6d941e67c090f562c09`; the security head remains an ancestor of `main`.
+- `./deploy.sh` completed from clean/current `main`; Apache was active, the forced vhost redirected to login, runtime hashes matched, anonymous machine ingress returned 401, and the retired browser route returned 404.
 
 ## Patient Flow 4D wall-display lockdown
 
-- [ ] W1.1 Treat wall mode as a render-only surface: no drill, patient, lens, inbox, alert-engagement, or Eddy controls may mount.
-- [ ] W1.2 Remove interactive semantics, focus targets, hover affordances, and pointer handlers from wall-mode tiles and overlays.
-- [ ] W1.3 Ignore or strip drill/patient URL state when wall mode is active.
-- [ ] W1.4 Do not fetch agent-inbox or patient-detail data in wall mode.
-- [ ] W1.5 Preserve current desk-mode drill, patient, inbox, lens, and Eddy behavior without duplication.
-- [ ] W1.6 Add component tests proving wall mode is chromeless/non-interactive and desk mode remains interactive.
+- [x] W1.1 Treat wall mode as a render-only surface: no drill, patient, lens, inbox, alert-engagement, or Eddy controls may mount.
+- [x] W1.2 Remove interactive semantics, focus targets, hover affordances, and pointer handlers from wall-mode tiles and overlays.
+- [x] W1.3 Ignore or strip drill/patient URL state when wall mode is active.
+- [x] W1.4 Do not fetch agent-inbox or patient-detail data in wall mode.
+- [x] W1.5 Preserve current desk-mode drill, patient, inbox, lens, and Eddy behavior without duplication.
+- [x] W1.6 Add component tests proving wall mode is chromeless/non-interactive and desk mode remains interactive.
 - [ ] W1.7 Publish as its own bounded PR, run full CI, merge, and deploy from `main`.
+
+Pre-PR local evidence on the isolated wall-lockdown branch:
+
+- Focused wall/desk suite: nine files and 60 tests passed.
+- Full Vitest suite: 81 files and 342 tests passed.
+- `npx tsc --noEmit`: passed.
+- `npm run build`: production build passed.
+- `scripts/check-ui-canon.sh`: passed; one pre-existing dashboard raw-palette match was converted to the canonical healthcare token to restore the ratchet from 77 to its baseline of 76.
 
 ## Integrations operational runtime
 

--- a/resources/js/Components/CommandCenter/Band.tsx
+++ b/resources/js/Components/CommandCenter/Band.tsx
@@ -14,16 +14,35 @@ const BAND_ICON: Record<BandData['key'], string> = {
   forecast: 'heroicons:presentation-chart-line',
 };
 
-function TileGrid({ metrics, emptyLabel, detailed }: { metrics: KpiMetric[]; emptyLabel: string; detailed: boolean }) {
+function TileGrid({
+  metrics,
+  emptyLabel,
+  detailed,
+  interactive,
+}: {
+  metrics: KpiMetric[];
+  emptyLabel: string;
+  detailed: boolean;
+  interactive: boolean;
+}) {
   if (metrics.length === 0) return <EmptyState message={emptyLabel} />;
   return (
     <div className="grid gap-2" style={{ gridTemplateColumns: GRID }}>
-      {metrics.map((m) => <KpiTile key={m.key} metric={m} detailed={detailed} />)}
+      {metrics.map((m) => <KpiTile key={m.key} metric={m} detailed={detailed} interactive={interactive} />)}
     </div>
   );
 }
 
-export function Band({ band, detailed = false }: { band: BandData; detailed?: boolean }) {
+export function Band({
+  band,
+  detailed = false,
+  interactive = true,
+}: {
+  band: BandData;
+  detailed?: boolean;
+  /** False for a wall: suppress the band CTA and every metric drill link. */
+  interactive?: boolean;
+}) {
   return (
     <section aria-label={band.title} className="flex flex-col gap-2">
       <header className="flex items-center justify-between gap-3 border-b border-healthcare-border dark:border-healthcare-border-dark pb-1 transition-colors duration-300">
@@ -37,10 +56,12 @@ export function Band({ band, detailed = false }: { band: BandData; detailed?: bo
           </span>
           <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">{band.summary}</span>
         </div>
-        <Link href={band.drillHref}
-              className="whitespace-nowrap text-xs font-medium text-healthcare-primary dark:text-healthcare-primary-dark hover:underline">
-          {band.drillLabel} {'→'}
-        </Link>
+        {interactive && (
+          <Link href={band.drillHref}
+                className="whitespace-nowrap text-xs font-medium text-healthcare-primary dark:text-healthcare-primary-dark hover:underline">
+            {band.drillLabel} {'→'}
+          </Link>
+        )}
       </header>
 
       {band.subgroups && band.subgroups.length > 0 ? (
@@ -48,12 +69,12 @@ export function Band({ band, detailed = false }: { band: BandData; detailed?: bo
           {band.subgroups.map((g) => (
             <div key={g.key} className="flex flex-col gap-1">
               <span className="text-xs font-medium text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">{g.label}</span>
-              <TileGrid metrics={g.metrics} emptyLabel={`No ${g.label} metrics reporting`} detailed={detailed} />
+              <TileGrid metrics={g.metrics} emptyLabel={`No ${g.label} metrics reporting`} detailed={detailed} interactive={interactive} />
             </div>
           ))}
         </div>
       ) : (
-        <TileGrid metrics={band.metrics} emptyLabel={`No ${band.title.toLowerCase()} metrics reporting`} detailed={detailed} />
+        <TileGrid metrics={band.metrics} emptyLabel={`No ${band.title.toLowerCase()} metrics reporting`} detailed={detailed} interactive={interactive} />
       )}
     </section>
   );

--- a/resources/js/Components/CommandCenter/CommandCenterView.tsx
+++ b/resources/js/Components/CommandCenter/CommandCenterView.tsx
@@ -8,11 +8,14 @@ import { ForecastCurve } from './ForecastCurve';
 
 interface CommandCenterViewProps {
   data: CommandCenterData;
-  onRefresh: () => void;
+  /** Desk-only manual refresh. Omit for wall mode. */
+  onRefresh?: () => void;
   updatedLabel: string;
   refreshing?: boolean;
   aging?: boolean;
   stale?: boolean;
+  /** Static wall fallback: suppress every link/control in the legacy grammar. */
+  interactive?: boolean;
 }
 
 export function CommandCenterView({
@@ -22,6 +25,7 @@ export function CommandCenterView({
   refreshing = false,
   aging = false,
   stale = false,
+  interactive = true,
 }: CommandCenterViewProps) {
   const role = useCommandCenterStore((s) => s.role);
 
@@ -48,15 +52,17 @@ export function CommandCenterView({
           )}
           Updated {updatedLabel}
         </span>
-        <button type="button" onClick={onRefresh} disabled={refreshing} aria-label="Refresh data"
-                className="inline-flex items-center gap-1 rounded-md border border-healthcare-border dark:border-healthcare-border-dark
-                           bg-healthcare-surface dark:bg-healthcare-surface-dark
-                           px-2 py-1 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark
-                           shadow-sm transition-colors duration-300 hover:bg-healthcare-hover dark:hover:bg-healthcare-hover-dark
-                           disabled:cursor-not-allowed disabled:opacity-60">
-          <span className={refreshing ? 'inline-block motion-safe:animate-spin' : 'inline-block'} aria-hidden="true">{'⟳'}</span>
-          {refreshing ? 'Refreshing…' : 'Refresh'}
-        </button>
+        {interactive && onRefresh && (
+          <button type="button" onClick={onRefresh} disabled={refreshing} aria-label="Refresh data"
+                  className="inline-flex items-center gap-1 rounded-md border border-healthcare-border dark:border-healthcare-border-dark
+                             bg-healthcare-surface dark:bg-healthcare-surface-dark
+                             px-2 py-1 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark
+                             shadow-sm transition-colors duration-300 hover:bg-healthcare-hover dark:hover:bg-healthcare-hover-dark
+                             disabled:cursor-not-allowed disabled:opacity-60">
+            <span className={refreshing ? 'inline-block motion-safe:animate-spin' : 'inline-block'} aria-hidden="true">{'⟳'}</span>
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </button>
+        )}
       </div>
 
       {/* The loud stale banner now lives app-chrome-wide (StaleDataBanner in
@@ -64,11 +70,11 @@ export function CommandCenterView({
           aging dot above and the sr-only recovery announcement. */}
 
       <HeroWall role={role} strain={data.strain} heroMetrics={data.heroMetrics}
-                objectives={data.objectives} detailed={detailed} />
+                objectives={data.objectives} detailed={detailed} interactive={interactive} />
 
       {bands.map((band) => (
         <div key={band.key} className="flex flex-col gap-2">
-          <Band band={band} detailed={detailed} />
+          <Band band={band} detailed={detailed} interactive={interactive} />
           {band.key === 'capacity' && showHeatStrip && <UnitHeatStrip units={data.unitCensus} />}
           {band.key === 'forecast' && <ForecastCurve forecast={data.forecastDetail} />}
         </div>

--- a/resources/js/Components/CommandCenter/HeroWall.tsx
+++ b/resources/js/Components/CommandCenter/HeroWall.tsx
@@ -11,9 +11,10 @@ interface HeroWallProps {
   heroMetrics: KpiMetric[];
   objectives: Objective[];
   detailed?: boolean;
+  interactive?: boolean;
 }
 
-export function HeroWall({ role, strain, heroMetrics, objectives, detailed = false }: HeroWallProps) {
+export function HeroWall({ role, strain, heroMetrics, objectives, detailed = false, interactive = true }: HeroWallProps) {
   if (role === 'executive') {
     return (
       <div aria-label="OKR scoreboard">
@@ -26,7 +27,7 @@ export function HeroWall({ role, strain, heroMetrics, objectives, detailed = fal
     <div className="grid gap-2"
          style={{ gridTemplateColumns: 'minmax(240px, 1.3fr) repeat(auto-fit, minmax(168px, 1fr))' }}>
       <StrainIndex strain={strain} />
-      {heroMetrics.map((m) => <KpiTile key={m.key} metric={m} detailed={detailed} />)}
+      {heroMetrics.map((m) => <KpiTile key={m.key} metric={m} detailed={detailed} interactive={interactive} />)}
     </div>
   );
 }

--- a/resources/js/Components/CommandCenter/KpiTile.tsx
+++ b/resources/js/Components/CommandCenter/KpiTile.tsx
@@ -65,7 +65,16 @@ function DetailVisualization({ metric }: { metric: KpiMetric }) {
   );
 }
 
-export function KpiTile({ metric, detailed = false }: { metric: KpiMetric; detailed?: boolean }) {
+export function KpiTile({
+  metric,
+  detailed = false,
+  interactive = true,
+}: {
+  metric: KpiMetric;
+  detailed?: boolean;
+  /** False for static wall/print surfaces; drill links become plain panels. */
+  interactive?: boolean;
+}) {
   const color = STATUS_VAR[metric.status];
   const arrow = metric.trajectory
     ? metric.trajectory.direction === 'up' ? '▲'
@@ -153,7 +162,7 @@ export function KpiTile({ metric, detailed = false }: { metric: KpiMetric; detai
     </Panel>
   );
 
-  if (metric.drillHref) {
+  if (interactive && metric.drillHref) {
     return (
       <Link href={metric.drillHref} className="block h-full" data-testid={`kpi-${metric.key}`}>
         {body}

--- a/resources/js/Components/Dashboard/DashboardLayout.tsx
+++ b/resources/js/Components/Dashboard/DashboardLayout.tsx
@@ -72,10 +72,12 @@ const DashboardLayout = ({ children, fullBleed = false, wall = false }: Dashboar
 
     return (
         <DarkModeContext.Provider value={{ isDarkMode, setIsDarkMode }}>
-            {/* Skip to content link for accessibility */}
-            <a href="#main-content" className="skip-to-content">
-                Skip to content
-            </a>
+            {/* Desk keyboard navigation only. A wall has no focusable chrome. */}
+            {!wall && (
+                <a href="#main-content" className="skip-to-content">
+                    Skip to content
+                </a>
+            )}
             <div className="min-h-screen bg-healthcare-background dark:bg-healthcare-background-dark transition-colors duration-300">
                 {/* Force password change modal — preserved per auth-system rules
                     (a wall is authenticated; the gate still applies). */}

--- a/resources/js/Components/Dashboard/Stats.jsx
+++ b/resources/js/Components/Dashboard/Stats.jsx
@@ -8,7 +8,7 @@ const Stats = ({ title, value, description, trend, icon }) => {
     };
 
     return (
-        <div className="rounded-lg bg-healthcare-surface dark:bg-healthcare-surface-dark p-4 shadow-sm border border-healthcare-border dark:border-healthcare-border-dark hover:border-indigo-100 transition-all duration-200 group">
+        <div className="rounded-lg bg-healthcare-surface dark:bg-healthcare-surface-dark p-4 shadow-sm border border-healthcare-border dark:border-healthcare-border-dark hover:border-healthcare-primary/30 dark:hover:border-healthcare-primary-dark/30 transition-all duration-200 group">
             <div className="flex items-center justify-between">
                 <div className="flex items-center">
                     {icon && (

--- a/resources/js/Components/Eddy/EddyDock.tsx
+++ b/resources/js/Components/Eddy/EddyDock.tsx
@@ -5,6 +5,11 @@ import { useEddyStore } from '@/stores/eddyStore';
 import { EddyLauncher } from './EddyLauncher';
 import { EddySlideOver } from './EddySlideOver';
 
+function isWallDisplay(): boolean {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).get('display') === 'wall';
+}
+
 /**
  * The single, global Eddy mount — rendered once in Providers, a sibling overlay
  * next to ToastProvider. Suppressed on guest/auth surfaces and while a forced
@@ -15,11 +20,12 @@ export function EddyDock() {
   const { props } = usePage<PageProps>();
   const user = props.auth?.user ?? null;
   const enabled = props.eddy?.enabled ?? false;
+  const wall = isWallDisplay();
   const isOpen = useEddyStore((state) => state.isOpen);
   const toggle = useEddyStore((state) => state.toggle);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || wall) return;
     const onKey = (event: KeyboardEvent) => {
       if (event.ctrlKey && event.shiftKey && (event.key === 'E' || event.key === 'e')) {
         event.preventDefault();
@@ -28,11 +34,12 @@ export function EddyDock() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [toggle, enabled]);
+  }, [toggle, enabled, wall]);
 
-  // Eddy ships disabled: no dock until EDDY_ENABLED=true. Also suppressed on
-  // guest/auth surfaces and while a forced password change owns the screen.
-  if (!enabled || !user || user.must_change_password) return null;
+  // Eddy ships disabled: no dock until EDDY_ENABLED=true. It is also absent
+  // from the static wall presentation, guest/auth surfaces, and the forced
+  // password-change gate.
+  if (!enabled || wall || !user || user.must_change_password) return null;
 
   return isOpen ? <EddySlideOver /> : <EddyLauncher />;
 }

--- a/resources/js/Components/cockpit/CockpitOverview.tsx
+++ b/resources/js/Components/cockpit/CockpitOverview.tsx
@@ -27,11 +27,11 @@ interface CockpitOverviewProps {
   refreshing: boolean;
   aging: boolean;
   stale: boolean;
-  onRefresh: () => void;
+  onRefresh?: () => void;
   /** D2: held drill state — P3 opens the matching DrillModal from this. */
   activeDrill: CockpitDrillDomain | null;
-  onDrillChange: (domain: CockpitDrillDomain | null) => void;
-  /** D2: ?display=wall — P2 wires the flag; P8 builds full wall mode on it. */
+  onDrillChange?: (domain: CockpitDrillDomain | null) => void;
+  /** Static kiosk presentation: preserve live data, remove every control. */
   wall?: boolean;
   /** P6 WS-4: ticker → EddyDock hand-off (wired by the page when Eddy is on). */
   onAlertEngage?: (alert: CockpitAlert) => void;
@@ -82,15 +82,16 @@ export function CockpitOverview({
   briefPanel,
 }: CockpitOverviewProps) {
   const okrsFirst = role === 'executive';
-  const scorecard = <OkrScorecard okrs={sections.okrs} onDrill={onDrillChange} />;
-  const grid = <DomainGrid domains={sections.domains} onDrill={onDrillChange} />;
+  const deskDrill = wall ? undefined : onDrillChange;
+  const scorecard = <OkrScorecard okrs={sections.okrs} onDrill={deskDrill} />;
+  const grid = <DomainGrid domains={sections.domains} onDrill={deskDrill} />;
 
   return (
     <div
       className="flex flex-col gap-3"
       data-testid="cockpit-overview"
       data-display={wall ? 'wall' : undefined}
-      data-drill={activeDrill ?? undefined}
+      data-drill={!wall ? activeDrill ?? undefined : undefined}
     >
       <CommandBar
         facility={sections.facility}
@@ -99,22 +100,22 @@ export function CockpitOverview({
         refreshing={refreshing}
         aging={aging}
         stale={stale}
-        onRefresh={onRefresh}
-        onOpenInbox={onOpenInbox}
-        inboxCount={inboxCount}
+        onRefresh={wall ? undefined : onRefresh}
+        onOpenInbox={wall ? undefined : onOpenInbox}
+        inboxCount={wall ? undefined : inboxCount}
       />
 
       {/* The loud stale banner now lives app-chrome-wide (StaleDataBanner in
           CommandCenter) so it fires at every scope, not just the house overview.
           CommandBar still carries the subtle aging/stale cue for this surface. */}
 
-      <AlertTicker alerts={sections.alerts} onEngage={onAlertEngage} />
+      <AlertTicker alerts={sections.alerts} onEngage={wall ? undefined : onAlertEngage} />
       <CensusStrip census={sections.census} />
 
       {okrsFirst ? scorecard : grid}
       {/* P6 WS-5: the executive persona reads the narrative brief right after
           its Outcomes scorecard; other roles never mount the panel. */}
-      {okrsFirst && briefPanel}
+      {okrsFirst && !wall && briefPanel}
       {okrsFirst ? grid : scorecard}
 
       <Legend asOf={sections.asOf} />

--- a/resources/js/Components/cockpit/CommandBar.tsx
+++ b/resources/js/Components/cockpit/CommandBar.tsx
@@ -16,7 +16,8 @@ interface CommandBarProps {
   refreshing: boolean;
   aging: boolean;
   stale: boolean;
-  onRefresh: () => void;
+  /** Desk-only manual refresh. Omit for a static wall presentation. */
+  onRefresh?: () => void;
   /** P6 WS-5: opens the in-cockpit ActionInboxModal (governed action queue). */
   onOpenInbox?: () => void;
   /** Pending-approval count for the inbox affordance (amber only when > 0). */
@@ -134,20 +135,22 @@ export function CommandBar({
         <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
           Updated {updatedLabel}
         </span>
-        <button
-          type="button"
-          onClick={onRefresh}
-          disabled={refreshing}
-          aria-label="Refresh data"
-          className="inline-flex items-center gap-1 rounded-md border border-healthcare-border dark:border-healthcare-border-dark
-                     bg-healthcare-surface dark:bg-healthcare-surface-dark
-                     px-2 py-1 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark
-                     shadow-sm transition-colors duration-300 hover:bg-healthcare-hover dark:hover:bg-healthcare-hover-dark
-                     disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <span className={refreshing ? 'inline-block motion-safe:animate-spin' : 'inline-block'} aria-hidden="true">{'⟳'}</span>
-          {refreshing ? 'Refreshing…' : 'Refresh'}
-        </button>
+        {onRefresh && (
+          <button
+            type="button"
+            onClick={onRefresh}
+            disabled={refreshing}
+            aria-label="Refresh data"
+            className="inline-flex items-center gap-1 rounded-md border border-healthcare-border dark:border-healthcare-border-dark
+                       bg-healthcare-surface dark:bg-healthcare-surface-dark
+                       px-2 py-1 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark
+                       shadow-sm transition-colors duration-300 hover:bg-healthcare-hover dark:hover:bg-healthcare-hover-dark
+                       disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <span className={refreshing ? 'inline-block motion-safe:animate-spin' : 'inline-block'} aria-hidden="true">{'⟳'}</span>
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </button>
+        )}
         <Clock />
       </span>
     </Surface>

--- a/resources/js/Components/cockpit/DomainGrid.tsx
+++ b/resources/js/Components/cockpit/DomainGrid.tsx
@@ -101,7 +101,8 @@ function DomainGauge({ metric }: { metric: CockpitMetricValue }) {
 
 interface DomainGridProps {
   domains: Record<string, CockpitDomain>;
-  onDrill: (domain: CockpitDrillDomain) => void;
+  /** Omit for static wall mode so panel headers are semantic text, not controls. */
+  onDrill?: (domain: CockpitDrillDomain) => void;
 }
 
 export function DomainGrid({ domains, onDrill }: DomainGridProps) {
@@ -124,7 +125,7 @@ export function DomainGrid({ domains, onDrill }: DomainGridProps) {
             title={DOMAIN_TITLES[key]}
             accent={panelAccent(domain.tiles)}
             meta={domain.provenance !== 'live' ? <ProvenanceBadge label={domain.provenance === 'demo' ? 'demo' : 'partial'} /> : undefined}
-            onDrill={() => onDrill(key)}
+            onDrill={onDrill ? () => onDrill(key) : undefined}
             className="min-w-0"
           >
             {gauge && <DomainGauge metric={gauge} />}

--- a/resources/js/Components/cockpit/OkrScorecard.tsx
+++ b/resources/js/Components/cockpit/OkrScorecard.tsx
@@ -27,7 +27,8 @@ export function okrProgressPct(card: OkrCard): number | null {
 
 interface OkrScorecardProps {
   okrs: OkrCard[];
-  onDrill: (domain: CockpitDrillDomain) => void;
+  /** Omit for static wall mode so the section heading has no control semantics. */
+  onDrill?: (domain: CockpitDrillDomain) => void;
 }
 
 export function OkrScorecard({ okrs, onDrill }: OkrScorecardProps) {
@@ -35,20 +36,26 @@ export function OkrScorecard({ okrs, onDrill }: OkrScorecardProps) {
 
   return (
     <section aria-label="Executive OKR scorecard" data-testid="cockpit-okr-scorecard" className="flex flex-col gap-2">
-      <button
-        type="button"
-        onClick={() => onDrill('okr')}
-        aria-haspopup="dialog"
-        aria-label="Open OKR scorecard drill-down"
-        className="-m-1 flex w-fit items-center gap-2 rounded p-1 text-left transition-colors hover:bg-healthcare-hover dark:hover:bg-healthcare-hover-dark"
-      >
+      {onDrill ? (
+        <button
+          type="button"
+          onClick={() => onDrill('okr')}
+          aria-haspopup="dialog"
+          aria-label="Open OKR scorecard drill-down"
+          className="-m-1 flex w-fit items-center gap-2 rounded p-1 text-left transition-colors hover:bg-healthcare-hover dark:hover:bg-healthcare-hover-dark"
+        >
+          <span className="text-base font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+            Executive OKR Scorecard
+          </span>
+          <span aria-hidden="true" className="text-sm leading-none text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+            {'⤢'}
+          </span>
+        </button>
+      ) : (
         <span className="text-base font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
           Executive OKR Scorecard
         </span>
-        <span aria-hidden="true" className="text-sm leading-none text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
-          {'⤢'}
-        </span>
-      </button>
+      )}
 
       <div className="grid gap-2" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))' }}>
         {okrs.map((card) => {

--- a/resources/js/Components/cockpit/ScopedFaceView.tsx
+++ b/resources/js/Components/cockpit/ScopedFaceView.tsx
@@ -54,9 +54,11 @@ export interface ScopedFaceViewProps {
   scopeToken: string;
   /** P8 WS-4 — a bed/board row descends to the A2P patient lens with its ptok. */
   onPatientDrill?: (patientRef: string) => void;
+  /** False for wall mode: remove links, retries, and patient-row controls. */
+  interactive?: boolean;
 }
 
-export function ScopedFaceView({ scopeToken, onPatientDrill }: ScopedFaceViewProps) {
+export function ScopedFaceView({ scopeToken, onPatientDrill, interactive = true }: ScopedFaceViewProps) {
   const query = useCockpitFace(scopeToken);
 
   const parsed = useMemo<ParsedFace>(() => {
@@ -85,22 +87,28 @@ export function ScopedFaceView({ scopeToken, onPatientDrill }: ScopedFaceViewPro
           <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
             {parsed.detail}
           </p>
-          <button
-            type="button"
-            onClick={() => void query.refetch()}
-            className="rounded-md border border-healthcare-border dark:border-healthcare-border-dark px-3 py-1.5 text-sm font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark hover:bg-healthcare-background dark:hover:bg-healthcare-background-dark"
-          >
-            Retry
-          </button>
+          {interactive && (
+            <button
+              type="button"
+              onClick={() => void query.refetch()}
+              className="rounded-md border border-healthcare-border dark:border-healthcare-border-dark px-3 py-1.5 text-sm font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark hover:bg-healthcare-background dark:hover:bg-healthcare-background-dark"
+            >
+              Retry
+            </button>
+          )}
         </div>
       )}
 
       {parsed.state === 'ready' && parsed.face.render === 'grid' && (
-        <HouseBounce label={parsed.face.scope.label} />
+        <HouseBounce label={parsed.face.scope.label} interactive={interactive} />
       )}
 
       {parsed.state === 'ready' && parsed.face.render === 'face' && (
-        <DetailFace face={parsed.face} onPatientDrill={onPatientDrill} />
+        <DetailFace
+          face={parsed.face}
+          onPatientDrill={interactive ? onPatientDrill : undefined}
+          interactive={interactive}
+        />
       )}
     </div>
   );
@@ -112,7 +120,7 @@ export function ScopedFaceView({ scopeToken, onPatientDrill }: ScopedFaceViewPro
  * empty scoped shell. A full navigation (not client-side) clears the ?scope=
  * read-once state cleanly.
  */
-function HouseBounce({ label }: { label: string }) {
+function HouseBounce({ label, interactive }: { label: string; interactive: boolean }) {
   return (
     <div className="flex flex-col items-start gap-2 rounded-md border border-healthcare-border dark:border-healthcare-border-dark bg-healthcare-surface dark:bg-healthcare-surface-dark p-4 shadow-sm">
       <p className="text-sm font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
@@ -121,17 +129,31 @@ function HouseBounce({ label }: { label: string }) {
       <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
         This scope resolved to the house cockpit.
       </p>
-      <a
-        href="/dashboard"
-        className="rounded-md border border-healthcare-border dark:border-healthcare-border-dark px-3 py-1.5 text-sm font-medium text-healthcare-primary dark:text-healthcare-primary-dark hover:bg-healthcare-background dark:hover:bg-healthcare-background-dark"
-      >
-        Open the house cockpit
-      </a>
+      {interactive ? (
+        <a
+          href="/dashboard"
+          className="rounded-md border border-healthcare-border dark:border-healthcare-border-dark px-3 py-1.5 text-sm font-medium text-healthcare-primary dark:text-healthcare-primary-dark hover:bg-healthcare-background dark:hover:bg-healthcare-background-dark"
+        >
+          Open the house cockpit
+        </a>
+      ) : (
+        <span className="text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+          House cockpit
+        </span>
+      )}
     </div>
   );
 }
 
-function DetailFace({ face, onPatientDrill }: { face: CockpitDetailFace; onPatientDrill?: (patientRef: string) => void }) {
+function DetailFace({
+  face,
+  onPatientDrill,
+  interactive,
+}: {
+  face: CockpitDetailFace;
+  onPatientDrill?: (patientRef: string) => void;
+  interactive: boolean;
+}) {
   const accent = COCKPIT_STATE_TO_LEVEL[worstStatus(face.kpis)];
   const accentStyle = statusStyle(accent);
   const empty = face.kpis.length === 0 && face.tables.length === 0;
@@ -146,9 +168,13 @@ function DetailFace({ face, onPatientDrill }: { face: CockpitDetailFace; onPatie
         />
         <div className="min-w-0 flex-1">
           <nav className="flex items-center gap-1.5 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
-            <a href="/dashboard" className="hover:text-healthcare-primary dark:hover:text-healthcare-primary-dark hover:underline underline-offset-2">
-              House
-            </a>
+            {interactive ? (
+              <a href="/dashboard" className="hover:text-healthcare-primary dark:hover:text-healthcare-primary-dark hover:underline underline-offset-2">
+                House
+              </a>
+            ) : (
+              <span>House</span>
+            )}
             <span aria-hidden="true">›</span>
             <span className="rounded border border-healthcare-border dark:border-healthcare-border-dark px-1 py-px font-medium uppercase tracking-wide">
               {LEVEL_LABEL[face.scope.level]}

--- a/resources/js/Components/cockpit/StaleDataBanner.tsx
+++ b/resources/js/Components/cockpit/StaleDataBanner.tsx
@@ -7,8 +7,8 @@ export interface StaleDataBannerProps {
   aging?: boolean;
   /** Human-readable label for when the data was last known good (e.g. "2 min ago"). */
   updatedLabel: string;
-  /** Invoked when the operator asks to re-fetch from the "Retry now" affordance. */
-  onRetry: () => void;
+  /** Desk-only retry affordance. Omit on a wall; background polling continues. */
+  onRetry?: () => void;
   /** Optional extra classes merged onto the outer container. */
   className?: string;
 }
@@ -49,14 +49,19 @@ export function StaleDataBanner({
           className="h-4 w-4 shrink-0 text-white"
         />
         <span className="min-w-0">
-          Live updates interrupted — showing last good data from {updatedLabel}.{' '}
-          <button
-            type="button"
-            onClick={onRetry}
-            className="font-medium text-white underline underline-offset-2 hover:no-underline"
-          >
-            Retry now
-          </button>
+          Live updates interrupted — showing last good data from {updatedLabel}.
+          {onRetry && (
+            <>
+              {' '}
+              <button
+                type="button"
+                onClick={onRetry}
+                className="font-medium text-white underline underline-offset-2 hover:no-underline"
+              >
+                Retry now
+              </button>
+            </>
+          )}
         </span>
       </div>
     );

--- a/resources/js/Pages/Dashboard/CommandCenter.tsx
+++ b/resources/js/Pages/Dashboard/CommandCenter.tsx
@@ -11,8 +11,9 @@
 // D2 deep links (load-bearing for P4a's redirects): ?drill={domain} is read on
 // mount, held in state, kept in sync with pushState/popstate so Back works —
 // the DrillModal (P3) auto-opens from this state, and ESC/backdrop/Back all
-// close it through the same handler. ?display=wall is wired through to the
-// overview (P8 builds full wall mode on it).
+// close it through the same handler. ?display=wall switches the same live
+// surface into its static, chromeless presentation: interaction deep links are
+// stripped and no drill, patient, inbox, or assistant surface is mounted.
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Head, usePage } from '@inertiajs/react';
 import DashboardLayout from '@/Components/Dashboard/DashboardLayout';
@@ -36,7 +37,6 @@ import { CockpitOverview } from '@/Components/cockpit/CockpitOverview';
 import { ScopedFaceView } from '@/Components/cockpit/ScopedFaceView';
 import { ScopePicker } from '@/Components/cockpit/ScopePicker';
 import { StaleDataBanner } from '@/Components/cockpit/StaleDataBanner';
-import { useIdleReset } from '@/features/cockpit/useIdleReset';
 import { useCockpitStream } from '@/features/cockpit/useCockpitStream';
 import { DrillModal } from '@/Components/cockpit/DrillModal';
 import { PatientLensModal } from '@/Components/cockpit/PatientLensModal';
@@ -53,12 +53,6 @@ const STALE_MS = REFRESH_MS * 2.5;
 // One overdue refresh ⇒ "aging": a quiet amber cue before the loud stale banner.
 const AGING_MS = REFRESH_MS * 1.4;
 const TICK_MS = 15_000;
-// P8 WS-5 auto-timeout-to-glance: after this much inactivity a wall mount closes
-// any open drill/patient overlay and returns to its glance (the CMIO PHI
-// mitigation for an always-on screen). Keeps the mount's ?scope — a unit wall
-// returns to its unit face, not the house.
-const WALL_IDLE_MS = 120_000;
-
 function urlParam(name: string): string | null {
   if (typeof window === 'undefined') return null;
   return new URLSearchParams(window.location.search).get(name);
@@ -75,6 +69,18 @@ function drillFromUrl(): CockpitDrillDomain | null {
 function patientFromUrl(): string | null {
   const param = urlParam('patient');
   return isPatientContextRef(param) ? param : null;
+}
+
+/** Remove desk-only interaction state without disturbing the mounted scope. */
+function stripWallInteractionParams(): void {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  const hasInteractionState = url.searchParams.has('drill') || url.searchParams.has('patient');
+  url.searchParams.delete('drill');
+  url.searchParams.delete('patient');
+  if (hasInteractionState) {
+    window.history.replaceState(window.history.state, '', url);
+  }
 }
 
 /** Seed TanStack's freshness clock from the payload's own timestamp. */
@@ -124,39 +130,48 @@ export default function CommandCenter({
   // freshness — not the house snapshot's. null off a scoped mount ⇒ no fetch.
   const scopedToken = isScopedMount(scopeToken) ? scopeToken : null;
   const faceQuery = useCockpitFace(scopedToken);
-  const [drill, setDrill] = useState<CockpitDrillDomain | null>(drillFromUrl);
-  const [patient, setPatient] = useState<string | null>(patientFromUrl);
+  const [drill, setDrill] = useState<CockpitDrillDomain | null>(() => wall ? null : drillFromUrl());
+  const [patient, setPatient] = useState<string | null>(() => wall ? null : patientFromUrl());
 
   // Drill state ↔ URL: pushState on change so drills are shareable and the
   // browser Back button walks drill history (popstate syncs state back).
   const handleDrillChange = useCallback((domain: CockpitDrillDomain | null) => {
+    if (wall) return;
     setDrill(domain);
     if (typeof window === 'undefined') return;
     const url = new URL(window.location.href);
     if (domain) url.searchParams.set('drill', domain);
     else url.searchParams.delete('drill');
     window.history.pushState(window.history.state, '', url);
-  }, []);
+  }, [wall]);
 
   // Patient lens ↔ URL: same pushState/popstate discipline as the drill, so the
   // A2P descent is shareable and Back closes it (WS-4 sets this from a row).
   const handlePatientChange = useCallback((contextRef: string | null) => {
+    if (wall) return;
     setPatient(contextRef);
     if (typeof window === 'undefined') return;
     const url = new URL(window.location.href);
     if (contextRef) url.searchParams.set('patient', contextRef);
     else url.searchParams.delete('patient');
     window.history.pushState(window.history.state, '', url);
-  }, []);
+  }, [wall]);
 
   useEffect(() => {
     const onPopState = () => {
+      if (wall) {
+        setDrill(null);
+        setPatient(null);
+        stripWallInteractionParams();
+        return;
+      }
       setDrill(drillFromUrl());
       setPatient(patientFromUrl());
     };
+    onPopState();
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
-  }, []);
+  }, [wall]);
 
   // Tick a clock so the freshness label and stale detection stay truthful even
   // when no fresh payload arrives. A silently failed refresh must surface.
@@ -164,21 +179,6 @@ export default function CommandCenter({
     const id = setInterval(() => setNowMs(Date.now()), TICK_MS);
     return () => clearInterval(id);
   }, []);
-
-  // P8 WS-5 auto-timeout-to-glance: on a wall mount, inactivity walks any open
-  // drill/patient overlay back to the mount's glance (scope preserved). No-op off
-  // the wall — a staffed desk keeps whatever it drilled into.
-  useIdleReset({
-    enabled: wall,
-    timeoutMs: WALL_IDLE_MS,
-    // Only walk back overlays that are actually open — a resting wall (nothing
-    // drilled) must not push history every idle tick. useIdleReset refs the latest
-    // onIdle, so drill/patient here are current.
-    onIdle: () => {
-      if (drill) handleDrillChange(null);
-      if (patient) handlePatientChange(null);
-    },
-  });
 
   const handleRefresh = useCallback(() => {
     void query.refetch();
@@ -208,7 +208,7 @@ export default function CommandCenter({
 
   // P6 WS-5: the governed action queue in the cockpit — one fetch per mount
   // (no polling; the useDecideApproval mutation invalidates on decisions).
-  const inbox = useAgentInbox();
+  const inbox = useAgentInbox(!wall);
   const [inboxOpen, setInboxOpen] = useState(false);
   const pendingApprovals = inbox.data?.summary.pendingApprovals ?? 0;
 
@@ -270,20 +270,24 @@ export default function CommandCenter({
         <StaleDataBanner
           stale={stale}
           updatedLabel={updatedLabel}
-          onRetry={handleRefresh}
+          onRetry={wall ? undefined : handleRefresh}
           className="mb-3"
         />
         {cockpitActive ? (
           <ErrorBoundary
             fallback={(error?: Error) => (
-              <CommandCenterError detail={error?.message} onRetry={handleRefresh} />
+              <CommandCenterError detail={error?.message} onRetry={wall ? undefined : handleRefresh} />
             )}
           >
             {scopedMount ? (
               // P8 WS-2b: a non-house mount — the scope's own altitude face,
               // fetched from /api/cockpit/face and rendered with the same
               // Tile / DataTable primitives the house grid and drills use.
-              <ScopedFaceView scopeToken={scopeToken as string} onPatientDrill={handlePatientChange} />
+              <ScopedFaceView
+                scopeToken={scopeToken as string}
+                interactive={!wall}
+                onPatientDrill={wall ? undefined : handlePatientChange}
+              />
             ) : (
               <>
                 <CockpitOverview
@@ -294,44 +298,47 @@ export default function CommandCenter({
                   aging={aging}
                   stale={stale}
                   onRefresh={handleRefresh}
-                  activeDrill={drill}
+                  activeDrill={wall ? null : drill}
                   onDrillChange={handleDrillChange}
                   wall={wall}
-                  onAlertEngage={eddyEnabled ? handleAlertEngage : undefined}
-                  onOpenInbox={() => setInboxOpen(true)}
+                  onAlertEngage={!wall && eddyEnabled ? handleAlertEngage : undefined}
+                  onOpenInbox={!wall ? () => setInboxOpen(true) : undefined}
                   inboxCount={pendingApprovals}
-                  briefPanel={role === 'executive' ? <ExecutiveBriefPanel /> : undefined}
+                  briefPanel={!wall && role === 'executive' ? <ExecutiveBriefPanel /> : undefined}
                 />
                 {/* A2 drill (P3): opens from panel/OKR headers AND from ?drill=
                     deep links; closing (ESC, backdrop, ×) clears the URL param. */}
-                <DrillModal domain={drill} onClose={() => handleDrillChange(null)} onPatientDrill={handlePatientChange} />
+                {!wall && (
+                  <DrillModal domain={drill} onClose={() => handleDrillChange(null)} onPatientDrill={handlePatientChange} />
+                )}
                 {/* P6 WS-5: the AgentInbox queue as an in-cockpit modal. */}
-                <ActionInboxModal open={inboxOpen} onClose={() => setInboxOpen(false)} />
+                {!wall && <ActionInboxModal open={inboxOpen} onClose={() => setInboxOpen(false)} />}
               </>
             )}
             {/* P8 WS-3: the A2P patient lens overlays ANY mount (house or
                 scoped) — ?patient={ptok} opens it; WS-4 wires bed/board rows. */}
-            <PatientLensModal contextRef={patient} onClose={() => handlePatientChange(null)} />
+            {!wall && <PatientLensModal contextRef={patient} onClose={() => handlePatientChange(null)} />}
           </ErrorBoundary>
         ) : parsed.ok ? (
           <ErrorBoundary
             fallback={(error?: Error) => (
-              <CommandCenterError detail={error?.message} onRetry={handleRefresh} />
+              <CommandCenterError detail={error?.message} onRetry={wall ? undefined : handleRefresh} />
             )}
           >
             <CommandCenterView
               data={parsed.data}
-              onRefresh={handleRefresh}
+              onRefresh={wall ? undefined : handleRefresh}
               refreshing={refreshing}
               updatedLabel={updatedLabel}
               aging={aging}
               stale={stale}
+              interactive={!wall}
             />
           </ErrorBoundary>
         ) : (
           <CommandCenterError
             detail={sections.ok ? parsed.error : sections.error}
-            onRetry={handleRefresh}
+            onRetry={wall ? undefined : handleRefresh}
           />
         )}
       </PageContentLayout>

--- a/resources/js/features/ops/hooks.ts
+++ b/resources/js/features/ops/hooks.ts
@@ -5,8 +5,8 @@ export function useAgentDefinitions() {
   return useQuery({ queryKey: ['ops', 'agent-definitions'], queryFn: fetchAgentDefinitions });
 }
 
-export function useAgentInbox() {
-  return useQuery({ queryKey: ['ops', 'agent-inbox'], queryFn: fetchAgentInbox });
+export function useAgentInbox(enabled = true) {
+  return useQuery({ queryKey: ['ops', 'agent-inbox'], queryFn: fetchAgentInbox, enabled });
 }
 
 export function useRunAgent() {

--- a/tests/js/cockpit/CockpitOverview.test.tsx
+++ b/tests/js/cockpit/CockpitOverview.test.tsx
@@ -120,11 +120,47 @@ describe('CockpitOverview', () => {
     expect(onDrillChange).toHaveBeenCalledWith('okr');
   });
 
-  it('wires ?display=wall and the held drill state onto the root (P8 / P3 seams)', () => {
-    renderOverview({ wall: true, activeDrill: 'rtdc' });
+  it('renders wall mode as a static surface even when desk callbacks are supplied', () => {
+    const onDrillChange = vi.fn();
+    const onRefresh = vi.fn();
+    const onOpenInbox = vi.fn();
+    const onAlertEngage = vi.fn();
+    renderOverview({
+      wall: true,
+      role: 'executive',
+      activeDrill: 'rtdc',
+      onDrillChange,
+      onRefresh,
+      onOpenInbox,
+      onAlertEngage,
+      inboxCount: 2,
+      briefPanel: <button type="button">Desk-only brief action</button>,
+    });
+
     const root = screen.getByTestId('cockpit-overview');
     expect(root.dataset.display).toBe('wall');
-    expect(root.dataset.drill).toBe('rtdc');
+    expect(root.dataset.drill).toBeUndefined();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByText('Desk-only brief action')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Inbox/)).not.toBeInTheDocument();
+  });
+
+  it('preserves refresh, inbox, alert engagement, and drill controls in desk mode', () => {
+    const onDrillChange = vi.fn();
+    const onRefresh = vi.fn();
+    const onOpenInbox = vi.fn();
+    const onAlertEngage = vi.fn();
+    renderOverview({ onDrillChange, onRefresh, onOpenInbox, onAlertEngage, inboxCount: 2 });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh data' }));
+    fireEvent.click(screen.getByRole('button', { name: /Open action inbox/ }));
+    fireEvent.click(screen.getByTestId('cockpit-alert-ed.nedocs'));
+    fireEvent.click(screen.getByRole('button', { name: 'Open Emergency drill-down' }));
+
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    expect(onOpenInbox).toHaveBeenCalledTimes(1);
+    expect(onAlertEngage).toHaveBeenCalledWith(sections.alerts[0]);
+    expect(onDrillChange).toHaveBeenCalledWith('ed');
   });
 
   it('delegates the loud stale banner to app chrome (no longer inline)', () => {

--- a/tests/js/cockpit/CommandCenterWallLockdown.test.tsx
+++ b/tests/js/cockpit/CommandCenterWallLockdown.test.tsx
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { usePage } from '@inertiajs/react';
+import type { ReactNode } from 'react';
+
+const mocks = vi.hoisted(() => ({
+  snapshot: vi.fn(),
+  face: vi.fn(),
+  inbox: vi.fn(),
+  overview: vi.fn(),
+}));
+
+vi.mock('@/features/cockpit/hooks', () => ({
+  COCKPIT_REFRESH_MS: 45_000,
+  useCockpitSnapshot: (...args: unknown[]) => mocks.snapshot(...args),
+  useCockpitFace: (...args: unknown[]) => mocks.face(...args),
+}));
+
+vi.mock('@/features/cockpit/live', () => ({ useLiveCockpit: () => undefined }));
+vi.mock('@/features/cockpit/useCockpitStream', () => ({ useCockpitStream: () => undefined }));
+vi.mock('@/features/ops/hooks', () => ({ useAgentInbox: (enabled?: boolean) => mocks.inbox(enabled) }));
+
+vi.mock('@/stores/eddyStore', () => ({
+  useEddyStore: (selector: (state: { openWithPrefill: ReturnType<typeof vi.fn> }) => unknown) =>
+    selector({ openWithPrefill: vi.fn() }),
+}));
+vi.mock('@/stores/commandCenterStore', () => ({
+  useCommandCenterStore: (selector: (state: { role: 'command' }) => unknown) => selector({ role: 'command' }),
+}));
+
+vi.mock('@/Components/Dashboard/DashboardLayout', () => ({
+  default: ({ children, wall }: { children: ReactNode; wall?: boolean }) => (
+    <div data-testid="layout" data-wall={wall ? 'true' : 'false'}>{children}</div>
+  ),
+}));
+vi.mock('@/Components/Common/PageContentLayout', () => ({
+  default: ({ children, headerContent }: { children: ReactNode; headerContent?: ReactNode }) => (
+    <main>{headerContent}{children}</main>
+  ),
+}));
+vi.mock('@/Components/ErrorBoundary', () => ({
+  default: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock('@/Components/CommandCenter/states', () => ({
+  CommandCenterError: () => <div data-testid="command-center-error" />,
+  relativeTimeFrom: () => 'just now',
+}));
+vi.mock('@/Components/CommandCenter/CommandCenterView', () => ({
+  CommandCenterView: () => <div data-testid="classic-command-center" />,
+}));
+vi.mock('@/Components/cockpit/CockpitOverview', () => ({
+  CockpitOverview: (props: Record<string, unknown>) => {
+    mocks.overview(props);
+    return <div data-testid="cockpit-overview" />;
+  },
+}));
+vi.mock('@/Components/cockpit/ScopedFaceView', () => ({
+  ScopedFaceView: () => <div data-testid="scoped-face" />,
+}));
+vi.mock('@/Components/cockpit/ScopePicker', () => ({
+  ScopePicker: () => <button type="button">Scope picker</button>,
+}));
+vi.mock('@/Components/cockpit/StaleDataBanner', () => ({
+  StaleDataBanner: () => <div data-testid="stale-banner" />,
+}));
+vi.mock('@/Components/cockpit/DrillModal', () => ({
+  DrillModal: ({ domain }: { domain: string | null }) => (
+    <div data-testid="drill-modal" data-domain={domain ?? undefined} />
+  ),
+}));
+vi.mock('@/Components/cockpit/PatientLensModal', () => ({
+  PatientLensModal: ({ contextRef }: { contextRef: string | null }) => (
+    <div data-testid="patient-modal" data-context={contextRef ?? undefined} />
+  ),
+}));
+vi.mock('@/Components/cockpit/ActionInboxModal', () => ({
+  ActionInboxModal: () => <div data-testid="inbox-modal" />,
+}));
+vi.mock('@/Components/cockpit/ExecutiveBriefPanel', () => ({
+  ExecutiveBriefPanel: () => <button type="button">Executive brief</button>,
+}));
+
+import CommandCenter from '@/Pages/Dashboard/CommandCenter';
+
+const metric = {
+  key: 'rtdc.occupancy',
+  label: 'Occupancy',
+  value: 88,
+  display: '88%',
+  unit: '%',
+  sub: null,
+  status: 'warn',
+  target: 85,
+  direction: 'down',
+  trend: [84, 86, 88],
+  trendLabel: null,
+  updatedAt: '2026-07-10T12:00:00+00:00',
+};
+
+const payload = {
+  asOf: '2026-07-10T12:00:00+00:00',
+  facility: { name: 'Summit Regional Medical Center', licensedBeds: 500, level: 'Academic Medical Center' },
+  capacityStatus: { level: 'Surge Level 2', code: 'yellow', status: 'warn' },
+  census: [metric],
+  alerts: [{ key: 'rtdc.occupancy', status: 'warn', text: 'House occupancy above safe zone' }],
+  okrs: [],
+  domains: { rtdc: { provenance: 'live', gaugeKey: 'rtdc.occupancy', tiles: [metric] } },
+};
+
+describe('CommandCenter wall interaction boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', '/dashboard');
+    vi.mocked(usePage).mockReturnValue({
+      props: { auth: { user: { id: 1 } }, eddy: { enabled: true }, flash: {} },
+    } as never);
+    mocks.snapshot.mockImplementation((data: unknown) => ({
+      data,
+      refetch: vi.fn(),
+      isFetching: false,
+    }));
+    mocks.face.mockReturnValue({ dataUpdatedAt: 0, isFetching: false, refetch: vi.fn() });
+    mocks.inbox.mockReturnValue({ data: { summary: { pendingApprovals: 2 } } });
+  });
+
+  it('strips interaction deep links, disables inbox fetch, and does not mount overlays on a wall', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/dashboard?display=wall&scope=house&drill=ed&patient=ptok_abc123',
+    );
+
+    render(<CommandCenter data={payload} cockpitEnabled />);
+
+    await waitFor(() => {
+      expect(window.location.search).toBe('?display=wall&scope=house');
+    });
+    expect(mocks.inbox).toHaveBeenCalledWith(false);
+    expect(screen.getByTestId('layout')).toHaveAttribute('data-wall', 'true');
+    expect(screen.queryByTestId('drill-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('patient-modal')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('inbox-modal')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Scope picker' })).not.toBeInTheDocument();
+
+    const props = mocks.overview.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(props.wall).toBe(true);
+    expect(props.activeDrill).toBeNull();
+    expect(props.onAlertEngage).toBeUndefined();
+    expect(props.onOpenInbox).toBeUndefined();
+    expect(props.briefPanel).toBeUndefined();
+  });
+
+  it('keeps deep links, inbox data, and overlay mounts available on a staffed desk', () => {
+    window.history.replaceState({}, '', '/dashboard?drill=ed&patient=ptok_abc123');
+
+    render(<CommandCenter data={payload} cockpitEnabled />);
+
+    expect(mocks.inbox).toHaveBeenCalledWith(true);
+    expect(screen.getByTestId('layout')).toHaveAttribute('data-wall', 'false');
+    expect(screen.getByTestId('drill-modal')).toHaveAttribute('data-domain', 'ed');
+    expect(screen.getByTestId('patient-modal')).toHaveAttribute('data-context', 'ptok_abc123');
+    expect(screen.getByTestId('inbox-modal')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Scope picker' })).toBeInTheDocument();
+
+    const props = mocks.overview.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+    expect(props.wall).toBe(false);
+    expect(props.activeDrill).toBe('ed');
+    expect(props.onAlertEngage).toEqual(expect.any(Function));
+    expect(props.onOpenInbox).toEqual(expect.any(Function));
+  });
+});

--- a/tests/js/cockpit/ScopedFaceView.test.tsx
+++ b/tests/js/cockpit/ScopedFaceView.test.tsx
@@ -76,11 +76,19 @@ const gridFace = {
   sub: 'House-wide operations overview',
 };
 
-function renderFace(scopeToken = 'unit:MICU', onPatientDrill?: (ref: string) => void) {
+function renderFace(
+  scopeToken = 'unit:MICU',
+  onPatientDrill?: (ref: string) => void,
+  interactive = true,
+) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={client}>
-      <ScopedFaceView scopeToken={scopeToken} onPatientDrill={onPatientDrill} />
+      <ScopedFaceView
+        scopeToken={scopeToken}
+        onPatientDrill={onPatientDrill}
+        interactive={interactive}
+      />
     </QueryClientProvider>,
   );
 }
@@ -135,6 +143,17 @@ describe('ScopedFaceView', () => {
     expect(onPatientDrill).toHaveBeenCalledWith('ptok_micu001');
   });
 
+  it('renders scoped wall faces without breadcrumb or patient-row controls', async () => {
+    const onPatientDrill = vi.fn();
+    mockedFetch.mockResolvedValue(drillFace);
+    renderFace('unit:MICU', onPatientDrill, false);
+
+    await screen.findByText('Bed 3');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(within(screen.getByRole('navigation')).queryByRole('link')).not.toBeInTheDocument();
+    expect(onPatientDrill).not.toHaveBeenCalled();
+  });
+
   it('shows the honest empty state when there is no live census (never fabricated)', async () => {
     mockedFetch.mockResolvedValue(emptyFace);
     renderFace();
@@ -155,6 +174,15 @@ describe('ScopedFaceView', () => {
     expect(link).toHaveAttribute('href', '/dashboard');
   });
 
+  it('keeps a wall-mode house bounce informational rather than navigable', async () => {
+    mockedFetch.mockResolvedValue(gridFace);
+    renderFace('unit:GHOST', undefined, false);
+
+    await screen.findByText('Mounted at Summit Regional Medical Center.');
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.getByText('House cockpit')).toBeInTheDocument();
+  });
+
   it('degrades to an in-place error card with retry when the payload breaks contract', async () => {
     mockedFetch.mockResolvedValue({ scope: gridFace.scope, render: 'face', title: 'broken' }); // missing kpis/tables
     renderFace();
@@ -173,5 +201,13 @@ describe('ScopedFaceView', () => {
 
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(screen.getByText(/Request failed/)).toBeInTheDocument();
+  });
+
+  it('keeps wall-mode error state visible without a retry control', async () => {
+    mockedFetch.mockRejectedValue(new Error('Request failed with status code 500'));
+    renderFace('unit:MICU', undefined, false);
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 });

--- a/tests/js/cockpit/StaleDataBanner.test.tsx
+++ b/tests/js/cockpit/StaleDataBanner.test.tsx
@@ -38,4 +38,11 @@ describe('StaleDataBanner', () => {
     expect(screen.getByRole('button', { name: /retry now/i })).toBeInTheDocument();
     expect(screen.queryByText(/Data aging/i)).not.toBeInTheDocument();
   });
+
+  it('keeps the wall stale warning visible without mounting a retry control', () => {
+    render(<StaleDataBanner stale updatedLabel="4 min ago" />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/Live updates interrupted/i);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
 });

--- a/tests/js/commandCenter/Band.test.tsx
+++ b/tests/js/commandCenter/Band.test.tsx
@@ -42,6 +42,11 @@ describe('Band', () => {
     expect(screen.getByText('First-Case On-Time')).toBeInTheDocument();
   });
 
+  it('suppresses the band drill link on a static wall', () => {
+    render(<Band band={flat} interactive={false} />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
   it('shows an empty state instead of a blank grid when a flat band has no metrics', () => {
     render(<Band band={{ ...flat, metrics: [] }} />);
     expect(screen.getByText('No capacity metrics reporting')).toBeInTheDocument();

--- a/tests/js/commandCenter/CommandCenterView.test.tsx
+++ b/tests/js/commandCenter/CommandCenterView.test.tsx
@@ -25,6 +25,19 @@ describe('CommandCenterView', () => {
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 
+  it('renders the classic wall fallback without a manual refresh control', () => {
+    render(
+      <CommandCenterView
+        data={commandCenterFixture}
+        updatedLabel="just now"
+        onRefresh={() => {}}
+        interactive={false}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /refresh data/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
   it('shows the OKR scoreboard when role is executive', () => {
     useCommandCenterStore.setState({ role: 'executive', serviceLine: null });
     render(<CommandCenterView data={commandCenterFixture} onRefresh={() => {}} updatedLabel="just now" />);

--- a/tests/js/commandCenter/KpiTile.test.tsx
+++ b/tests/js/commandCenter/KpiTile.test.tsx
@@ -31,6 +31,11 @@ describe('KpiTile', () => {
     expect(screen.getByTestId('kpi-x').closest('a')).toBeNull();
   });
 
+  it('renders a drillable metric as a plain panel on a static wall', () => {
+    render(<KpiTile metric={base} interactive={false} />);
+    expect(screen.getByTestId('kpi-occupancy').closest('a')).toBeNull();
+  });
+
   it('renders source trust when lineage metadata is available', () => {
     render(<KpiTile metric={{
       ...base,

--- a/tests/js/components/DashboardLayout.test.tsx
+++ b/tests/js/components/DashboardLayout.test.tsx
@@ -49,6 +49,20 @@ describe('DashboardLayout (unified shell)', () => {
     expect(skip).toHaveAttribute('href', '#main-content');
   });
 
+  it('replaces desk navigation with non-focusable wall identity chrome', () => {
+    render(
+      <DashboardLayout wall>
+        <span>wall content</span>
+      </DashboardLayout>
+    );
+
+    expect(screen.queryByTestId('topnavbar')).not.toBeInTheDocument();
+    expect(screen.queryByText('Skip to content')).not.toBeInTheDocument();
+    expect(screen.getByText('Zephyrus · Operations Cockpit')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
   it('renders ChangePasswordModal when must_change_password is set', () => {
     stubPage({ id: 1, name: 'Temp User', must_change_password: true });
 

--- a/tests/js/eddy/EddyDock.test.tsx
+++ b/tests/js/eddy/EddyDock.test.tsx
@@ -9,7 +9,10 @@ import { EddyDock } from '@/Components/Eddy/EddyDock';
 const user = { id: 1, username: 'u', name: 'Operator', email: 'u@x.io', must_change_password: false };
 
 describe('EddyDock visibility gate', () => {
-  beforeEach(() => mockPage.mockReset());
+  beforeEach(() => {
+    mockPage.mockReset();
+    window.history.replaceState({}, '', '/dashboard');
+  });
 
   it('renders nothing when Eddy is disabled (ships disabled)', () => {
     mockPage.mockReturnValue({ props: { auth: { user }, eddy: { enabled: false } } });
@@ -31,6 +34,14 @@ describe('EddyDock visibility gate', () => {
 
   it('renders nothing for a guest even when enabled', () => {
     mockPage.mockReturnValue({ props: { auth: { user: null }, eddy: { enabled: true } } });
+    const { container } = render(<EddyDock />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing on a wall display even when enabled and authenticated', () => {
+    window.history.replaceState({}, '', '/dashboard?display=wall');
+    mockPage.mockReturnValue({ props: { auth: { user }, eddy: { enabled: true } } });
+
     const { container } = render(<EddyDock />);
     expect(container.firstChild).toBeNull();
   });


### PR DESCRIPTION
## Summary

- make display=wall a render-only presentation across the primary cockpit, scoped faces, and the classic rollback grammar
- strip drill and patient deep-link state, do not mount drill/patient/inbox/brief overlays, disable inbox queries, and suppress the global Eddy dock and keyboard shortcut
- render refresh, stale, panel, OKR, patient-row, breadcrumb, retry, and legacy KPI surfaces without control semantics on a wall while preserving desk behavior
- update the operational closure checklist with completed security deployment evidence and wall-tranche evidence
- repair the pre-existing dashboard raw-palette ratchet drift with the canonical healthcare hover token

## Local validation

- TypeScript: passed
- focused wall and desk suite: 9 files, 60 tests passed
- full Vitest suite: 81 files, 342 tests passed
- production Vite build: passed
- UI canon check: passed at the 76-match ratchet baseline

## Release gate

This PR must pass the full exact-head GitHub CI matrix, merge normally into main, and deploy only through ./deploy.sh from merged main.