### PR TITLE
feat(integrations): operationalize async connector runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,12 @@ DB_SCHEMA=prod
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file
 FILESYSTEM_DISK=local
-QUEUE_CONNECTION=sync
+QUEUE_CONNECTION=database
+DB_QUEUE_CONNECTION=pgsql
+DB_QUEUE_TABLE=jobs
+DB_QUEUE=default
+DB_QUEUE_RETRY_AFTER=360
+QUEUE_FAILED_DRIVER=database-uuids
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
@@ -113,6 +118,20 @@ EDDY_CALLBACK_TOKEN=                        # bearer Eddy uses on non-user telem
 # it and caches discovered maps in arena.maps; it is stateless + PHI-free.
 ARENA_ENABLED=false
 ARENA_BASE_URL=http://arena:8100           # dev (compose); prod=http://127.0.0.1:8100 (systemd/uvicorn) or the arena container
+
+# Governed enterprise integration runtime. Keep the outbound allowlist exact;
+# private key material stays outside the repository under the configured root.
+INTEGRATION_ALLOWED_HOSTS=fhir.epic.com
+INTEGRATION_ALLOWED_PORTS=443
+INTEGRATION_REQUIRE_HTTPS=true
+INTEGRATION_REQUIRE_DNS_RESOLUTION=true
+INTEGRATION_SECRET_FILE_ROOT=/etc/zephyrus/secrets
+INTEGRATION_HEALTH_TIMEOUT_SECONDS=10
+INTEGRATION_FHIR_PAGE_LIMIT=10
+INTEGRATION_FHIR_RESOURCE_LIMIT=1000
+EPIC_FHIR_CLIENT_ID=
+EPIC_FHIR_PRIVATE_KEY_REF=
+EPIC_FHIR_KEY_ID=
 ARENA_PORT=8110                            # docker-compose host port
 ARENA_TIMEOUT_SECONDS=60
 ARENA_CACHE_TTL_SECONDS=900                # discovered-map cache lifetime

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /public/build
 /public/hot
 /public/storage
+/coverage/
 /storage/*.key
 /storage/pail
 /vendor
@@ -40,6 +41,9 @@ config.local.php
 
 # Playwright MCP scratch captures (per-session browser artifacts)
 /.playwright-mcp/
+
+# Firecrawl research captures (untrusted, per-session web artifacts)
+/.firecrawl/
 
 # Deployment specific
 /public/mix-manifest.json

--- a/app/Console/Commands/ConfigureHl7AdtSource.php
+++ b/app/Console/Commands/ConfigureHl7AdtSource.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Integrations\Healthcare\Services\OperationalIntegrationConfigurator;
+use Illuminate\Console\Command;
+
+class ConfigureHl7AdtSource extends Command
+{
+    protected $signature = 'integrations:configure-hl7-adt-source
+        {source-key : Stable lowercase source key supplied in X-Integration-Source}
+        {--name= : Operator-facing source name}
+        {--vendor=Epic : EHR or interface-engine vendor}
+        {--facility=main : Facility key}
+        {--environment=sandbox : sandbox, testing, or production}
+        {--contract-status=unknown : Contract governance status}
+        {--baa-status=unknown : BAA governance status}
+        {--go-live-status=not_started : Deployment lifecycle status}
+        {--phi-allowed : Confirm this source is approved to carry PHI}
+        {--activate : Activate machine ingress after all production governance checks pass}';
+
+    protected $description = 'Configure a governed HL7 v2 ADT source for the canonical Patient Flow machine ingress.';
+
+    public function handle(OperationalIntegrationConfigurator $configurator): int
+    {
+        $sourceKey = (string) $this->argument('source-key');
+        $result = $configurator->configureHl7Source([
+            'source_key' => $sourceKey,
+            'source_name' => $this->option('name') ?: $sourceKey,
+            'vendor' => (string) $this->option('vendor'),
+            'facility_key' => (string) $this->option('facility'),
+            'environment' => (string) $this->option('environment'),
+            'contract_status' => (string) $this->option('contract-status'),
+            'baa_status' => (string) $this->option('baa-status'),
+            'go_live_status' => (string) $this->option('go-live-status'),
+            'phi_allowed' => (bool) $this->option('phi-allowed'),
+            'activate' => (bool) $this->option('activate'),
+        ]);
+
+        $this->components->info("HL7 source {$result['sourceKey']} is {$result['activeStatus']}.");
+        if ($result['activeStatus'] !== 'active') {
+            $this->components->warn('Ingress remains disabled until production governance and machine-token activation are complete.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ConfigureOperationalIntegrations.php
+++ b/app/Console/Commands/ConfigureOperationalIntegrations.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Integrations\Healthcare\Services\OperationalIntegrationConfigurator;
+use Illuminate\Console\Command;
+
+class ConfigureOperationalIntegrations extends Command
+{
+    protected $signature = 'integrations:configure-operational-sources
+        {--epic-client-id= : Registered Epic non-production backend client ID}
+        {--epic-private-key-ref= : Approved private-key reference; never the key material}
+        {--epic-key-id= : Optional public key identifier used in the client assertion}
+        {--activate-epic : Activate scheduled sandbox polling after credentials are configured}';
+
+    protected $description = 'Idempotently configure the governed Epic FHIR sandbox and Patient Flow HL7 ADT boundary.';
+
+    public function handle(OperationalIntegrationConfigurator $configurator): int
+    {
+        $epic = $configurator->configureEpicSandbox(
+            clientId: $this->option('epic-client-id'),
+            privateKeyRef: $this->option('epic-private-key-ref'),
+            keyId: $this->option('epic-key-id'),
+            activate: (bool) $this->option('activate-epic'),
+        );
+        $hl7 = $configurator->configureHl7Boundary();
+
+        $this->components->info('Epic FHIR source: '.$epic['status'].'; SMART credential: '.$epic['credentialStatus'].'.');
+        $this->components->info('HL7 v2 boundary: '.$hl7['status'].' at '.$hl7['route'].'.');
+
+        if ($epic['credentialStatus'] !== 'configured') {
+            $this->components->warn('Epic data polling remains activation-gated until a registered client ID and private-key reference are supplied.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/IssueHl7MachineToken.php
+++ b/app/Console/Commands/IssueHl7MachineToken.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService;
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class IssueHl7MachineToken extends Command
+{
+    protected $signature = 'integrations:issue-hl7-token
+        {user : Active integration identity user ID}
+        {--name=patient-flow-hl7v2 : Token label}
+        {--expires=90 : Token lifetime in days}';
+
+    protected $description = 'Issue a bounded Sanctum machine token for canonical Patient Flow HL7 v2 ADT ingestion.';
+
+    public function handle(IntegrationConfigurationAuditService $audit): int
+    {
+        $user = User::query()->findOrFail((int) $this->argument('user'));
+        if (! $user->is_active || ! in_array($user->role, ['integration', 'integration-machine'], true)) {
+            $this->components->error('The token owner must be an active dedicated integration identity.');
+
+            return self::FAILURE;
+        }
+        $days = (int) $this->option('expires');
+        if ($days < 1 || $days > 365) {
+            $this->components->error('Token lifetime must be between 1 and 365 days.');
+
+            return self::FAILURE;
+        }
+        $name = trim((string) $this->option('name'));
+        if ($name === '' || strlen($name) > 120) {
+            $this->components->error('Token name must be 1-120 characters.');
+
+            return self::FAILURE;
+        }
+
+        $expiresAt = now()->addDays($days);
+        $token = $user->createToken($name, ['integration:patient-flow:ingest'], $expiresAt);
+        $audit->record(null, 'issued', 'machine_credential', (int) $token->accessToken->getKey(), $name, [], [
+            'userId' => (int) $user->getKey(),
+            'ability' => 'integration:patient-flow:ingest',
+            'expiresAtIso' => $expiresAt->toIso8601String(),
+        ], (string) Str::uuid());
+
+        $this->components->warn('Store this token immediately in the sending system secret manager; it will not be shown again.');
+        $this->line($token->plainTextToken);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/Admin/EnterpriseConnectorController.php
+++ b/app/Http/Controllers/Api/Admin/EnterpriseConnectorController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Admin;
 
+use App\Http\Controllers\Api\Admin\Concerns\ResolvesIntegrationCorrelation;
 use App\Http\Controllers\Controller;
 use App\Integrations\Healthcare\Services\EnterpriseConnectorControlService;
 use Illuminate\Http\JsonResponse;
@@ -10,6 +11,8 @@ use Illuminate\Validation\Rule;
 
 class EnterpriseConnectorController extends Controller
 {
+    use ResolvesIntegrationCorrelation;
+
     public function __construct(private readonly EnterpriseConnectorControlService $connectors) {}
 
     public function summary(): JsonResponse
@@ -17,14 +20,63 @@ class EnterpriseConnectorController extends Controller
         return response()->json(['data' => $this->connectors->summary()]);
     }
 
-    public function discoverFhir(): JsonResponse
+    public function discoverFhir(Request $request): JsonResponse
     {
-        return response()->json([
-            'error' => [
-                'code' => 'fhir_discovery_not_configured',
-                'message' => 'FHIR discovery requires a configured protocol checker.',
-            ],
-        ], 501);
+        $validated = $request->validate(['source_id' => ['required', 'integer', 'min:1']]);
+
+        return response()->json(['data' => $this->connectors->queueHealthCheck(
+            (int) $validated['source_id'],
+            $request->user()?->getAuthIdentifier(),
+            $this->correlationId($request),
+        )], 202);
+    }
+
+    public function healthCheck(Request $request, int $source): JsonResponse
+    {
+        return response()->json(['data' => $this->connectors->queueHealthCheck(
+            $source,
+            $request->user()?->getAuthIdentifier(),
+            $this->correlationId($request),
+        )], 202);
+    }
+
+    public function pollFhir(Request $request, int $source): JsonResponse
+    {
+        $validated = $request->validate([
+            'resource_type' => ['required', Rule::in(['Encounter', 'Location'])],
+        ]);
+
+        return response()->json(['data' => $this->connectors->queueFhirPoll(
+            $source,
+            (string) $validated['resource_type'],
+            $request->user()?->getAuthIdentifier(),
+            $this->correlationId($request),
+        )], 202);
+    }
+
+    public function previewReplay(Request $request): JsonResponse
+    {
+        return response()->json(['data' => $this->connectors->previewReplay($this->replayScope($request))]);
+    }
+
+    public function queueReplay(Request $request): JsonResponse
+    {
+        $idempotencyKey = trim((string) $request->header('Idempotency-Key'));
+        if ($idempotencyKey === '' || strlen($idempotencyKey) > 190 || preg_match('/^[A-Za-z0-9._:-]+$/', $idempotencyKey) !== 1) {
+            return response()->json(['error' => [
+                'code' => 'idempotency_key_required',
+                'message' => 'Idempotency-Key must be 1-190 URL-safe characters.',
+            ]], 422);
+        }
+
+        $result = $this->connectors->queueReplay(
+            $this->replayScope($request),
+            $idempotencyKey,
+            $request->user()?->getAuthIdentifier(),
+            $this->correlationId($request),
+        );
+
+        return response()->json(['data' => $result], $result['created'] ? 202 : 200);
     }
 
     public function createWritebackDraft(Request $request): JsonResponse
@@ -40,6 +92,19 @@ class EnterpriseConnectorController extends Controller
 
         return response()->json([
             'data' => $this->connectors->createWritebackDraft($validated, $request->user()?->id),
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function replayScope(Request $request): array
+    {
+        return $request->validate([
+            'source_id' => ['sometimes', 'nullable', 'integer', 'min:1', Rule::exists(\App\Models\Integration\Source::class, 'source_id')],
+            'from' => ['required', 'date'],
+            'to' => ['required', 'date'],
+            'event_types' => ['sometimes', 'array', 'min:1', 'max:5'],
+            'event_types.*' => ['string', Rule::in(['EncounterStarted', 'EncounterTransferred', 'EncounterDischarged', 'BedStatusChanged', 'AcuityChanged'])],
+            'limit' => ['sometimes', 'integer', 'min:1', 'max:1000'],
         ]);
     }
 }

--- a/app/Http/Controllers/Api/Admin/IntegrationHealthController.php
+++ b/app/Http/Controllers/Api/Admin/IntegrationHealthController.php
@@ -26,8 +26,13 @@ class IntegrationHealthController extends Controller
                 'degradedSources' => $snapshot['counts']['degradedSources'],
                 'staleSources' => $snapshot['counts']['staleSources'],
                 'failedSources' => $snapshot['counts']['failedSources'],
+                'protocolHealthySources' => $snapshot['counts']['protocolHealthySources'],
+                'protocolDegradedSources' => $snapshot['counts']['protocolDegradedSources'],
+                'protocolFailedSources' => $snapshot['counts']['protocolFailedSources'],
                 'openDeadLetters' => $snapshot['counts']['openDeadLetters'],
                 'pendingProjectionEvents' => $snapshot['counts']['pendingProjectionEvents'],
+                'queuedJobs' => $snapshot['counts']['queuedJobs'],
+                'failedQueueJobs' => $snapshot['counts']['failedQueueJobs'],
             ],
         ]]);
     }

--- a/app/Integrations/Healthcare/Exceptions/IntegrationCredentialException.php
+++ b/app/Integrations/Healthcare/Exceptions/IntegrationCredentialException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Integrations\Healthcare\Exceptions;
+
+use RuntimeException;
+
+class IntegrationCredentialException extends RuntimeException
+{
+    public function __construct(public readonly string $errorCode)
+    {
+        parent::__construct($errorCode);
+    }
+}

--- a/app/Integrations/Healthcare/Exceptions/IntegrationProtocolException.php
+++ b/app/Integrations/Healthcare/Exceptions/IntegrationProtocolException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Integrations\Healthcare\Exceptions;
+
+use RuntimeException;
+
+class IntegrationProtocolException extends RuntimeException
+{
+    public function __construct(public readonly string $errorCode)
+    {
+        parent::__construct($errorCode);
+    }
+}

--- a/app/Integrations/Healthcare/Services/EnterpriseConnectorControlService.php
+++ b/app/Integrations/Healthcare/Services/EnterpriseConnectorControlService.php
@@ -2,15 +2,21 @@
 
 namespace App\Integrations\Healthcare\Services;
 
+use App\Jobs\PollEpicFhirResource;
+use App\Jobs\ReplayPendingIntegrationEvents;
+use App\Jobs\RunIntegrationProtocolHealthCheck;
 use App\Models\Ops\Approval;
 use App\Models\Ops\OperationalAction;
 use App\Models\Ops\Recommendation;
 use App\Support\Api\JsonMap;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class EnterpriseConnectorControlService
 {
+    public function __construct(private readonly IntegrationConfigurationAuditService $audit) {}
+
     /** @return array<string,mixed> */
     public function summary(): array
     {
@@ -130,6 +136,182 @@ class EnterpriseConnectorControlService
         ];
     }
 
+    /** @return array<string, mixed> */
+    public function queueHealthCheck(int $sourceId, ?int $userId, string $correlationId): array
+    {
+        return DB::transaction(function () use ($sourceId, $userId, $correlationId): array {
+            $source = DB::table('integration.sources')->where('source_id', $sourceId)->lockForUpdate()->first();
+            abort_unless($source, 404);
+            $interface = strtolower((string) $source->interface_type);
+            if (! str_contains($interface, 'fhir') && ! str_contains($interface, 'hl7')) {
+                abort(422, 'Protocol health checks support FHIR and HL7 v2 sources.');
+            }
+
+            $existing = DB::table('raw.ingest_runs')
+                ->where('source_id', $sourceId)
+                ->where('run_type', 'protocol_health')
+                ->whereIn('status', ['queued', 'running', 'retrying'])
+                ->where('created_at', '>=', now()->subMinutes(10))
+                ->orderByDesc('ingest_run_id')
+                ->first();
+            if ($existing) {
+                return $this->healthRunPayload($existing, false);
+            }
+
+            $runUuid = (string) Str::uuid();
+            $runId = DB::table('raw.ingest_runs')->insertGetId([
+                'run_uuid' => $runUuid,
+                'source_id' => $sourceId,
+                'connector_key' => 'integration.protocol-health',
+                'run_type' => 'protocol_health',
+                'status' => 'queued',
+                'started_at' => now(),
+                'metadata' => json_encode([
+                    'protocol' => $interface,
+                    'correlation_id' => $correlationId,
+                    'requested_by_user_id' => $userId,
+                ], JSON_THROW_ON_ERROR),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ], 'ingest_run_id');
+
+            $this->audit->record($userId, 'queued', 'protocol_health_check', (int) $runId, $source->source_key, [], [
+                'runUuid' => $runUuid,
+                'sourceId' => $sourceId,
+                'status' => 'queued',
+            ], $correlationId);
+            RunIntegrationProtocolHealthCheck::dispatch((int) $runId, $userId, $correlationId)->afterCommit();
+
+            return $this->healthRunPayload(DB::table('raw.ingest_runs')->where('ingest_run_id', $runId)->first(), true);
+        });
+    }
+
+    /** @return array<string, mixed> */
+    public function queueFhirPoll(int $sourceId, string $resourceType, ?int $userId, string $correlationId): array
+    {
+        if (! in_array($resourceType, ['Encounter', 'Location'], true)) {
+            abort(422, 'The FHIR resource type is not enabled for this operational slice.');
+        }
+
+        return DB::transaction(function () use ($sourceId, $resourceType, $userId, $correlationId): array {
+            $source = DB::table('integration.sources')->where('source_id', $sourceId)->lockForUpdate()->first();
+            abort_unless($source, 404);
+            if ($source->active_status !== 'active' || ! str_contains(strtolower((string) $source->interface_type), 'fhir')) {
+                abort(422, 'The FHIR source must be active before polling.');
+            }
+            $connectionReady = DB::table('integration.fhir_client_connections')
+                ->where('source_id', $sourceId)->where('health_status', 'healthy')->exists();
+            $credentialReady = DB::table('integration.smart_backend_credentials')
+                ->where('source_id', $sourceId)->whereIn('status', ['ready', 'active'])->exists();
+            if (! $connectionReady || ! $credentialReady) {
+                abort(422, 'Live discovery and resolved SMART credentials are required before polling.');
+            }
+
+            $connectorKey = 'epic.fhir-r4.'.strtolower($resourceType);
+            $existing = DB::table('raw.ingest_runs')
+                ->where('source_id', $sourceId)
+                ->where('connector_key', $connectorKey)
+                ->where('run_type', 'fhir_poll')
+                ->whereIn('status', ['queued', 'running', 'retrying'])
+                ->where('created_at', '>=', now()->subMinutes(30))
+                ->orderByDesc('ingest_run_id')->first();
+            if ($existing) {
+                return $this->fhirRunPayload($existing, $resourceType, false);
+            }
+
+            $runUuid = (string) Str::uuid();
+            $runId = DB::table('raw.ingest_runs')->insertGetId([
+                'run_uuid' => $runUuid,
+                'source_id' => $sourceId,
+                'connector_key' => $connectorKey,
+                'run_type' => 'fhir_poll',
+                'status' => 'queued',
+                'started_at' => now(),
+                'metadata' => json_encode([
+                    'resource_type' => $resourceType,
+                    'correlation_id' => $correlationId,
+                    'requested_by_user_id' => $userId,
+                ], JSON_THROW_ON_ERROR),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ], 'ingest_run_id');
+            $this->audit->record($userId, 'queued', 'fhir_poll', (int) $runId, $source->source_key, [], [
+                'runUuid' => $runUuid,
+                'sourceId' => $sourceId,
+                'resourceType' => $resourceType,
+                'status' => 'queued',
+            ], $correlationId);
+            PollEpicFhirResource::dispatch((int) $runId, $resourceType, $userId, $correlationId)->afterCommit();
+
+            return $this->fhirRunPayload(DB::table('raw.ingest_runs')->where('ingest_run_id', $runId)->first(), $resourceType, true);
+        });
+    }
+
+    /** @param array<string, mixed> $scope @return array<string, mixed> */
+    public function previewReplay(array $scope): array
+    {
+        $normalized = $this->normalizedReplayScope($scope);
+        $query = $this->replayQuery($normalized);
+        $total = (clone $query)->count();
+        $bounds = (clone $query)->selectRaw('min(occurred_at) as oldest, max(occurred_at) as newest')->first();
+        $byType = (clone $query)->selectRaw('event_type, count(*) as aggregate')
+            ->groupBy('event_type')->orderBy('event_type')->get()
+            ->map(fn (object $row): array => ['eventType' => $row->event_type, 'count' => (int) $row->aggregate])->all();
+
+        return [
+            'eligibleEvents' => min($total, $normalized['limit']),
+            'totalMatchingEvents' => $total,
+            'truncated' => $total > $normalized['limit'],
+            'oldestAtIso' => $bounds?->oldest ? CarbonImmutable::parse($bounds->oldest)->toIso8601String() : null,
+            'newestAtIso' => $bounds?->newest ? CarbonImmutable::parse($bounds->newest)->toIso8601String() : null,
+            'byEventType' => $byType,
+            'scope' => $normalized,
+            'mutation' => false,
+        ];
+    }
+
+    /** @param array<string, mixed> $scope @return array<string, mixed> */
+    public function queueReplay(array $scope, string $idempotencyKey, ?int $userId, string $correlationId): array
+    {
+        $normalized = $this->normalizedReplayScope($scope);
+        $requestHash = hash('sha256', json_encode($normalized, JSON_THROW_ON_ERROR));
+
+        return DB::transaction(function () use ($normalized, $idempotencyKey, $requestHash, $userId, $correlationId): array {
+            $existing = DB::table('integration.event_replay_jobs')->where('idempotency_key', $idempotencyKey)->lockForUpdate()->first();
+            if ($existing) {
+                if (! hash_equals((string) $existing->request_hash, $requestHash)) {
+                    abort(409, 'The idempotency key was already used with a different replay scope.');
+                }
+
+                return $this->replayRunPayload($existing, false);
+            }
+
+            $replayUuid = (string) Str::uuid();
+            $replayId = DB::table('integration.event_replay_jobs')->insertGetId([
+                'replay_uuid' => $replayUuid,
+                'replay_type' => 'pending_canonical_projection',
+                'status' => 'queued',
+                'scope' => json_encode($normalized, JSON_THROW_ON_ERROR),
+                'source_id' => $normalized['sourceId'],
+                'requested_by_user_id' => $userId,
+                'idempotency_key' => $idempotencyKey,
+                'request_hash' => $requestHash,
+                'dry_run' => false,
+                'metadata' => json_encode(['correlation_id' => $correlationId], JSON_THROW_ON_ERROR),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ], 'event_replay_job_id');
+            $this->audit->record($userId, 'queued', 'canonical_event_replay', (int) $replayId, $replayUuid, [], [
+                'replayUuid' => $replayUuid,
+                'scope' => $normalized,
+                'status' => 'queued',
+            ], $correlationId);
+            ReplayPendingIntegrationEvents::dispatch((int) $replayId, $userId, $correlationId)->afterCommit();
+
+            return $this->replayRunPayload(DB::table('integration.event_replay_jobs')->where('event_replay_job_id', $replayId)->first(), true);
+        });
+    }
+
     private function sourceFor(string $sourceKey, string $vendor): object
     {
         DB::table('integration.sources')->updateOrInsert(
@@ -164,6 +346,69 @@ class EnterpriseConnectorControlService
 
     private function templateSafeStatus(string $status): string
     {
-        return $status === 'ready' ? 'template' : $status;
+        return $status;
+    }
+
+    /** @return array<string, mixed> */
+    private function healthRunPayload(object $run, bool $created): array
+    {
+        return [
+            'runId' => (int) $run->ingest_run_id,
+            'runUuid' => $run->run_uuid,
+            'status' => $run->status,
+            'created' => $created,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function fhirRunPayload(object $run, string $resourceType, bool $created): array
+    {
+        return array_merge($this->healthRunPayload($run, $created), ['resourceType' => $resourceType]);
+    }
+
+    /** @param array<string, mixed> $scope @return array<string, mixed> */
+    private function normalizedReplayScope(array $scope): array
+    {
+        $from = CarbonImmutable::parse((string) $scope['from']);
+        $to = CarbonImmutable::parse((string) $scope['to']);
+        if ($to->lessThan($from) || $from->diffInDays($to) > 7) {
+            abort(422, 'Replay windows must be ordered and no longer than seven days.');
+        }
+        $supported = ['EncounterStarted', 'EncounterTransferred', 'EncounterDischarged', 'BedStatusChanged', 'AcuityChanged'];
+        $requested = array_values(array_unique(array_map('strval', $scope['event_types'] ?? $supported)));
+        if (array_diff($requested, $supported) !== []) {
+            abort(422, 'The replay includes an unsupported canonical event type.');
+        }
+        sort($requested);
+
+        return [
+            'sourceId' => isset($scope['source_id']) ? (int) $scope['source_id'] : null,
+            'from' => $from->toIso8601String(),
+            'to' => $to->toIso8601String(),
+            'eventTypes' => $requested,
+            'projectionStatuses' => ['pending', 'failed'],
+            'limit' => min(1000, max(1, (int) ($scope['limit'] ?? 500))),
+        ];
+    }
+
+    /** @param array<string, mixed> $scope */
+    private function replayQuery(array $scope): \Illuminate\Database\Query\Builder
+    {
+        return DB::table('integration.canonical_events')
+            ->when($scope['sourceId'], fn ($query, $sourceId) => $query->where('source_id', $sourceId))
+            ->whereBetween('occurred_at', [$scope['from'], $scope['to']])
+            ->whereIn('event_type', $scope['eventTypes'])
+            ->whereIn('projection_status', $scope['projectionStatuses']);
+    }
+
+    /** @return array<string, mixed> */
+    private function replayRunPayload(object $row, bool $created): array
+    {
+        return [
+            'replayJobId' => (int) $row->event_replay_job_id,
+            'replayUuid' => $row->replay_uuid,
+            'status' => $row->status,
+            'created' => $created,
+        ];
     }
 }

--- a/app/Integrations/Healthcare/Services/EpicSmartFhirClient.php
+++ b/app/Integrations/Healthcare/Services/EpicSmartFhirClient.php
@@ -1,0 +1,373 @@
+<?php
+
+namespace App\Integrations\Healthcare\Services;
+
+use App\Integrations\Healthcare\Exceptions\IntegrationCredentialException;
+use App\Integrations\Healthcare\Exceptions\IntegrationProtocolException;
+use App\Models\Integration\Source;
+use App\Security\Network\IntegrationUrlPolicy;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+
+class EpicSmartFhirClient
+{
+    private const RESOURCE_TYPES = ['Encounter', 'Location'];
+
+    public function __construct(
+        private readonly IntegrationUrlPolicy $urlPolicy,
+        private readonly IntegrationSecretReferenceResolver $secrets,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function poll(int $sourceId, string $resourceType, int $ingestRunId): array
+    {
+        if (! in_array($resourceType, self::RESOURCE_TYPES, true)) {
+            throw new IntegrationProtocolException('fhir_resource_not_allowed');
+        }
+
+        $source = Source::query()->findOrFail($sourceId);
+        if (strtolower((string) $source->vendor) !== 'epic' || ! str_contains(strtolower((string) $source->interface_type), 'fhir')) {
+            throw new IntegrationProtocolException('epic_fhir_source_required');
+        }
+        if ($source->active_status !== 'active') {
+            throw new IntegrationProtocolException('fhir_source_not_active');
+        }
+        if ($source->environment === 'production'
+            && (! $source->phi_allowed || $source->go_live_status !== 'live')) {
+            throw new IntegrationProtocolException('fhir_phi_governance_incomplete');
+        }
+
+        $connection = DB::table('integration.fhir_client_connections')
+            ->where('source_id', $sourceId)->orderBy('fhir_client_connection_id')->first();
+        if (! $connection || $connection->health_status !== 'healthy' || ! filled($connection->base_url)) {
+            throw new IntegrationProtocolException('fhir_discovery_required');
+        }
+        $supported = DB::table('integration.source_capabilities')
+            ->where('source_id', $sourceId)
+            ->where('capability_type', 'fhir_resource')
+            ->where('resource_type', $resourceType)
+            ->where('supported', true)
+            ->exists();
+        if (! $supported) {
+            throw new IntegrationProtocolException('fhir_resource_not_supported');
+        }
+
+        $credential = DB::table('integration.smart_backend_credentials')
+            ->where('source_id', $sourceId)->orderBy('smart_backend_credential_id')->first();
+        if (! $credential || ! filled($credential->client_id) || ! filled($credential->jwks_secret_ref) || ! filled($credential->token_url)) {
+            throw new IntegrationProtocolException('smart_credentials_required');
+        }
+
+        $token = $this->accessToken($credential);
+        $baseUrl = rtrim((string) $connection->base_url, '/');
+        $this->urlPolicy->assertSafe($baseUrl);
+        $since = DB::table('integration.connector_watermarks')
+            ->where('source_id', $sourceId)
+            ->where('connector_key', 'epic.fhir-r4')
+            ->where('scope_type', 'resource_type')
+            ->where('scope_key', $resourceType)
+            ->where('watermark_kind', 'last_updated')
+            ->value('watermark_value');
+
+        $url = $baseUrl.'/'.$resourceType;
+        $query = ['_count' => 100, '_sort' => '_lastUpdated'];
+        if (is_string($since) && $since !== '') {
+            $query['_lastUpdated'] = 'gt'.$since;
+        }
+
+        $pages = 0;
+        $received = 0;
+        $persisted = 0;
+        $skipped = 0;
+        $resourceLimitExceeded = false;
+        $latestUpdated = is_string($since) && $since !== '' ? CarbonImmutable::parse($since) : null;
+        $pageLimit = (int) config('integrations.fhir_page_limit', 10);
+        $resourceLimit = (int) config('integrations.fhir_resource_limit', 1000);
+
+        while ($url !== null && $pages < $pageLimit && $received < $resourceLimit) {
+            $this->urlPolicy->assertSafe($url);
+            if ($this->origin($url) !== $this->origin($baseUrl)) {
+                throw new IntegrationProtocolException('fhir_pagination_origin_mismatch');
+            }
+            $response = Http::withToken($token['accessToken'])
+                ->accept('application/fhir+json')
+                ->connectTimeout(5)
+                ->timeout((int) config('integrations.health_timeout_seconds', 10) * 3)
+                ->withOptions(['allow_redirects' => false])
+                ->get($url, $pages === 0 ? $query : []);
+            $bundle = $this->fhirJson($response);
+            if (($bundle['resourceType'] ?? null) !== 'Bundle') {
+                throw new IntegrationProtocolException('fhir_search_bundle_required');
+            }
+
+            foreach ((array) ($bundle['entry'] ?? []) as $entry) {
+                if ($received >= $resourceLimit) {
+                    $resourceLimitExceeded = true;
+                    break;
+                }
+                $resource = is_array($entry) ? ($entry['resource'] ?? null) : null;
+                if (! is_array($resource) || ($resource['resourceType'] ?? null) !== $resourceType || ! filled($resource['id'] ?? null)) {
+                    $skipped++;
+
+                    continue;
+                }
+                $received++;
+                $created = $this->persistResource($sourceId, $resourceType, $resource, $ingestRunId);
+                $persisted += $created ? 1 : 0;
+                $skipped += $created ? 0 : 1;
+                $updated = data_get($resource, 'meta.lastUpdated');
+                if (is_string($updated) && $updated !== '') {
+                    $candidate = CarbonImmutable::parse($updated);
+                    $latestUpdated = $latestUpdated === null || $candidate->greaterThan($latestUpdated) ? $candidate : $latestUpdated;
+                }
+            }
+
+            $pages++;
+            $url = $this->nextUrl($bundle);
+        }
+
+        if ($url !== null || $resourceLimitExceeded) {
+            throw new IntegrationProtocolException('fhir_poll_limit_exceeded');
+        }
+
+        if ($latestUpdated !== null) {
+            DB::table('integration.connector_watermarks')->updateOrInsert(
+                [
+                    'source_id' => $sourceId,
+                    'connector_key' => 'epic.fhir-r4',
+                    'scope_type' => 'resource_type',
+                    'scope_key' => $resourceType,
+                    'watermark_kind' => 'last_updated',
+                ],
+                [
+                    'watermark_value' => $latestUpdated->toIso8601String(),
+                    'last_success_at' => now(),
+                    'metadata' => json_encode(['pages' => $pages], JSON_THROW_ON_ERROR),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+            );
+        }
+
+        DB::table('integration.smart_backend_credentials')
+            ->where('smart_backend_credential_id', $credential->smart_backend_credential_id)
+            ->update([
+                'status' => 'active',
+                'issued_at' => now(),
+                'expires_at' => now()->addSeconds($token['expiresIn']),
+                'updated_at' => now(),
+            ]);
+        DB::table('integration.fhir_client_connections')
+            ->where('fhir_client_connection_id', $connection->fhir_client_connection_id)
+            ->update(['status' => 'active', 'updated_at' => now()]);
+
+        return [
+            'resourceType' => $resourceType,
+            'pages' => $pages,
+            'resourcesReceived' => $received,
+            'resourcesPersisted' => $persisted,
+            'resourcesSkipped' => $skipped,
+            'watermarkAdvanced' => $latestUpdated !== null,
+        ];
+    }
+
+    /** @return array{accessToken: string, expiresIn: int} */
+    private function accessToken(object $credential): array
+    {
+        $tokenUrl = (string) $credential->token_url;
+        $this->urlPolicy->assertSafe($tokenUrl);
+        try {
+            $privateKey = $this->secrets->resolve((string) $credential->jwks_secret_ref);
+        } catch (IntegrationCredentialException $exception) {
+            throw new IntegrationProtocolException($exception->errorCode);
+        }
+
+        $metadata = $this->decodeMap($credential->metadata);
+        $header = array_filter([
+            'alg' => 'RS384',
+            'typ' => 'JWT',
+            'kid' => $metadata['key_id'] ?? null,
+        ], fn (mixed $value): bool => filled($value));
+        $now = time();
+        $claims = [
+            'iss' => (string) $credential->client_id,
+            'sub' => (string) $credential->client_id,
+            'aud' => $tokenUrl,
+            'jti' => (string) Str::uuid(),
+            'iat' => $now,
+            'exp' => $now + 300,
+        ];
+        $signingInput = $this->base64Url(json_encode($header, JSON_THROW_ON_ERROR)).'.'.$this->base64Url(json_encode($claims, JSON_THROW_ON_ERROR));
+        $key = openssl_pkey_get_private($privateKey);
+        if ($key === false) {
+            throw new IntegrationProtocolException('credential_private_key_invalid');
+        }
+        $signature = '';
+        if (! openssl_sign($signingInput, $signature, $key, OPENSSL_ALGO_SHA384)) {
+            throw new IntegrationProtocolException('client_assertion_signing_failed');
+        }
+        $assertion = $signingInput.'.'.$this->base64Url($signature);
+        $scopes = array_values(array_filter($this->decodeList($credential->scope_payload), 'is_string'));
+
+        $response = Http::asForm()
+            ->acceptJson()
+            ->connectTimeout(5)
+            ->timeout((int) config('integrations.health_timeout_seconds', 10) * 2)
+            ->withOptions(['allow_redirects' => false])
+            ->post($tokenUrl, [
+                'grant_type' => 'client_credentials',
+                'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+                'client_assertion' => $assertion,
+                'scope' => implode(' ', $scopes),
+            ]);
+        if ($response->redirect()) {
+            throw new IntegrationProtocolException('smart_token_redirect_rejected');
+        }
+        if (! $response->successful()) {
+            throw new IntegrationProtocolException('smart_token_http_'.$response->status());
+        }
+        $payload = $response->json();
+        $accessToken = is_array($payload) ? ($payload['access_token'] ?? null) : null;
+        if (! is_string($accessToken) || $accessToken === '') {
+            throw new IntegrationProtocolException('smart_access_token_missing');
+        }
+        $expiresIn = min(300, max(1, (int) ($payload['expires_in'] ?? 300)));
+
+        return ['accessToken' => $accessToken, 'expiresIn' => $expiresIn];
+    }
+
+    /** @param array<string, mixed> $resource */
+    private function persistResource(int $sourceId, string $resourceType, array $resource, int $ingestRunId): bool
+    {
+        $resourceJson = json_encode($resource, JSON_THROW_ON_ERROR);
+        $hash = hash('sha256', $resourceJson);
+        $fhirId = (string) $resource['id'];
+        $versionId = (string) (data_get($resource, 'meta.versionId') ?: 'hash-'.substr($hash, 0, 32));
+        $idempotencyKey = 'fhir:sha256:'.hash('sha256', "{$resourceType}\0{$fhirId}\0{$versionId}");
+
+        return DB::transaction(function () use ($sourceId, $resourceType, $resource, $resourceJson, $hash, $fhirId, $versionId, $idempotencyKey, $ingestRunId): bool {
+            $existing = DB::table('raw.inbound_messages')
+                ->where('source_id', $sourceId)
+                ->where('idempotency_key', $idempotencyKey)
+                ->lockForUpdate()->first();
+            if ($existing) {
+                if (! hash_equals((string) $existing->payload_hash, $hash)) {
+                    throw new IntegrationProtocolException('fhir_version_hash_conflict');
+                }
+
+                return false;
+            }
+
+            $messageId = DB::table('raw.inbound_messages')->insertGetId([
+                'message_uuid' => (string) Str::uuid(),
+                'source_id' => $sourceId,
+                'ingest_run_id' => $ingestRunId,
+                'message_type' => 'FHIR_R4_'.$resourceType,
+                'external_id' => Str::limit("{$resourceType}/{$fhirId}/_history/{$versionId}", 190, ''),
+                'idempotency_key' => $idempotencyKey,
+                'payload_hash' => $hash,
+                'payload' => $resourceJson,
+                'normalized_payload' => null,
+                'received_at' => now(),
+                'parse_status' => 'persisted',
+                'metadata' => json_encode(['protocol' => 'fhir_r4'], JSON_THROW_ON_ERROR),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ], 'inbound_message_id');
+
+            $resourceVersionId = DB::table('fhir.resource_versions')->insertGetId([
+                'source_id' => $sourceId,
+                'resource_type' => $resourceType,
+                'fhir_id' => $fhirId,
+                'version_id' => $versionId,
+                'last_updated' => data_get($resource, 'meta.lastUpdated'),
+                'resource_hash' => $hash,
+                'resource_data' => $resourceJson,
+                'ingest_run_id' => $ingestRunId,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ], 'resource_version_id');
+
+            DB::table('integration.provenance_records')->insert([
+                'source_id' => $sourceId,
+                'inbound_message_id' => $messageId,
+                'canonical_event_id' => null,
+                'target_schema' => 'fhir',
+                'target_table' => 'resource_versions',
+                'target_pk' => (string) $resourceVersionId,
+                'lineage' => json_encode([
+                    'raw_message' => "raw.inbound_messages:{$messageId}",
+                    'projection' => "fhir.resource_versions:{$resourceVersionId}",
+                ], JSON_THROW_ON_ERROR),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            return true;
+        });
+    }
+
+    /** @return array<string, mixed> */
+    private function fhirJson(Response $response): array
+    {
+        if ($response->redirect()) {
+            throw new IntegrationProtocolException('fhir_redirect_rejected');
+        }
+        if (! $response->successful()) {
+            throw new IntegrationProtocolException('fhir_http_'.$response->status());
+        }
+        if (strlen($response->body()) > 10_485_760) {
+            throw new IntegrationProtocolException('fhir_response_too_large');
+        }
+        $payload = $response->json();
+        if (! is_array($payload)) {
+            throw new IntegrationProtocolException('fhir_response_not_json');
+        }
+
+        return $payload;
+    }
+
+    /** @param array<string, mixed> $bundle */
+    private function nextUrl(array $bundle): ?string
+    {
+        foreach ((array) ($bundle['link'] ?? []) as $link) {
+            if (is_array($link) && ($link['relation'] ?? null) === 'next' && is_string($link['url'] ?? null)) {
+                return $link['url'];
+            }
+        }
+
+        return null;
+    }
+
+    private function origin(string $url): string
+    {
+        $parts = parse_url($url);
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        $port = (int) ($parts['port'] ?? ($scheme === 'https' ? 443 : 80));
+
+        return "{$scheme}://{$host}:{$port}";
+    }
+
+    private function base64Url(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeMap(mixed $value): array
+    {
+        return is_string($value) ? (json_decode($value, true) ?: []) : (is_array($value) ? $value : []);
+    }
+
+    /** @return list<mixed> */
+    private function decodeList(mixed $value): array
+    {
+        $decoded = is_string($value) ? json_decode($value, true) : $value;
+
+        return is_array($decoded) && array_is_list($decoded) ? $decoded : [];
+    }
+}

--- a/app/Integrations/Healthcare/Services/IntegrationControlPlaneService.php
+++ b/app/Integrations/Healthcare/Services/IntegrationControlPlaneService.php
@@ -7,6 +7,7 @@ use Carbon\CarbonImmutable;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class IntegrationControlPlaneService
 {
@@ -27,6 +28,9 @@ class IntegrationControlPlaneService
             'degradedSources' => $sources->whereIn('healthStatus', ['degraded', 'unobserved'])->count(),
             'staleSources' => $sources->where('healthStatus', 'stale')->count(),
             'failedSources' => $sources->where('healthStatus', 'failed')->count(),
+            'protocolHealthySources' => $sources->where('protocolHealthStatus', 'healthy')->count(),
+            'protocolDegradedSources' => $sources->where('protocolHealthStatus', 'degraded')->count(),
+            'protocolFailedSources' => $sources->where('protocolHealthStatus', 'failed')->count(),
             'endpoints' => DB::table('integration.source_endpoints')->count(),
             'capabilities' => DB::table('integration.source_capabilities')->where('supported', true)->count(),
             'credentials' => DB::table('integration.source_credentials')->count()
@@ -46,6 +50,8 @@ class IntegrationControlPlaneService
             'terminologyMaps' => DB::table('integration.terminology_maps')->count(),
             'writebackDrafts' => DB::table('ops.writeback_drafts')->count(),
             'configurationAudits' => DB::table('integration.configuration_audits')->count(),
+            'queuedJobs' => Schema::hasTable('jobs') ? DB::table('jobs')->count() : 0,
+            'failedQueueJobs' => Schema::hasTable('failed_jobs') ? DB::table('failed_jobs')->count() : 0,
         ];
 
         return [
@@ -114,6 +120,9 @@ class IntegrationControlPlaneService
             'interfaceType' => $source->interface_type,
             'configuredStatus' => $source->active_status,
             'healthStatus' => $health,
+            'protocolHealthStatus' => $source->protocol_health_status,
+            'protocolHealthCheckedAtIso' => $this->iso($source->protocol_health_checked_at),
+            'protocolHealthErrorCode' => $source->protocol_health_error,
             'goLiveStatus' => $source->go_live_status,
             'contractStatus' => $source->contract_status,
             'baaStatus' => $source->baa_status,
@@ -141,6 +150,7 @@ class IntegrationControlPlaneService
     {
         $latestRunIds = DB::table('raw.ingest_runs')
             ->selectRaw('source_id, max(ingest_run_id) as ingest_run_id')
+            ->whereNot('run_type', 'protocol_health')
             ->groupBy('source_id');
 
         $latestRuns = DB::table('raw.ingest_runs as run')
@@ -247,16 +257,23 @@ class IntegrationControlPlaneService
                 'connection.status',
                 'connection.fhir_version',
                 'connection.capability_checked_at',
+                'connection.health_status',
+                'connection.health_checked_at',
+                'connection.last_health_error',
                 'connection.base_url',
                 'source.source_name',
             ])
             ->map(fn (object $row): array => [
                 'connectionId' => (int) $row->fhir_client_connection_id,
+                'sourceId' => (int) $row->source_id,
                 'sourceName' => $row->source_name,
                 'connectionKey' => $row->connection_key,
                 'status' => $row->status,
                 'fhirVersion' => $row->fhir_version,
                 'capabilityCheckedAtIso' => $this->iso($row->capability_checked_at),
+                'healthStatus' => $row->health_status,
+                'healthCheckedAtIso' => $this->iso($row->health_checked_at),
+                'healthErrorCode' => $row->last_health_error,
                 'baseUrlConfigured' => filled($row->base_url),
                 'supportedResourceCount' => (int) $resourceCounts->get($row->source_id, 0),
             ])->all();
@@ -404,7 +421,9 @@ class IntegrationControlPlaneService
             ->map(fn (object $row): array => [
                 'replayJobId' => (int) $row->event_replay_job_id,
                 'replayType' => $row->replay_type,
+                'sourceId' => $row->source_id ? (int) $row->source_id : null,
                 'status' => $row->status,
+                'dryRun' => (bool) $row->dry_run,
                 'eventsReplayed' => (int) $row->events_replayed,
                 'eventsFailed' => (int) $row->events_failed,
                 'startedAtIso' => $this->iso($row->started_at),
@@ -613,7 +632,7 @@ class IntegrationControlPlaneService
 
     private function templateSafeStatus(string $status): string
     {
-        return $status === 'ready' ? 'template' : $status;
+        return $status;
     }
 
     /** @return array<string, mixed> */

--- a/app/Integrations/Healthcare/Services/IntegrationProtocolHealthService.php
+++ b/app/Integrations/Healthcare/Services/IntegrationProtocolHealthService.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace App\Integrations\Healthcare\Services;
+
+use App\Integrations\Healthcare\Exceptions\IntegrationProtocolException;
+use App\Models\Integration\Source;
+use App\Models\User;
+use App\Security\Network\IntegrationUrlPolicy;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\PersonalAccessToken;
+use Throwable;
+
+class IntegrationProtocolHealthService
+{
+    public function __construct(
+        private readonly IntegrationUrlPolicy $urlPolicy,
+        private readonly IntegrationSecretReferenceResolver $secrets,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function check(int $sourceId): array
+    {
+        $source = Source::query()->findOrFail($sourceId);
+        $interface = strtolower((string) $source->interface_type);
+
+        try {
+            $result = match (true) {
+                str_contains($interface, 'fhir') => $this->checkFhir($source),
+                str_contains($interface, 'hl7') => $this->checkHl7($source),
+                default => throw new IntegrationProtocolException('protocol_health_not_supported'),
+            };
+
+            $source->forceFill([
+                'protocol_health_status' => $result['status'],
+                'protocol_health_checked_at' => now(),
+                'protocol_health_error' => null,
+            ])->save();
+
+            return $result;
+        } catch (IntegrationProtocolException $exception) {
+            $this->recordFailure($source, $exception->errorCode);
+            throw $exception;
+        } catch (Throwable $exception) {
+            $this->recordFailure($source, 'protocol_health_check_failed');
+            throw new IntegrationProtocolException('protocol_health_check_failed');
+        }
+    }
+
+    /** @return array<string, mixed> */
+    private function checkFhir(Source $source): array
+    {
+        $connection = DB::table('integration.fhir_client_connections')
+            ->where('source_id', $source->source_id)
+            ->orderBy('fhir_client_connection_id')
+            ->first();
+        if (! $connection || ! filled($connection->base_url ?? $source->base_url)) {
+            throw new IntegrationProtocolException('fhir_connection_not_configured');
+        }
+
+        $baseUrl = rtrim((string) ($connection->base_url ?: $source->base_url), '/');
+        $smartUrl = $this->endpointUrl((int) $source->source_id, 'smart_configuration')
+            ?? $baseUrl.'/.well-known/smart-configuration';
+        $this->urlPolicy->assertSafe($baseUrl);
+        $this->urlPolicy->assertSafe($smartUrl);
+
+        $smart = $this->json($smartUrl, 'application/json');
+        $tokenUrl = $smart['token_endpoint'] ?? null;
+        $capabilities = is_array($smart['capabilities'] ?? null) ? $smart['capabilities'] : [];
+        if (! is_string($tokenUrl) || $tokenUrl === '') {
+            throw new IntegrationProtocolException('smart_token_endpoint_missing');
+        }
+        $this->urlPolicy->assertSafe($tokenUrl);
+        if (! in_array('client-confidential-asymmetric', $capabilities, true)) {
+            throw new IntegrationProtocolException('smart_asymmetric_client_not_supported');
+        }
+
+        $statement = $this->json($baseUrl.'/metadata', 'application/fhir+json');
+        if (($statement['resourceType'] ?? null) !== 'CapabilityStatement') {
+            throw new IntegrationProtocolException('fhir_capability_statement_invalid');
+        }
+        $fhirVersion = (string) ($statement['fhirVersion'] ?? '');
+        if ($fhirVersion !== '4.0.1') {
+            throw new IntegrationProtocolException('fhir_r4_version_required');
+        }
+
+        $resources = collect(data_get($statement, 'rest.0.resource', []))
+            ->pluck('type')
+            ->filter(fn (mixed $type): bool => is_string($type) && preg_match('/^[A-Z][A-Za-z]{1,79}$/', $type) === 1)
+            ->unique()->sort()->values()->all();
+        $softwareName = trim((string) data_get($statement, 'software.name', 'Unknown'));
+        if (strtolower((string) $source->vendor) === 'epic' && ! str_contains(strtolower($softwareName), 'epic')) {
+            throw new IntegrationProtocolException('fhir_vendor_mismatch');
+        }
+
+        $credential = DB::table('integration.smart_backend_credentials')
+            ->where('source_id', $source->source_id)
+            ->orderBy('smart_backend_credential_id')
+            ->first();
+        $credentialReady = filled($credential?->client_id)
+            && filled($credential?->jwks_secret_ref)
+            && $this->secrets->resolvable($credential?->jwks_secret_ref);
+        $activationStatus = $credentialReady ? 'ready' : 'credential_required';
+
+        DB::transaction(function () use ($source, $connection, $statement, $smart, $tokenUrl, $resources, $fhirVersion, $softwareName, $credential, $credentialReady): void {
+            DB::table('integration.fhir_client_connections')
+                ->where('fhir_client_connection_id', $connection->fhir_client_connection_id)
+                ->update([
+                    'status' => $credentialReady ? 'ready' : 'activation_required',
+                    'health_status' => 'healthy',
+                    'health_checked_at' => now(),
+                    'last_health_error' => null,
+                    'fhir_version' => $fhirVersion,
+                    'capability_checked_at' => now(),
+                    'capability_statement' => json_encode([
+                        'resourceType' => 'CapabilityStatement',
+                        'fhirVersion' => $fhirVersion,
+                        'software' => [
+                            'name' => $softwareName,
+                            'version' => data_get($statement, 'software.version'),
+                        ],
+                        'formats' => array_values(array_filter((array) ($statement['format'] ?? []), 'is_string')),
+                        'resourceTypes' => $resources,
+                    ], JSON_THROW_ON_ERROR),
+                    'smart_configuration' => json_encode([
+                        'tokenEndpoint' => $tokenUrl,
+                        'capabilities' => array_values(array_filter((array) ($smart['capabilities'] ?? []), 'is_string')),
+                    ], JSON_THROW_ON_ERROR),
+                    'updated_at' => now(),
+                ]);
+
+            if ($credential) {
+                DB::table('integration.smart_backend_credentials')
+                    ->where('smart_backend_credential_id', $credential->smart_backend_credential_id)
+                    ->update([
+                        'status' => $credentialReady ? 'ready' : 'activation_required',
+                        'token_url' => $tokenUrl,
+                        'updated_at' => now(),
+                    ]);
+            }
+
+            DB::table('integration.source_capabilities')->where('source_id', $source->source_id)->where('capability_type', 'fhir_resource')->delete();
+            foreach ($resources as $resourceType) {
+                DB::table('integration.source_capabilities')->insert([
+                    'source_id' => $source->source_id,
+                    'resource_type' => $resourceType,
+                    'capability_type' => 'fhir_resource',
+                    'operation' => 'read_search',
+                    'supported' => true,
+                    'metadata' => json_encode([], JSON_THROW_ON_ERROR),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        });
+
+        return [
+            'status' => 'healthy',
+            'protocol' => 'fhir_r4_smart',
+            'vendor' => $softwareName,
+            'fhirVersion' => $fhirVersion,
+            'supportedResourceCount' => count($resources),
+            'activationStatus' => $activationStatus,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function checkHl7(Source $source): array
+    {
+        $boundary = DB::table('integration.interface_engines')
+            ->where('engine_key', 'patient-flow-hl7v2-ingress')
+            ->where('status', 'ready')
+            ->exists();
+        if (! $boundary) {
+            throw new IntegrationProtocolException('hl7_boundary_not_configured');
+        }
+
+        $machineIdentities = $this->activeMachineIdentityCount();
+        $latestSuccess = DB::table('raw.ingest_runs')
+            ->where('source_id', $source->source_id)
+            ->where('connector_key', 'patient-flow.hl7v2.adt')
+            ->where('status', 'completed')
+            ->max('completed_at');
+        $status = $machineIdentities > 0 ? 'healthy' : 'degraded';
+
+        return [
+            'status' => $status,
+            'protocol' => 'hl7v2_adt_https',
+            'boundaryStatus' => 'ready',
+            'machineIdentityStatus' => $machineIdentities > 0 ? 'ready' : 'token_required',
+            'activeMachineIdentityCount' => $machineIdentities,
+            'lastIngressAtIso' => $latestSuccess ? CarbonImmutable::parse($latestSuccess)->toIso8601String() : null,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function json(string $url, string $accept): array
+    {
+        $response = Http::accept($accept)
+            ->connectTimeout(5)
+            ->timeout((int) config('integrations.health_timeout_seconds', 10))
+            ->withOptions(['allow_redirects' => false])
+            ->get($url);
+
+        $this->assertResponse($response);
+        if (strlen($response->body()) > 5_242_880) {
+            throw new IntegrationProtocolException('protocol_response_too_large');
+        }
+        $payload = $response->json();
+        if (! is_array($payload)) {
+            throw new IntegrationProtocolException('protocol_response_not_json');
+        }
+
+        return $payload;
+    }
+
+    private function assertResponse(Response $response): void
+    {
+        if ($response->redirect()) {
+            throw new IntegrationProtocolException('protocol_redirect_rejected');
+        }
+        if (! $response->successful()) {
+            throw new IntegrationProtocolException('protocol_http_'.$response->status());
+        }
+    }
+
+    private function endpointUrl(int $sourceId, string $type): ?string
+    {
+        $url = DB::table('integration.source_endpoints')
+            ->where('source_id', $sourceId)
+            ->where('endpoint_type', $type)
+            ->where('is_active', true)
+            ->value('url');
+
+        return is_string($url) && $url !== '' ? $url : null;
+    }
+
+    private function activeMachineIdentityCount(): int
+    {
+        if (! Schema::hasTable('personal_access_tokens')) {
+            return 0;
+        }
+
+        $userIds = PersonalAccessToken::query()
+            ->where('tokenable_type', User::class)
+            ->get(['tokenable_id', 'abilities'])
+            ->filter(fn (PersonalAccessToken $token): bool => in_array('integration:patient-flow:ingest', $token->abilities ?? [], true))
+            ->pluck('tokenable_id')->unique()->all();
+
+        return User::query()->whereIn('id', $userIds)->where('is_active', true)->count();
+    }
+
+    private function recordFailure(Source $source, string $errorCode): void
+    {
+        $source->forceFill([
+            'protocol_health_status' => 'failed',
+            'protocol_health_checked_at' => now(),
+            'protocol_health_error' => $errorCode,
+        ])->save();
+        DB::table('integration.fhir_client_connections')
+            ->where('source_id', $source->source_id)
+            ->update([
+                'health_status' => 'failed',
+                'health_checked_at' => now(),
+                'last_health_error' => $errorCode,
+                'updated_at' => now(),
+            ]);
+    }
+}

--- a/app/Integrations/Healthcare/Services/IntegrationSecretReferenceResolver.php
+++ b/app/Integrations/Healthcare/Services/IntegrationSecretReferenceResolver.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Integrations\Healthcare\Services;
+
+use App\Integrations\Healthcare\Exceptions\IntegrationCredentialException;
+
+class IntegrationSecretReferenceResolver
+{
+    public function resolvable(?string $reference): bool
+    {
+        try {
+            $this->filePath((string) $reference, false);
+
+            return true;
+        } catch (IntegrationCredentialException) {
+            return false;
+        }
+    }
+
+    public function resolve(string $reference): string
+    {
+        $path = $this->filePath($reference, true);
+        $value = file_get_contents($path);
+        if (! is_string($value) || trim($value) === '') {
+            throw new IntegrationCredentialException('credential_file_empty');
+        }
+
+        return $value;
+    }
+
+    private function filePath(string $reference, bool $read): string
+    {
+        $parts = parse_url($reference);
+        if (! is_array($parts) || strtolower((string) ($parts['scheme'] ?? '')) !== 'file') {
+            throw new IntegrationCredentialException('credential_provider_not_available');
+        }
+        if (filled($parts['host'] ?? null) || isset($parts['query']) || isset($parts['fragment'])) {
+            throw new IntegrationCredentialException('credential_reference_invalid');
+        }
+
+        $root = realpath((string) config('integrations.secret_file_root'));
+        $path = realpath(rawurldecode((string) ($parts['path'] ?? '')));
+        if ($root === false || $path === false || ! str_starts_with($path, rtrim($root, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR)) {
+            throw new IntegrationCredentialException('credential_reference_outside_root');
+        }
+        if (! is_file($path) || ! is_readable($path)) {
+            throw new IntegrationCredentialException('credential_file_unreadable');
+        }
+        $size = filesize($path);
+        if ($size === false || $size < 1 || $size > 65_536) {
+            throw new IntegrationCredentialException('credential_file_size_invalid');
+        }
+        $permissions = fileperms($path);
+        if ($permissions !== false && ($permissions & 0x0007) !== 0) {
+            throw new IntegrationCredentialException('credential_file_permissions_unsafe');
+        }
+        if ($read && ! is_readable($path)) {
+            throw new IntegrationCredentialException('credential_file_unreadable');
+        }
+
+        return $path;
+    }
+}

--- a/app/Integrations/Healthcare/Services/OperationalIntegrationConfigurator.php
+++ b/app/Integrations/Healthcare/Services/OperationalIntegrationConfigurator.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace App\Integrations\Healthcare\Services;
+
+use App\Models\Integration\Source;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class OperationalIntegrationConfigurator
+{
+    public function __construct(private readonly IntegrationConfigurationAuditService $audit) {}
+
+    /** @return array<string, mixed> */
+    public function configureEpicSandbox(
+        ?string $clientId = null,
+        ?string $privateKeyRef = null,
+        ?string $keyId = null,
+        bool $activate = false,
+    ): array {
+        $settings = config('integrations.epic_sandbox');
+        $sourceKey = (string) $settings['source_key'];
+        $correlationId = (string) Str::uuid();
+
+        return DB::transaction(function () use ($settings, $sourceKey, $clientId, $privateKeyRef, $keyId, $activate, $correlationId): array {
+            $source = Source::query()->firstOrNew(['source_key' => $sourceKey]);
+            $before = $source->exists ? $this->epicSummary($source) : [];
+            if (! $source->exists) {
+                $source->source_uuid = (string) Str::uuid();
+            }
+
+            $existingCredential = $source->exists
+                ? DB::table('integration.smart_backend_credentials')
+                    ->where('source_id', $source->source_id)
+                    ->where('credential_key', 'epic-smart-backend')
+                    ->first()
+                : null;
+            $resolvedClientId = filled($clientId) ? trim((string) $clientId) : ($existingCredential?->client_id ?: $settings['client_id']);
+            $resolvedKeyRef = filled($privateKeyRef) ? trim((string) $privateKeyRef) : ($existingCredential?->jwks_secret_ref ?: $settings['private_key_ref']);
+            $resolvedKeyId = filled($keyId) ? trim((string) $keyId) : ($this->decodeMap($existingCredential?->metadata ?? null)['key_id'] ?? $settings['key_id']);
+            $credentialsReady = filled($resolvedClientId) && filled($resolvedKeyRef);
+
+            if ($activate && ! $credentialsReady) {
+                throw ValidationException::withMessages([
+                    'credentials' => 'Epic sandbox activation requires both a registered client ID and a private-key reference.',
+                ]);
+            }
+
+            $source->fill([
+                'tenant_key' => 'default',
+                'facility_key' => null,
+                'source_name' => 'Epic FHIR R4 Public Sandbox',
+                'vendor' => 'Epic',
+                'system_class' => 'ehr',
+                'environment' => 'sandbox',
+                'base_url' => $settings['base_url'],
+                'interface_type' => 'fhir_r4',
+                'active_status' => $activate ? 'active' : ($source->active_status ?: 'testing'),
+                'fhir_version' => '4.0.1',
+                'smart_supported' => true,
+                'bulk_supported' => false,
+                'subscriptions_supported' => false,
+                'contract_status' => 'public_sandbox',
+                'baa_status' => 'not_required',
+                'phi_allowed' => false,
+                'go_live_status' => $activate ? 'validation' : ($source->go_live_status ?: 'not_started'),
+                'metadata' => [
+                    'owner' => 'Integration governance',
+                    'expected_cadence_minutes' => 15,
+                    'managed_by' => 'integrations:configure-operational-sources',
+                    'data_classification' => 'synthetic_sandbox',
+                ],
+            ]);
+            $source->save();
+
+            foreach ([
+                'fhir_base' => [$settings['base_url'], 'smart_backend_services'],
+                'smart_configuration' => [$settings['smart_configuration_url'], 'none'],
+                'oauth_token' => [$settings['token_url'], 'private_key_jwt'],
+            ] as $type => [$url, $authType]) {
+                DB::table('integration.source_endpoints')->updateOrInsert(
+                    ['source_id' => $source->source_id, 'endpoint_type' => $type],
+                    [
+                        'url' => $url,
+                        'auth_type' => $authType,
+                        'tls_mode' => 'tls_1_2_or_newer',
+                        'is_active' => true,
+                        'metadata' => json_encode(['managed' => true], JSON_THROW_ON_ERROR),
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ],
+                );
+            }
+
+            DB::table('integration.fhir_client_connections')->updateOrInsert(
+                ['source_id' => $source->source_id, 'connection_key' => 'epic-fhir-r4-sandbox'],
+                [
+                    'connection_uuid' => $this->stableUuid(
+                        'integration.fhir_client_connections',
+                        ['source_id' => $source->source_id, 'connection_key' => 'epic-fhir-r4-sandbox'],
+                        'connection_uuid',
+                    ),
+                    'status' => $credentialsReady ? 'configured' : 'discovery_only',
+                    'base_url' => $settings['base_url'],
+                    'fhir_version' => '4.0.1',
+                    'polling_payload' => json_encode([
+                        'resource_types' => ['Encounter', 'Location'],
+                        'cadence_minutes' => 15,
+                        'credential_activation_required' => ! $credentialsReady,
+                    ], JSON_THROW_ON_ERROR),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+            );
+
+            DB::table('integration.smart_backend_credentials')->updateOrInsert(
+                ['source_id' => $source->source_id, 'credential_key' => 'epic-smart-backend'],
+                [
+                    'credential_uuid' => $this->stableUuid(
+                        'integration.smart_backend_credentials',
+                        ['source_id' => $source->source_id, 'credential_key' => 'epic-smart-backend'],
+                        'credential_uuid',
+                    ),
+                    'status' => $credentialsReady ? 'configured' : 'activation_required',
+                    'client_id' => $resolvedClientId,
+                    'jwks_secret_ref' => $resolvedKeyRef,
+                    'token_url' => $settings['token_url'],
+                    'scope_payload' => json_encode($settings['default_scopes'], JSON_THROW_ON_ERROR),
+                    'metadata' => json_encode(array_filter([
+                        'auth_method' => 'private_key_jwt',
+                        'algorithm' => 'RS384',
+                        'key_id' => $resolvedKeyId,
+                    ], fn (mixed $value): bool => filled($value)), JSON_THROW_ON_ERROR),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+            );
+
+            $after = $this->epicSummary($source->fresh());
+            if ($before !== $after) {
+                $this->audit->record(null, $before === [] ? 'created' : 'updated', 'operational_connector', (int) $source->source_id, $sourceKey, $before, $after, $correlationId);
+            }
+
+            return $after;
+        });
+    }
+
+    /** @return array<string, mixed> */
+    public function configureHl7Boundary(): array
+    {
+        $key = 'patient-flow-hl7v2-ingress';
+        $existing = DB::table('integration.interface_engines')->where('engine_key', $key)->first();
+        $before = $existing ? $this->hl7Summary($existing) : [];
+
+        DB::table('integration.interface_engines')->updateOrInsert(
+            ['engine_key' => $key],
+            [
+                'interface_engine_uuid' => $existing?->interface_engine_uuid ?? (string) Str::uuid(),
+                'label' => 'Patient Flow HL7 v2 ADT Ingress',
+                'engine_type' => 'canonical_https_gateway',
+                'environment' => app()->environment('production') ? 'production' : 'sandbox',
+                'status' => 'ready',
+                'boundary_payload' => json_encode([
+                    'protocol' => 'hl7v2_adt',
+                    'transport' => 'https',
+                    'route' => '/api/integrations/v1/patient-flow/hl7v2',
+                    'authentication' => 'sanctum_machine_token',
+                    'required_ability' => 'integration:patient-flow:ingest',
+                    'pipeline' => ['raw', 'canonical', 'patient_flow_projection', 'provenance'],
+                ], JSON_THROW_ON_ERROR),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        );
+
+        $after = $this->hl7Summary(DB::table('integration.interface_engines')->where('engine_key', $key)->first());
+        if ($before !== $after) {
+            $this->audit->record(null, $before === [] ? 'created' : 'updated', 'interface_engine', (int) $after['interfaceEngineId'], $key, $before, $after, (string) Str::uuid());
+        }
+
+        return $after;
+    }
+
+    /** @param array<string, mixed> $attributes @return array<string, mixed> */
+    public function configureHl7Source(array $attributes): array
+    {
+        $sourceKey = trim((string) $attributes['source_key']);
+        if (preg_match('/^[a-z0-9][a-z0-9._-]{0,159}$/', $sourceKey) !== 1) {
+            throw ValidationException::withMessages(['source_key' => 'The HL7 source key is invalid.']);
+        }
+        $activate = (bool) ($attributes['activate'] ?? false);
+        if ($activate && (
+            ($attributes['environment'] ?? null) !== 'production'
+            || ($attributes['contract_status'] ?? null) !== 'executed'
+            || ($attributes['baa_status'] ?? null) !== 'executed'
+            || ! ($attributes['phi_allowed'] ?? false)
+            || ($attributes['go_live_status'] ?? null) !== 'live'
+        )) {
+            throw ValidationException::withMessages([
+                'activation' => 'An active HL7 ADT source requires production/live state, executed contract and BAA, and explicit PHI approval.',
+            ]);
+        }
+
+        return DB::transaction(function () use ($attributes, $sourceKey, $activate): array {
+            $source = Source::query()->firstOrNew(['source_key' => $sourceKey]);
+            $before = $source->exists ? $this->hl7SourceSummary($source) : [];
+            if (! $source->exists) {
+                $source->source_uuid = (string) Str::uuid();
+            }
+            $source->fill([
+                'tenant_key' => 'default',
+                'facility_key' => $attributes['facility_key'] ?? 'main',
+                'source_name' => $attributes['source_name'],
+                'vendor' => $attributes['vendor'],
+                'system_class' => 'ehr',
+                'environment' => $attributes['environment'],
+                'base_url' => null,
+                'interface_type' => 'hl7v2',
+                'active_status' => $activate ? 'active' : 'inactive',
+                'fhir_version' => null,
+                'smart_supported' => false,
+                'bulk_supported' => false,
+                'subscriptions_supported' => false,
+                'contract_status' => $attributes['contract_status'],
+                'baa_status' => $attributes['baa_status'],
+                'phi_allowed' => (bool) $attributes['phi_allowed'],
+                'go_live_status' => $attributes['go_live_status'],
+                'metadata' => [
+                    'owner' => 'Integration governance',
+                    'expected_cadence_minutes' => 5,
+                    'managed_by' => 'integrations:configure-hl7-adt-source',
+                    'ingress_route' => '/api/integrations/v1/patient-flow/hl7v2',
+                ],
+            ]);
+            $source->save();
+
+            $after = $this->hl7SourceSummary($source->fresh());
+            if ($before !== $after) {
+                $this->audit->record(null, $before === [] ? 'created' : 'updated', 'operational_connector', (int) $source->source_id, $sourceKey, $before, $after, (string) Str::uuid());
+            }
+
+            return $after;
+        });
+    }
+
+    /** @return array<string, mixed> */
+    private function epicSummary(Source $source): array
+    {
+        $credential = DB::table('integration.smart_backend_credentials')
+            ->where('source_id', $source->source_id)
+            ->where('credential_key', 'epic-smart-backend')
+            ->first();
+
+        return [
+            'sourceId' => (int) $source->source_id,
+            'sourceKey' => $source->source_key,
+            'status' => $source->active_status,
+            'goLiveStatus' => $source->go_live_status,
+            'credentialStatus' => $credential?->status ?? 'activation_required',
+            'clientIdConfigured' => filled($credential?->client_id),
+            'privateKeyReferenceConfigured' => filled($credential?->jwks_secret_ref),
+            'baseUrl' => (string) config('integrations.epic_sandbox.base_url'),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function hl7Summary(object $engine): array
+    {
+        return [
+            'interfaceEngineId' => (int) $engine->interface_engine_id,
+            'engineKey' => $engine->engine_key,
+            'status' => $engine->status,
+            'environment' => $engine->environment,
+            'route' => '/api/integrations/v1/patient-flow/hl7v2',
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function hl7SourceSummary(Source $source): array
+    {
+        return [
+            'sourceId' => (int) $source->source_id,
+            'sourceKey' => $source->source_key,
+            'sourceName' => $source->source_name,
+            'vendor' => $source->vendor,
+            'environment' => $source->environment,
+            'activeStatus' => $source->active_status,
+            'contractStatus' => $source->contract_status,
+            'baaStatus' => $source->baa_status,
+            'phiAllowed' => (bool) $source->phi_allowed,
+            'goLiveStatus' => $source->go_live_status,
+            'ingressRoute' => '/api/integrations/v1/patient-flow/hl7v2',
+        ];
+    }
+
+    /** @param array<string, mixed> $keys */
+    private function stableUuid(string $table, array $keys, string $uuidColumn): string
+    {
+        return (string) (DB::table($table)->where($keys)->value($uuidColumn) ?? Str::uuid());
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeMap(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        return is_string($value) ? (json_decode($value, true) ?: []) : [];
+    }
+}

--- a/app/Integrations/Healthcare/Services/OperationalIntegrationConfigurator.php
+++ b/app/Integrations/Healthcare/Services/OperationalIntegrationConfigurator.php
@@ -35,9 +35,15 @@ class OperationalIntegrationConfigurator
                     ->where('credential_key', 'epic-smart-backend')
                     ->first()
                 : null;
-            $resolvedClientId = filled($clientId) ? trim((string) $clientId) : ($existingCredential?->client_id ?: $settings['client_id']);
-            $resolvedKeyRef = filled($privateKeyRef) ? trim((string) $privateKeyRef) : ($existingCredential?->jwks_secret_ref ?: $settings['private_key_ref']);
-            $resolvedKeyId = filled($keyId) ? trim((string) $keyId) : ($this->decodeMap($existingCredential?->metadata ?? null)['key_id'] ?? $settings['key_id']);
+            $resolvedClientId = $this->normalizedOptionalString(
+                filled($clientId) ? $clientId : ($existingCredential?->client_id ?: $settings['client_id']),
+            );
+            $resolvedKeyRef = $this->normalizedOptionalString(
+                filled($privateKeyRef) ? $privateKeyRef : ($existingCredential?->jwks_secret_ref ?: $settings['private_key_ref']),
+            );
+            $resolvedKeyId = $this->normalizedOptionalString(
+                filled($keyId) ? $keyId : ($this->decodeMap($existingCredential?->metadata ?? null)['key_id'] ?? $settings['key_id']),
+            );
             $credentialsReady = filled($resolvedClientId) && filled($resolvedKeyRef);
 
             if ($activate && ! $credentialsReady) {
@@ -297,6 +303,13 @@ class OperationalIntegrationConfigurator
     private function stableUuid(string $table, array $keys, string $uuidColumn): string
     {
         return (string) (DB::table($table)->where($keys)->value($uuidColumn) ?? Str::uuid());
+    }
+
+    private function normalizedOptionalString(mixed $value): ?string
+    {
+        $normalized = trim((string) ($value ?? ''));
+
+        return $normalized === '' ? null : $normalized;
     }
 
     /** @return array<string, mixed> */

--- a/app/Jobs/DispatchScheduledFhirPolls.php
+++ b/app/Jobs/DispatchScheduledFhirPolls.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Integrations\Healthcare\Services\EnterpriseConnectorControlService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class DispatchScheduledFhirPolls implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 1;
+
+    public function __construct()
+    {
+        $this->onConnection('database')->onQueue('integrations');
+    }
+
+    public function handle(EnterpriseConnectorControlService $connectors): void
+    {
+        DB::table('integration.sources as source')
+            ->join('integration.fhir_client_connections as connection', 'connection.source_id', '=', 'source.source_id')
+            ->join('integration.smart_backend_credentials as credential', 'credential.source_id', '=', 'source.source_id')
+            ->where('source.active_status', 'active')
+            ->where('connection.health_status', 'healthy')
+            ->whereIn('credential.status', ['ready', 'active'])
+            ->distinct()->pluck('source.source_id')
+            ->each(function (mixed $sourceId) use ($connectors): void {
+                foreach (['Encounter', 'Location'] as $resourceType) {
+                    $connectors->queueFhirPoll((int) $sourceId, $resourceType, null, (string) Str::uuid());
+                }
+            });
+    }
+}

--- a/app/Jobs/DispatchScheduledIntegrationHealthChecks.php
+++ b/app/Jobs/DispatchScheduledIntegrationHealthChecks.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Integrations\Healthcare\Services\EnterpriseConnectorControlService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class DispatchScheduledIntegrationHealthChecks implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 1;
+
+    public function __construct()
+    {
+        $this->onConnection('database')->onQueue('integrations');
+    }
+
+    public function handle(EnterpriseConnectorControlService $connectors): void
+    {
+        DB::table('integration.sources')
+            ->whereIn('active_status', ['active', 'testing'])
+            ->where(function ($query): void {
+                $query->where('interface_type', 'like', '%fhir%')
+                    ->orWhere('interface_type', 'like', '%hl7%');
+            })
+            ->orderBy('source_id')
+            ->pluck('source_id')
+            ->each(fn (mixed $sourceId) => $connectors->queueHealthCheck((int) $sourceId, null, (string) Str::uuid()));
+    }
+}

--- a/app/Jobs/PollEpicFhirResource.php
+++ b/app/Jobs/PollEpicFhirResource.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Integrations\Healthcare\Exceptions\IntegrationProtocolException;
+use App\Integrations\Healthcare\Services\EpicSmartFhirClient;
+use App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Throwable;
+
+class PollEpicFhirResource implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public int $timeout = 300;
+
+    /** @return list<int> */
+    public function backoff(): array
+    {
+        return [10, 30, 60];
+    }
+
+    public function __construct(
+        public readonly int $runId,
+        public readonly string $resourceType,
+        public readonly ?int $actorUserId,
+        public readonly string $correlationId,
+    ) {
+        $this->onConnection('database')->onQueue('integrations');
+    }
+
+    public function handle(EpicSmartFhirClient $client, IntegrationConfigurationAuditService $audit): void
+    {
+        $run = DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->first();
+        if (! $run || $run->status === 'completed') {
+            return;
+        }
+        DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->update([
+            'status' => 'running', 'started_at' => now(), 'completed_at' => null, 'error_summary' => null, 'updated_at' => now(),
+        ]);
+
+        try {
+            $result = $client->poll((int) $run->source_id, $this->resourceType, $this->runId);
+            DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->update([
+                'status' => 'completed',
+                'completed_at' => now(),
+                'messages_received' => $result['resourcesReceived'],
+                'messages_succeeded' => $result['resourcesPersisted'],
+                'messages_skipped' => $result['resourcesSkipped'],
+                'metadata' => json_encode(array_merge($this->metadata($run->metadata), ['result' => $result]), JSON_THROW_ON_ERROR),
+                'updated_at' => now(),
+            ]);
+            DB::table('raw.dead_letters')
+                ->where('ingest_run_id', $this->runId)
+                ->where('failure_stage', 'fhir_poll')
+                ->where('status', 'open')
+                ->update([
+                    'status' => 'resolved',
+                    'resolved_at' => now(),
+                    'replayed_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            $audit->record($this->actorUserId, 'completed', 'fhir_poll', $this->runId, (string) $run->run_uuid, [], $result, $this->correlationId);
+        } catch (Throwable $exception) {
+            $errorCode = $exception instanceof IntegrationProtocolException ? $exception->errorCode : 'fhir_poll_failed';
+            DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->update([
+                'status' => 'retrying', 'completed_at' => null,
+                'error_summary' => $errorCode,
+                'metadata' => json_encode(array_merge($this->metadata($run->metadata), ['errorCode' => $errorCode]), JSON_THROW_ON_ERROR),
+                'updated_at' => now(),
+            ]);
+
+            throw $exception;
+        }
+    }
+
+    public function failed(?Throwable $exception): void
+    {
+        $run = DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->first();
+        if (! $run || $run->status === 'completed') {
+            return;
+        }
+        $errorCode = $exception instanceof IntegrationProtocolException ? $exception->errorCode : 'fhir_poll_failed';
+        DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->update([
+            'status' => 'failed',
+            'completed_at' => now(),
+            'messages_failed' => 1,
+            'error_summary' => $errorCode,
+            'updated_at' => now(),
+        ]);
+        if (! DB::table('raw.dead_letters')->where('ingest_run_id', $this->runId)->where('failure_stage', 'fhir_poll')->where('status', 'open')->exists()) {
+            DB::table('raw.dead_letters')->insert([
+                'dead_letter_uuid' => (string) Str::uuid(),
+                'source_id' => $run->source_id,
+                'ingest_run_id' => $this->runId,
+                'failure_stage' => 'fhir_poll',
+                'reason_code' => $errorCode,
+                'message' => 'The governed FHIR poll did not complete.',
+                'exception_class' => $exception::class,
+                'context' => json_encode(['resource_type' => $this->resourceType], JSON_THROW_ON_ERROR),
+                'status' => 'open',
+                'metadata' => json_encode([], JSON_THROW_ON_ERROR),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+        app(IntegrationConfigurationAuditService::class)->record(
+            $this->actorUserId,
+            'failed',
+            'fhir_poll',
+            $this->runId,
+            (string) $run->run_uuid,
+            [],
+            ['errorCode' => $errorCode],
+            $this->correlationId,
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function metadata(mixed $value): array
+    {
+        return is_string($value) ? (json_decode($value, true) ?: []) : (is_array($value) ? $value : []);
+    }
+}

--- a/app/Jobs/ReplayPendingIntegrationEvents.php
+++ b/app/Jobs/ReplayPendingIntegrationEvents.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Integrations\Healthcare\DTO\CanonicalOperationalEvent;
+use App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService;
+use App\Integrations\Healthcare\Services\RtdcProjectionHandler;
+use Carbon\CarbonImmutable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class ReplayPendingIntegrationEvents implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 1;
+
+    public int $timeout = 300;
+
+    public function __construct(
+        public readonly int $replayJobId,
+        public readonly ?int $actorUserId,
+        public readonly string $correlationId,
+    ) {
+        $this->onConnection('database')->onQueue('integrations');
+    }
+
+    public function handle(RtdcProjectionHandler $projector, IntegrationConfigurationAuditService $audit): void
+    {
+        $replay = DB::table('integration.event_replay_jobs')->where('event_replay_job_id', $this->replayJobId)->first();
+        if (! $replay || in_array($replay->status, ['completed', 'completed_with_errors'], true)) {
+            return;
+        }
+        $scope = $this->map($replay->scope);
+        DB::table('integration.event_replay_jobs')->where('event_replay_job_id', $this->replayJobId)->update([
+            'status' => 'running', 'started_at' => now(), 'completed_at' => null, 'error_summary' => null, 'updated_at' => now(),
+        ]);
+
+        $events = DB::table('integration.canonical_events')
+            ->when($scope['sourceId'] ?? null, fn ($query, $sourceId) => $query->where('source_id', $sourceId))
+            ->whereBetween('occurred_at', [$scope['from'], $scope['to']])
+            ->whereIn('event_type', $scope['eventTypes'])
+            ->whereIn('projection_status', ['pending', 'failed'])
+            ->orderBy('occurred_at')->orderBy('canonical_event_id')
+            ->limit((int) $scope['limit'])->get();
+
+        $replayed = 0;
+        $failed = 0;
+        foreach ($events as $row) {
+            try {
+                $event = new CanonicalOperationalEvent(
+                    eventId: (string) $row->event_id,
+                    eventType: (string) $row->event_type,
+                    entityType: $row->entity_type,
+                    entityRef: $row->entity_ref,
+                    payload: $this->map($row->payload),
+                    occurredAt: CarbonImmutable::parse($row->occurred_at),
+                    idempotencyKey: (string) $row->idempotency_key,
+                    correlationId: $row->correlation_id,
+                    causationId: $row->causation_id,
+                    sequenceKey: $row->sequence_key,
+                    metadata: $this->map($row->metadata),
+                );
+                if (! $projector->supports($event)) {
+                    throw new \InvalidArgumentException('Unsupported replay event.');
+                }
+                $projector->project($event);
+                DB::table('integration.canonical_events')->where('canonical_event_id', $row->canonical_event_id)->update([
+                    'projection_status' => 'projected', 'projected_at' => now(), 'updated_at' => now(),
+                ]);
+                DB::table('integration.event_projection_errors')->where('canonical_event_id', $row->canonical_event_id)->where('status', 'open')->update([
+                    'status' => 'resolved', 'updated_at' => now(),
+                ]);
+                $replayed++;
+            } catch (Throwable $exception) {
+                $failed++;
+                DB::table('integration.canonical_events')->where('canonical_event_id', $row->canonical_event_id)->update([
+                    'projection_status' => 'failed', 'updated_at' => now(),
+                ]);
+                DB::table('integration.event_projection_errors')->insert([
+                    'canonical_event_id' => $row->canonical_event_id,
+                    'projector_key' => 'rtdc.census',
+                    'error_code' => 'replay_projection_failed',
+                    'message' => 'The canonical event could not be replayed into the RTDC projection.',
+                    'exception_class' => $exception::class,
+                    'context' => json_encode(['replay_job_id' => $this->replayJobId], JSON_THROW_ON_ERROR),
+                    'status' => 'open',
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        }
+
+        $status = $failed > 0 ? 'completed_with_errors' : 'completed';
+        DB::table('integration.event_replay_jobs')->where('event_replay_job_id', $this->replayJobId)->update([
+            'status' => $status,
+            'events_replayed' => $replayed,
+            'events_failed' => $failed,
+            'completed_at' => now(),
+            'error_summary' => $failed > 0 ? 'one_or_more_events_failed' : null,
+            'updated_at' => now(),
+        ]);
+        $audit->record($this->actorUserId, $status, 'canonical_event_replay', $this->replayJobId, (string) $replay->replay_uuid, [], [
+            'status' => $status, 'eventsReplayed' => $replayed, 'eventsFailed' => $failed,
+        ], $this->correlationId);
+    }
+
+    public function failed(?Throwable $exception): void
+    {
+        $replay = DB::table('integration.event_replay_jobs')->where('event_replay_job_id', $this->replayJobId)->first();
+        if (! $replay || in_array($replay->status, ['completed', 'completed_with_errors', 'failed'], true)) {
+            return;
+        }
+
+        DB::table('integration.event_replay_jobs')->where('event_replay_job_id', $this->replayJobId)->update([
+            'status' => 'failed',
+            'completed_at' => now(),
+            'error_summary' => 'replay_job_failed',
+            'updated_at' => now(),
+        ]);
+        app(IntegrationConfigurationAuditService::class)->record(
+            $this->actorUserId,
+            'failed',
+            'canonical_event_replay',
+            $this->replayJobId,
+            (string) $replay->replay_uuid,
+            [],
+            ['status' => 'failed', 'errorCode' => 'replay_job_failed'],
+            $this->correlationId,
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function map(mixed $value): array
+    {
+        return is_string($value) ? (json_decode($value, true) ?: []) : (is_array($value) ? $value : []);
+    }
+}

--- a/app/Jobs/RunIntegrationProtocolHealthCheck.php
+++ b/app/Jobs/RunIntegrationProtocolHealthCheck.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Integrations\Healthcare\Exceptions\IntegrationProtocolException;
+use App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService;
+use App\Integrations\Healthcare\Services\IntegrationProtocolHealthService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+class RunIntegrationProtocolHealthCheck implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public int $timeout = 60;
+
+    /** @return list<int> */
+    public function backoff(): array
+    {
+        return [10, 30, 60];
+    }
+
+    public function __construct(
+        public readonly int $runId,
+        public readonly ?int $actorUserId,
+        public readonly string $correlationId,
+    ) {
+        $this->onConnection('database')->onQueue('integrations');
+    }
+
+    public function handle(
+        IntegrationProtocolHealthService $health,
+        IntegrationConfigurationAuditService $audit,
+    ): void {
+        $run = DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->first();
+        if (! $run || $run->status === 'completed') {
+            return;
+        }
+
+        DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->update([
+            'status' => 'running',
+            'started_at' => now(),
+            'completed_at' => null,
+            'error_summary' => null,
+            'updated_at' => now(),
+        ]);
+
+        try {
+            $result = $health->check((int) $run->source_id);
+            DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->update([
+                'status' => 'completed',
+                'completed_at' => now(),
+                'metadata' => json_encode(array_merge($this->metadata($run->metadata), ['result' => $result]), JSON_THROW_ON_ERROR),
+                'updated_at' => now(),
+            ]);
+            $audit->record($this->actorUserId, 'completed', 'protocol_health_check', $this->runId, (string) $run->run_uuid, [], $result, $this->correlationId);
+        } catch (Throwable $exception) {
+            $errorCode = $exception instanceof IntegrationProtocolException
+                ? $exception->errorCode
+                : 'protocol_health_check_failed';
+            DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->update([
+                'status' => 'retrying',
+                'completed_at' => null,
+                'error_summary' => $errorCode,
+                'metadata' => json_encode(array_merge($this->metadata($run->metadata), ['errorCode' => $errorCode]), JSON_THROW_ON_ERROR),
+                'updated_at' => now(),
+            ]);
+
+            throw $exception;
+        }
+    }
+
+    public function failed(?Throwable $exception): void
+    {
+        $run = DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->first();
+        if (! $run || $run->status === 'completed') {
+            return;
+        }
+        $errorCode = $exception instanceof IntegrationProtocolException
+            ? $exception->errorCode
+            : 'protocol_health_check_failed';
+        DB::table('raw.ingest_runs')->where('ingest_run_id', $this->runId)->update([
+            'status' => 'failed',
+            'completed_at' => now(),
+            'error_summary' => $errorCode,
+            'updated_at' => now(),
+        ]);
+        app(IntegrationConfigurationAuditService::class)->record(
+            $this->actorUserId,
+            'failed',
+            'protocol_health_check',
+            $this->runId,
+            (string) $run->run_uuid,
+            [],
+            ['errorCode' => $errorCode],
+            $this->correlationId,
+        );
+    }
+
+    /** @return array<string, mixed> */
+    private function metadata(mixed $value): array
+    {
+        return is_string($value) ? (json_decode($value, true) ?: []) : (is_array($value) ? $value : []);
+    }
+}

--- a/app/Rules/SecretReference.php
+++ b/app/Rules/SecretReference.php
@@ -20,9 +20,23 @@ class SecretReference implements ValidationRule
             && (filled($parts['host'] ?? null) || filled($parts['path'] ?? null));
 
         if (! in_array($scheme, $allowed, true) || ! $hasLocation) {
-            $fail('Credential values must be references to an approved secret manager.');
+            $fail('Credential values must be references to an approved secret provider.');
 
             return;
+        }
+
+        if ($scheme === 'file') {
+            $path = (string) ($parts['path'] ?? '');
+            $root = rtrim((string) config('integrations.secret_file_root'), '/');
+            if (filled($parts['host'] ?? null)
+                || $path === ''
+                || ! str_starts_with($path, $root.'/')
+                || str_contains($path, '/../')
+                || str_ends_with($path, '/..')) {
+                $fail('File credential references must point beneath the configured integration secret root.');
+
+                return;
+            }
         }
 
         if (isset($parts['user']) || isset($parts['pass']) || isset($parts['query']) || isset($parts['fragment'])) {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -69,5 +69,11 @@ return $builder
         // and cache the worst hand-off synchronization wait as a flow-domain
         // cockpit tile. Same ARENA_ENABLED gate + off-snapshot cadence discipline.
         $schedule->job(new \App\Jobs\RefreshArenaPerformance)->everyThirtyMinutes()->withoutOverlapping();
+        // Governed integration runtime: dispatch protocol checks to the dedicated
+        // database-backed queue. Health observations never advance data cursors.
+        $schedule->job(new \App\Jobs\DispatchScheduledIntegrationHealthChecks)
+            ->everyFiveMinutes()->withoutOverlapping();
+        $schedule->job(new \App\Jobs\DispatchScheduledFhirPolls)
+            ->everyFifteenMinutes()->withoutOverlapping();
     })
     ->create();

--- a/config/integrations.php
+++ b/config/integrations.php
@@ -3,6 +3,20 @@
 return [
     'fresh_after_minutes' => (int) env('INTEGRATION_FRESH_AFTER_MINUTES', 15),
     'stale_after_minutes' => (int) env('INTEGRATION_STALE_AFTER_MINUTES', 60),
+    'health_timeout_seconds' => max(2, (int) env('INTEGRATION_HEALTH_TIMEOUT_SECONDS', 10)),
+    'fhir_page_limit' => max(1, (int) env('INTEGRATION_FHIR_PAGE_LIMIT', 10)),
+    'fhir_resource_limit' => max(1, (int) env('INTEGRATION_FHIR_RESOURCE_LIMIT', 1000)),
+    'secret_file_root' => env('INTEGRATION_SECRET_FILE_ROOT', '/etc/zephyrus/secrets'),
+    'epic_sandbox' => [
+        'source_key' => 'epic.fhir-r4.sandbox',
+        'base_url' => 'https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4',
+        'smart_configuration_url' => 'https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/.well-known/smart-configuration',
+        'token_url' => 'https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token',
+        'default_scopes' => ['system/Encounter.rs', 'system/Location.rs'],
+        'client_id' => env('EPIC_FHIR_CLIENT_ID'),
+        'private_key_ref' => env('EPIC_FHIR_PRIVATE_KEY_REF'),
+        'key_id' => env('EPIC_FHIR_KEY_ID'),
+    ],
     'network' => [
         'require_https' => (bool) env('INTEGRATION_REQUIRE_HTTPS', true),
         'allowed_hosts' => array_values(array_filter(array_map(
@@ -18,6 +32,7 @@ return [
         'max_redirects' => 3,
     ],
     'credential_reference_schemes' => [
+        'file',
         'vault',
         'aws-secretsmanager',
         'gcp-secretmanager',

--- a/database/migrations/2026_07_10_000200_operationalize_integration_runtime.php
+++ b/database/migrations/2026_07_10_000200_operationalize_integration_runtime.php
@@ -1,0 +1,95 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('integration.sources', function (Blueprint $table): void {
+            if (! Schema::hasColumn('integration.sources', 'protocol_health_status')) {
+                $table->string('protocol_health_status', 40)->default('unobserved');
+            }
+            if (! Schema::hasColumn('integration.sources', 'protocol_health_checked_at')) {
+                $table->timestamp('protocol_health_checked_at')->nullable();
+            }
+            if (! Schema::hasColumn('integration.sources', 'protocol_health_error')) {
+                $table->string('protocol_health_error', 120)->nullable();
+            }
+        });
+
+        Schema::table('integration.fhir_client_connections', function (Blueprint $table): void {
+            if (! Schema::hasColumn('integration.fhir_client_connections', 'health_status')) {
+                $table->string('health_status', 40)->default('unobserved');
+            }
+            if (! Schema::hasColumn('integration.fhir_client_connections', 'health_checked_at')) {
+                $table->timestamp('health_checked_at')->nullable();
+            }
+            if (! Schema::hasColumn('integration.fhir_client_connections', 'last_health_error')) {
+                $table->string('last_health_error', 120)->nullable();
+            }
+            if (! Schema::hasColumn('integration.fhir_client_connections', 'smart_configuration')) {
+                $table->jsonb('smart_configuration')->default('{}');
+            }
+        });
+
+        Schema::table('integration.event_replay_jobs', function (Blueprint $table): void {
+            if (! Schema::hasColumn('integration.event_replay_jobs', 'source_id')) {
+                $table->unsignedBigInteger('source_id')->nullable();
+                $table->foreign('source_id', 'integration_replay_source_fk')
+                    ->references('source_id')->on('integration.sources')->nullOnDelete();
+            }
+            if (! Schema::hasColumn('integration.event_replay_jobs', 'requested_by_user_id')) {
+                $table->unsignedBigInteger('requested_by_user_id')->nullable();
+            }
+            if (! Schema::hasColumn('integration.event_replay_jobs', 'idempotency_key')) {
+                $table->string('idempotency_key', 190)->nullable();
+                $table->unique('idempotency_key', 'integration_replay_idempotency_unique');
+            }
+            if (! Schema::hasColumn('integration.event_replay_jobs', 'request_hash')) {
+                $table->string('request_hash', 64)->nullable();
+            }
+            if (! Schema::hasColumn('integration.event_replay_jobs', 'dry_run')) {
+                $table->boolean('dry_run')->default(false);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('integration.event_replay_jobs', function (Blueprint $table): void {
+            if (Schema::hasColumn('integration.event_replay_jobs', 'source_id')) {
+                $table->dropForeign('integration_replay_source_fk');
+            }
+            if (Schema::hasColumn('integration.event_replay_jobs', 'idempotency_key')) {
+                $table->dropUnique('integration_replay_idempotency_unique');
+            }
+            $columns = array_values(array_filter([
+                'source_id', 'requested_by_user_id', 'idempotency_key', 'request_hash', 'dry_run',
+            ], fn (string $column): bool => Schema::hasColumn('integration.event_replay_jobs', $column)));
+            if ($columns !== []) {
+                $table->dropColumn($columns);
+            }
+        });
+
+        Schema::table('integration.fhir_client_connections', function (Blueprint $table): void {
+            $columns = array_values(array_filter([
+                'health_status', 'health_checked_at', 'last_health_error', 'smart_configuration',
+            ], fn (string $column): bool => Schema::hasColumn('integration.fhir_client_connections', $column)));
+            if ($columns !== []) {
+                $table->dropColumn($columns);
+            }
+        });
+
+        Schema::table('integration.sources', function (Blueprint $table): void {
+            $columns = array_values(array_filter([
+                'protocol_health_status', 'protocol_health_checked_at', 'protocol_health_error',
+            ], fn (string $column): bool => Schema::hasColumn('integration.sources', $column)));
+            if ($columns !== []) {
+                $table->dropColumn($columns);
+            }
+        });
+    }
+};

--- a/deploy.sh
+++ b/deploy.sh
@@ -65,10 +65,28 @@ sudo chown -R www-data:www-data /var/www/Zephyrus
 echo "Clearing Laravel caches..."
 # Clear Laravel caches
 cd /var/www/Zephyrus
+if [[ "${DEPLOY_RUN_MIGRATIONS:-0}" == "1" ]]; then
+    echo "Running database migrations..."
+    sudo -u www-data php artisan migrate --force
+fi
 sudo -u www-data php artisan cache:clear
 sudo -u www-data php artisan view:clear
 sudo -u www-data php artisan config:clear
 sudo -u www-data php artisan route:clear
+
+echo "Installing and restarting the supervised queue worker..."
+WORKER_UNIT_SOURCE="/var/www/Zephyrus/deploy/systemd/zephyrus-queue-worker.service"
+WORKER_UNIT_DEST="/etc/systemd/system/zephyrus-queue-worker.service"
+if [[ ! -f "$WORKER_UNIT_SOURCE" ]]; then
+    echo "❌ Error: Queue worker unit is missing from the deployment"
+    exit 1
+fi
+if ! sudo cmp -s "$WORKER_UNIT_SOURCE" "$WORKER_UNIT_DEST"; then
+    sudo install -o root -g root -m 0644 "$WORKER_UNIT_SOURCE" "$WORKER_UNIT_DEST"
+    sudo systemctl daemon-reload
+fi
+sudo systemctl enable --now zephyrus-queue-worker.service
+sudo systemctl restart zephyrus-queue-worker.service
 
 echo "🔄 Restarting Apache..."
 # Restart Apache
@@ -81,6 +99,12 @@ echo "🔍 Verifying deployment..."
 if ! systemctl is-active --quiet apache2; then
     echo "❌ Error: Apache failed to start"
     echo "💡 Check Apache logs: sudo journalctl -u apache2.service -n 50"
+    exit 1
+fi
+
+if ! systemctl is-active --quiet zephyrus-queue-worker.service; then
+    echo "❌ Error: Zephyrus queue worker failed to start"
+    echo "💡 Check worker logs: sudo journalctl -u zephyrus-queue-worker.service -n 50"
     exit 1
 fi
 
@@ -109,4 +133,5 @@ echo "
 echo "  - View Laravel logs: tail -f /var/www/Zephyrus/storage/logs/laravel.log"
 echo "  - View Apache logs: sudo journalctl -u apache2.service -n 50"
 echo "  - Check Apache status: sudo systemctl status apache2"
+echo "  - Check worker status: sudo systemctl status zephyrus-queue-worker.service"
 echo "  - Clear Laravel cache: cd /var/www/Zephyrus && php artisan cache:clear"

--- a/deploy/systemd/zephyrus-queue-worker.service
+++ b/deploy/systemd/zephyrus-queue-worker.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Zephyrus Laravel queue worker
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+WorkingDirectory=/var/www/Zephyrus
+ExecStart=/usr/bin/php artisan queue:work database --queue=integrations,default --sleep=3 --tries=3 --backoff=10,30,60 --timeout=300 --max-time=3600 --memory=256
+Restart=always
+RestartSec=5
+TimeoutStopSec=330
+KillSignal=SIGTERM
+UMask=0027
+PrivateTmp=true
+ProtectHome=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/operations/INTEGRATIONS-RUNTIME-RUNBOOK.md
+++ b/docs/operations/INTEGRATIONS-RUNTIME-RUNBOOK.md
@@ -1,0 +1,134 @@
+# Integrations Runtime Runbook
+
+**Status:** Operational first slice
+
+**Scope:** Supervised Laravel queues, FHIR R4/SMART Backend Services, Patient Flow HL7 v2 ADT ingress, protocol health, replay, and production activation.
+
+## Safety properties
+
+- Integration administration remains behind `viewIntegrations` / `manageIntegrations`; no general administrator or operations role inherits it.
+- Outbound checks allow HTTPS only, reject redirects, resolve only allowlisted public hosts, and never serialize an access token or private key.
+- Private keys are referenced as `file:///...` values rooted under `INTEGRATION_SECRET_FILE_ROOT`; the file must be readable by `www-data`, no larger than 64 KiB, and inaccessible to world users.
+- Protocol reachability and clinical-data freshness are separate. A successful discovery check does not advance a connector data watermark.
+- Replay preview never mutates. Execution is limited to pending/failed RTDC canonical events, seven days, and 1,000 events; already-projected events cannot be force-replayed.
+- HL7 accepts only a persisted Sanctum bearer token with the exact `integration:patient-flow:ingest` ability, an active dedicated integration identity, and a production/live/PHI-approved source in production.
+
+## Deploy and worker lifecycle
+
+The repository unit is `deploy/systemd/zephyrus-queue-worker.service`. `./deploy.sh` installs or refreshes it, enables it, restarts it after Laravel caches are cleared, and fails deployment if it is not active. The worker explicitly consumes `integrations,default` from the database connection with a 300-second timeout and a retry window longer than the job timeout.
+
+For the schema-bearing first deployment:
+
+```bash
+DEPLOY_RUN_MIGRATIONS=1 ./deploy.sh
+```
+
+Required production values:
+
+```dotenv
+QUEUE_CONNECTION=database
+DB_QUEUE_CONNECTION=pgsql
+DB_QUEUE_RETRY_AFTER=360
+INTEGRATION_ALLOWED_HOSTS=fhir.epic.com
+INTEGRATION_SECRET_FILE_ROOT=/etc/zephyrus/secrets
+```
+
+Verify:
+
+```bash
+systemctl is-active zephyrus-queue-worker.service
+systemctl status zephyrus-queue-worker.service --no-pager
+sudo -u www-data php /var/www/Zephyrus/artisan queue:monitor integrations,default --max=100
+sudo -u www-data php /var/www/Zephyrus/artisan schedule:list
+```
+
+Rollback is operationally safe: stop/disable the worker before reverting application code. Do not roll back the additive database migration while replay or FHIR jobs remain queued.
+
+## Epic FHIR R4 / SMART activation
+
+The configured public non-production endpoints are Epic's published sandbox endpoints:
+
+- FHIR R4 base: `https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4`
+- SMART discovery: `https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/.well-known/smart-configuration`
+- OAuth token: `https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token`
+
+The implementation follows [Epic's backend OAuth guidance](https://fhir.epic.com/Documentation?docId=oauth2&section=BackendOAuth2Guide) and the [HL7 SMART Backend Services profile](https://hl7.org/fhir/smart-app-launch/backend-services.html): private-key JWT client assertions use RS384, a five-minute assertion lifetime, `client_credentials`, and minimal system scopes.
+
+Configure discovery-only (safe without credentials):
+
+```bash
+sudo -u www-data php artisan integrations:configure-operational-sources
+```
+
+The source remains `testing` / `activation_required`. Live discovery can run, but the UI disables polling.
+
+For authenticated non-production polling:
+
+1. Register Zephyrus as an Epic non-production backend-services client.
+2. Place its private PEM key outside the repository, for example `/etc/zephyrus/secrets/epic-fhir-private-key.pem`, owned `root:www-data` and mode `0640`.
+3. Set `EPIC_FHIR_CLIENT_ID`, `EPIC_FHIR_PRIVATE_KEY_REF=file:///etc/zephyrus/secrets/epic-fhir-private-key.pem`, and optional `EPIC_FHIR_KEY_ID` in production `.env`.
+4. Clear config and activate:
+
+```bash
+sudo -u www-data php artisan config:clear
+sudo -u www-data php artisan integrations:configure-operational-sources --activate-epic
+```
+
+5. In Integrations → FHIR R4 / SMART, run **Check**. Only after live SMART and CapabilityStatement validation plus key resolution does the connection become `ready` and allow Encounter/Location polling.
+
+FHIR polling retains raw versioned resources, `fhir.resource_versions`, provenance, run counters, and a per-resource `_lastUpdated` watermark. A token is held in process memory only. Production PHI polling additionally requires the source to be production/live and PHI-approved.
+
+## HL7 v2 ADT activation
+
+The boundary is configured by `integrations:configure-operational-sources`, but no feed is called live merely because a route exists.
+
+Configure a source in inactive form first:
+
+```bash
+sudo -u www-data php artisan integrations:configure-hl7-adt-source epic.adt.production \
+  --name="Epic ADT Production" --vendor=Epic --environment=production
+```
+
+After the executed contract, executed BAA, PHI approval, and live-state evidence are recorded, activate explicitly:
+
+```bash
+sudo -u www-data php artisan integrations:configure-hl7-adt-source epic.adt.production \
+  --name="Epic ADT Production" --vendor=Epic --environment=production \
+  --contract-status=executed --baa-status=executed --go-live-status=live \
+  --phi-allowed --activate
+```
+
+Create or select a dedicated active `prod.users` identity whose role is `integration` or `integration-machine`, then issue a bounded token:
+
+```bash
+sudo -u www-data php artisan integrations:issue-hl7-token USER_ID --expires=90
+```
+
+Store the one-time plaintext token immediately in the sender's secret manager. Send ADT to `/api/integrations/v1/patient-flow/hl7v2` with:
+
+```text
+Authorization: Bearer <token>
+X-Integration-Source: epic.adt.production
+Idempotency-Key: <stable delivery identifier>
+Content-Type: application/json
+```
+
+The body is `{"raw_hl7":"..."}`. Successful ingress writes raw message → canonical event → Patient Flow projection → provenance and returns opaque receipt UUIDs only.
+
+## Health, replay, and recovery
+
+- **FHIR Check** validates SMART discovery, asymmetric-client capability, the token endpoint, FHIR 4.0.1 CapabilityStatement, expected vendor, supported resources, and local key resolvability.
+- **HL7 Check** validates the canonical boundary, exact-ability machine identity, and last successful source ingress without exposing patient or token data.
+- **Replay Preview** returns aggregate counts and event types only.
+- **Queue Replay** requires `Idempotency-Key`; reusing the key with an identical scope returns the original job, while a different scope returns conflict.
+- Poll failures create a dead letter with a stable error code. Correct the endpoint/credential condition, rerun protocol health, and queue the poll again. Never paste credentials or raw patient content into replay metadata or configuration audit records.
+
+Useful inspection commands:
+
+```bash
+sudo -u www-data php artisan queue:failed
+sudo -u www-data php artisan queue:retry <failed-job-uuid>
+journalctl -u zephyrus-queue-worker.service -n 100 --no-pager
+```
+
+Credential rotation uses overlap: provision the new key with Epic, replace the referenced file atomically, clear config only if reference metadata changed, run a health check, then retire the old public key after successful polling. Do not store a PEM, access token, HL7 payload, or client assertion in Git, command history, application logs, or configuration audits.

--- a/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
+++ b/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
@@ -80,7 +80,7 @@ Pre-PR local evidence on the isolated security branch:
 - [x] W1.4 Do not fetch agent-inbox or patient-detail data in wall mode.
 - [x] W1.5 Preserve current desk-mode drill, patient, inbox, lens, and Eddy behavior without duplication.
 - [x] W1.6 Add component tests proving wall mode is chromeless/non-interactive and desk mode remains interactive.
-- [ ] W1.7 Publish as its own bounded PR, run full CI, merge, and deploy from `main`.
+- [x] W1.7 Publish as its own bounded PR, run full CI, merge, and deploy from `main`.
 
 Pre-PR local evidence on the isolated wall-lockdown branch:
 
@@ -89,17 +89,37 @@ Pre-PR local evidence on the isolated wall-lockdown branch:
 - `npx tsc --noEmit`: passed.
 - `npm run build`: production build passed.
 - `scripts/check-ui-canon.sh`: passed; one pre-existing dashboard raw-palette match was converted to the canonical healthcare token to restore the ratchet from 77 to its baseline of 76.
+- PR #16 passed all five exact-head CI checks, merged as `356b5004d856eac0cb67c1b05cb07f23a309c935`, and was deployed through `./deploy.sh` from clean/current `main`.
+- Runtime parity checks matched local/production source and manifest hashes; the public wall URL returned 200 and the deployed bundle omitted patient lens, inbox, drill URL state, and Eddy wall controls.
 
 ## Integrations operational runtime
 
-- [ ] I1.1 Replace the synchronous production queue posture with supervised asynchronous workers, retry/backoff policy, failed-job visibility, and deploy-safe restart behavior.
-- [ ] I1.2 Add protocol-aware health checks for FHIR R4/SMART and HL7 v2 rather than configuration-presence checks.
-- [ ] I1.3 Add audited replay controls with bounded source/time/event scope, dry-run preview, idempotency, and operator authorization.
-- [ ] I1.4 Configure one real Epic FHIR R4/SMART source, endpoint, secret reference, capabilities, and watermark without committing credentials.
-- [ ] I1.5 Prove SMART backend-service authentication, CapabilityStatement compatibility, minimal read scope, polling, canonical mapping, projection, and watermark advancement.
-- [ ] I1.6 Add the first real HL7 v2 ADT source through the machine-authenticated canonical ingress established in S1.
-- [ ] I1.7 Exercise failure, dead-letter, replay, recovery, stale-watermark, secret-rotation, and rollback paths.
-- [ ] I1.8 Publish configuration/runbook evidence while keeping environment-specific secrets outside Git.
+- [x] I1.1a Change the repository/runtime default to the database queue and add an `integrations,default` worker with bounded timeout, backoff, memory, and lifecycle settings.
+- [x] I1.1b Add a hardened systemd unit plus deploy-time install/restart/active verification; keep first-run migrations explicit through `DEPLOY_RUN_MIGRATIONS=1`.
+- [ ] I1.1c Install the unit in production, change production from `sync` to `database`, and prove scheduler → database job → worker completion.
+- [x] I1.2 Add protocol-aware health checks for FHIR R4/SMART and HL7 v2 rather than configuration-presence checks; keep protocol health separate from data freshness.
+- [x] I1.3 Add audited replay controls with bounded source/time/event scope, read-only preview, idempotency, and strict operator authorization. Execution excludes already-projected events.
+- [x] I1.4a Add an idempotent real Epic public-sandbox source with official FHIR, SMART-discovery, and token endpoints; never commit credentials.
+- [ ] I1.4b Configure that source in production and complete a live discovery run.
+- [x] I1.5a Prove RS384 SMART client assertion construction, five-minute JWT lifetime, minimal Encounter/Location scope, FHIR 4.0.1 compatibility, version retention, provenance, pagination bounds, and watermark advancement in integration tests.
+- [ ] I1.5b Complete a real Epic token exchange and poll. External gate: registered Epic non-production client ID plus an approved private-key reference.
+- [x] I1.6a Operationalize the S1 HL7 boundary with source-governance and bounded machine-token commands plus protocol health.
+- [ ] I1.6b Configure/activate the first real production HL7 v2 ADT source and deliver a test ADT through raw → canonical → Patient Flow projection → provenance. External gate: executed interface/BAA/PHI approval and sender identity.
+- [x] I1.7a Exercise discovery-only activation, unsafe/unresolved credentials, bounded retry/backoff, dead-letter recovery, replay idempotency/conflict, strict authorization, FHIR lineage, and worker dispatch in tests.
+- [ ] I1.7b Exercise live token/poll failure, dead-letter recovery, source staleness, credential rotation, worker restart, and rollback in production.
+- [x] I1.8 Publish `docs/operations/INTEGRATIONS-RUNTIME-RUNBOOK.md` while keeping environment-specific secrets outside Git.
+
+Current isolated branch evidence:
+
+- `IntegrationOperationalRuntimeTest`: seven end-to-end feature tests and 64 assertions cover idempotent source configuration, queued live discovery, RSA-signed SMART authentication, versioned FHIR persistence/provenance/watermarking, exhausted-retry dead-letter recovery, replay, HL7 governance/token issuance, and authorization.
+- `tests/js/integrations/api.test.ts`: operator API schemas and health/poll/replay request contracts pass.
+- `npx tsc --noEmit`: passed after adding operator controls to FHIR, HL7, and replay panels.
+- `bash -n deploy.sh` and `systemd-analyze verify deploy/systemd/zephyrus-queue-worker.service`: repository unit and deploy script validated (host-wide verifier emitted unrelated unreadable-unit notices only).
+- Repository `./vendor/bin/pint --test`: 890 files passed.
+- Full `php artisan test`: exit 0 with 7,471 assertions; the isolated worktree reported its known missing-local-environment `file_get_contents` warnings but no failing test.
+- Full `npx vitest run --coverage`: 81 files and 343 tests passed; `npm run build` and `scripts/check-ui-canon.sh` passed.
+- Clean Arena environment: 17 pytest tests passed.
+- Production pre-change audit: `QUEUE_CONNECTION=sync`, no Zephyrus worker, no endpoints/watermarks/FHIR or SMART rows, and only the synthetic non-PHI HL7 file source. No Epic client identity or private-key reference exists on the host.
 
 ## Staffing operations completion
 

--- a/resources/js/Pages/Integrations/Index.tsx
+++ b/resources/js/Pages/Integrations/Index.tsx
@@ -1,8 +1,14 @@
 import PageContentLayout from '@/Components/Common/PageContentLayout';
 import DashboardLayout from '@/Components/Dashboard/DashboardLayout';
 import { CredentialConfiguration, EndpointConfiguration, SourceConfiguration } from '@/Components/Integrations/ConfigurationForms';
-import { useIntegrationControlPlane } from '@/features/integrations/hooks';
-import type { IntegrationControlPlane, IntegrationSource } from '@/features/integrations/api';
+import {
+  useIntegrationControlPlane,
+  usePreviewIntegrationReplay,
+  useQueueEpicFhirPoll,
+  useQueueIntegrationHealthCheck,
+  useQueueIntegrationReplay,
+} from '@/features/integrations/hooks';
+import type { IntegrationControlPlane, IntegrationReplayInput, IntegrationSource } from '@/features/integrations/api';
 import { Head } from '@inertiajs/react';
 import {
   Activity,
@@ -77,6 +83,11 @@ function formatTime(value: string | null): string {
   return value ? new Date(value).toLocaleString([], { dateStyle: 'medium', timeStyle: 'medium' }) : 'Never';
 }
 
+function localDateTime(value: Date): string {
+  const offsetMs = value.getTimezoneOffset() * 60_000;
+  return new Date(value.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
 function StatusBadge({ value }: { value: string }) {
   return (
     <span className={`inline-flex whitespace-nowrap rounded-md border px-2 py-0.5 text-xs/[16px] font-semibold ${statusClasses[value] ?? statusClasses.template}`}>
@@ -118,6 +129,19 @@ function Panel({ title, actions, children }: { title: string; actions?: ReactNod
       </div>
       {children}
     </section>
+  );
+}
+
+function ActionButton({ children, disabled = false, onClick }: { children: ReactNode; disabled?: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="inline-flex min-h-8 items-center justify-center rounded-md border border-healthcare-border px-2.5 py-1 text-xs/[16px] font-semibold text-healthcare-text-primary transition hover:bg-healthcare-hover disabled:cursor-not-allowed disabled:opacity-50 dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark dark:hover:bg-healthcare-hover-dark"
+    >
+      {children}
+    </button>
   );
 }
 
@@ -187,11 +211,13 @@ function OverviewPanel({ data }: { data: IntegrationControlPlane }) {
       <Panel title="Source Health" actions={<span className="text-xs/[16px] text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">Stale after {formatDurationMinutes(data.freshnessPolicy.staleAfterMinutes)}</span>}>
         <SourceTable sources={data.sources} />
       </Panel>
-      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
         <Metric label="Ingest Runs" value={data.counts.ingestRuns} />
         <Metric label="Inbound Messages" value={data.counts.inboundMessages} />
         <Metric label="Canonical Events" value={data.counts.canonicalEvents} />
         <Metric label="Open Projection Errors" value={data.counts.openProjectionErrors} status={data.counts.openProjectionErrors ? 'critical' : undefined} />
+        <Metric label="Queued Jobs" value={data.counts.queuedJobs} status={data.counts.queuedJobs > 100 ? 'warning' : undefined} />
+        <Metric label="Failed Queue Jobs" value={data.counts.failedQueueJobs} status={data.counts.failedQueueJobs ? 'critical' : undefined} />
       </div>
     </div>
   );
@@ -225,24 +251,38 @@ function SourcesPanel({ data }: { data: IntegrationControlPlane }) {
 
 function FhirPanel({ data }: { data: IntegrationControlPlane }) {
   const smartCredentials = data.credentials.filter((credential) => credential.credentialType === 'smart_backend_services');
+  const healthCheck = useQueueIntegrationHealthCheck();
+  const poll = useQueueEpicFhirPoll();
   return (
     <div className="space-y-5">
       <Panel title="FHIR R4 Connections">
         {data.fhirConnections.length === 0 ? <EmptyRows label="No FHIR R4 connections configured." /> : (
-          <Table headings={['Source', 'Connection', 'FHIR Version', 'Status', 'Capability Check', 'Resources', 'Base URL']}>
+          <Table headings={['Source', 'Connection', 'FHIR Version', 'Status', 'Protocol Health', 'Capability Check', 'Resources', 'Controls']}>
             {data.fhirConnections.map((connection) => (
               <tr key={connection.connectionId}>
                 <td className={primaryCellClass}>{connection.sourceName}</td>
                 <td className={cellClass}>{connection.connectionKey}</td>
                 <td className={cellClass}>{connection.fhirVersion ?? 'Unknown'}</td>
                 <td className={cellClass}><StatusBadge value={connection.status} /></td>
+                <td className={cellClass}>
+                  <StatusBadge value={connection.healthStatus} />
+                  {connection.healthErrorCode && <div className="mt-1 text-xs/[16px]">{humanize(connection.healthErrorCode)}</div>}
+                </td>
                 <td className={cellClass}>{formatTime(connection.capabilityCheckedAtIso)}</td>
                 <td className={`${cellClass} tabular-nums`}>{connection.supportedResourceCount}</td>
-                <td className={cellClass}>{connection.baseUrlConfigured ? 'Configured' : 'Missing'}</td>
+                <td className={cellClass}>
+                  <div className="flex min-w-max flex-wrap gap-1.5">
+                    <ActionButton disabled={healthCheck.isPending} onClick={() => healthCheck.mutate(connection.sourceId)}>Check</ActionButton>
+                    <ActionButton disabled={poll.isPending || !['ready', 'active'].includes(connection.status)} onClick={() => poll.mutate({ sourceId: connection.sourceId, resourceType: 'Encounter' })}>Poll Encounter</ActionButton>
+                    <ActionButton disabled={poll.isPending || !['ready', 'active'].includes(connection.status)} onClick={() => poll.mutate({ sourceId: connection.sourceId, resourceType: 'Location' })}>Poll Location</ActionButton>
+                  </div>
+                </td>
               </tr>
             ))}
           </Table>
         )}
+        {(healthCheck.isSuccess || poll.isSuccess) && <p role="status" className="mt-2 text-xs/[16px] text-healthcare-success dark:text-healthcare-success-dark">The integration run was queued on the supervised worker.</p>}
+        {(healthCheck.isError || poll.isError) && <p role="alert" className="mt-2 text-xs/[16px] text-healthcare-critical dark:text-healthcare-critical-dark">The run could not be queued. Verify activation and protocol health.</p>}
       </Panel>
       <Panel title="SMART Backend Services">
         {smartCredentials.length === 0 ? <EmptyRows label="No SMART Backend Services credentials configured." /> : (
@@ -267,6 +307,7 @@ function FhirPanel({ data }: { data: IntegrationControlPlane }) {
 
 function Hl7Panel({ data }: { data: IntegrationControlPlane }) {
   const hl7Sources = data.sources.filter((source) => source.interfaceType.toLowerCase().includes('hl7'));
+  const healthCheck = useQueueIntegrationHealthCheck();
   return (
     <div className="space-y-5">
       <Panel title="Interface Engine Boundary">
@@ -284,6 +325,21 @@ function Hl7Panel({ data }: { data: IntegrationControlPlane }) {
         )}
       </Panel>
       <Panel title="HL7 v2 Sources"><SourceTable sources={hl7Sources} /></Panel>
+      <Panel title="Ingress Health Controls">
+        {hl7Sources.length === 0 ? <EmptyRows label="No HL7 v2 source is configured for a protocol check." /> : (
+          <div className="space-y-2">
+            {hl7Sources.map((source) => (
+              <div key={source.sourceId} className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-healthcare-border p-3 dark:border-healthcare-border-dark">
+                <div>
+                  <div className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">{source.sourceName}</div>
+                  <div className="text-xs/[16px] text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">Protocol: {humanize(source.protocolHealthStatus)} · checked {formatTime(source.protocolHealthCheckedAtIso)}</div>
+                </div>
+                <ActionButton disabled={healthCheck.isPending} onClick={() => healthCheck.mutate(source.sourceId)}>Check boundary</ActionButton>
+              </div>
+            ))}
+          </div>
+        )}
+      </Panel>
     </div>
   );
 }
@@ -387,6 +443,23 @@ function RunsPanel({ data }: { data: IntegrationControlPlane }) {
 }
 
 function DeadLettersPanel({ data }: { data: IntegrationControlPlane }) {
+  const preview = usePreviewIntegrationReplay();
+  const replay = useQueueIntegrationReplay();
+  const [sourceId, setSourceId] = useState('');
+  const [from, setFrom] = useState(() => localDateTime(new Date(Date.now() - 24 * 60 * 60 * 1000)));
+  const [to, setTo] = useState(() => localDateTime(new Date()));
+  const [previewedInput, setPreviewedInput] = useState<IntegrationReplayInput | null>(null);
+  const replayInput = (): IntegrationReplayInput => ({
+    source_id: sourceId ? Number(sourceId) : null,
+    from: new Date(from).toISOString(),
+    to: new Date(to).toISOString(),
+    limit: 500,
+  });
+  const resetReplayScope = () => {
+    setPreviewedInput(null);
+    preview.reset();
+    replay.reset();
+  };
   return (
     <div className="space-y-5">
       <div className="grid gap-3 sm:grid-cols-3">
@@ -410,6 +483,33 @@ function DeadLettersPanel({ data }: { data: IntegrationControlPlane }) {
             ))}
           </Table>
         )}
+      </Panel>
+      <Panel title="Canonical Projection Replay">
+        <div className="grid gap-3 rounded-md border border-healthcare-border p-3 md:grid-cols-4 dark:border-healthcare-border-dark">
+          <label className="text-xs/[16px] font-semibold text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+            Source
+            <select value={sourceId} onChange={(event) => { setSourceId(event.target.value); resetReplayScope(); }} className="mt-1 block min-h-9 w-full rounded-md border border-healthcare-border bg-healthcare-surface px-2 text-sm/[18px] text-healthcare-text-primary dark:border-healthcare-border-dark dark:bg-healthcare-surface-dark dark:text-healthcare-text-primary-dark">
+              <option value="">All sources</option>
+              {data.sources.map((source) => <option key={source.sourceId} value={source.sourceId}>{source.sourceName}</option>)}
+            </select>
+          </label>
+          <label className="text-xs/[16px] font-semibold text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+            From
+            <input type="datetime-local" value={from} onChange={(event) => { setFrom(event.target.value); resetReplayScope(); }} className="mt-1 block min-h-9 w-full rounded-md border border-healthcare-border bg-healthcare-surface px-2 text-sm/[18px] text-healthcare-text-primary dark:border-healthcare-border-dark dark:bg-healthcare-surface-dark dark:text-healthcare-text-primary-dark" />
+          </label>
+          <label className="text-xs/[16px] font-semibold text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+            To
+            <input type="datetime-local" value={to} onChange={(event) => { setTo(event.target.value); resetReplayScope(); }} className="mt-1 block min-h-9 w-full rounded-md border border-healthcare-border bg-healthcare-surface px-2 text-sm/[18px] text-healthcare-text-primary dark:border-healthcare-border-dark dark:bg-healthcare-surface-dark dark:text-healthcare-text-primary-dark" />
+          </label>
+          <div className="flex items-end gap-2">
+            <ActionButton disabled={preview.isPending || !from || !to} onClick={() => { const input = replayInput(); preview.mutate(input, { onSuccess: () => setPreviewedInput(input) }); }}>Preview</ActionButton>
+            <ActionButton disabled={replay.isPending || replay.isSuccess || !previewedInput || !preview.data || preview.data.eligibleEvents === 0} onClick={() => replay.mutate({ input: previewedInput!, idempotencyKey: globalThis.crypto?.randomUUID?.() ?? `replay-${Date.now()}` })}>Queue replay</ActionButton>
+          </div>
+        </div>
+        <p className="mt-2 text-xs/[16px] text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">Only pending or failed RTDC canonical projections are eligible. Preview is read-only; already-projected events are excluded.</p>
+        {preview.data && <p role="status" className="mt-2 text-sm/[18px] text-healthcare-text-primary dark:text-healthcare-text-primary-dark">{preview.data.eligibleEvents} eligible of {preview.data.totalMatchingEvents} matching events{preview.data.truncated ? ' (bounded by the replay limit)' : ''}.</p>}
+        {replay.isSuccess && <p role="status" className="mt-2 text-sm/[18px] text-healthcare-success dark:text-healthcare-success-dark">Replay #{replay.data.replayJobId} was queued with an idempotency key.</p>}
+        {(preview.isError || replay.isError) && <p role="alert" className="mt-2 text-sm/[18px] text-healthcare-critical dark:text-healthcare-critical-dark">The replay request was rejected. Check the seven-day window and source selection.</p>}
       </Panel>
       <Panel title="Replay History">
         {data.replayJobs.length === 0 ? <EmptyRows label="No replay jobs recorded." /> : (

--- a/resources/js/features/integrations/api.ts
+++ b/resources/js/features/integrations/api.ts
@@ -13,6 +13,9 @@ const sourceSchema = z.object({
   interfaceType: z.string(),
   configuredStatus: z.string(),
   healthStatus: z.string(),
+  protocolHealthStatus: z.string(),
+  protocolHealthCheckedAtIso: nullableString,
+  protocolHealthErrorCode: nullableString,
   goLiveStatus: z.string(),
   contractStatus: z.string(),
   baaStatus: z.string(),
@@ -70,6 +73,9 @@ const integrationControlPlaneSchema = z.object({
     degradedSources: z.number(),
     staleSources: z.number(),
     failedSources: z.number(),
+    protocolHealthySources: z.number(),
+    protocolDegradedSources: z.number(),
+    protocolFailedSources: z.number(),
     endpoints: z.number(),
     capabilities: z.number(),
     credentials: z.number(),
@@ -88,6 +94,8 @@ const integrationControlPlaneSchema = z.object({
     terminologyMaps: z.number(),
     writebackDrafts: z.number(),
     configurationAudits: z.number(),
+    queuedJobs: z.number(),
+    failedQueueJobs: z.number(),
   }),
   sources: z.array(sourceSchema),
   endpoints: z.array(z.object({
@@ -105,11 +113,15 @@ const integrationControlPlaneSchema = z.object({
   })),
   fhirConnections: z.array(z.object({
     connectionId: z.number(),
+    sourceId: z.number(),
     sourceName: z.string(),
     connectionKey: z.string(),
     status: z.string(),
     fhirVersion: nullableString,
     capabilityCheckedAtIso: nullableString,
+    healthStatus: z.string(),
+    healthCheckedAtIso: nullableString,
+    healthErrorCode: nullableString,
     baseUrlConfigured: z.boolean(),
     supportedResourceCount: z.number(),
   })),
@@ -175,8 +187,10 @@ const integrationControlPlaneSchema = z.object({
   })),
   replayJobs: z.array(z.object({
     replayJobId: z.number(),
+    sourceId: z.number().nullable(),
     replayType: z.string(),
     status: z.string(),
+    dryRun: z.boolean(),
     eventsReplayed: z.number(),
     eventsFailed: z.number(),
     startedAtIso: nullableString,
@@ -292,6 +306,39 @@ export interface IntegrationCredentialInput {
   owner?: string | null;
 }
 
+export interface IntegrationReplayInput {
+  source_id?: number | null;
+  from: string;
+  to: string;
+  event_types?: string[];
+  limit?: number;
+}
+
+const queuedRunSchema = z.object({
+  runId: z.number(), runUuid: z.string(), status: z.string(), created: z.boolean(),
+  resourceType: z.string().optional(),
+});
+
+const replayPreviewSchema = z.object({
+  eligibleEvents: z.number(),
+  totalMatchingEvents: z.number(),
+  truncated: z.boolean(),
+  oldestAtIso: nullableString,
+  newestAtIso: nullableString,
+  byEventType: z.array(z.object({ eventType: z.string(), count: z.number() })),
+  scope: z.object({
+    sourceId: z.number().nullable(), from: z.string(), to: z.string(),
+    eventTypes: z.array(z.string()), projectionStatuses: z.array(z.string()), limit: z.number(),
+  }),
+  mutation: z.literal(false),
+});
+
+const queuedReplaySchema = z.object({
+  replayJobId: z.number(), replayUuid: z.string(), status: z.string(), created: z.boolean(),
+});
+
+export type IntegrationReplayPreview = z.infer<typeof replayPreviewSchema>;
+
 function parseEnvelope<T>(schema: z.ZodType<T>, payload: unknown): T {
   const envelope = z.object({ data: z.unknown() }).parse(payload);
 
@@ -344,4 +391,26 @@ export async function updateIntegrationCredential(sourceId: number, credentialId
 
 export async function deleteIntegrationCredential(sourceId: number, credentialId: number): Promise<void> {
   await axios.delete(`/api/admin/integrations/sources/${sourceId}/credentials/${credentialId}`);
+}
+
+export async function queueIntegrationHealthCheck(sourceId: number) {
+  const response = await axios.post(`/api/admin/integrations/sources/${sourceId}/health-check`);
+  return parseEnvelope(queuedRunSchema, response.data);
+}
+
+export async function queueEpicFhirPoll(sourceId: number, resourceType: 'Encounter' | 'Location') {
+  const response = await axios.post(`/api/admin/integrations/sources/${sourceId}/fhir/poll`, { resource_type: resourceType });
+  return parseEnvelope(queuedRunSchema, response.data);
+}
+
+export async function previewIntegrationReplay(input: IntegrationReplayInput) {
+  const response = await axios.post('/api/admin/integrations/enterprise/replays/preview', input);
+  return parseEnvelope(replayPreviewSchema, response.data);
+}
+
+export async function queueIntegrationReplay(input: IntegrationReplayInput, idempotencyKey: string) {
+  const response = await axios.post('/api/admin/integrations/enterprise/replays', input, {
+    headers: { 'Idempotency-Key': idempotencyKey },
+  });
+  return parseEnvelope(queuedReplaySchema, response.data);
 }

--- a/resources/js/features/integrations/hooks.ts
+++ b/resources/js/features/integrations/hooks.ts
@@ -6,6 +6,10 @@ import {
   deleteIntegrationCredential,
   deleteIntegrationEndpoint,
   fetchIntegrationControlPlane,
+  previewIntegrationReplay,
+  queueEpicFhirPoll,
+  queueIntegrationHealthCheck,
+  queueIntegrationReplay,
   retireIntegrationSource,
   updateIntegrationEndpoint,
   updateIntegrationCredential,
@@ -13,6 +17,7 @@ import {
   type IntegrationCredentialInput,
   type IntegrationEndpointInput,
   type IntegrationSourceInput,
+  type IntegrationReplayInput,
 } from './api';
 
 const controlPlaneKey = ['admin', 'integrations', 'control-plane'] as const;
@@ -25,7 +30,7 @@ export function useIntegrationControlPlane() {
   });
 }
 
-function useRefreshingMutation<TInput>(mutationFn: (input: TInput) => Promise<unknown>) {
+function useRefreshingMutation<TInput, TOutput>(mutationFn: (input: TInput) => Promise<TOutput>) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn,
@@ -67,4 +72,20 @@ export function useUpdateIntegrationCredential() {
 
 export function useDeleteIntegrationCredential() {
   return useRefreshingMutation(({ sourceId, credentialId }: { sourceId: number; credentialId: number }) => deleteIntegrationCredential(sourceId, credentialId));
+}
+
+export function useQueueIntegrationHealthCheck() {
+  return useRefreshingMutation((sourceId: number) => queueIntegrationHealthCheck(sourceId));
+}
+
+export function useQueueEpicFhirPoll() {
+  return useRefreshingMutation(({ sourceId, resourceType }: { sourceId: number; resourceType: 'Encounter' | 'Location' }) => queueEpicFhirPoll(sourceId, resourceType));
+}
+
+export function usePreviewIntegrationReplay() {
+  return useMutation({ mutationFn: (input: IntegrationReplayInput) => previewIntegrationReplay(input) });
+}
+
+export function useQueueIntegrationReplay() {
+  return useRefreshingMutation(({ input, idempotencyKey }: { input: IntegrationReplayInput; idempotencyKey: string }) => queueIntegrationReplay(input, idempotencyKey));
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -367,7 +367,11 @@ Route::middleware(['web', 'auth', 'throttle:60,1', 'can:manageIntegrations'])->p
     Route::post('/sources/{source}/credentials', [IntegrationCredentialController::class, 'store'])->whereNumber('source');
     Route::patch('/sources/{source}/credentials/{credential}', [IntegrationCredentialController::class, 'update'])->whereNumber(['source', 'credential']);
     Route::delete('/sources/{source}/credentials/{credential}', [IntegrationCredentialController::class, 'destroy'])->whereNumber(['source', 'credential']);
+    Route::post('/sources/{source}/health-check', [EnterpriseConnectorController::class, 'healthCheck'])->whereNumber('source');
+    Route::post('/sources/{source}/fhir/poll', [EnterpriseConnectorController::class, 'pollFhir'])->whereNumber('source');
     Route::post('/enterprise/fhir/capability-discovery', [EnterpriseConnectorController::class, 'discoverFhir']);
+    Route::post('/enterprise/replays/preview', [EnterpriseConnectorController::class, 'previewReplay']);
+    Route::post('/enterprise/replays', [EnterpriseConnectorController::class, 'queueReplay']);
     Route::post('/enterprise/writeback-drafts', [EnterpriseConnectorController::class, 'createWritebackDraft']);
 });
 

--- a/tests/Feature/ApiAuthorizationTest.php
+++ b/tests/Feature/ApiAuthorizationTest.php
@@ -84,7 +84,8 @@ class ApiAuthorizationTest extends TestCase
         ])->assertForbidden();
         $this->actingAs($superuser)->postJson('/api/admin/integrations/enterprise/fhir/capability-discovery', [
             'source_key' => 'epic.fhir.sandbox',
-        ])->assertStatus(501);
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors('source_id');
     }
 
     public function test_mobile_bff_requires_sanctum_read_and_act_abilities(): void

--- a/tests/Feature/Integrations/IntegrationOperationalRuntimeTest.php
+++ b/tests/Feature/Integrations/IntegrationOperationalRuntimeTest.php
@@ -1,0 +1,438 @@
+<?php
+
+namespace Tests\Feature\Integrations;
+
+use App\Integrations\Healthcare\Exceptions\IntegrationProtocolException;
+use App\Integrations\Healthcare\Services\EpicSmartFhirClient;
+use App\Integrations\Healthcare\Services\IntegrationProtocolHealthService;
+use App\Integrations\Healthcare\Services\OperationalIntegrationConfigurator;
+use App\Integrations\Healthcare\Services\SourceRegistryService;
+use App\Jobs\PollEpicFhirResource;
+use App\Jobs\ReplayPendingIntegrationEvents;
+use App\Jobs\RunIntegrationProtocolHealthCheck;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class IntegrationOperationalRuntimeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ?string $secretDirectory = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->secretDirectory) {
+            foreach (glob($this->secretDirectory.'/*') ?: [] as $path) {
+                @unlink($path);
+            }
+            @rmdir($this->secretDirectory);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_operational_source_command_is_idempotent_and_truthful_about_activation(): void
+    {
+        $this->artisan('integrations:configure-operational-sources')
+            ->expectsOutputToContain('activation-gated')
+            ->assertSuccessful();
+        $this->artisan('integrations:configure-operational-sources')->assertSuccessful();
+
+        $this->assertDatabaseHas('integration.sources', [
+            'source_key' => 'epic.fhir-r4.sandbox',
+            'active_status' => 'testing',
+            'phi_allowed' => false,
+        ]);
+        $this->assertSame(3, DB::table('integration.source_endpoints')->count());
+        $this->assertSame(1, DB::table('integration.fhir_client_connections')->count());
+        $this->assertDatabaseHas('integration.smart_backend_credentials', [
+            'credential_key' => 'epic-smart-backend',
+            'status' => 'activation_required',
+            'client_id' => null,
+        ]);
+        $this->assertDatabaseHas('integration.interface_engines', [
+            'engine_key' => 'patient-flow-hl7v2-ingress',
+            'status' => 'ready',
+        ]);
+        $this->assertSame(2, DB::table('integration.configuration_audits')->count());
+    }
+
+    public function test_fhir_discovery_runs_on_the_integration_queue_and_records_protocol_health(): void
+    {
+        config([
+            'integrations.network.allowed_hosts' => ['fhir.epic.com'],
+            'integrations.network.require_dns_resolution' => false,
+        ]);
+        app(OperationalIntegrationConfigurator::class)->configureEpicSandbox();
+        $sourceId = (int) DB::table('integration.sources')->where('source_key', 'epic.fhir-r4.sandbox')->value('source_id');
+        Http::fake($this->epicDiscoveryResponses());
+        Queue::fake();
+
+        $response = $this->actingAs($this->superuser())
+            ->postJson('/api/admin/integrations/sources/'.$sourceId.'/health-check')
+            ->assertAccepted()
+            ->assertJsonPath('data.status', 'queued');
+
+        $runId = (int) $response->json('data.runId');
+        Queue::assertPushed(RunIntegrationProtocolHealthCheck::class, function (RunIntegrationProtocolHealthCheck $job) use ($runId): bool {
+            return $job->runId === $runId && $job->connection === 'database' && $job->queue === 'integrations';
+        });
+        $job = new RunIntegrationProtocolHealthCheck($runId, null, (string) Str::uuid());
+        $job->handle(app(IntegrationProtocolHealthService::class), app(\App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService::class));
+
+        $this->assertDatabaseHas('raw.ingest_runs', ['ingest_run_id' => $runId, 'status' => 'completed']);
+        $this->assertDatabaseHas('integration.sources', ['source_id' => $sourceId, 'protocol_health_status' => 'healthy']);
+        $this->assertDatabaseHas('integration.fhir_client_connections', [
+            'source_id' => $sourceId,
+            'health_status' => 'healthy',
+            'status' => 'activation_required',
+            'fhir_version' => '4.0.1',
+        ]);
+        $this->assertDatabaseHas('integration.source_capabilities', [
+            'source_id' => $sourceId,
+            'resource_type' => 'Encounter',
+            'capability_type' => 'fhir_resource',
+        ]);
+        $this->assertSame(0, DB::table('integration.connector_watermarks')->count(), 'Protocol reachability must not advance a data watermark.');
+    }
+
+    public function test_epic_smart_backend_poll_signs_a_jwt_and_persists_versioned_fhir_lineage(): void
+    {
+        config([
+            'integrations.network.allowed_hosts' => ['fhir.epic.com'],
+            'integrations.network.require_dns_resolution' => false,
+        ]);
+        $keyReference = $this->privateKeyReference();
+        $source = app(OperationalIntegrationConfigurator::class)->configureEpicSandbox(
+            clientId: 'registered-non-production-client',
+            privateKeyRef: $keyReference,
+            keyId: 'test-key-1',
+            activate: true,
+        );
+        $sourceId = (int) $source['sourceId'];
+        Http::fake($this->epicDiscoveryResponses());
+        app(IntegrationProtocolHealthService::class)->check($sourceId);
+
+        Http::fake(function (Request $request) {
+            if ($request->url() === config('integrations.epic_sandbox.token_url')) {
+                return Http::response(['access_token' => 'ephemeral-test-token', 'token_type' => 'Bearer', 'expires_in' => 300]);
+            }
+            if (str_starts_with($request->url(), config('integrations.epic_sandbox.base_url').'/Encounter')) {
+                return Http::response([
+                    'resourceType' => 'Bundle',
+                    'type' => 'searchset',
+                    'entry' => [[
+                        'resource' => [
+                            'resourceType' => 'Encounter',
+                            'id' => 'sandbox-encounter-1',
+                            'meta' => ['versionId' => '1', 'lastUpdated' => '2026-07-10T12:00:00Z'],
+                            'status' => 'finished',
+                        ],
+                    ]],
+                ], 200, ['Content-Type' => 'application/fhir+json']);
+            }
+
+            return Http::response([], 404);
+        });
+        $runId = DB::table('raw.ingest_runs')->insertGetId([
+            'run_uuid' => (string) Str::uuid(),
+            'source_id' => $sourceId,
+            'connector_key' => 'epic.fhir-r4.encounter',
+            'run_type' => 'fhir_poll',
+            'status' => 'running',
+            'started_at' => now(),
+            'metadata' => json_encode([]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], 'ingest_run_id');
+
+        $result = app(EpicSmartFhirClient::class)->poll($sourceId, 'Encounter', (int) $runId);
+
+        $this->assertSame(1, $result['resourcesPersisted']);
+        $this->assertDatabaseHas('raw.inbound_messages', [
+            'source_id' => $sourceId,
+            'ingest_run_id' => $runId,
+            'message_type' => 'FHIR_R4_Encounter',
+            'parse_status' => 'persisted',
+        ]);
+        $this->assertDatabaseHas('fhir.resource_versions', [
+            'source_id' => $sourceId,
+            'resource_type' => 'Encounter',
+            'fhir_id' => 'sandbox-encounter-1',
+            'version_id' => '1',
+        ]);
+        $this->assertDatabaseHas('integration.provenance_records', ['target_schema' => 'fhir', 'target_table' => 'resource_versions']);
+        $this->assertDatabaseHas('integration.connector_watermarks', [
+            'source_id' => $sourceId,
+            'connector_key' => 'epic.fhir-r4',
+            'scope_key' => 'Encounter',
+        ]);
+        Http::assertSent(function (Request $request): bool {
+            if ($request->url() !== config('integrations.epic_sandbox.token_url')) {
+                return false;
+            }
+            $assertion = (string) ($request['client_assertion'] ?? '');
+
+            return ($request['grant_type'] ?? null) === 'client_credentials'
+                && substr_count($assertion, '.') === 2
+                && ! str_contains($assertion, 'PRIVATE KEY');
+        });
+        Http::assertSent(fn (Request $request): bool => str_starts_with($request->url(), config('integrations.epic_sandbox.base_url').'/Encounter')
+            && $request->hasHeader('Authorization', 'Bearer ephemeral-test-token'));
+        $databaseDump = json_encode([
+            DB::table('integration.smart_backend_credentials')->get(),
+            DB::table('raw.ingest_runs')->get(),
+            DB::table('integration.configuration_audits')->get(),
+        ]);
+        $this->assertStringNotContainsString('ephemeral-test-token', (string) $databaseDump);
+        $this->assertStringNotContainsString('BEGIN PRIVATE KEY', (string) $databaseDump);
+    }
+
+    public function test_replay_preview_is_read_only_and_execution_is_bounded_idempotent_and_audited(): void
+    {
+        $source = app(SourceRegistryService::class)->ensureSource([
+            'source_key' => 'replay.test',
+            'source_name' => 'Replay Test',
+        ]);
+        $pendingId = $this->canonicalEvent((int) $source->source_id, 'pending');
+        $this->canonicalEvent((int) $source->source_id, 'projected');
+        $user = $this->superuser();
+        $scope = [
+            'source_id' => $source->source_id,
+            'from' => now()->subHour()->toIso8601String(),
+            'to' => now()->addHour()->toIso8601String(),
+            'limit' => 50,
+        ];
+
+        $this->actingAs($user)->postJson('/api/admin/integrations/enterprise/replays/preview', $scope)
+            ->assertOk()
+            ->assertJsonPath('data.eligibleEvents', 1)
+            ->assertJsonPath('data.mutation', false);
+        $this->assertSame(0, DB::table('integration.event_replay_jobs')->count());
+
+        Queue::fake();
+        $first = $this->actingAs($user)->postJson('/api/admin/integrations/enterprise/replays', $scope, ['Idempotency-Key' => 'replay-test-1'])
+            ->assertAccepted();
+        $replayId = (int) $first->json('data.replayJobId');
+        $this->actingAs($user)->postJson('/api/admin/integrations/enterprise/replays', $scope, ['Idempotency-Key' => 'replay-test-1'])
+            ->assertOk()->assertJsonPath('data.replayJobId', $replayId)->assertJsonPath('data.created', false);
+        $changedScope = array_merge($scope, ['limit' => 49]);
+        $this->actingAs($user)->postJson('/api/admin/integrations/enterprise/replays', $changedScope, ['Idempotency-Key' => 'replay-test-1'])
+            ->assertConflict();
+        $job = new ReplayPendingIntegrationEvents($replayId, $user->id, (string) Str::uuid());
+        $this->assertSame('database', $job->connection);
+        $this->assertSame('integrations', $job->queue);
+        $job->handle(app(\App\Integrations\Healthcare\Services\RtdcProjectionHandler::class), app(\App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService::class));
+
+        $this->assertDatabaseHas('integration.event_replay_jobs', [
+            'event_replay_job_id' => $replayId,
+            'status' => 'completed',
+            'events_replayed' => 1,
+            'events_failed' => 0,
+        ]);
+        $this->assertDatabaseHas('integration.canonical_events', [
+            'canonical_event_id' => $pendingId,
+            'projection_status' => 'projected',
+        ]);
+        $this->assertSame(1, DB::table('prod.operational_events')->count());
+        $this->assertDatabaseHas('integration.configuration_audits', [
+            'entity_type' => 'canonical_event_replay',
+            'action' => 'completed',
+        ]);
+    }
+
+    public function test_failed_fhir_poll_dead_letters_and_a_successful_retry_resolves_it(): void
+    {
+        config([
+            'integrations.network.allowed_hosts' => ['fhir.epic.com'],
+            'integrations.network.require_dns_resolution' => false,
+        ]);
+        $source = app(OperationalIntegrationConfigurator::class)->configureEpicSandbox(
+            clientId: 'registered-non-production-client',
+            privateKeyRef: $this->privateKeyReference(),
+            activate: true,
+        );
+        $sourceId = (int) $source['sourceId'];
+        Http::fake($this->epicDiscoveryResponses());
+        app(IntegrationProtocolHealthService::class)->check($sourceId);
+        $runId = DB::table('raw.ingest_runs')->insertGetId([
+            'run_uuid' => (string) Str::uuid(),
+            'source_id' => $sourceId,
+            'connector_key' => 'epic.fhir-r4.encounter',
+            'run_type' => 'fhir_poll',
+            'status' => 'queued',
+            'started_at' => now(),
+            'metadata' => json_encode([]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], 'ingest_run_id');
+        $job = new PollEpicFhirResource((int) $runId, 'Encounter', null, (string) Str::uuid());
+        $tokenAttempts = 0;
+        Http::fake(function (Request $request) use (&$tokenAttempts) {
+            if ($request->url() === config('integrations.epic_sandbox.token_url')) {
+                $tokenAttempts++;
+
+                return $tokenAttempts === 1
+                    ? Http::response(['error' => 'invalid_client'], 401)
+                    : Http::response(['access_token' => 'retry-token', 'expires_in' => 300]);
+            }
+
+            return Http::response(['resourceType' => 'Bundle', 'type' => 'searchset', 'entry' => []], 200, ['Content-Type' => 'application/fhir+json']);
+        });
+
+        $failure = null;
+        try {
+            $job->handle(app(EpicSmartFhirClient::class), app(\App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService::class));
+            $this->fail('The invalid SMART client should fail the poll.');
+        } catch (IntegrationProtocolException $exception) {
+            $failure = $exception;
+            $this->assertSame('smart_token_http_401', $exception->errorCode);
+        }
+        $this->assertNotNull($failure);
+        $this->assertDatabaseHas('raw.ingest_runs', ['ingest_run_id' => $runId, 'status' => 'retrying']);
+        $job->failed($failure);
+        $this->assertDatabaseHas('raw.ingest_runs', ['ingest_run_id' => $runId, 'status' => 'failed']);
+        $this->assertDatabaseHas('raw.dead_letters', [
+            'ingest_run_id' => $runId,
+            'failure_stage' => 'fhir_poll',
+            'reason_code' => 'smart_token_http_401',
+            'status' => 'open',
+        ]);
+
+        $job->handle(app(EpicSmartFhirClient::class), app(\App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService::class));
+
+        $this->assertDatabaseHas('raw.ingest_runs', ['ingest_run_id' => $runId, 'status' => 'completed']);
+        $this->assertDatabaseHas('raw.dead_letters', [
+            'ingest_run_id' => $runId,
+            'status' => 'resolved',
+        ]);
+    }
+
+    public function test_hl7_source_activation_requires_governance_and_issues_only_a_bounded_machine_token(): void
+    {
+        $configurator = app(OperationalIntegrationConfigurator::class);
+        $configurator->configureHl7Boundary();
+        try {
+            $configurator->configureHl7Source([
+                'source_key' => 'epic.adt.production',
+                'source_name' => 'Epic ADT Production',
+                'vendor' => 'Epic',
+                'environment' => 'production',
+                'contract_status' => 'unknown',
+                'baa_status' => 'unknown',
+                'phi_allowed' => false,
+                'go_live_status' => 'not_started',
+                'activate' => true,
+            ]);
+            $this->fail('Ungoverned HL7 activation should be rejected.');
+        } catch (\Illuminate\Validation\ValidationException $exception) {
+            $this->assertArrayHasKey('activation', $exception->errors());
+        }
+
+        $source = $configurator->configureHl7Source([
+            'source_key' => 'epic.adt.production',
+            'source_name' => 'Epic ADT Production',
+            'vendor' => 'Epic',
+            'environment' => 'production',
+            'contract_status' => 'executed',
+            'baa_status' => 'executed',
+            'phi_allowed' => true,
+            'go_live_status' => 'live',
+            'activate' => true,
+        ]);
+        $machine = User::factory()->create(['role' => 'integration', 'is_active' => true]);
+        $this->artisan('integrations:issue-hl7-token', ['user' => $machine->id, '--expires' => 7])->assertSuccessful();
+
+        $token = $machine->tokens()->firstOrFail();
+        $this->assertSame(['integration:patient-flow:ingest'], $token->abilities);
+        $this->assertTrue($token->expires_at->isBetween(now()->addDays(6), now()->addDays(8)));
+        $health = app(IntegrationProtocolHealthService::class)->check((int) $source['sourceId']);
+        $this->assertSame('healthy', $health['status']);
+        $this->assertSame('ready', $health['machineIdentityStatus']);
+        $this->assertDatabaseHas('integration.configuration_audits', [
+            'entity_type' => 'machine_credential',
+            'entity_id' => $token->getKey(),
+            'action' => 'issued',
+        ]);
+        $auditDump = DB::table('integration.configuration_audits')->get()->toJson();
+        $this->assertStringNotContainsString((string) $token->token, $auditDump);
+    }
+
+    public function test_new_operational_controls_keep_the_strict_superuser_boundary(): void
+    {
+        $source = app(SourceRegistryService::class)->ensureSource(['source_key' => 'auth.test']);
+        $user = User::factory()->create(['role' => 'admin', 'must_change_password' => false]);
+
+        $this->actingAs($user)->postJson('/api/admin/integrations/sources/'.$source->source_id.'/health-check')->assertForbidden();
+        $this->actingAs($user)->postJson('/api/admin/integrations/sources/'.$source->source_id.'/fhir/poll', ['resource_type' => 'Encounter'])->assertForbidden();
+        $this->actingAs($user)->postJson('/api/admin/integrations/enterprise/replays/preview', [])->assertForbidden();
+        $this->actingAs($user)->postJson('/api/admin/integrations/enterprise/replays', [])->assertForbidden();
+    }
+
+    /** @return array<string, \Illuminate\Http\Client\Response> */
+    private function epicDiscoveryResponses(): array
+    {
+        return [
+            config('integrations.epic_sandbox.smart_configuration_url') => Http::response([
+                'token_endpoint' => config('integrations.epic_sandbox.token_url'),
+                'capabilities' => ['client-confidential-asymmetric'],
+            ]),
+            config('integrations.epic_sandbox.base_url').'/metadata' => Http::response([
+                'resourceType' => 'CapabilityStatement',
+                'fhirVersion' => '4.0.1',
+                'software' => ['name' => 'Epic', 'version' => 'sandbox'],
+                'format' => ['json'],
+                'rest' => [['resource' => [['type' => 'Encounter'], ['type' => 'Location']]]],
+            ], 200, ['Content-Type' => 'application/fhir+json']),
+        ];
+    }
+
+    private function privateKeyReference(): string
+    {
+        $this->secretDirectory = storage_path('framework/testing-integration-secrets-'.Str::random(8));
+        mkdir($this->secretDirectory, 0700, true);
+        $resource = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        $this->assertNotFalse($resource);
+        $this->assertTrue(openssl_pkey_export($resource, $pem));
+        $path = $this->secretDirectory.'/epic-private-key.pem';
+        file_put_contents($path, $pem);
+        chmod($path, 0640);
+        config(['integrations.secret_file_root' => $this->secretDirectory]);
+
+        return 'file://'.$path;
+    }
+
+    private function canonicalEvent(int $sourceId, string $projectionStatus): int
+    {
+        $eventId = (string) Str::uuid();
+
+        return DB::table('integration.canonical_events')->insertGetId([
+            'event_id' => $eventId,
+            'source_id' => $sourceId,
+            'event_type' => 'BedStatusChanged',
+            'entity_type' => 'bed',
+            'entity_ref' => 'bed-999999',
+            'occurred_at' => now(),
+            'received_at' => now(),
+            'payload' => json_encode(['bed_id' => 999999, 'status' => 'available']),
+            'payload_hash' => hash('sha256', $eventId),
+            'idempotency_key' => 'test:'.$eventId,
+            'projection_status' => $projectionStatus,
+            'projected_at' => $projectionStatus === 'projected' ? now() : null,
+            'metadata' => json_encode([]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], 'canonical_event_id');
+    }
+
+    private function superuser(): User
+    {
+        return User::factory()->create(['role' => 'superuser', 'must_change_password' => false]);
+    }
+}

--- a/tests/Feature/Integrations/SyntheticHealthcareConnectorTest.php
+++ b/tests/Feature/Integrations/SyntheticHealthcareConnectorTest.php
@@ -4,11 +4,13 @@ namespace Tests\Feature\Integrations;
 
 use App\Integrations\Healthcare\DTO\ReplayRequest;
 use App\Integrations\Healthcare\DTO\WebhookEnvelope;
+use App\Integrations\Healthcare\Services\SourceRegistryService;
 use App\Integrations\Healthcare\Synthetic\SyntheticHealthcareConnector;
 use App\Models\User;
 use Database\Seeders\IntegrationConnectorTemplateSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
@@ -221,23 +223,31 @@ class SyntheticHealthcareConnectorTest extends TestCase
         ]);
     }
 
-    public function test_fabricated_fhir_capability_discovery_is_disabled(): void
+    public function test_fhir_discovery_queues_a_real_check_and_ignores_fabricated_capabilities(): void
     {
         $user = User::factory()->create(['role' => 'superuser', 'must_change_password' => false]);
+        $source = app(SourceRegistryService::class)->ensureSource([
+            'source_key' => 'epic.fhir.sandbox',
+            'vendor' => 'Epic',
+            'interface_type' => 'fhir_r4',
+            'active_status' => 'testing',
+        ]);
+        Queue::fake();
 
         $this->actingAs($user)
             ->postJson('/api/admin/integrations/enterprise/fhir/capability-discovery', [
-                'source_key' => 'epic.fhir.sandbox',
-                'vendor' => 'Epic',
+                'source_id' => $source->source_id,
                 'fhir_version' => '4.0.1',
                 'client_id' => 'zephyrus-system-client',
             ])
-            ->assertStatus(501)
-            ->assertJsonPath('error.code', 'fhir_discovery_not_configured');
+            ->assertAccepted()
+            ->assertJsonPath('data.status', 'queued');
 
         $this->assertSame(0, DB::table('integration.fhir_client_connections')->count());
         $this->assertSame(0, DB::table('integration.smart_backend_credentials')->count());
-        $this->assertSame(0, DB::table('integration.sources')->count());
+        $this->assertSame(0, DB::table('integration.source_capabilities')->count());
+        $this->assertSame(1, DB::table('integration.sources')->count());
+        $this->assertDatabaseHas('raw.ingest_runs', ['source_id' => $source->source_id, 'run_type' => 'protocol_health', 'status' => 'queued']);
     }
 
     public function test_writeback_draft_creates_pending_ops_approval_gate(): void

--- a/tests/js/integrations/api.test.ts
+++ b/tests/js/integrations/api.test.ts
@@ -1,6 +1,14 @@
 import axios from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createIntegrationCredential, fetchIntegrationControlPlane, updateIntegrationCredential } from '@/features/integrations/api';
+import {
+  createIntegrationCredential,
+  fetchIntegrationControlPlane,
+  previewIntegrationReplay,
+  queueEpicFhirPoll,
+  queueIntegrationHealthCheck,
+  queueIntegrationReplay,
+  updateIntegrationCredential,
+} from '@/features/integrations/api';
 
 vi.mock('axios');
 const mocked = vi.mocked(axios, true);
@@ -16,6 +24,9 @@ const emptySnapshot = {
     degradedSources: 0,
     staleSources: 0,
     failedSources: 0,
+    protocolHealthySources: 0,
+    protocolDegradedSources: 0,
+    protocolFailedSources: 0,
     endpoints: 0,
     capabilities: 0,
     credentials: 0,
@@ -34,6 +45,8 @@ const emptySnapshot = {
     terminologyMaps: 0,
     writebackDrafts: 0,
     configurationAudits: 0,
+    queuedJobs: 0,
+    failedQueueJobs: 0,
   },
   sources: [],
   endpoints: [],
@@ -117,5 +130,35 @@ describe('integration control-plane API', () => {
     expect(created.credentialType).toBe('smart_backend_services');
     expect(updated.status).toBe('disabled');
     expect(mocked.patch).toHaveBeenCalledWith('/api/admin/integrations/sources/3/credentials/9', { is_active: false });
+  });
+
+  it('queues governed protocol, poll, and replay operations with their required contracts', async () => {
+    mocked.post
+      .mockResolvedValueOnce({ data: { data: { runId: 10, runUuid: 'run-health', status: 'queued', created: true } } })
+      .mockResolvedValueOnce({ data: { data: { runId: 11, runUuid: 'run-poll', status: 'queued', created: true, resourceType: 'Encounter' } } })
+      .mockResolvedValueOnce({ data: { data: {
+        eligibleEvents: 2, totalMatchingEvents: 2, truncated: false,
+        oldestAtIso: '2026-07-10T10:00:00Z', newestAtIso: '2026-07-10T11:00:00Z',
+        byEventType: [{ eventType: 'EncounterStarted', count: 2 }],
+        scope: {
+          sourceId: 3, from: '2026-07-10T09:00:00Z', to: '2026-07-10T12:00:00Z',
+          eventTypes: ['EncounterStarted'], projectionStatuses: ['pending', 'failed'], limit: 50,
+        },
+        mutation: false,
+      } } })
+      .mockResolvedValueOnce({ data: { data: { replayJobId: 12, replayUuid: 'replay-uuid', status: 'queued', created: true } } });
+
+    await queueIntegrationHealthCheck(3);
+    await queueEpicFhirPoll(3, 'Encounter');
+    const input = { source_id: 3, from: '2026-07-10T09:00:00Z', to: '2026-07-10T12:00:00Z', limit: 50 };
+    const preview = await previewIntegrationReplay(input);
+    await queueIntegrationReplay(input, 'replay-key-1');
+
+    expect(preview.mutation).toBe(false);
+    expect(mocked.post).toHaveBeenNthCalledWith(1, '/api/admin/integrations/sources/3/health-check');
+    expect(mocked.post).toHaveBeenNthCalledWith(2, '/api/admin/integrations/sources/3/fhir/poll', { resource_type: 'Encounter' });
+    expect(mocked.post).toHaveBeenNthCalledWith(4, '/api/admin/integrations/enterprise/replays', input, {
+      headers: { 'Idempotency-Key': 'replay-key-1' },
+    });
   });
 });


### PR DESCRIPTION
## Summary

- replace the production sync-queue posture with a database-backed `integrations,default` worker, a hardened systemd unit, bounded retry/backoff, queue/failure visibility, and deploy-time worker verification
- replace the FHIR discovery 501 stub with queued protocol checks; add an idempotent Epic public-sandbox configuration, SMART Backend Services RS384 client assertions, bounded Encounter/Location polling, version retention, provenance, watermarks, and dead-letter recovery
- operationalize the Patient Flow HL7 v2 boundary with explicit source-governance and bounded machine-token commands
- add strict, audited replay preview/execution for pending or failed RTDC canonical projections only, plus operator controls in the Integrations console
- add the production activation/rollback runbook and update the canonical closure checklist

## Safety boundaries

- all operator mutations remain behind `can:manageIntegrations`
- outbound checks require allowlisted HTTPS, reject redirects, and never persist access tokens, client assertions, or private keys
- private-key references are constrained to the configured secret-file root; raw secrets remain prohibited
- protocol reachability is separate from clinical-data freshness
- replay is limited to seven days / 1,000 events, requires an idempotency key, and excludes already-projected events
- production HL7 activation requires production/live state, executed contract + BAA, PHI approval, a dedicated integration identity, and the exact ingest ability

## Local verification

- `./vendor/bin/pint --test`: 890 files passed
- `php artisan test`: exit 0, 7,471 assertions (the isolated worktree emitted only expected missing-local-`.env` warnings)
- focused runtime suite: 7 tests / 64 assertions
- Patient Flow security regression: 9 tests / 100 assertions
- `npx tsc --noEmit`: passed
- `npx vitest run --coverage`: 81 files / 343 tests passed
- `npm run build`: passed
- `scripts/check-ui-canon.sh`: passed
- Arena: 17 pytest tests passed in a clean requirements environment
- `bash -n deploy.sh` and the new systemd unit verification passed

## Production activation

This PR intentionally does not fabricate Epic credentials or mark an HL7 feed live. The first deploy must use `DEPLOY_RUN_MIGRATIONS=1 ./deploy.sh`, set `QUEUE_CONNECTION=database`, install the exact outbound host allowlist, run `integrations:configure-operational-sources`, and complete live discovery. Authenticated Epic polling remains gated on a registered non-production client ID and approved private-key reference. HL7 activation remains gated on the real sender/source governance evidence described in the runbook.