### PR TITLE
feat(staffing): enforce canonical shift fulfillment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -172,6 +172,14 @@ DEMO_DATA_ENABLED=false
 DEMO_DATA_FACILITY_ALLOWLIST=SUMMIT_REGIONAL
 DEMO_DATA_SCHEDULE_ENABLED=false
 DEMO_DATA_SCHEDULE_TIME=05:15
+
+# Canonical staffing shift/availability projection. The materializer scopes
+# roster assignments to this facility and stores all shift boundaries in UTC.
+STAFFING_DEFAULT_FACILITY_KEY=SUMMIT_REGIONAL
+STAFFING_DEFAULT_TIMEZONE=America/New_York
+STAFFING_MATERIALIZATION_DAYS=28
+STAFFING_MATERIALIZATION_SCHEDULE_ENABLED=true
+STAFFING_MATERIALIZATION_SCHEDULE_TIME=04:10
 COCKPIT_METRIC_VALUES_RETENTION_DAYS=90     # ops.metric_values snapshot-grain retention (aligned to TREND_DAYS)
 COCKPIT_ALERT_OPEN_HOLDS=2                  # P6 flap-damping: consecutive alerting snapshots before an alert OPENS
 COCKPIT_ALERT_CLEAR_HOLDS=3                 # P6 flap-damping: consecutive normal snapshots before an open alert CLEARS

--- a/app/Console/Commands/MaterializeCanonicalStaffing.php
+++ b/app/Console/Commands/MaterializeCanonicalStaffing.php
@@ -1,0 +1,313 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Staffing\StaffingShiftWindowService;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Ramsey\Uuid\Uuid;
+
+class MaterializeCanonicalStaffing extends Command
+{
+    protected $signature = 'staffing:materialize-canonical
+        {--from= : First local operating date (YYYY-MM-DD)}
+        {--days= : Number of operating days to materialize (1-90)}
+        {--facility= : Facility key used by canonical assignments}
+        {--dry-run : Execute the full projection and roll it back after reporting counts}';
+
+    protected $description = 'Idempotently project role qualifications and explicit availability windows from the canonical workforce roster.';
+
+    public function __construct(private readonly StaffingShiftWindowService $shiftWindows)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $timezone = (string) config('staffing.default_timezone');
+        $from = CarbonImmutable::parse($this->option('from') ?: now($timezone)->toDateString(), $timezone)->startOfDay();
+        $days = max(1, min(90, (int) ($this->option('days') ?: config('staffing.materialization_days', 28))));
+        $facility = (string) ($this->option('facility') ?: config('staffing.default_facility_key'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        DB::beginTransaction();
+        try {
+            $qualificationCount = $this->materializeRoleQualifications($timezone, $facility);
+            $availabilityCount = $this->materializeAvailability($from, $days, $timezone, $facility);
+            $result = [
+                'qualifications' => $qualificationCount,
+                'availability_windows' => $availabilityCount,
+                'facility' => $facility,
+                'from' => $from->toDateString(),
+                'through' => $from->addDays($days - 1)->toDateString(),
+            ];
+            $dryRun ? DB::rollBack() : DB::commit();
+        } catch (\Throwable $exception) {
+            if (DB::transactionLevel() > 0) {
+                DB::rollBack();
+            }
+
+            throw $exception;
+        }
+
+        $this->info(sprintf(
+            'Canonical staffing%s: %d effective qualifications; %d availability windows; %s through %s.',
+            $dryRun ? ' dry run' : ' materialized',
+            $result['qualifications'],
+            $result['availability_windows'],
+            $result['from'],
+            $result['through'],
+        ));
+
+        return self::SUCCESS;
+    }
+
+    private function materializeRoleQualifications(string $timezone, string $facility): int
+    {
+        $roles = DB::table('hosp_ref.staff_roles')->orderBy('role_code')->get();
+        foreach ($roles as $role) {
+            $qualificationCode = 'role.'.Str::lower((string) $role->role_code);
+            DB::table('hosp_ref.staff_qualifications')->updateOrInsert(
+                ['qualification_code' => $qualificationCode],
+                [
+                    'display_name' => $role->display_name.' role qualification',
+                    'qualification_type' => 'role',
+                    'issuing_authority' => 'Canonical workforce assignment',
+                    'is_regulated' => (bool) $role->is_regulated,
+                    'metadata' => json_encode([
+                        'managed_by' => 'staffing:materialize-canonical',
+                        'role_code' => $role->role_code,
+                    ], JSON_THROW_ON_ERROR),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+            );
+            DB::table('hosp_ref.staff_role_qualification_requirements')->updateOrInsert(
+                [
+                    'facility_key' => null,
+                    'unit_id' => null,
+                    'service_line_code' => null,
+                    'role_code' => $role->role_code,
+                    'qualification_code' => $qualificationCode,
+                    'effective_start' => null,
+                ],
+                [
+                    'effective_end' => null,
+                    'is_required' => true,
+                    'metadata' => json_encode(['managed_by' => 'staffing:materialize-canonical'], JSON_THROW_ON_ERROR),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+            );
+        }
+
+        DB::table('hosp_org.staff_member_qualifications')
+            ->whereRaw("metadata->>'managed_by' = ?", ['staffing:materialize-canonical'])
+            ->whereRaw("metadata->>'facility_key' = ?", [$facility])
+            ->update([
+                'status' => 'expired',
+                'verified_at' => null,
+                'expires_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+        $count = 0;
+        $rows = [];
+        DB::table('hosp_org.staff_assignments as sa')
+            ->join('hosp_org.staff_members as sm', 'sm.staff_member_id', '=', 'sa.staff_member_id')
+            ->join('hosp_ref.staff_roles as sr', 'sr.role_code', '=', 'sa.role_code')
+            ->where('sa.is_active', true)
+            ->where('sm.is_active', true)
+            ->where('sa.facility_key', $facility)
+            ->orderBy('sa.staff_assignment_id')
+            ->select([
+                'sa.staff_assignment_id', 'sa.staff_member_id', 'sa.role_code', 'sa.review_status',
+                'sa.effective_start', 'sa.effective_end', 'sm.first_seen_at', 'sr.is_regulated',
+            ])
+            ->each(function (object $assignment) use ($timezone, $facility, &$count, &$rows): void {
+                $qualificationCode = 'role.'.Str::lower((string) $assignment->role_code);
+                $effectiveStart = CarbonImmutable::parse(
+                    $assignment->effective_start ?: $assignment->first_seen_at ?: '2000-01-01',
+                    $timezone,
+                )->startOfDay()->utc();
+                $effectiveEnd = $assignment->effective_end
+                    ? CarbonImmutable::parse($assignment->effective_end, $timezone)->endOfDay()->utc()
+                    : null;
+                $verified = ! (bool) $assignment->is_regulated
+                    || in_array($assignment->review_status, ['source_verified', 'client_verified'], true);
+
+                $rows[] = [
+                    'qualification_uuid' => $this->stableUuid("qualification:{$assignment->staff_assignment_id}"),
+                    'staff_member_id' => $assignment->staff_member_id,
+                    'staff_assignment_id' => $assignment->staff_assignment_id,
+                    'qualification_code' => $qualificationCode,
+                    'status' => $verified ? 'verified' : 'provisional',
+                    'source' => "staff_assignment:{$assignment->staff_assignment_id}",
+                    'verified_at' => $verified ? now() : null,
+                    'effective_start' => $effectiveStart,
+                    'effective_end' => $effectiveEnd,
+                    'expires_at' => $effectiveEnd,
+                    'identifier_hash' => hash('sha256', "assignment:{$assignment->staff_assignment_id}:{$qualificationCode}"),
+                    'metadata' => json_encode([
+                        'managed_by' => 'staffing:materialize-canonical',
+                        'facility_key' => $facility,
+                        'review_status' => $assignment->review_status,
+                    ], JSON_THROW_ON_ERROR),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ];
+                if (count($rows) >= 500) {
+                    $this->upsertMemberQualifications($rows);
+                    $rows = [];
+                }
+                $count++;
+            });
+        if ($rows !== []) {
+            $this->upsertMemberQualifications($rows);
+        }
+
+        return $count;
+    }
+
+    private function materializeAvailability(
+        CarbonImmutable $from,
+        int $days,
+        string $timezone,
+        string $facility,
+    ): int {
+        $rangeStart = $from->utc();
+        $rangeEnd = $from->addDays($days)->utc();
+        DB::table('prod.staff_availability_windows')
+            ->where('source', 'canonical-materializer')
+            ->where('external_key', 'like', "canonical:{$facility}:%")
+            ->where('ends_at', '>', $rangeStart)
+            ->delete();
+
+        $rows = [];
+        $members = DB::table('hosp_org.staff_members')
+            ->where('is_active', true)
+            ->where(function ($query): void {
+                $query->whereNull('employment_status')->orWhereNotIn('employment_status', ['terminated']);
+            })
+            ->whereExists(function ($query) use ($facility, $from, $days): void {
+                $query->selectRaw('1')
+                    ->from('hosp_org.staff_assignments as sa')
+                    ->whereColumn('sa.staff_member_id', 'hosp_org.staff_members.staff_member_id')
+                    ->where('sa.facility_key', $facility)
+                    ->where('sa.is_active', true)
+                    ->where(function ($query) use ($from, $days): void {
+                        $query->whereNull('sa.effective_start')
+                            ->orWhereDate('sa.effective_start', '<=', $from->addDays($days - 1)->toDateString());
+                    })
+                    ->where(function ($query) use ($from): void {
+                        $query->whereNull('sa.effective_end')->orWhereDate('sa.effective_end', '>=', $from->toDateString());
+                    });
+            })
+            ->orderBy('staff_member_id')
+            ->get(['staff_member_id', 'metadata']);
+        foreach ($members as $member) {
+            $metadata = $this->decodeMap($member->metadata);
+            $state = (string) data_get($metadata, 'availability', '');
+            $shift = (string) data_get($metadata, 'preferred_shift', '');
+            if (! in_array($state, ['available', 'on_call', 'unavailable', 'leave'], true)) {
+                continue;
+            }
+            if (in_array($state, ['available', 'on_call'], true) && ! array_key_exists($shift, (array) config('staffing.shifts'))) {
+                continue;
+            }
+
+            for ($offset = 0; $offset < $days; $offset++) {
+                $date = $from->addDays($offset)->toDateString();
+                if (in_array($state, ['unavailable', 'leave'], true)) {
+                    $startsAt = CarbonImmutable::parse("{$date} 00:00", $timezone)->utc();
+                    $endsAt = CarbonImmutable::parse("{$date} 00:00", $timezone)->addDay()->utc();
+                    $windowType = $state;
+                    $windowShift = 'all_day';
+                } else {
+                    $window = $this->shiftWindows->forDateAndShift($date, $shift, $timezone);
+                    $startsAt = $window['starts_at'];
+                    $endsAt = $window['ends_at'];
+                    $windowType = $state;
+                    $windowShift = $shift;
+                }
+                $externalKey = "canonical:{$facility}:{$member->staff_member_id}:{$date}:{$windowShift}:{$windowType}";
+                $rows[] = [
+                    'availability_uuid' => $this->stableUuid("availability:{$externalKey}"),
+                    'external_key' => $externalKey,
+                    'staff_member_id' => $member->staff_member_id,
+                    'window_type' => $windowType,
+                    'starts_at' => $startsAt,
+                    'ends_at' => $endsAt,
+                    'timezone' => $timezone,
+                    'source' => 'canonical-materializer',
+                    'priority' => in_array($windowType, ['unavailable', 'leave'], true) ? 10 : 100,
+                    'metadata' => json_encode([
+                        'managed_by' => 'staffing:materialize-canonical',
+                        'facility_key' => $facility,
+                        'data_origin' => data_get($metadata, 'data_origin'),
+                        'preferred_shift' => $shift ?: null,
+                    ], JSON_THROW_ON_ERROR),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ];
+                if (count($rows) >= 1000) {
+                    $this->upsertAvailability($rows);
+                    $rows = [];
+                }
+            }
+        }
+        if ($rows !== []) {
+            $this->upsertAvailability($rows);
+        }
+
+        return (int) DB::table('prod.staff_availability_windows')
+            ->where('source', 'canonical-materializer')
+            ->where('external_key', 'like', "canonical:{$facility}:%")
+            ->where('starts_at', '<', $rangeEnd)
+            ->where('ends_at', '>', $rangeStart)
+            ->count();
+    }
+
+    /** @param list<array<string,mixed>> $rows */
+    private function upsertMemberQualifications(array $rows): void
+    {
+        DB::table('hosp_org.staff_member_qualifications')->upsert(
+            $rows,
+            ['staff_assignment_id', 'qualification_code', 'effective_start'],
+            [
+                'qualification_uuid', 'staff_member_id', 'status', 'source', 'verified_at',
+                'effective_end', 'expires_at', 'identifier_hash', 'metadata', 'updated_at',
+            ],
+        );
+    }
+
+    /** @param list<array<string,mixed>> $rows */
+    private function upsertAvailability(array $rows): void
+    {
+        DB::table('prod.staff_availability_windows')->upsert(
+            $rows,
+            ['external_key'],
+            ['window_type', 'starts_at', 'ends_at', 'timezone', 'source', 'priority', 'metadata', 'updated_at'],
+        );
+    }
+
+    private function stableUuid(string $key): string
+    {
+        return Uuid::uuid5(Uuid::NAMESPACE_URL, "https://zephyrus.acumenus.net/staffing/{$key}")->toString();
+    }
+
+    /** @return array<string,mixed> */
+    private function decodeMap(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+        if (is_object($value)) {
+            return (array) $value;
+        }
+
+        return is_string($value) ? (json_decode($value, true) ?: []) : [];
+    }
+}

--- a/app/Http/Controllers/Api/Mobile/StaffingController.php
+++ b/app/Http/Controllers/Api/Mobile/StaffingController.php
@@ -3,31 +3,32 @@
 namespace App\Http\Controllers\Api\Mobile;
 
 use App\Http\Concerns\AuthorizesMobilePersonaActions;
-use App\Http\Concerns\ReadsMobileIdempotencyKey;
 use App\Http\Concerns\RendersMobileEnvelope;
 use App\Http\Controllers\Controller;
 use App\Models\Staffing\StaffingRequest;
 use App\Services\Mobile\MobilePersonaCatalog;
 use App\Services\Mobile\OperationalActivityLedger;
+use App\Services\Staffing\CanonicalStaffingService;
 use App\Services\Staffing\StaffingOperationsService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 
 /**
  * Staffing Coordinator (P10) — GET /api/mobile/v1/staffing/overview (read),
  * POST /api/mobile/v1/staffing/requests/{id}/fill (mobile:act).
  * Reads reuse StaffingOperationsService::overview() (already mobile-shaped: metrics, coverage,
- * units_at_risk, queue). The fill action assigns a source then marks the request filled.
+ * units_at_risk, queue). The fill action uses the canonical qualified/available fulfillment path.
  */
 class StaffingController extends Controller
 {
     use AuthorizesMobilePersonaActions;
-    use ReadsMobileIdempotencyKey;
     use RendersMobileEnvelope;
 
     public function __construct(
         private readonly StaffingOperationsService $staffing,
+        private readonly CanonicalStaffingService $canonicalStaffing,
         private readonly OperationalActivityLedger $ledger,
         private readonly MobilePersonaCatalog $personas,
     ) {}
@@ -37,20 +38,46 @@ class StaffingController extends Controller
         return $this->envelope($this->staffing->overview(), links: ['web' => url('/staffing')]);
     }
 
+    public function candidates(Request $request, int $id): JsonResponse
+    {
+        $this->authorizeMobilePersonaAction($request, ['staffing_coordinator'], 'view staffing candidates');
+        $validated = $request->validate([
+            'page' => ['sometimes', 'integer', 'min:1'],
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+            'eligible_only' => ['sometimes', 'boolean'],
+        ]);
+        $staffingRequest = StaffingRequest::query()
+            ->where('staffing_request_id', $id)
+            ->where('is_deleted', false)
+            ->firstOrFail();
+
+        return $this->envelope(
+            $this->canonicalStaffing->candidates($staffingRequest, $validated),
+            links: ['web' => url('/staffing')],
+        );
+    }
+
     public function fill(Request $request, int $id): JsonResponse
     {
         $actorRole = $this->authorizeMobilePersonaAction($request, ['staffing_coordinator'], 'fill staffing requests');
 
         $validated = $request->validate([
-            'assigned_source' => ['required', 'string', 'max:120'],
+            'staff_member_id' => ['required', 'integer', 'min:1'],
+            'assigned_source' => ['required', 'in:float_pool,overtime,agency,on_call'],
             'owner_name' => ['sometimes', 'nullable', 'string', 'max:120'],
         ]);
 
         $req = StaffingRequest::where('staffing_request_id', $id)->where('is_deleted', false)->firstOrFail();
         $actorId = $request->user()?->id;
         $from = $req->status;
+        $idempotencyKey = trim((string) $request->header('Idempotency-Key', ''));
+        if ($idempotencyKey === '' || mb_strlen($idempotencyKey) > 200 || preg_match('/^[A-Za-z0-9._:-]+$/', $idempotencyKey) !== 1) {
+            throw ValidationException::withMessages([
+                'idempotency_key' => 'A 1-200 character Idempotency-Key header using letters, numbers, dot, underscore, colon, or hyphen is required.',
+            ]);
+        }
         $eventAttributes = [
-            'idempotency_key' => $this->mobileIdempotencyKey($request),
+            'idempotency_key' => $idempotencyKey,
             'actor_user_id' => $actorId,
             'actor_role' => $actorRole,
             'domain' => 'staffing',
@@ -59,25 +86,28 @@ class StaffingController extends Controller
                 'staffing_request_id' => $req->staffing_request_id,
             ],
             'idempotency_payload' => [
+                'staff_member_id' => (int) $validated['staff_member_id'],
                 'assigned_source' => $validated['assigned_source'],
                 'owner_name' => $validated['owner_name'] ?? null,
             ],
         ];
 
-        if ($this->ledger->replay('staffing.request_filled', $eventAttributes) !== null) {
-            return $this->envelope($this->staffing->serializeRequest($req->fresh()), links: ['web' => url('/staffing')]);
-        }
-
-        $filled = DB::transaction(function () use ($actorId, $eventAttributes, $from, $req, $request, $validated): StaffingRequest {
-            $assigned = $this->staffing->assign($req, [
-                'assigned_source' => $validated['assigned_source'],
-                'owner_name' => $validated['owner_name'] ?? ($request->user()?->name),
-            ], $actorId);
-
-            $filled = $this->staffing->transition($assigned, 'filled', [
-                'assigned_source' => $validated['assigned_source'],
-            ], $actorId);
-
+        [$filled, $fulfillment] = DB::transaction(function () use ($actorId, $eventAttributes, $from, $idempotencyKey, $req, $validated): array {
+            $fulfillment = $this->canonicalStaffing->directFill(
+                $req,
+                (int) $validated['staff_member_id'],
+                (string) $validated['assigned_source'],
+                $actorId,
+                $idempotencyKey,
+            );
+            $filled = $req->fresh();
+            if (array_key_exists('owner_name', $validated)) {
+                $filled->update([
+                    'owner_name' => $validated['owner_name'],
+                    'updated_by_user_id' => $actorId,
+                ]);
+                $filled->refresh();
+            }
             $this->ledger->record('staffing.request_filled', [
                 ...$eventAttributes,
                 'status' => [
@@ -88,7 +118,9 @@ class StaffingController extends Controller
                 'payload' => [
                     'unit_label' => $filled->unit_label,
                     'role' => $filled->role,
+                    'staff_member_id' => (int) $validated['staff_member_id'],
                     'assigned_source' => $validated['assigned_source'],
+                    'fulfillment_uuid' => $fulfillment['fulfillment_uuid'],
                 ],
                 'entities' => [[
                     'entity_type' => 'staffing_request',
@@ -96,9 +128,12 @@ class StaffingController extends Controller
                 ]],
             ]);
 
-            return $filled;
+            return [$filled, $fulfillment];
         });
 
-        return $this->envelope($this->staffing->serializeRequest($filled), links: ['web' => url('/staffing')]);
+        return $this->envelope(array_merge(
+            $this->staffing->serializeRequest($filled),
+            ['canonical_fulfillment' => $fulfillment],
+        ), links: ['web' => url('/staffing')]);
     }
 }

--- a/app/Http/Controllers/Api/Staffing/StaffingController.php
+++ b/app/Http/Controllers/Api/Staffing/StaffingController.php
@@ -11,14 +11,19 @@ use App\Models\Staffing\StaffingRequest;
 use App\Services\Staffing\StaffingOperationsService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 
 class StaffingController extends Controller
 {
     public function __construct(private readonly StaffingOperationsService $staffing) {}
 
-    public function overview(): JsonResponse
+    public function overview(Request $request): JsonResponse
     {
-        return response()->json(['data' => $this->staffing->overview()]);
+        return response()->json(['data' => array_merge($this->staffing->overview(), [
+            'permissions' => [
+                'manage' => Gate::forUser($request->user())->allows('manageStaffingOperations'),
+            ],
+        ])]);
     }
 
     public function plans(): JsonResponse

--- a/app/Http/Controllers/Api/Staffing/StaffingFulfillmentController.php
+++ b/app/Http/Controllers/Api/Staffing/StaffingFulfillmentController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers\Api\Staffing;
+
+use App\Http\Controllers\Controller;
+use App\Models\Staffing\StaffingRequest;
+use App\Services\Staffing\CanonicalStaffingService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+
+class StaffingFulfillmentController extends Controller
+{
+    public function __construct(private readonly CanonicalStaffingService $staffing) {}
+
+    public function candidates(Request $request, int $staffingRequestId): JsonResponse
+    {
+        $staffingRequest = $this->request($staffingRequestId);
+        $validated = $request->validate([
+            'page' => ['sometimes', 'integer', 'min:1'],
+            'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+            'eligible_only' => ['sometimes', 'boolean'],
+        ]);
+
+        return response()->json($this->staffing->candidates($staffingRequest, $validated));
+    }
+
+    public function index(int $staffingRequestId): JsonResponse
+    {
+        $staffingRequest = $this->request($staffingRequestId);
+
+        return response()->json(['data' => $this->staffing->fulfillments($staffingRequest)]);
+    }
+
+    public function store(Request $request, int $staffingRequestId): JsonResponse
+    {
+        $validated = $request->validate([
+            'staff_member_id' => ['required', 'integer', 'min:1'],
+            'source' => ['required', 'in:float_pool,overtime,agency,on_call'],
+        ]);
+        $result = $this->staffing->offer(
+            $this->request($staffingRequestId),
+            (int) $validated['staff_member_id'],
+            (string) $validated['source'],
+            $request->user()?->id,
+            $this->idempotencyKey($request),
+        );
+
+        return response()->json(['data' => $result], 201);
+    }
+
+    public function transition(Request $request, string $fulfillmentUuid): JsonResponse
+    {
+        $validated = $request->validate([
+            'status' => ['required', 'in:accepted,filled,released,canceled'],
+            'note' => ['sometimes', 'nullable', 'string', 'max:500'],
+        ]);
+        $result = $this->staffing->transition(
+            $fulfillmentUuid,
+            (string) $validated['status'],
+            $validated['note'] ?? null,
+            $request->user()?->id,
+            $this->idempotencyKey($request),
+        );
+
+        return response()->json(['data' => $result]);
+    }
+
+    private function request(int $id): StaffingRequest
+    {
+        return StaffingRequest::query()->where('is_deleted', false)->findOrFail($id);
+    }
+
+    private function idempotencyKey(Request $request): string
+    {
+        $key = trim((string) $request->header('Idempotency-Key', ''));
+        if ($key === '' || mb_strlen($key) > 200 || preg_match('/^[A-Za-z0-9._:-]+$/', $key) !== 1) {
+            throw ValidationException::withMessages([
+                'idempotency_key' => 'A 1-200 character Idempotency-Key header using letters, numbers, dot, underscore, colon, or hyphen is required.',
+            ]);
+        }
+
+        return $key;
+    }
+}

--- a/app/Http/Requests/Staffing/AssignStaffingRequestRequest.php
+++ b/app/Http/Requests/Staffing/AssignStaffingRequestRequest.php
@@ -15,7 +15,6 @@ class AssignStaffingRequestRequest extends FormRequest
     {
         return [
             'assigned_source' => 'required|in:float_pool,overtime,agency,on_call',
-            'assigned_staff_ref' => 'nullable|string|max:120',
             'owner_name' => 'nullable|string|max:120',
         ];
     }

--- a/app/Http/Requests/Staffing/StaffingStatusUpdateRequest.php
+++ b/app/Http/Requests/Staffing/StaffingStatusUpdateRequest.php
@@ -14,7 +14,7 @@ class StaffingStatusUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'status' => 'required|in:requested,open,sourcing,assigned,filled,completed,canceled,escalated,unfilled',
+            'status' => 'required|in:requested,open,sourcing,completed,canceled,escalated,unfilled',
             'note' => 'nullable|string|max:500',
             'payload' => 'nullable|array',
         ];

--- a/app/Models/Staffing/StaffAvailabilityWindow.php
+++ b/app/Models/Staffing/StaffAvailabilityWindow.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models\Staffing;
+
+use App\Models\Org\StaffMember;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class StaffAvailabilityWindow extends Model
+{
+    protected $table = 'prod.staff_availability_windows';
+
+    protected $primaryKey = 'staff_availability_window_id';
+
+    protected $fillable = [
+        'availability_uuid', 'external_key', 'staff_member_id', 'window_type',
+        'starts_at', 'ends_at', 'timezone', 'source', 'priority', 'metadata',
+    ];
+
+    protected $casts = [
+        'staff_member_id' => 'integer',
+        'starts_at' => 'immutable_datetime',
+        'ends_at' => 'immutable_datetime',
+        'priority' => 'integer',
+        'metadata' => 'array',
+    ];
+
+    public function staffMember(): BelongsTo
+    {
+        return $this->belongsTo(StaffMember::class, 'staff_member_id', 'staff_member_id');
+    }
+}

--- a/app/Models/Staffing/StaffShiftAssignment.php
+++ b/app/Models/Staffing/StaffShiftAssignment.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models\Staffing;
+
+use App\Models\Org\StaffMember;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class StaffShiftAssignment extends Model
+{
+    protected $table = 'prod.staff_shift_assignments';
+
+    protected $primaryKey = 'staff_shift_assignment_id';
+
+    protected $fillable = [
+        'shift_assignment_uuid', 'staffing_request_id', 'staff_member_id',
+        'unit_id', 'facility_key', 'service_line_code', 'role_code',
+        'starts_at', 'ends_at', 'timezone', 'status', 'validation_snapshot',
+        'created_by_user_id', 'updated_by_user_id',
+    ];
+
+    protected $casts = [
+        'staffing_request_id' => 'integer',
+        'staff_member_id' => 'integer',
+        'unit_id' => 'integer',
+        'starts_at' => 'immutable_datetime',
+        'ends_at' => 'immutable_datetime',
+        'validation_snapshot' => 'array',
+        'created_by_user_id' => 'integer',
+        'updated_by_user_id' => 'integer',
+    ];
+
+    public function request(): BelongsTo
+    {
+        return $this->belongsTo(StaffingRequest::class, 'staffing_request_id', 'staffing_request_id');
+    }
+
+    public function staffMember(): BelongsTo
+    {
+        return $this->belongsTo(StaffMember::class, 'staff_member_id', 'staff_member_id');
+    }
+}

--- a/app/Models/Staffing/StaffingFulfillmentEvent.php
+++ b/app/Models/Staffing/StaffingFulfillmentEvent.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models\Staffing;
+
+use Illuminate\Database\Eloquent\Model;
+
+class StaffingFulfillmentEvent extends Model
+{
+    public $timestamps = false;
+
+    protected $table = 'prod.staffing_fulfillment_events';
+
+    protected $primaryKey = 'staffing_fulfillment_event_id';
+
+    protected $fillable = [
+        'event_uuid', 'fulfillment_uuid', 'staffing_request_id', 'staff_member_id',
+        'event_type', 'from_status', 'to_status', 'payload', 'actor_user_id',
+        'occurred_at', 'created_at',
+    ];
+
+    protected $casts = [
+        'staffing_request_id' => 'integer',
+        'staff_member_id' => 'integer',
+        'payload' => 'array',
+        'actor_user_id' => 'integer',
+        'occurred_at' => 'immutable_datetime',
+        'created_at' => 'immutable_datetime',
+    ];
+}

--- a/app/Models/Staffing/StaffingRequest.php
+++ b/app/Models/Staffing/StaffingRequest.php
@@ -62,6 +62,11 @@ class StaffingRequest extends Model
         return $this->hasMany(StaffingEvent::class, 'staffing_request_id', 'staffing_request_id');
     }
 
+    public function fulfillments(): HasMany
+    {
+        return $this->hasMany(StaffingRequestFulfillment::class, 'staffing_request_id', 'staffing_request_id');
+    }
+
     public function plan(): BelongsTo
     {
         return $this->belongsTo(StaffingPlan::class, 'staffing_plan_id', 'staffing_plan_id');

--- a/app/Models/Staffing/StaffingRequestFulfillment.php
+++ b/app/Models/Staffing/StaffingRequestFulfillment.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models\Staffing;
+
+use App\Models\Org\StaffMember;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class StaffingRequestFulfillment extends Model
+{
+    protected $table = 'prod.staffing_request_fulfillments';
+
+    protected $primaryKey = 'staffing_request_fulfillment_id';
+
+    protected $fillable = [
+        'fulfillment_uuid', 'staffing_request_id', 'staff_shift_assignment_id',
+        'staff_member_id', 'status', 'source', 'version', 'offered_at',
+        'accepted_at', 'filled_at', 'released_at', 'canceled_at',
+        'last_actor_user_id', 'metadata',
+    ];
+
+    protected $casts = [
+        'staffing_request_id' => 'integer',
+        'staff_shift_assignment_id' => 'integer',
+        'staff_member_id' => 'integer',
+        'version' => 'integer',
+        'offered_at' => 'immutable_datetime',
+        'accepted_at' => 'immutable_datetime',
+        'filled_at' => 'immutable_datetime',
+        'released_at' => 'immutable_datetime',
+        'canceled_at' => 'immutable_datetime',
+        'last_actor_user_id' => 'integer',
+        'metadata' => 'array',
+    ];
+
+    public function request(): BelongsTo
+    {
+        return $this->belongsTo(StaffingRequest::class, 'staffing_request_id', 'staffing_request_id');
+    }
+
+    public function shiftAssignment(): BelongsTo
+    {
+        return $this->belongsTo(StaffShiftAssignment::class, 'staff_shift_assignment_id', 'staff_shift_assignment_id');
+    }
+
+    public function staffMember(): BelongsTo
+    {
+        return $this->belongsTo(StaffMember::class, 'staff_member_id', 'staff_member_id');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -47,6 +47,12 @@ class AuthServiceProvider extends ServiceProvider
      */
     private const INTEGRATION_CONTROL_ROLES = ['super_admin', 'superuser'];
 
+    /** @var list<string> */
+    private const STAFFING_OPERATION_ROLES = [
+        'super_admin', 'superuser', 'admin', 'ops_leader', 'staffing_coordinator',
+        'house_supervisor',
+    ];
+
     /**
      * Roles allowed to create governed Eddy action proposals or mint the scoped
      * draft token used by the agent callback. Plain authenticated accounts can
@@ -114,6 +120,12 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('manageIntegrations', fn (User $user): bool => in_array(
             self::canonicalRole((string) $user->role),
             self::INTEGRATION_CONTROL_ROLES,
+            true,
+        ));
+
+        Gate::define('manageStaffingOperations', fn (User $user): bool => in_array(
+            self::canonicalRole((string) $user->role),
+            self::STAFFING_OPERATION_ROLES,
             true,
         ));
 

--- a/app/Services/Staffing/CanonicalStaffingService.php
+++ b/app/Services/Staffing/CanonicalStaffingService.php
@@ -1,0 +1,941 @@
+<?php
+
+namespace App\Services\Staffing;
+
+use App\Models\Staffing\StaffingEvent;
+use App\Models\Staffing\StaffingFulfillmentEvent;
+use App\Models\Staffing\StaffingRequest;
+use App\Models\Staffing\StaffingRequestFulfillment;
+use App\Models\Staffing\StaffShiftAssignment;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+
+class CanonicalStaffingService
+{
+    private const ACTIVE_FULFILLMENT_STATUSES = ['offered', 'accepted', 'filled'];
+
+    private const ACTIVE_SHIFT_STATUSES = ['offered', 'accepted', 'filled'];
+
+    /** @var array<string,list<string>> */
+    private const TRANSITIONS = [
+        'offered' => ['accepted', 'canceled'],
+        'accepted' => ['filled', 'released', 'canceled'],
+        'filled' => ['released', 'canceled'],
+        'released' => [],
+        'canceled' => [],
+    ];
+
+    private ?bool $tablesAvailable = null;
+
+    public function __construct(private readonly StaffingShiftWindowService $shiftWindows) {}
+
+    /** @return array<string,mixed>|null */
+    public function workforceState(int $staffMemberId): ?array
+    {
+        if (! $this->tablesAvailable()) {
+            return null;
+        }
+
+        $now = now();
+        $windows = DB::table('prod.staff_availability_windows')
+            ->where('staff_member_id', $staffMemberId)
+            ->where('starts_at', '<=', $now)
+            ->where('ends_at', '>', $now)
+            ->orderBy('priority')
+            ->get(['window_type', 'source', 'starts_at', 'ends_at']);
+        $blocking = $windows->first(fn (object $window): bool => in_array($window->window_type, ['unavailable', 'leave', 'conflict'], true));
+        $positive = $windows->first(fn (object $window): bool => in_array($window->window_type, ['available', 'on_call'], true));
+        $qualifications = DB::table('hosp_org.staff_member_qualifications as smq')
+            ->join('hosp_ref.staff_qualifications as sq', 'sq.qualification_code', '=', 'smq.qualification_code')
+            ->where('smq.staff_member_id', $staffMemberId)
+            ->where('smq.effective_start', '<=', $now)
+            ->where(function ($query) use ($now): void {
+                $query->whereNull('smq.effective_end')->orWhere('smq.effective_end', '>', $now);
+            })
+            ->get(['smq.qualification_code', 'sq.display_name', 'smq.status', 'smq.expires_at']);
+        $credentialStatus = match (true) {
+            $qualifications->contains(fn (object $row): bool => in_array($row->status, ['expired', 'revoked'], true)
+                || ($row->expires_at !== null && CarbonImmutable::parse($row->expires_at)->isPast())) => 'expired',
+            $qualifications->contains(fn (object $row): bool => $row->status === 'provisional') => 'attention',
+            $qualifications->isNotEmpty() => 'verified',
+            default => 'unverified',
+        };
+
+        return [
+            'availability' => $blocking?->window_type ?? $positive?->window_type ?? 'unverified',
+            'availability_source' => $blocking?->source ?? $positive?->source,
+            'credential_status' => $credentialStatus,
+            'qualifications' => $qualifications->map(fn (object $row): array => [
+                'qualification_code' => $row->qualification_code,
+                'display_name' => $row->display_name,
+                'status' => $row->status,
+            ])->values()->all(),
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    public function summaryForRequest(StaffingRequest $request): array
+    {
+        if (! $this->tablesAvailable()) {
+            return [
+                'available' => false,
+                'state' => 'unconfigured',
+                'offered_count' => 0,
+                'accepted_count' => 0,
+                'filled_count' => 0,
+                'remaining_count' => (int) $request->headcount_needed,
+                'latest' => null,
+                'active' => [],
+                'actions' => ['can_offer' => false],
+            ];
+        }
+
+        $fulfillments = StaffingRequestFulfillment::query()
+            ->where('staffing_request_id', $request->staffing_request_id)
+            ->with(['staffMember', 'shiftAssignment'])
+            ->orderByDesc('offered_at')
+            ->orderByDesc('staffing_request_fulfillment_id')
+            ->get();
+        $filled = $fulfillments->where('status', 'filled')->count();
+        $remaining = max(0, (int) $request->headcount_needed - $filled);
+
+        return [
+            'available' => true,
+            'state' => match (true) {
+                $remaining === 0 => 'filled',
+                $fulfillments->contains('status', 'accepted') => 'partially_fulfilled',
+                $fulfillments->contains('status', 'offered') => 'offer_pending',
+                default => 'unfilled',
+            },
+            'offered_count' => $fulfillments->where('status', 'offered')->count(),
+            'accepted_count' => $fulfillments->where('status', 'accepted')->count(),
+            'filled_count' => $filled,
+            'remaining_count' => $remaining,
+            'latest' => $fulfillments->first() ? $this->serializeFulfillment($fulfillments->first()) : null,
+            'active' => $fulfillments
+                ->whereIn('status', self::ACTIVE_FULFILLMENT_STATUSES)
+                ->map(fn (StaffingRequestFulfillment $fulfillment): array => $this->serializeFulfillment($fulfillment))
+                ->values()
+                ->all(),
+            'actions' => [
+                'can_offer' => $remaining > 0 && ! in_array($request->status, ['completed', 'canceled'], true),
+            ],
+        ];
+    }
+
+    /** @return array{data:list<array<string,mixed>>,meta:array<string,int>,shift:array<string,string>} */
+    public function candidates(StaffingRequest $request, array $filters = []): array
+    {
+        $this->requireTables();
+        $perPage = max(1, min(100, (int) ($filters['per_page'] ?? config('staffing.candidate_page_size', 25))));
+        $page = max(1, (int) ($filters['page'] ?? 1));
+        $eligibleOnly = filter_var($filters['eligible_only'] ?? false, FILTER_VALIDATE_BOOL);
+        $shift = $this->shiftWindows->forRequest($request);
+
+        $evaluated = $this->evaluateCandidates($request, $this->candidateRows($request), $shift)
+            ->sortBy(fn (array $candidate): string => sprintf(
+                '%d|%03d|%020d',
+                $candidate['eligible'] ? 0 : 1,
+                count($candidate['reason_codes']),
+                $candidate['staff_assignment_id'],
+            ))
+            ->unique('staff_member_id')
+            ->when($eligibleOnly, fn (Collection $rows): Collection => $rows->where('eligible', true))
+            ->sortBy(fn (array $candidate): string => sprintf(
+                '%d|%s|%020d',
+                $candidate['eligible'] ? 0 : 1,
+                mb_strtolower($candidate['display_name']),
+                $candidate['staff_member_id'],
+            ))
+            ->values();
+        $total = $evaluated->count();
+        $lastPage = max(1, (int) ceil($total / $perPage));
+
+        return [
+            'data' => $evaluated->forPage($page, $perPage)->values()->all(),
+            'meta' => [
+                'current_page' => $page,
+                'last_page' => $lastPage,
+                'per_page' => $perPage,
+                'total' => $total,
+            ],
+            'shift' => [
+                'starts_at' => $shift['starts_at']->toISOString(),
+                'ends_at' => $shift['ends_at']->toISOString(),
+                'timezone' => $shift['timezone'],
+            ],
+        ];
+    }
+
+    /** @return list<array<string,mixed>> */
+    public function fulfillments(StaffingRequest $request): array
+    {
+        if (! $this->tablesAvailable()) {
+            return [];
+        }
+
+        return StaffingRequestFulfillment::query()
+            ->where('staffing_request_id', $request->staffing_request_id)
+            ->with(['staffMember', 'shiftAssignment'])
+            ->orderByDesc('offered_at')
+            ->orderByDesc('staffing_request_fulfillment_id')
+            ->get()
+            ->map(fn (StaffingRequestFulfillment $fulfillment): array => $this->serializeFulfillment($fulfillment))
+            ->all();
+    }
+
+    /** @return array<string,mixed> */
+    public function offer(
+        StaffingRequest $request,
+        int $staffMemberId,
+        string $source,
+        ?int $actorUserId,
+        string $idempotencyKey,
+    ): array {
+        return $this->executeIdempotent(
+            $request->staffing_request_id,
+            'offer',
+            $idempotencyKey,
+            ['staff_member_id' => $staffMemberId, 'source' => $source],
+            $actorUserId,
+            function () use ($request, $staffMemberId, $source, $actorUserId): array {
+                $lockedRequest = $this->lockedRequest((int) $request->staffing_request_id);
+                $this->assertRequestOpen($lockedRequest);
+                $requestFrom = (string) $lockedRequest->status;
+                $this->lockStaffMember($staffMemberId);
+
+                if (StaffingRequestFulfillment::query()
+                    ->where('staffing_request_id', $lockedRequest->staffing_request_id)
+                    ->where('staff_member_id', $staffMemberId)
+                    ->whereIn('status', self::ACTIVE_FULFILLMENT_STATUSES)
+                    ->exists()) {
+                    throw new ConflictHttpException('This staff member already has an active fulfillment for the request.');
+                }
+
+                $candidate = $this->eligibleCandidate($lockedRequest, $staffMemberId);
+                $shift = $this->shiftWindows->forRequest($lockedRequest);
+                $assignment = StaffShiftAssignment::create([
+                    'shift_assignment_uuid' => (string) Str::uuid(),
+                    'staffing_request_id' => $lockedRequest->staffing_request_id,
+                    'staff_member_id' => $staffMemberId,
+                    'unit_id' => $lockedRequest->unit_id,
+                    'facility_key' => $candidate['facility_key'],
+                    'service_line_code' => $candidate['service_line_code'],
+                    'role_code' => $candidate['role_code'],
+                    'starts_at' => $shift['starts_at'],
+                    'ends_at' => $shift['ends_at'],
+                    'timezone' => $shift['timezone'],
+                    'status' => 'offered',
+                    'validation_snapshot' => $candidate,
+                    'created_by_user_id' => $actorUserId,
+                    'updated_by_user_id' => $actorUserId,
+                ]);
+                $fulfillment = StaffingRequestFulfillment::create([
+                    'fulfillment_uuid' => (string) Str::uuid(),
+                    'staffing_request_id' => $lockedRequest->staffing_request_id,
+                    'staff_shift_assignment_id' => $assignment->staff_shift_assignment_id,
+                    'staff_member_id' => $staffMemberId,
+                    'status' => 'offered',
+                    'source' => $source,
+                    'version' => 1,
+                    'offered_at' => now(),
+                    'last_actor_user_id' => $actorUserId,
+                    'metadata' => [],
+                ]);
+
+                $lockedRequest->update([
+                    'status' => 'sourcing',
+                    'assigned_source' => $source,
+                    'assigned_staff_ref' => null,
+                    'assigned_at' => null,
+                    'filled_at' => null,
+                    'updated_by_user_id' => $actorUserId,
+                ]);
+                $this->recordFulfillmentEvent($fulfillment, null, 'offered', [], $actorUserId);
+                $this->recordLegacyEvent($lockedRequest, 'staffing.offer_created', $requestFrom, 'sourcing', [
+                    'fulfillment_uuid' => $fulfillment->fulfillment_uuid,
+                    'staff_member_id' => $staffMemberId,
+                ], $actorUserId);
+
+                return $this->serializeFulfillment($fulfillment->fresh(['staffMember', 'shiftAssignment']));
+            },
+        );
+    }
+
+    /** @return array<string,mixed> */
+    public function transition(
+        string $fulfillmentUuid,
+        string $targetStatus,
+        ?string $note,
+        ?int $actorUserId,
+        string $idempotencyKey,
+    ): array {
+        $existing = StaffingRequestFulfillment::query()->where('fulfillment_uuid', $fulfillmentUuid)->firstOrFail();
+
+        return $this->executeIdempotent(
+            (int) $existing->staffing_request_id,
+            "transition:{$targetStatus}",
+            $idempotencyKey,
+            ['fulfillment_uuid' => $fulfillmentUuid, 'target_status' => $targetStatus, 'note' => $note],
+            $actorUserId,
+            function () use ($fulfillmentUuid, $targetStatus, $note, $actorUserId): array {
+                $fulfillment = StaffingRequestFulfillment::query()
+                    ->where('fulfillment_uuid', $fulfillmentUuid)
+                    ->lockForUpdate()
+                    ->firstOrFail();
+                $request = $this->lockedRequest((int) $fulfillment->staffing_request_id);
+                $this->assertRequestOpen($request, allowFilled: true);
+                $this->lockStaffMember((int) $fulfillment->staff_member_id);
+                $allowed = self::TRANSITIONS[$fulfillment->status] ?? [];
+                if (! in_array($targetStatus, $allowed, true)) {
+                    throw ValidationException::withMessages([
+                        'status' => "Illegal staffing fulfillment transition: {$fulfillment->status} -> {$targetStatus}.",
+                    ]);
+                }
+
+                $assignment = StaffShiftAssignment::query()
+                    ->where('staff_shift_assignment_id', $fulfillment->staff_shift_assignment_id)
+                    ->lockForUpdate()
+                    ->firstOrFail();
+                $validation = null;
+                if (in_array($targetStatus, ['accepted', 'filled'], true)) {
+                    $this->assertFulfillmentCapacity(
+                        $request,
+                        (int) $fulfillment->staffing_request_fulfillment_id,
+                    );
+                    $validation = $this->eligibleCandidate(
+                        $request,
+                        (int) $fulfillment->staff_member_id,
+                        (int) $assignment->staff_shift_assignment_id,
+                    );
+                }
+
+                $from = (string) $fulfillment->status;
+                $timestampColumn = "{$targetStatus}_at";
+                $updates = [
+                    'status' => $targetStatus,
+                    'version' => $fulfillment->version + 1,
+                    'last_actor_user_id' => $actorUserId,
+                ];
+                if (in_array($timestampColumn, ['accepted_at', 'filled_at', 'released_at', 'canceled_at'], true)) {
+                    $updates[$timestampColumn] = now();
+                }
+                $fulfillment->update($updates);
+                $assignment->update([
+                    'status' => $targetStatus,
+                    'validation_snapshot' => $validation ?? $assignment->validation_snapshot,
+                    'updated_by_user_id' => $actorUserId,
+                ]);
+                $requestFrom = (string) $request->status;
+                $this->recordFulfillmentEvent($fulfillment, $from, $targetStatus, [
+                    'note' => $note,
+                    'validation' => $validation,
+                ], $actorUserId);
+                $this->syncRequestStatus($request, $actorUserId);
+                $this->recordLegacyEvent($request, "staffing.fulfillment_{$targetStatus}", $requestFrom, $request->status, [
+                    'fulfillment_uuid' => $fulfillmentUuid,
+                    'staff_member_id' => $fulfillment->staff_member_id,
+                    'note' => $note,
+                ], $actorUserId);
+
+                return $this->serializeFulfillment($fulfillment->fresh(['staffMember', 'shiftAssignment']));
+            },
+        );
+    }
+
+    /**
+     * Mobile uses one deliberate action, but the immutable ledger still records
+     * offered -> accepted -> filled so web and mobile share the same lifecycle.
+     *
+     * @return array<string,mixed>
+     */
+    public function directFill(
+        StaffingRequest $request,
+        int $staffMemberId,
+        string $source,
+        ?int $actorUserId,
+        string $idempotencyKey,
+    ): array {
+        return $this->executeIdempotent(
+            (int) $request->staffing_request_id,
+            'direct_fill',
+            $idempotencyKey,
+            ['staff_member_id' => $staffMemberId, 'source' => $source],
+            $actorUserId,
+            function () use ($request, $staffMemberId, $source, $actorUserId): array {
+                $lockedRequest = $this->lockedRequest((int) $request->staffing_request_id);
+                $this->assertRequestOpen($lockedRequest);
+                $requestFrom = (string) $lockedRequest->status;
+                $this->lockStaffMember($staffMemberId);
+                if (StaffingRequestFulfillment::query()
+                    ->where('staffing_request_id', $lockedRequest->staffing_request_id)
+                    ->where('staff_member_id', $staffMemberId)
+                    ->whereIn('status', self::ACTIVE_FULFILLMENT_STATUSES)
+                    ->exists()) {
+                    throw new ConflictHttpException('This staff member already has an active fulfillment for the request.');
+                }
+                $this->assertFulfillmentCapacity($lockedRequest);
+                $candidate = $this->eligibleCandidate($lockedRequest, $staffMemberId);
+                $shift = $this->shiftWindows->forRequest($lockedRequest);
+                $now = now();
+                $assignment = StaffShiftAssignment::create([
+                    'shift_assignment_uuid' => (string) Str::uuid(),
+                    'staffing_request_id' => $lockedRequest->staffing_request_id,
+                    'staff_member_id' => $staffMemberId,
+                    'unit_id' => $lockedRequest->unit_id,
+                    'facility_key' => $candidate['facility_key'],
+                    'service_line_code' => $candidate['service_line_code'],
+                    'role_code' => $candidate['role_code'],
+                    'starts_at' => $shift['starts_at'],
+                    'ends_at' => $shift['ends_at'],
+                    'timezone' => $shift['timezone'],
+                    'status' => 'filled',
+                    'validation_snapshot' => $candidate,
+                    'created_by_user_id' => $actorUserId,
+                    'updated_by_user_id' => $actorUserId,
+                ]);
+                $fulfillment = StaffingRequestFulfillment::create([
+                    'fulfillment_uuid' => (string) Str::uuid(),
+                    'staffing_request_id' => $lockedRequest->staffing_request_id,
+                    'staff_shift_assignment_id' => $assignment->staff_shift_assignment_id,
+                    'staff_member_id' => $staffMemberId,
+                    'status' => 'filled',
+                    'source' => $source,
+                    'version' => 3,
+                    'offered_at' => $now,
+                    'accepted_at' => $now,
+                    'filled_at' => $now,
+                    'last_actor_user_id' => $actorUserId,
+                    'metadata' => ['direct_mobile_action' => true],
+                ]);
+                foreach ([
+                    [null, 'offered'],
+                    ['offered', 'accepted'],
+                    ['accepted', 'filled'],
+                ] as [$from, $to]) {
+                    $this->recordFulfillmentEvent($fulfillment, $from, $to, [
+                        'direct_mobile_action' => true,
+                        'validation' => $to === 'filled' ? $candidate : null,
+                    ], $actorUserId);
+                }
+                $this->syncRequestStatus($lockedRequest, $actorUserId);
+                $this->recordLegacyEvent($lockedRequest, 'staffing.fulfillment_filled', $requestFrom, $lockedRequest->status, [
+                    'fulfillment_uuid' => $fulfillment->fulfillment_uuid,
+                    'staff_member_id' => $staffMemberId,
+                    'direct_mobile_action' => true,
+                ], $actorUserId);
+
+                return $this->serializeFulfillment($fulfillment->fresh(['staffMember', 'shiftAssignment']));
+            },
+        );
+    }
+
+    /** @return array<string,mixed> */
+    public function serializeFulfillment(StaffingRequestFulfillment $fulfillment): array
+    {
+        $fulfillment->loadMissing(['staffMember', 'shiftAssignment']);
+        $assignment = $fulfillment->shiftAssignment;
+
+        return [
+            'fulfillment_uuid' => $fulfillment->fulfillment_uuid,
+            'staffing_request_id' => (int) $fulfillment->staffing_request_id,
+            'staff_member_id' => (int) $fulfillment->staff_member_id,
+            'staff_member_name' => (string) ($fulfillment->staffMember?->display_name ?? 'Unknown staff member'),
+            'status' => $fulfillment->status,
+            'source' => $fulfillment->source,
+            'version' => (int) $fulfillment->version,
+            'role_code' => $assignment?->role_code,
+            'unit_id' => $assignment?->unit_id === null ? null : (int) $assignment->unit_id,
+            'starts_at' => $assignment?->starts_at?->toISOString(),
+            'ends_at' => $assignment?->ends_at?->toISOString(),
+            'timezone' => $assignment?->timezone,
+            'validation' => $assignment?->validation_snapshot ?? [],
+            'offered_at' => $fulfillment->offered_at?->toISOString(),
+            'accepted_at' => $fulfillment->accepted_at?->toISOString(),
+            'filled_at' => $fulfillment->filled_at?->toISOString(),
+            'released_at' => $fulfillment->released_at?->toISOString(),
+            'canceled_at' => $fulfillment->canceled_at?->toISOString(),
+            'actions' => [
+                'can_accept' => in_array('accepted', self::TRANSITIONS[$fulfillment->status] ?? [], true),
+                'can_fill' => in_array('filled', self::TRANSITIONS[$fulfillment->status] ?? [], true),
+                'can_release' => in_array('released', self::TRANSITIONS[$fulfillment->status] ?? [], true),
+                'can_cancel' => in_array('canceled', self::TRANSITIONS[$fulfillment->status] ?? [], true),
+            ],
+        ];
+    }
+
+    /** @return Collection<int,object> */
+    private function candidateRows(StaffingRequest $request, ?int $staffMemberId = null): Collection
+    {
+        $roles = $this->canonicalRolesFor((string) $request->role);
+        $shiftDate = $request->shift_date?->toDateString() ?? now()->toDateString();
+        $facility = (string) data_get($request->metadata, 'facility_key', config('staffing.default_facility_key'));
+        $serviceLine = (string) data_get($request->metadata, 'service_line_code', '');
+
+        return DB::table('hosp_org.staff_assignments as sa')
+            ->join('hosp_org.staff_members as sm', 'sm.staff_member_id', '=', 'sa.staff_member_id')
+            ->join('hosp_ref.staff_roles as sr', 'sr.role_code', '=', 'sa.role_code')
+            ->where('sm.is_active', true)
+            ->where('sa.is_active', true)
+            ->where('sa.facility_key', $facility)
+            ->when($staffMemberId !== null, fn ($query) => $query->where('sm.staff_member_id', $staffMemberId))
+            ->where(function ($query): void {
+                $query->whereNull('sm.employment_status')
+                    ->orWhereNotIn('sm.employment_status', ['terminated', 'leave']);
+            })
+            ->whereIn('sa.role_code', $roles)
+            ->where(function ($query) use ($shiftDate): void {
+                $query->whereNull('sa.effective_start')->orWhereDate('sa.effective_start', '<=', $shiftDate);
+            })
+            ->where(function ($query) use ($shiftDate): void {
+                $query->whereNull('sa.effective_end')->orWhereDate('sa.effective_end', '>=', $shiftDate);
+            })
+            ->when($serviceLine !== '', fn ($query) => $query->where('sa.service_line_code', $serviceLine))
+            ->when($request->unit_id !== null, function ($query) use ($request): void {
+                $query->where(function ($query) use ($request): void {
+                    $query->where('sa.unit_id', $request->unit_id)
+                        ->orWhere(function ($query): void {
+                            $query->whereNull('sa.unit_id')
+                                ->whereIn('sa.coverage_model', ['float', 'on_call', 'in_house']);
+                        });
+                });
+            })
+            ->select([
+                'sm.staff_member_id', 'sm.display_name', 'sm.employee_type', 'sm.employment_status',
+                'sa.staff_assignment_id', 'sa.facility_key', 'sa.service_line_code', 'sa.role_code',
+                'sa.unit_id', 'sa.coverage_model', 'sr.display_name as role_label',
+            ])
+            ->orderByRaw('CASE WHEN sa.unit_id = ? THEN 0 ELSE 1 END', [$request->unit_id ?? 0])
+            ->orderBy('sm.display_name')
+            ->orderBy('sm.staff_member_id')
+            ->orderBy('sa.staff_assignment_id')
+            ->get()
+            ->values();
+    }
+
+    /**
+     * Evaluate a candidate page with four bounded set queries instead of issuing
+     * qualification, availability, and conflict queries once per staff member.
+     *
+     * @param  Collection<int,object>  $candidates
+     * @param  array{starts_at:CarbonImmutable,ends_at:CarbonImmutable,timezone:string}  $shift
+     * @return Collection<int,array<string,mixed>>
+     */
+    private function evaluateCandidates(
+        StaffingRequest $request,
+        Collection $candidates,
+        array $shift,
+        ?int $excludeShiftAssignmentId = null,
+    ): Collection {
+        if ($candidates->isEmpty()) {
+            return collect();
+        }
+
+        $staffMemberIds = $candidates->pluck('staff_member_id')->map(fn ($id): int => (int) $id)->unique()->values();
+        $roleCodes = $candidates->pluck('role_code')->filter()->unique()->values();
+        $requirements = DB::table('hosp_ref.staff_role_qualification_requirements as srqr')
+            ->join('hosp_ref.staff_qualifications as sq', 'sq.qualification_code', '=', 'srqr.qualification_code')
+            ->whereIn('srqr.role_code', $roleCodes)
+            ->where('srqr.is_required', true)
+            ->where(function ($query) use ($shift): void {
+                $query->whereNull('srqr.effective_start')->orWhereDate('srqr.effective_start', '<=', $shift['starts_at']->toDateString());
+            })
+            ->where(function ($query) use ($shift): void {
+                $query->whereNull('srqr.effective_end')->orWhereDate('srqr.effective_end', '>=', $shift['starts_at']->toDateString());
+            })
+            ->get([
+                'srqr.role_code', 'srqr.facility_key', 'srqr.unit_id', 'srqr.service_line_code',
+                'srqr.qualification_code', 'sq.display_name',
+            ])
+            ->groupBy('role_code');
+        $qualifications = DB::table('hosp_org.staff_member_qualifications as smq')
+            ->join('hosp_ref.staff_qualifications as sq', 'sq.qualification_code', '=', 'smq.qualification_code')
+            ->whereIn('smq.staff_member_id', $staffMemberIds)
+            ->where('smq.status', 'verified')
+            ->where('smq.effective_start', '<=', $shift['starts_at'])
+            ->where(function ($query) use ($shift): void {
+                $query->whereNull('smq.effective_end')->orWhere('smq.effective_end', '>=', $shift['ends_at']);
+            })
+            ->where(function ($query) use ($shift): void {
+                $query->whereNull('smq.expires_at')->orWhere('smq.expires_at', '>=', $shift['ends_at']);
+            })
+            ->get(['smq.staff_member_id', 'smq.qualification_code', 'sq.display_name'])
+            ->groupBy('staff_member_id');
+        $availability = DB::table('prod.staff_availability_windows')
+            ->whereIn('staff_member_id', $staffMemberIds)
+            ->where('starts_at', '<', $shift['ends_at'])
+            ->where('ends_at', '>', $shift['starts_at'])
+            ->orderBy('priority')
+            ->get(['staff_member_id', 'window_type', 'starts_at', 'ends_at', 'source'])
+            ->groupBy('staff_member_id');
+        $conflicts = DB::table('prod.staff_shift_assignments')
+            ->whereIn('staff_member_id', $staffMemberIds)
+            ->whereIn('status', self::ACTIVE_SHIFT_STATUSES)
+            ->where('starts_at', '<', $shift['ends_at'])
+            ->where('ends_at', '>', $shift['starts_at'])
+            ->when($excludeShiftAssignmentId !== null, fn ($query) => $query->where('staff_shift_assignment_id', '!=', $excludeShiftAssignmentId))
+            ->groupBy('staff_member_id')
+            ->selectRaw('staff_member_id, COUNT(*) AS conflict_count')
+            ->pluck('conflict_count', 'staff_member_id');
+
+        return $candidates->map(function (object $candidate) use ($request, $shift, $requirements, $qualifications, $availability, $conflicts): array {
+            $candidateRequirements = collect($requirements->get($candidate->role_code, []))
+                ->filter(function (object $requirement) use ($candidate, $request): bool {
+                    $facilityMatches = $requirement->facility_key === null || $requirement->facility_key === $candidate->facility_key;
+                    $unitMatches = $requirement->unit_id === null
+                        || ($request->unit_id !== null && (int) $requirement->unit_id === (int) $request->unit_id);
+                    $serviceLineMatches = $requirement->service_line_code === null
+                        || $requirement->service_line_code === $candidate->service_line_code;
+
+                    return $facilityMatches && $unitMatches && $serviceLineMatches;
+                })
+                ->unique('qualification_code')
+                ->values();
+            $candidateQualifications = collect($qualifications->get($candidate->staff_member_id, []))
+                ->keyBy('qualification_code');
+            $candidateAvailability = collect($availability->get($candidate->staff_member_id, []));
+
+            return $this->shapeCandidateEvaluation(
+                $candidate,
+                $shift,
+                $candidateRequirements,
+                $candidateQualifications,
+                $candidateAvailability,
+                (int) ($conflicts[$candidate->staff_member_id] ?? 0),
+            );
+        });
+    }
+
+    /**
+     * @param  Collection<int,object>  $requirements
+     * @param  Collection<string,object>  $qualificationRows
+     * @param  Collection<int,object>  $availability
+     * @param  array{starts_at:CarbonImmutable,ends_at:CarbonImmutable,timezone:string}  $shift
+     * @return array<string,mixed>
+     */
+    private function shapeCandidateEvaluation(
+        object $candidate,
+        array $shift,
+        Collection $requirements,
+        Collection $qualificationRows,
+        Collection $availability,
+        int $conflicts,
+    ): array {
+        $missing = $requirements
+            ->reject(fn (object $requirement): bool => $qualificationRows->has($requirement->qualification_code))
+            ->values();
+        $blocking = $availability->whereIn('window_type', ['unavailable', 'leave', 'conflict'])->values();
+        $covering = $availability->filter(function (object $window) use ($shift): bool {
+            return in_array($window->window_type, ['available', 'on_call'], true)
+                && CarbonImmutable::parse($window->starts_at)->lessThanOrEqualTo($shift['starts_at'])
+                && CarbonImmutable::parse($window->ends_at)->greaterThanOrEqualTo($shift['ends_at']);
+        })->values();
+
+        $reasons = [];
+        if ($requirements->isEmpty()) {
+            $reasons[] = 'qualification_requirements_unconfigured';
+        } elseif ($missing->isNotEmpty()) {
+            $reasons[] = 'missing_required_qualification';
+        }
+        if ($blocking->isNotEmpty()) {
+            $reasons[] = 'unavailable_or_on_leave';
+        } elseif ($covering->isEmpty()) {
+            $reasons[] = 'availability_unverified';
+        }
+        if ($conflicts > 0) {
+            $reasons[] = 'overlapping_shift_assignment';
+        }
+
+        return [
+            'staff_member_id' => (int) $candidate->staff_member_id,
+            'display_name' => (string) $candidate->display_name,
+            'staff_assignment_id' => (int) $candidate->staff_assignment_id,
+            'facility_key' => (string) $candidate->facility_key,
+            'service_line_code' => (string) $candidate->service_line_code,
+            'role_code' => (string) $candidate->role_code,
+            'role_label' => (string) $candidate->role_label,
+            'unit_id' => $candidate->unit_id === null ? null : (int) $candidate->unit_id,
+            'coverage_model' => $candidate->coverage_model,
+            'eligible' => $reasons === [],
+            'eligibility_state' => match (true) {
+                in_array('overlapping_shift_assignment', $reasons, true) => 'conflicted',
+                in_array('unavailable_or_on_leave', $reasons, true), in_array('availability_unverified', $reasons, true) => 'unavailable',
+                in_array('missing_required_qualification', $reasons, true), in_array('qualification_requirements_unconfigured', $reasons, true) => 'unqualified',
+                default => 'eligible',
+            },
+            'reason_codes' => $reasons,
+            'qualification_requirements' => $requirements->map(fn (object $requirement): array => [
+                'qualification_code' => $requirement->qualification_code,
+                'display_name' => $requirement->display_name,
+                'verified' => $qualificationRows->has($requirement->qualification_code),
+            ])->values()->all(),
+            'availability' => [
+                'covering_windows' => $covering->count(),
+                'blocking_windows' => $blocking->count(),
+                'timezone' => $shift['timezone'],
+            ],
+            'overlapping_assignments' => $conflicts,
+            'shift' => [
+                'starts_at' => $shift['starts_at']->toISOString(),
+                'ends_at' => $shift['ends_at']->toISOString(),
+                'timezone' => $shift['timezone'],
+            ],
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function eligibleCandidate(StaffingRequest $request, int $staffMemberId, ?int $excludeShiftAssignmentId = null): array
+    {
+        $candidates = $this->candidateRows($request, $staffMemberId);
+        if ($candidates->isEmpty()) {
+            throw ValidationException::withMessages([
+                'staff_member_id' => 'The selected staff member is not active in a compatible role and unit/service-line assignment.',
+            ]);
+        }
+
+        $evaluations = $this->evaluateCandidates(
+            $request,
+            $candidates,
+            $this->shiftWindows->forRequest($request),
+            $excludeShiftAssignmentId,
+        );
+        $evaluation = $evaluations->firstWhere('eligible', true)
+            ?? $evaluations->sortBy(fn (array $candidate): int => count($candidate['reason_codes']))->first();
+        if (! $evaluation['eligible']) {
+            throw ValidationException::withMessages([
+                'staff_member_id' => 'The selected staff member is not eligible: '.implode(', ', $evaluation['reason_codes']).'.',
+            ]);
+        }
+
+        return $evaluation;
+    }
+
+    /** @return list<string> */
+    private function canonicalRolesFor(string $requestRole): array
+    {
+        $mapped = config("staffing.legacy_role_map.{$requestRole}");
+
+        return is_array($mapped) && $mapped !== [] ? array_values($mapped) : [$requestRole];
+    }
+
+    private function syncRequestStatus(StaffingRequest $request, ?int $actorUserId): void
+    {
+        $rows = StaffingRequestFulfillment::query()
+            ->where('staffing_request_id', $request->staffing_request_id)
+            ->orderByDesc('offered_at')
+            ->orderByDesc('staffing_request_fulfillment_id')
+            ->get(['status', 'staff_member_id', 'source']);
+        $filled = $rows->where('status', 'filled')->count();
+        $accepted = $rows->where('status', 'accepted')->count();
+        $offered = $rows->where('status', 'offered')->count();
+        $active = $rows->firstWhere('status', 'filled')
+            ?? $rows->firstWhere('status', 'accepted')
+            ?? $rows->firstWhere('status', 'offered');
+        $status = match (true) {
+            $filled >= (int) $request->headcount_needed => 'filled',
+            $accepted > 0 || $filled > 0 => 'assigned',
+            $offered > 0 => 'sourcing',
+            default => 'open',
+        };
+        $updates = [
+            'status' => $status,
+            'assigned_staff_ref' => $active ? "staff:{$active->staff_member_id}" : null,
+            'assigned_source' => $active?->source,
+            'updated_by_user_id' => $actorUserId,
+            'resolution_payload' => [
+                'canonical_fulfillment' => true,
+                'filled_count' => $filled,
+                'headcount_needed' => (int) $request->headcount_needed,
+            ],
+        ];
+        if (in_array($status, ['assigned', 'filled'], true)) {
+            $updates['assigned_at'] = $request->assigned_at ?? now();
+        } else {
+            $updates['assigned_at'] = null;
+        }
+        if ($status === 'filled') {
+            $updates['filled_at'] = $request->filled_at ?? now();
+        } else {
+            $updates['filled_at'] = null;
+        }
+        $request->update($updates);
+    }
+
+    private function assertFulfillmentCapacity(StaffingRequest $request, ?int $excludeFulfillmentId = null): void
+    {
+        $reserved = StaffingRequestFulfillment::query()
+            ->where('staffing_request_id', $request->staffing_request_id)
+            ->whereIn('status', ['accepted', 'filled'])
+            ->when($excludeFulfillmentId !== null, fn ($query) => $query
+                ->where('staffing_request_fulfillment_id', '!=', $excludeFulfillmentId))
+            ->count();
+        if ($reserved >= (int) $request->headcount_needed) {
+            throw ValidationException::withMessages([
+                'request' => 'The staffing request already has its required accepted or filled canonical headcount.',
+            ]);
+        }
+    }
+
+    private function recordFulfillmentEvent(
+        StaffingRequestFulfillment $fulfillment,
+        ?string $from,
+        string $to,
+        array $payload,
+        ?int $actorUserId,
+    ): void {
+        StaffingFulfillmentEvent::create([
+            'event_uuid' => (string) Str::uuid(),
+            'fulfillment_uuid' => $fulfillment->fulfillment_uuid,
+            'staffing_request_id' => $fulfillment->staffing_request_id,
+            'staff_member_id' => $fulfillment->staff_member_id,
+            'event_type' => "staffing.fulfillment_{$to}",
+            'from_status' => $from,
+            'to_status' => $to,
+            'payload' => $payload,
+            'actor_user_id' => $actorUserId,
+            'occurred_at' => now(),
+            'created_at' => now(),
+        ]);
+    }
+
+    private function recordLegacyEvent(
+        StaffingRequest $request,
+        string $eventType,
+        ?string $from,
+        ?string $to,
+        array $payload,
+        ?int $actorUserId,
+    ): void {
+        StaffingEvent::create([
+            'event_uuid' => (string) Str::uuid(),
+            'staffing_request_id' => $request->staffing_request_id,
+            'event_type' => $eventType,
+            'from_status' => $from,
+            'to_status' => $to,
+            'payload' => $payload,
+            'source' => 'canonical-staffing',
+            'actor_user_id' => $actorUserId,
+            'occurred_at' => now(),
+            'created_at' => now(),
+        ]);
+    }
+
+    /** @return array<string,mixed> */
+    private function executeIdempotent(
+        int $requestId,
+        string $commandType,
+        string $idempotencyKey,
+        array $payload,
+        ?int $actorUserId,
+        callable $operation,
+    ): array {
+        $this->requireTables();
+        if ($idempotencyKey === '' || mb_strlen($idempotencyKey) > 200) {
+            throw ValidationException::withMessages(['idempotency_key' => 'A valid Idempotency-Key header is required.']);
+        }
+        $hash = hash('sha256', json_encode($this->canonicalize([
+            'request_id' => $requestId,
+            'command_type' => $commandType,
+            'payload' => $payload,
+        ]), JSON_THROW_ON_ERROR));
+
+        return DB::transaction(function () use ($requestId, $commandType, $idempotencyKey, $payload, $actorUserId, $operation, $hash): array {
+            DB::select('SELECT pg_advisory_xact_lock(hashtextextended(?, 0))', [$idempotencyKey]);
+            $existing = DB::table('prod.staffing_fulfillment_commands')
+                ->where('idempotency_key', $idempotencyKey)
+                ->first();
+            if ($existing) {
+                if (! hash_equals((string) $existing->request_hash, $hash)) {
+                    throw new ConflictHttpException('The idempotency key was already used for a different staffing command.');
+                }
+
+                return $this->decodeMap($existing->response_payload);
+            }
+
+            $response = $operation($payload);
+            DB::table('prod.staffing_fulfillment_commands')->insert([
+                'command_uuid' => (string) Str::uuid(),
+                'idempotency_key' => $idempotencyKey,
+                'staffing_request_id' => $requestId,
+                'command_type' => $commandType,
+                'request_hash' => $hash,
+                'response_payload' => json_encode($response, JSON_THROW_ON_ERROR),
+                'actor_user_id' => $actorUserId,
+                'created_at' => now(),
+            ]);
+
+            return $response;
+        }, 3);
+    }
+
+    private function lockedRequest(int $requestId): StaffingRequest
+    {
+        return StaffingRequest::query()
+            ->where('staffing_request_id', $requestId)
+            ->where('is_deleted', false)
+            ->lockForUpdate()
+            ->firstOrFail();
+    }
+
+    private function assertRequestOpen(StaffingRequest $request, bool $allowFilled = false): void
+    {
+        $terminal = ['completed', 'canceled'];
+        if (! $allowFilled) {
+            $terminal[] = 'filled';
+        }
+        if (in_array($request->status, $terminal, true)) {
+            throw ValidationException::withMessages(['request' => 'The staffing request is not open for fulfillment.']);
+        }
+    }
+
+    private function lockStaffMember(int $staffMemberId): void
+    {
+        DB::select('SELECT pg_advisory_xact_lock(?)', [7000000000 + $staffMemberId]);
+    }
+
+    private function tablesAvailable(): bool
+    {
+        return $this->tablesAvailable ??= Schema::hasTable('prod.staffing_request_fulfillments')
+            && Schema::hasTable('prod.staff_shift_assignments')
+            && Schema::hasTable('prod.staff_availability_windows')
+            && Schema::hasTable('hosp_org.staff_member_qualifications');
+    }
+
+    private function requireTables(): void
+    {
+        if (! $this->tablesAvailable()) {
+            throw ValidationException::withMessages(['staffing' => 'Canonical staffing fulfillment is not configured.']);
+        }
+    }
+
+    private function canonicalize(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+        if (array_is_list($value)) {
+            return array_map(fn (mixed $item): mixed => $this->canonicalize($item), $value);
+        }
+        ksort($value);
+
+        return array_map(fn (mixed $item): mixed => $this->canonicalize($item), $value);
+    }
+
+    /** @return array<string,mixed> */
+    private function decodeMap(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+        if (is_object($value)) {
+            return (array) $value;
+        }
+
+        return is_string($value) ? (json_decode($value, true) ?: []) : [];
+    }
+}

--- a/app/Services/Staffing/StaffingOperationsService.php
+++ b/app/Services/Staffing/StaffingOperationsService.php
@@ -14,9 +14,23 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class StaffingOperationsService
 {
+    /** @var array<string,list<string>> */
+    private const LEGACY_TRANSITIONS = [
+        'requested' => ['open', 'sourcing', 'escalated', 'canceled', 'unfilled'],
+        'open' => ['sourcing', 'escalated', 'canceled', 'unfilled'],
+        'sourcing' => ['open', 'escalated', 'canceled', 'unfilled'],
+        'assigned' => ['open', 'completed', 'canceled', 'escalated'],
+        'filled' => ['completed', 'canceled'],
+        'escalated' => ['open', 'sourcing', 'canceled', 'unfilled'],
+        'unfilled' => ['open', 'canceled'],
+        'completed' => [],
+        'canceled' => [],
+    ];
+
     public const ACTIVE_REQUEST_STATUSES = [
         'requested',
         'open',
@@ -34,6 +48,8 @@ class StaffingOperationsService
         'respiratory' => 'Respiratory Therapist',
         'unit_secretary' => 'Unit Secretary',
     ];
+
+    public function __construct(private readonly CanonicalStaffingService $canonical) {}
 
     public function list(array $filters = []): LengthAwarePaginator
     {
@@ -121,17 +137,26 @@ class StaffingOperationsService
     public function assign(StaffingRequest $request, array $data, ?int $actorUserId): StaffingRequest
     {
         return DB::transaction(function () use ($request, $data, $actorUserId): StaffingRequest {
+            $request = StaffingRequest::query()
+                ->where('staffing_request_id', $request->staffing_request_id)
+                ->where('is_deleted', false)
+                ->lockForUpdate()
+                ->firstOrFail();
             $from = $request->status;
+            if (! in_array('sourcing', self::LEGACY_TRANSITIONS[$from] ?? [], true)) {
+                throw ValidationException::withMessages([
+                    'status' => "The request cannot enter sourcing from {$from}.",
+                ]);
+            }
             $request->update([
-                'status' => 'assigned',
+                'status' => 'sourcing',
                 'assigned_source' => $data['assigned_source'] ?? $request->assigned_source,
-                'assigned_staff_ref' => $data['assigned_staff_ref'] ?? $request->assigned_staff_ref,
+                'assigned_staff_ref' => null,
                 'owner_name' => $data['owner_name'] ?? $request->owner_name,
-                'assigned_at' => now(),
                 'updated_by_user_id' => $actorUserId,
             ]);
 
-            $this->recordEvent($request, 'staffing.assigned', $from, 'assigned', $data, $actorUserId);
+            $this->recordEvent($request, 'staffing.sourcing', $from, 'sourcing', $data, $actorUserId);
 
             return $request->refresh();
         });
@@ -140,21 +165,43 @@ class StaffingOperationsService
     public function transition(StaffingRequest $request, string $status, array $payload, ?int $actorUserId): StaffingRequest
     {
         return DB::transaction(function () use ($request, $status, $payload, $actorUserId): StaffingRequest {
+            $request = StaffingRequest::query()
+                ->where('staffing_request_id', $request->staffing_request_id)
+                ->where('is_deleted', false)
+                ->lockForUpdate()
+                ->firstOrFail();
             $from = $request->status;
+            if (! in_array($status, self::LEGACY_TRANSITIONS[$from] ?? [], true)) {
+                throw ValidationException::withMessages([
+                    'status' => "Illegal staffing request transition: {$from} -> {$status}. Person assignment and fill must use the canonical fulfillment workflow.",
+                ]);
+            }
+            $summary = null;
+            if (in_array($status, ['completed', 'canceled'], true)) {
+                $summary = $this->canonical->summaryForRequest($request);
+            }
+            if ($status === 'completed') {
+                if (($summary['filled_count'] ?? 0) < (int) $request->headcount_needed) {
+                    throw ValidationException::withMessages([
+                        'status' => 'A staffing request cannot complete until canonical fulfillments cover its required headcount.',
+                    ]);
+                }
+            }
+            if ($status === 'canceled' && (($summary['offered_count'] ?? 0) + ($summary['accepted_count'] ?? 0) + ($summary['filled_count'] ?? 0)) > 0) {
+                throw ValidationException::withMessages([
+                    'status' => 'Cancel or release every active canonical fulfillment before canceling the staffing request.',
+                ]);
+            }
             $updates = [
                 'status' => $status,
                 'updated_by_user_id' => $actorUserId,
             ];
 
-            if ($status === 'filled' && $request->filled_at === null) {
-                $updates['filled_at'] = now();
-            }
-
             if (in_array($status, ['completed', 'canceled', 'unfilled'], true) && $request->completed_at === null) {
                 $updates['completed_at'] = now();
             }
 
-            if (in_array($status, ['filled', 'completed'], true)) {
+            if ($status === 'completed') {
                 $updates['resolution_payload'] = $payload;
             }
 
@@ -309,6 +356,7 @@ class StaffingOperationsService
                 ? ($this->isSyntheticRequest($request) ? 'expired' : 'stale')
                 : 'current',
             'sla' => $this->sla($request),
+            'fulfillment' => $this->canonical->summaryForRequest($request),
         ];
     }
 
@@ -498,6 +546,7 @@ class StaffingOperationsService
     private function serializeWorkforceMember(object $row): array
     {
         $metadata = $this->decodeJsonMap($row->member_metadata);
+        $canonical = $this->canonical->workforceState((int) $row->staff_member_id);
 
         return [
             'staff_member_id' => (int) $row->staff_member_id,
@@ -513,9 +562,12 @@ class StaffingOperationsService
             'fte' => (float) $row->fte,
             'coverage_model' => $row->coverage_model,
             'preferred_shift' => data_get($metadata, 'preferred_shift'),
-            'availability' => (string) data_get($metadata, 'availability', $row->member_active ? 'available' : 'inactive'),
-            'credential_status' => (string) data_get($metadata, 'credential_status', 'unknown'),
-            'credentials' => array_values((array) data_get($metadata, 'credentials', [])),
+            'availability' => (string) ($canonical['availability'] ?? data_get($metadata, 'availability', $row->member_active ? 'available' : 'inactive')),
+            'availability_source' => $canonical['availability_source'] ?? null,
+            'credential_status' => (string) ($canonical['credential_status'] ?? data_get($metadata, 'credential_status', 'unknown')),
+            'credentials' => $canonical === null
+                ? array_values((array) data_get($metadata, 'credentials', []))
+                : array_values(array_map(fn (array $qualification): string => (string) $qualification['display_name'], $canonical['qualifications'])),
             'eligible_float_units' => array_values((array) data_get($metadata, 'eligible_float_units', [])),
             'is_active' => (bool) $row->member_active && (bool) $row->assignment_active,
             'is_synthetic' => data_get($metadata, 'data_origin') === 'synthetic',

--- a/app/Services/Staffing/StaffingShiftWindowService.php
+++ b/app/Services/Staffing/StaffingShiftWindowService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services\Staffing;
+
+use App\Models\Staffing\StaffingRequest;
+use Carbon\CarbonImmutable;
+use Illuminate\Validation\ValidationException;
+
+class StaffingShiftWindowService
+{
+    /** @return array{starts_at:CarbonImmutable,ends_at:CarbonImmutable,timezone:string} */
+    public function forRequest(StaffingRequest $request): array
+    {
+        $timezone = (string) data_get($request->metadata, 'timezone', config('staffing.default_timezone'));
+
+        return $this->forDateAndShift(
+            $request->shift_date?->toDateString() ?? now($timezone)->toDateString(),
+            (string) $request->shift,
+            $timezone,
+        );
+    }
+
+    /** @return array{starts_at:CarbonImmutable,ends_at:CarbonImmutable,timezone:string} */
+    public function forDateAndShift(string $date, string $shift, ?string $timezone = null): array
+    {
+        $timezone = $timezone ?: (string) config('staffing.default_timezone');
+        $definition = config("staffing.shifts.{$shift}");
+        if (! is_array($definition) || ! isset($definition['starts_at'], $definition['ends_at'])) {
+            throw ValidationException::withMessages(['shift' => 'Unknown staffing shift.']);
+        }
+
+        try {
+            $startsAt = CarbonImmutable::parse("{$date} {$definition['starts_at']}", $timezone);
+            $endsAt = CarbonImmutable::parse("{$date} {$definition['ends_at']}", $timezone);
+        } catch (\Throwable) {
+            throw ValidationException::withMessages(['timezone' => 'The staffing shift timezone is invalid.']);
+        }
+
+        if ($endsAt->lessThanOrEqualTo($startsAt)) {
+            $endsAt = $endsAt->addDay();
+        }
+
+        return [
+            'starts_at' => $startsAt->utc(),
+            'ends_at' => $endsAt->utc(),
+            'timezone' => $timezone,
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -75,5 +75,11 @@ return $builder
             ->everyFiveMinutes()->withoutOverlapping();
         $schedule->job(new \App\Jobs\DispatchScheduledFhirPolls)
             ->everyFifteenMinutes()->withoutOverlapping();
+        if (config('staffing.materialization_schedule_enabled', true)) {
+            $schedule->command('staffing:materialize-canonical')
+                ->dailyAt((string) config('staffing.materialization_schedule_time', '04:10'))
+                ->withoutOverlapping(180)
+                ->runInBackground();
+        }
     })
     ->create();

--- a/config/staffing.php
+++ b/config/staffing.php
@@ -1,0 +1,42 @@
+<?php
+
+return [
+    'default_facility_key' => env('STAFFING_DEFAULT_FACILITY_KEY', 'SUMMIT_REGIONAL'),
+    'default_timezone' => env('STAFFING_DEFAULT_TIMEZONE', 'America/New_York'),
+
+    'shifts' => [
+        'day' => ['starts_at' => '07:00', 'ends_at' => '15:00'],
+        'evening' => ['starts_at' => '15:00', 'ends_at' => '23:00'],
+        'night' => ['starts_at' => '23:00', 'ends_at' => '07:00'],
+    ],
+
+    /*
+     * Compatibility only: operational requests still carry the seven legacy
+     * role values. Eligibility is always resolved against the canonical
+     * hosp_ref.staff_roles taxonomy before a person can be offered or filled.
+     */
+    'legacy_role_map' => [
+        'rn' => [
+            'staff_nurse', 'critical_care_nurse', 'emergency_nurse',
+            'perioperative_nurse', 'pacu_nurse', 'neonatal_nurse',
+            'pediatric_nurse', 'behavioral_health_nurse', 'float_pool_nurse',
+        ],
+        'lpn' => ['licensed_practical_nurse'],
+        'tech' => [
+            'patient_care_technician', 'nursing_assistant',
+            'emergency_department_technician', 'surgical_technologist',
+        ],
+        'charge' => ['charge_nurse', 'clinical_coordinator'],
+        'provider' => [
+            'hospitalist', 'intensivist', 'emergency_physician', 'physician',
+            'nurse_practitioner', 'physician_assistant',
+        ],
+        'respiratory' => ['respiratory_therapist'],
+        'unit_secretary' => ['unit_clerk'],
+    ],
+
+    'candidate_page_size' => 25,
+    'materialization_days' => (int) env('STAFFING_MATERIALIZATION_DAYS', 28),
+    'materialization_schedule_enabled' => (bool) env('STAFFING_MATERIALIZATION_SCHEDULE_ENABLED', true),
+    'materialization_schedule_time' => env('STAFFING_MATERIALIZATION_SCHEDULE_TIME', '04:10'),
+];

--- a/database/migrations/2026_07_10_000300_create_canonical_staffing_fulfillment_tables.php
+++ b/database/migrations/2026_07_10_000300_create_canonical_staffing_fulfillment_tables.php
@@ -1,0 +1,250 @@
+<?php
+
+use App\Traits\SafeMigration;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    use SafeMigration;
+
+    public function up(): void
+    {
+        DB::unprepared(<<<'SQL'
+            CREATE TABLE IF NOT EXISTS hosp_ref.staff_qualifications (
+                qualification_code text PRIMARY KEY,
+                display_name text NOT NULL,
+                qualification_type text NOT NULL,
+                issuing_authority text,
+                is_regulated boolean NOT NULL DEFAULT false,
+                metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                created_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now(),
+                CONSTRAINT staff_qualifications_type_chk CHECK (
+                    qualification_type IN ('role','license','certification','competency','privilege','training')
+                )
+            );
+
+            CREATE TABLE IF NOT EXISTS hosp_ref.staff_role_qualification_requirements (
+                staff_role_qualification_requirement_id bigserial PRIMARY KEY,
+                facility_key text,
+                unit_id bigint REFERENCES prod.units(unit_id) ON DELETE CASCADE,
+                service_line_code text,
+                role_code text NOT NULL REFERENCES hosp_ref.staff_roles(role_code),
+                qualification_code text NOT NULL REFERENCES hosp_ref.staff_qualifications(qualification_code),
+                effective_start date,
+                effective_end date,
+                is_required boolean NOT NULL DEFAULT true,
+                metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                created_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now(),
+                CONSTRAINT staff_role_qualification_dates_chk CHECK (
+                    effective_end IS NULL OR effective_start IS NULL OR effective_end >= effective_start
+                )
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_staff_role_qualification_scope
+                ON hosp_ref.staff_role_qualification_requirements (
+                    COALESCE(facility_key, ''), COALESCE(unit_id, 0),
+                    COALESCE(service_line_code, ''), role_code, qualification_code,
+                    COALESCE(effective_start, DATE '1900-01-01')
+                );
+
+            CREATE INDEX IF NOT EXISTS idx_staff_role_qualification_lookup
+                ON hosp_ref.staff_role_qualification_requirements(role_code, unit_id, effective_start, effective_end)
+                WHERE is_required;
+
+            CREATE TABLE IF NOT EXISTS hosp_org.staff_member_qualifications (
+                staff_member_qualification_id bigserial PRIMARY KEY,
+                qualification_uuid uuid UNIQUE NOT NULL,
+                staff_member_id bigint NOT NULL REFERENCES hosp_org.staff_members(staff_member_id) ON DELETE CASCADE,
+                staff_assignment_id bigint REFERENCES hosp_org.staff_assignments(staff_assignment_id) ON DELETE SET NULL,
+                qualification_code text NOT NULL REFERENCES hosp_ref.staff_qualifications(qualification_code),
+                status text NOT NULL DEFAULT 'verified',
+                source text NOT NULL,
+                verified_at timestamptz,
+                effective_start timestamptz NOT NULL,
+                effective_end timestamptz,
+                expires_at timestamptz,
+                identifier_hash char(64),
+                metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                created_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now(),
+                CONSTRAINT staff_member_qualifications_status_chk CHECK (
+                    status IN ('verified','provisional','expired','revoked')
+                ),
+                CONSTRAINT staff_member_qualifications_dates_chk CHECK (
+                    effective_end IS NULL OR effective_end > effective_start
+                )
+            );
+
+            ALTER TABLE hosp_org.staff_member_qualifications
+                ADD COLUMN IF NOT EXISTS staff_assignment_id bigint
+                REFERENCES hosp_org.staff_assignments(staff_assignment_id) ON DELETE SET NULL;
+
+            DROP INDEX IF EXISTS hosp_org.uq_staff_member_qualification_effective;
+
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_staff_member_assignment_qualification
+                ON hosp_org.staff_member_qualifications(staff_assignment_id, qualification_code, effective_start);
+
+            CREATE INDEX IF NOT EXISTS idx_staff_member_qualification_effective
+                ON hosp_org.staff_member_qualifications(staff_member_id, qualification_code, effective_start);
+
+            CREATE INDEX IF NOT EXISTS idx_staff_member_qualification_lookup
+                ON hosp_org.staff_member_qualifications(staff_member_id, status, effective_start, effective_end, expires_at);
+
+            CREATE TABLE IF NOT EXISTS prod.staff_availability_windows (
+                staff_availability_window_id bigserial PRIMARY KEY,
+                availability_uuid uuid UNIQUE NOT NULL,
+                external_key text UNIQUE,
+                staff_member_id bigint NOT NULL REFERENCES hosp_org.staff_members(staff_member_id) ON DELETE CASCADE,
+                window_type text NOT NULL,
+                starts_at timestamptz NOT NULL,
+                ends_at timestamptz NOT NULL,
+                timezone text NOT NULL,
+                source text NOT NULL,
+                priority integer NOT NULL DEFAULT 100,
+                metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                created_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now(),
+                CONSTRAINT staff_availability_window_type_chk CHECK (
+                    window_type IN ('available','unavailable','leave','on_call','preference','conflict')
+                ),
+                CONSTRAINT staff_availability_window_dates_chk CHECK (ends_at > starts_at)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_staff_availability_overlap
+                ON prod.staff_availability_windows(staff_member_id, starts_at, ends_at, window_type);
+
+            CREATE TABLE IF NOT EXISTS prod.staff_shift_assignments (
+                staff_shift_assignment_id bigserial PRIMARY KEY,
+                shift_assignment_uuid uuid UNIQUE NOT NULL,
+                staffing_request_id bigint REFERENCES prod.staffing_requests(staffing_request_id) ON DELETE SET NULL,
+                staff_member_id bigint NOT NULL REFERENCES hosp_org.staff_members(staff_member_id) ON DELETE RESTRICT,
+                unit_id bigint REFERENCES prod.units(unit_id) ON DELETE SET NULL,
+                facility_key text NOT NULL,
+                service_line_code text,
+                role_code text NOT NULL REFERENCES hosp_ref.staff_roles(role_code),
+                starts_at timestamptz NOT NULL,
+                ends_at timestamptz NOT NULL,
+                timezone text NOT NULL,
+                status text NOT NULL DEFAULT 'offered',
+                validation_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+                created_by_user_id bigint,
+                updated_by_user_id bigint,
+                created_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now(),
+                CONSTRAINT staff_shift_assignment_status_chk CHECK (
+                    status IN ('offered','accepted','filled','released','canceled')
+                ),
+                CONSTRAINT staff_shift_assignment_dates_chk CHECK (ends_at > starts_at)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_staff_shift_assignment_overlap
+                ON prod.staff_shift_assignments(staff_member_id, starts_at, ends_at, status);
+
+            CREATE INDEX IF NOT EXISTS idx_staff_shift_assignment_request
+                ON prod.staff_shift_assignments(staffing_request_id, status);
+
+            CREATE TABLE IF NOT EXISTS prod.staffing_request_fulfillments (
+                staffing_request_fulfillment_id bigserial PRIMARY KEY,
+                fulfillment_uuid uuid UNIQUE NOT NULL,
+                staffing_request_id bigint NOT NULL REFERENCES prod.staffing_requests(staffing_request_id) ON DELETE CASCADE,
+                staff_shift_assignment_id bigint NOT NULL REFERENCES prod.staff_shift_assignments(staff_shift_assignment_id) ON DELETE RESTRICT,
+                staff_member_id bigint NOT NULL REFERENCES hosp_org.staff_members(staff_member_id) ON DELETE RESTRICT,
+                status text NOT NULL DEFAULT 'offered',
+                source text NOT NULL,
+                version integer NOT NULL DEFAULT 1,
+                offered_at timestamptz NOT NULL,
+                accepted_at timestamptz,
+                filled_at timestamptz,
+                released_at timestamptz,
+                canceled_at timestamptz,
+                last_actor_user_id bigint,
+                metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+                created_at timestamptz NOT NULL DEFAULT now(),
+                updated_at timestamptz NOT NULL DEFAULT now(),
+                CONSTRAINT staffing_request_fulfillment_status_chk CHECK (
+                    status IN ('offered','accepted','filled','released','canceled')
+                )
+            );
+
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_staffing_active_fulfillment_member
+                ON prod.staffing_request_fulfillments(staffing_request_id, staff_member_id)
+                WHERE status IN ('offered','accepted','filled');
+
+            CREATE INDEX IF NOT EXISTS idx_staffing_fulfillment_request_status
+                ON prod.staffing_request_fulfillments(staffing_request_id, status, offered_at);
+
+            CREATE TABLE IF NOT EXISTS prod.staffing_fulfillment_events (
+                staffing_fulfillment_event_id bigserial PRIMARY KEY,
+                event_uuid uuid UNIQUE NOT NULL,
+                fulfillment_uuid uuid NOT NULL,
+                staffing_request_id bigint NOT NULL REFERENCES prod.staffing_requests(staffing_request_id) ON DELETE CASCADE,
+                staff_member_id bigint NOT NULL REFERENCES hosp_org.staff_members(staff_member_id) ON DELETE RESTRICT,
+                event_type text NOT NULL,
+                from_status text,
+                to_status text NOT NULL,
+                payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+                actor_user_id bigint,
+                occurred_at timestamptz NOT NULL DEFAULT now(),
+                created_at timestamptz NOT NULL DEFAULT now()
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_staffing_fulfillment_event_request
+                ON prod.staffing_fulfillment_events(staffing_request_id, occurred_at, staffing_fulfillment_event_id);
+
+            CREATE TABLE IF NOT EXISTS prod.staffing_fulfillment_commands (
+                staffing_fulfillment_command_id bigserial PRIMARY KEY,
+                command_uuid uuid UNIQUE NOT NULL,
+                idempotency_key varchar(200) UNIQUE NOT NULL,
+                staffing_request_id bigint NOT NULL REFERENCES prod.staffing_requests(staffing_request_id) ON DELETE CASCADE,
+                command_type text NOT NULL,
+                request_hash char(64) NOT NULL,
+                response_payload jsonb NOT NULL,
+                actor_user_id bigint,
+                created_at timestamptz NOT NULL DEFAULT now()
+            );
+
+            CREATE OR REPLACE FUNCTION prod.reject_staffing_fulfillment_ledger_mutation()
+            RETURNS trigger LANGUAGE plpgsql AS $$
+            BEGIN
+                RAISE EXCEPTION 'staffing fulfillment ledgers are append-only';
+            END;
+            $$;
+
+            DROP TRIGGER IF EXISTS trg_staffing_fulfillment_events_append_only
+                ON prod.staffing_fulfillment_events;
+            CREATE TRIGGER trg_staffing_fulfillment_events_append_only
+                BEFORE UPDATE OR DELETE ON prod.staffing_fulfillment_events
+                FOR EACH ROW EXECUTE FUNCTION prod.reject_staffing_fulfillment_ledger_mutation();
+
+            DROP TRIGGER IF EXISTS trg_staffing_fulfillment_commands_append_only
+                ON prod.staffing_fulfillment_commands;
+            CREATE TRIGGER trg_staffing_fulfillment_commands_append_only
+                BEFORE UPDATE OR DELETE ON prod.staffing_fulfillment_commands
+                FOR EACH ROW EXECUTE FUNCTION prod.reject_staffing_fulfillment_ledger_mutation();
+        SQL);
+    }
+
+    public function down(): void
+    {
+        if (! $this->isLocalEnvironment()) {
+            return;
+        }
+
+        DB::unprepared(<<<'SQL'
+            DROP TRIGGER IF EXISTS trg_staffing_fulfillment_commands_append_only ON prod.staffing_fulfillment_commands;
+            DROP TRIGGER IF EXISTS trg_staffing_fulfillment_events_append_only ON prod.staffing_fulfillment_events;
+            DROP TABLE IF EXISTS prod.staffing_fulfillment_commands;
+            DROP TABLE IF EXISTS prod.staffing_fulfillment_events;
+            DROP TABLE IF EXISTS prod.staffing_request_fulfillments;
+            DROP TABLE IF EXISTS prod.staff_shift_assignments;
+            DROP TABLE IF EXISTS prod.staff_availability_windows;
+            DROP TABLE IF EXISTS hosp_org.staff_member_qualifications;
+            DROP TABLE IF EXISTS hosp_ref.staff_role_qualification_requirements;
+            DROP TABLE IF EXISTS hosp_ref.staff_qualifications;
+            DROP FUNCTION IF EXISTS prod.reject_staffing_fulfillment_ledger_mutation();
+        SQL);
+    }
+};

--- a/docs/hummingbird/api-contract/hummingbird-bff.v1.yaml
+++ b/docs/hummingbird/api-contract/hummingbird-bff.v1.yaml
@@ -916,10 +916,33 @@ paths:
           }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
+  /staffing/requests/{id}/candidates:
+    get:
+      tags: [staffing]
+      summary: Canonical staffing candidates with qualification, availability, and conflict evidence.
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: integer } }
+        - { name: page, in: query, schema: { type: integer, minimum: 1 } }
+        - { name: per_page, in: query, schema: { type: integer, minimum: 1, maximum: 100 } }
+        - { name: eligible_only, in: query, schema: { type: boolean } }
+      responses:
+        "200":
+          {
+            description: Candidate page,
+            content:
+              {
+                application/json:
+                  { schema: { $ref: "#/components/schemas/StaffingCandidatePageEnvelope" } },
+              },
+          }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "422": { $ref: "#/components/responses/InvalidBody" }
   /staffing/requests/{id}/fill:
     post:
       tags: [staffing]
-      summary: Assign a source and mark a staffing request filled. Requires mobile:act.
+      summary: Fill with a named, server-validated canonical staff member. Requires mobile:act.
       parameters:
         [{ name: id, in: path, required: true, schema: { type: string } }]
       requestBody:
@@ -2648,10 +2671,56 @@ components:
     StaffingFill:
       type: object
       properties:
-        assigned_source: { type: string, maxLength: 120 }
+        staff_member_id: { type: integer, minimum: 1 }
+        assigned_source:
+          { type: string, enum: [float_pool, overtime, agency, on_call] }
         owner_name:
           { oneOf: [{ type: string, maxLength: 120 }, { type: "null" }] }
-      required: [assigned_source]
+      required: [staff_member_id, assigned_source]
+    StaffingCandidatePageEnvelope:
+      allOf:
+        - { $ref: "#/components/schemas/Envelope" }
+        - type: object
+          properties:
+            data:
+              type: object
+              properties:
+                data:
+                  { type: array, items: { $ref: "#/components/schemas/StaffingCandidate" } }
+                meta:
+                  type: object
+                  properties:
+                    current_page: { type: integer }
+                    last_page: { type: integer }
+                    per_page: { type: integer }
+                    total: { type: integer }
+                  required: [current_page, last_page, per_page, total]
+                shift:
+                  type: object
+                  properties:
+                    starts_at: { type: string, format: date-time }
+                    ends_at: { type: string, format: date-time }
+                    timezone: { type: string }
+                  required: [starts_at, ends_at, timezone]
+              required: [data, meta, shift]
+    StaffingCandidate:
+      type: object
+      properties:
+        staff_member_id: { type: integer }
+        display_name: { type: string }
+        role_code: { type: string }
+        role_label: { type: string }
+        eligible: { type: boolean }
+        eligibility_state:
+          { type: string, enum: [eligible, unqualified, unavailable, conflicted] }
+        reason_codes: { type: array, items: { type: string } }
+        qualification_requirements:
+          { type: array, items: { type: object, additionalProperties: true } }
+        availability: { type: object, additionalProperties: true }
+        overlapping_assignments: { type: integer }
+        shift: { type: object, additionalProperties: true }
+      required:
+        [staff_member_id, display_name, role_code, role_label, eligible, eligibility_state, reason_codes, overlapping_assignments]
     StaffingRequestEnvelope:
       allOf:
         - { $ref: "#/components/schemas/Envelope" }

--- a/docs/hummingbird/api-contract/mobile-route-contract-inventory.md
+++ b/docs/hummingbird/api-contract/mobile-route-contract-inventory.md
@@ -44,6 +44,7 @@ npx @redocly/cli lint docs/hummingbird/api-contract/hummingbird-bff.v1.yaml
 | GET    | `/rtdc/census`                               |
 | GET    | `/rtdc/house`                                |
 | GET    | `/staffing/overview`                         |
+| GET    | `/staffing/requests/{id}/candidates`         |
 | GET    | `/transport/queue`                           |
 | POST   | `/activity/{eventUuid}/ack`                  |
 | POST   | `/devices`                                   |

--- a/docs/operations/CANONICAL-STAFFING-RUNBOOK.md
+++ b/docs/operations/CANONICAL-STAFFING-RUNBOOK.md
@@ -1,0 +1,120 @@
+# Canonical Staffing Fulfillment Runbook
+
+## Purpose
+
+This runbook operates the qualification, availability, shift-assignment, and request-fulfillment runtime introduced by migration `2026_07_10_000300_create_canonical_staffing_fulfillment_tables.php`.
+
+The runtime fails closed: a person cannot be offered, accepted, or filled unless the request resolves to an active canonical assignment, all effective requirements have verified qualifications, an explicit availability window covers the whole shift, and no blocking window or overlapping active shift exists.
+
+## Runtime invariants
+
+- `hosp_org.staff_members` plus `hosp_org.staff_assignments` remain the workforce identity and role/unit/service-line authority.
+- `hosp_ref.staff_qualifications` and `hosp_ref.staff_role_qualification_requirements` define the effective requirement vocabulary.
+- `hosp_org.staff_member_qualifications` stores effective verification state and its canonical assignment lineage.
+- `prod.staff_availability_windows` stores timezone-labelled availability, on-call, leave, unavailable, preference, and conflict intervals in UTC.
+- `prod.staff_shift_assignments` is the active capacity/conflict boundary.
+- `prod.staffing_request_fulfillments` follows `offered -> accepted -> filled -> released` or the allowed cancellation branches.
+- `prod.staffing_fulfillment_events` and `prod.staffing_fulfillment_commands` are append-only. Never repair them with direct updates or deletes.
+- Every web and Hummingbird write requires an idempotency key and passes through the same locked service path.
+
+## Configuration
+
+```dotenv
+STAFFING_DEFAULT_FACILITY_KEY=SUMMIT_REGIONAL
+STAFFING_DEFAULT_TIMEZONE=America/New_York
+STAFFING_MATERIALIZATION_DAYS=28
+STAFFING_MATERIALIZATION_SCHEDULE_ENABLED=true
+STAFFING_MATERIALIZATION_SCHEDULE_TIME=04:10
+```
+
+Use an IANA timezone. The materializer selects only active assignments for the configured facility and reconciles only rows it owns. Manual or integrated qualification and availability rows are not deleted.
+
+## Deployment and first activation
+
+1. Capture the database backup and migration ledger required by the normal production change procedure.
+2. Deploy the merged `main` tree only through `DEPLOY_RUN_MIGRATIONS=1 ./deploy.sh`.
+3. Confirm the migration is recorded:
+
+   ```bash
+   php artisan migrate:status | rg '2026_07_10_000300'
+   ```
+
+4. Execute the complete projection inside a rollback-only transaction:
+
+   ```bash
+   php artisan staffing:materialize-canonical --facility=SUMMIT_REGIONAL --days=28 --dry-run
+   ```
+
+5. Review the projected qualification and window counts. Unexpected zero counts are a stop condition.
+6. Commit the same projection:
+
+   ```bash
+   php artisan staffing:materialize-canonical --facility=SUMMIT_REGIONAL --days=28
+   ```
+
+7. Re-run it and confirm stable counts. This is the idempotency check.
+8. Confirm the daily schedule is registered:
+
+   ```bash
+   php artisan schedule:list | rg 'staffing:materialize-canonical'
+   ```
+
+## Verification queries
+
+Run these read-only checks through the approved PostgreSQL console:
+
+```sql
+SELECT status, count(*)
+FROM hosp_org.staff_member_qualifications
+GROUP BY status
+ORDER BY status;
+
+SELECT window_type, count(*)
+FROM prod.staff_availability_windows
+WHERE source = 'canonical-materializer'
+  AND ends_at > now()
+GROUP BY window_type
+ORDER BY window_type;
+
+SELECT status, count(*)
+FROM prod.staffing_request_fulfillments
+GROUP BY status
+ORDER BY status;
+
+SELECT count(*) AS overfilled_requests
+FROM (
+    SELECT f.staffing_request_id
+    FROM prod.staffing_request_fulfillments f
+    JOIN prod.staffing_requests r USING (staffing_request_id)
+    WHERE f.status = 'filled'
+    GROUP BY f.staffing_request_id, r.headcount_needed
+    HAVING count(*) > r.headcount_needed
+) violations;
+
+SELECT count(*) AS overlapping_active_assignments
+FROM prod.staff_shift_assignments a
+JOIN prod.staff_shift_assignments b
+  ON a.staff_member_id = b.staff_member_id
+ AND a.staff_shift_assignment_id < b.staff_shift_assignment_id
+ AND a.starts_at < b.ends_at
+ AND a.ends_at > b.starts_at
+WHERE a.status IN ('offered', 'accepted', 'filled')
+  AND b.status IN ('offered', 'accepted', 'filled');
+```
+
+Both violation counts must be zero.
+
+## Operational response
+
+- `qualification_requirements_unconfigured`: run the dry-run materializer and inspect the role vocabulary before committing it.
+- `missing_required_qualification`: verify the source assignment review state or record an approved credential; do not bypass eligibility.
+- `availability_unverified`: load an explicit covering availability/on-call window. Metadata alone is not sufficient during fulfillment.
+- `unavailable_or_on_leave`: resolve the blocking source record; a positive window does not override leave or conflict.
+- `overlapping_shift_assignment`: release/cancel the existing governed assignment or choose another person.
+- headcount rejection: another accepted or filled command won the request lock. Refresh and cancel the now-unneeded offer.
+
+## Rollback
+
+Disable future projection first with `STAFFING_MATERIALIZATION_SCHEDULE_ENABLED=false`, clear configuration cache, and redeploy the prior merged `main` tree through `./deploy.sh`.
+
+Do not roll back the migration after fulfillment events exist: its ledgers are intentionally append-only and reference operational requests. Keep the additive tables, disable the write surface, and restore application behavior through a forward fix. Database restoration is reserved for the approved full-release rollback procedure.

--- a/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
+++ b/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
@@ -123,12 +123,25 @@ Current isolated branch evidence:
 
 ## Staffing operations completion
 
-- [ ] ST1.1 Establish the canonical qualification vocabulary and effective-dated staff qualification records.
-- [ ] ST1.2 Model availability, leave, preference, and conflict windows with timezone-safe overlap rules.
-- [ ] ST1.3 Validate each assignment against role, qualification, unit/service-line capability, availability, and overlapping shifts.
-- [ ] ST1.4 Implement shift fulfillment as a governed lifecycle with idempotent accept/fill/release/cancel transitions and an immutable activity trail.
-- [ ] ST1.5 Surface explicit unfilled/unsafe/conflicted states to web and Hummingbird with server-enforced action policies.
-- [ ] ST1.6 Add migration, service, API, policy, concurrency, pagination, and mobile parity tests.
+- [x] ST1.1 Establish the canonical qualification vocabulary and effective-dated staff qualification records.
+- [x] ST1.2 Model availability, leave, preference, and conflict windows with timezone-safe overlap rules.
+- [x] ST1.3 Validate each assignment against role, qualification, unit/service-line capability, availability, and overlapping shifts.
+- [x] ST1.4 Implement shift fulfillment as a governed lifecycle with idempotent accept/fill/release/cancel transitions and an immutable activity trail.
+- [x] ST1.5 Surface explicit unfilled/unsafe/conflicted states to web and Hummingbird with server-enforced action policies.
+- [x] ST1.6 Add migration, service, API, policy, concurrency, pagination, and mobile parity tests.
+
+Current isolated branch evidence:
+
+- `2026_07_10_000300_create_canonical_staffing_fulfillment_tables.php`, `config/staffing.php`, and the canonical staffing models establish effective-dated qualifications, availability windows, shift assignments, request fulfillments, and append-only command/event ledgers without replacing legacy source records.
+- `MaterializeCanonicalStaffing` projects configured roles, qualifications, and timezone-safe shift windows in deterministic batches; dry runs roll back the complete projection, deactivated source qualifications expire, and shortened horizons remove stale source-owned windows.
+- `CanonicalStaffingService` applies facility scope, verified qualifications, effective dates, availability/leave/conflicts, overlapping assignments, unit/service-line capability, accepted/filled headcount reservation, row locks, and advisory idempotency locks before every governed transition.
+- The web API and Staffing Office expose all active fulfillments and explicit ineligible/unavailable/conflicted states. Legacy source selection can no longer assign a person or mark a request filled, and cancellation/completion are tied to canonical fulfillment state.
+- Hummingbird Android and iOS now select an eligible named candidate through the same canonical API; the mobile write requires header idempotency and records offer, accept, and fill atomically with operational activity. OpenAPI and the mobile route inventory carry the contract.
+- `CanonicalStaffingFulfillmentTest`: six feature tests and 109 assertions cover pagination and facility scope, authorization and immutable idempotency, transition-time revalidation, headcount reservation, DST/materialization reconciliation, and legacy/mobile parity.
+- Full `php artisan test` after rebasing onto `main`: 43 tests passed with 9,593 assertions and only the isolated worktree's known missing-local-`.env` warnings. Repository `./vendor/bin/pint --test`: 901 files passed.
+- Full `npx vitest run --coverage` after rebasing onto `main`: 82 files and 346 tests passed. `npx tsc --noEmit` and `npm run build` passed.
+- `scripts/check-ui-canon.sh` names no staffing file, but the branch inherits pre-existing failures from `main` commit `025139f` in the newly added Arena UI (font weight, arbitrary text sizes, and raw palette ratchet); those unrelated files remain outside this tranche.
+- Android `testDebugUnitTest` passed under the repository-supported JDK 17. Native iOS compilation is unavailable on this Linux host; shared contract/parity guards cover the iOS request and model seams pending GitHub/macOS validation if configured.
 
 ## Transport lifecycle completion
 

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/ApiClient.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/ApiClient.kt
@@ -120,8 +120,20 @@ class ApiClient(private val baseUrl: String = BASE_URL) {
         JSONObject(text).optJSONObject("data")?.optStringOrNull("decision") == decision
     }
 
-    suspend fun fillStaffingRequest(bearer: String, id: Int, assignedSource: String): Boolean = withContext(Dispatchers.IO) {
-        val body = JSONObject().put("assigned_source", assignedSource.ifBlank { "Mobile" })
+    suspend fun staffingCandidates(bearer: String, id: Int): List<StaffingCandidate> = withContext(Dispatchers.IO) {
+        val page = getData("/api/mobile/v1/staffing/requests/$id/candidates?persona=staffing_coordinator&per_page=100", bearer)
+        page.optJSONArray("data").objects().map(::parseStaffingCandidate)
+    }
+
+    suspend fun fillStaffingRequest(
+        bearer: String,
+        id: Int,
+        staffMemberId: Int,
+        assignedSource: String,
+    ): Boolean = withContext(Dispatchers.IO) {
+        val body = JSONObject()
+            .put("staff_member_id", staffMemberId)
+            .put("assigned_source", assignedSource.ifBlank { "float_pool" })
         val (code, text) = send("POST", "/api/mobile/v1/staffing/requests/$id/fill", body.toString(), bearer)
         if (code !in 200..299) throw ApiException(errorMessage(text, code), code)
         JSONObject(text).has("data")
@@ -797,6 +809,16 @@ class ApiClient(private val baseUrl: String = BASE_URL) {
             ),
         )
     }
+
+    internal fun parseStaffingCandidate(o: JSONObject): StaffingCandidate = StaffingCandidate(
+        staffMemberId = o.optInt("staff_member_id"),
+        displayName = o.optStringOrNull("display_name") ?: "Staff member",
+        roleLabel = o.optStringOrNull("role_label") ?: "Staff",
+        eligible = o.optBoolean("eligible", false),
+        eligibilityState = o.optStringOrNull("eligibility_state") ?: "unavailable",
+        reasonCodes = o.optJSONArray("reason_codes").strings(),
+        overlappingAssignments = o.optInt("overlapping_assignments"),
+    )
 
     internal fun parsePdsaCycle(o: JSONObject): PdsaCycle = PdsaCycle(
         id = o.optInt("id"),

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/ForYouViewModel.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/ForYouViewModel.kt
@@ -80,14 +80,6 @@ class ForYouViewModel(app: Application) : AndroidViewModel(app) {
         decideOpsAction(bearer, item, role, "rejected")
     }
 
-    fun fillStaffingRequest(bearer: String, item: ForYouItem, role: MobileRole) {
-        val id = refId(item.id, "staffing-") ?: return
-        mutate(item.id) {
-            api.fillStaffingRequest(bearer, id, role.title)
-            items = api.forYou(bearer, role.id)
-        }
-    }
-
     private fun decideOpsAction(bearer: String, item: ForYouItem, role: MobileRole, decision: String) {
         val approvalUuid = refString(item.id, "ops-approval-") ?: return
         mutate(item.id) {

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/Models.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/data/Models.kt
@@ -282,8 +282,18 @@ data class StaffingReq(
             priority == "stat" -> CapacityStatus.CRITICAL
             priority == "urgent" || sla.atRisk -> CapacityStatus.WARNING
             else -> CapacityStatus.INFO
-        }
+    }
 }
+
+data class StaffingCandidate(
+    val staffMemberId: Int,
+    val displayName: String,
+    val roleLabel: String,
+    val eligible: Boolean,
+    val eligibilityState: String,
+    val reasonCodes: List<String>,
+    val overlappingAssignments: Int,
+)
 
 data class PdsaCycle(
     val id: Int,

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/ForYouScreen.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/ForYouScreen.kt
@@ -273,7 +273,6 @@ private fun actionsFor(item: ForYouItem, vm: ForYouViewModel, bearer: String, ro
         ForYouAction("Approve", CapacityStatus.SUCCESS) { vm.approveOpsAction(bearer, item, role) },
         ForYouAction("Reject", CapacityStatus.WARNING) { vm.rejectOpsAction(bearer, item, role) },
     )
-    item.id.startsWith("staffing-") -> listOf(ForYouAction("Fill") { vm.fillStaffingRequest(bearer, item, role) })
     else -> emptyList()
 }
 
@@ -281,7 +280,8 @@ private fun supportsDrill(id: String): Boolean =
     id.startsWith("bedreq-") ||
         id.startsWith("barrier-") ||
         id.startsWith("transport-") ||
-        id.startsWith("evs-")
+        id.startsWith("evs-") ||
+        id.startsWith("staffing-")
 
 private fun metaLine(item: ForYouItem): String? {
     val parts = listOfNotNull(item.unit, relTime(item.at))

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/staffing/StaffingScreens.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/staffing/StaffingScreens.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import net.acumenus.hummingbird.data.AuthViewModel
+import net.acumenus.hummingbird.data.StaffingCandidate
 import net.acumenus.hummingbird.data.StaffingMetrics
 import net.acumenus.hummingbird.data.StaffingReq
 import net.acumenus.hummingbird.data.UnitAtRisk
@@ -155,9 +156,7 @@ fun StaffingScreen(
                         items(overview.queue, key = { it.staffingRequestId }) { request ->
                             StaffingRequestRow(
                                 request = request,
-                                working = request.staffingRequestId in vm.workingRequestIds,
                                 onClick = { onOpenRequest(request, overview.webLink) },
-                                onFill = { vm.fillFromFloatPool(bearer, request) },
                             )
                         }
                     }
@@ -182,8 +181,11 @@ fun StaffingRequestDetailScreen(
     val bearer = auth.accessToken ?: ""
     val uriHandler = LocalUriHandler.current
     val working = request.staffingRequestId in vm.workingRequestIds
+    val candidates = vm.candidatesByRequest[request.staffingRequestId].orEmpty()
+    val selectedCandidateId = vm.selectedCandidateByRequest[request.staffingRequestId]
 
     LaunchedEffect(vm.needsReauth) { if (vm.needsReauth) auth.logout() }
+    LaunchedEffect(request.staffingRequestId, bearer) { vm.loadCandidates(bearer, request) }
 
     Scaffold(
         containerColor = Z.bg,
@@ -205,12 +207,12 @@ fun StaffingRequestDetailScreen(
         bottomBar = {
             Column(Modifier.fillMaxWidth().background(Z.surface).padding(16.dp)) {
                 Button(
-                    onClick = { vm.fillFromFloatPool(bearer, request, onBack) },
-                    enabled = !working,
+                    onClick = { vm.fillSelected(bearer, request, onBack) },
+                    enabled = !working && selectedCandidateId != null,
                     modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp),
                     colors = ButtonDefaults.buttonColors(containerColor = if (working) Z.primary.copy(alpha = 0.55f) else Z.primary),
                 ) {
-                    Text(if (working) "Working" else "Fill from float pool", fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
+                    Text(if (working) "Filling shift" else "Fill with selected staff", fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
                 }
             }
         },
@@ -222,6 +224,20 @@ fun StaffingRequestDetailScreen(
         ) {
             item { StaffingRequestDetailCard(request) }
             vm.error?.let { item { StaffingError(it) } }
+            if (request.staffingRequestId in vm.candidateLoadingIds) {
+                item { Text("Checking qualifications, availability, and conflicts...", color = Z.inkMuted, fontSize = 13.sp) }
+            } else if (candidates.isEmpty()) {
+                item { StaffingError("No staff currently pass the canonical role, qualification, availability, and conflict checks.") }
+            } else {
+                item { StaffingSectionLabel("QUALIFIED AND REVIEWED CANDIDATES") }
+                items(candidates, key = { it.staffMemberId }) { candidate ->
+                    StaffingCandidateRow(
+                        candidate = candidate,
+                        selected = selectedCandidateId == candidate.staffMemberId,
+                        onSelect = { vm.selectCandidate(request.staffingRequestId, candidate.staffMemberId) },
+                    )
+                }
+            }
             webLink?.let { link ->
                 item {
                     OutlinedButton(onClick = { uriHandler.openUri(link) }, modifier = Modifier.fillMaxWidth().heightIn(min = 48.dp)) {
@@ -282,9 +298,7 @@ private fun UnitAtRiskRow(unit: UnitAtRisk) {
 @Composable
 private fun StaffingRequestRow(
     request: StaffingReq,
-    working: Boolean,
     onClick: () -> Unit,
-    onFill: () -> Unit,
 ) {
     Column(
         Modifier
@@ -301,13 +315,40 @@ private fun StaffingRequestRow(
         }
         Text("${request.roleLabel ?: "Staff"} / ${request.unitLabel ?: "-"}", color = Z.ink, fontSize = 15.sp, fontWeight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
         Button(
-            onClick = onFill,
-            enabled = !working,
+            onClick = onClick,
             modifier = Modifier.fillMaxWidth().heightIn(min = 44.dp),
-            colors = ButtonDefaults.buttonColors(containerColor = if (working) Z.primary.copy(alpha = 0.55f) else Z.primary),
+            colors = ButtonDefaults.buttonColors(containerColor = Z.primary),
         ) {
-            Text(if (working) "Working" else "Fill from float pool", fontWeight = FontWeight.SemiBold)
+            Text("Choose qualified staff", fontWeight = FontWeight.SemiBold)
         }
+    }
+}
+
+@Composable
+private fun StaffingCandidateRow(
+    candidate: StaffingCandidate,
+    selected: Boolean,
+    onSelect: () -> Unit,
+) {
+    OutlinedButton(
+        onClick = onSelect,
+        enabled = candidate.eligible,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(candidate.displayName, color = if (candidate.eligible) Z.ink else Z.inkMuted, fontWeight = FontWeight.SemiBold)
+            Text(
+                if (candidate.eligible) candidate.roleLabel else candidate.reasonCodes.joinToString(" / ") { it.replace('_', ' ') },
+                color = Z.inkMuted,
+                fontSize = 12.sp,
+            )
+        }
+        Text(
+            if (selected) "Selected" else candidate.eligibilityState.replace('_', ' '),
+            color = if (candidate.eligible) Z.primary else CapacityStatus.WARNING.color,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
     }
 }
 
@@ -319,7 +360,7 @@ private fun StaffingRequestDetailCard(request: StaffingReq) {
         request.headcountNeeded?.let { StaffingDetailLine("Headcount", "$it") }
         StaffingDetailLine("Status", request.status)
         StaffingDetailLine("SLA", request.sla.label)
-        Text("Filling assigns Float Pool and closes the request through the governed staffing lifecycle.", color = Z.inkMuted, fontSize = 13.sp)
+        Text("Filling requires a named person who passes canonical qualification, availability, unit, and overlap checks.", color = Z.inkMuted, fontSize = 13.sp)
     }
 }
 

--- a/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/staffing/StaffingViewModel.kt
+++ b/hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/staffing/StaffingViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 import net.acumenus.hummingbird.data.ApiClient
 import net.acumenus.hummingbird.data.ApiException
+import net.acumenus.hummingbird.data.StaffingCandidate
 import net.acumenus.hummingbird.data.StaffingOverview
 import net.acumenus.hummingbird.data.StaffingReq
 
@@ -20,6 +21,10 @@ class StaffingViewModel(app: Application) : AndroidViewModel(app) {
     var error by mutableStateOf<String?>(null); private set
     var needsReauth by mutableStateOf(false); private set
     var workingRequestIds by mutableStateOf<Set<Int>>(emptySet()); private set
+    var candidateLoadingIds by mutableStateOf<Set<Int>>(emptySet()); private set
+    var candidatesByRequest by mutableStateOf<Map<Int, List<StaffingCandidate>>>(emptyMap()); private set
+    var selectedCandidateByRequest by mutableStateOf<Map<Int, Int>>(emptyMap()); private set
+    var sourceByRequest by mutableStateOf<Map<Int, String>>(emptyMap()); private set
 
     fun load(bearer: String) {
         loading = true
@@ -37,12 +42,51 @@ class StaffingViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
-    fun fillFromFloatPool(bearer: String, request: StaffingReq, onDone: () -> Unit = {}) {
+    fun loadCandidates(bearer: String, request: StaffingReq) {
+        candidateLoadingIds = candidateLoadingIds + request.staffingRequestId
+        viewModelScope.launch {
+            try {
+                val candidates = api.staffingCandidates(bearer, request.staffingRequestId)
+                candidatesByRequest = candidatesByRequest + (request.staffingRequestId to candidates)
+                val firstEligible = candidates.firstOrNull { it.eligible }
+                selectedCandidateByRequest = if (firstEligible == null) {
+                    selectedCandidateByRequest - request.staffingRequestId
+                } else {
+                    selectedCandidateByRequest + (request.staffingRequestId to firstEligible.staffMemberId)
+                }
+                sourceByRequest = sourceByRequest + (request.staffingRequestId to (sourceByRequest[request.staffingRequestId] ?: "float_pool"))
+                error = null
+            } catch (e: ApiException) {
+                if (e.statusCode == 401) needsReauth = true
+                error = e.message
+            } catch (e: Exception) {
+                error = e.message
+            }
+            candidateLoadingIds = candidateLoadingIds - request.staffingRequestId
+        }
+    }
+
+    fun selectCandidate(requestId: Int, staffMemberId: Int) {
+        selectedCandidateByRequest = selectedCandidateByRequest + (requestId to staffMemberId)
+    }
+
+    fun fillSelected(bearer: String, request: StaffingReq, onDone: () -> Unit = {}) {
+        val staffMemberId = selectedCandidateByRequest[request.staffingRequestId] ?: run {
+            error = "Select a qualified, available staff member."
+            return
+        }
         workingRequestIds = workingRequestIds + request.staffingRequestId
         viewModelScope.launch {
             try {
-                api.fillStaffingRequest(bearer, request.staffingRequestId, "Float Pool")
+                api.fillStaffingRequest(
+                    bearer,
+                    request.staffingRequestId,
+                    staffMemberId,
+                    sourceByRequest[request.staffingRequestId] ?: "float_pool",
+                )
                 overview = api.staffingOverview(bearer)
+                candidatesByRequest = candidatesByRequest - request.staffingRequestId
+                selectedCandidateByRequest = selectedCandidateByRequest - request.staffingRequestId
                 error = null
                 onDone()
             } catch (e: ApiException) {

--- a/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/data/SharedDtoFixtureDecodeTest.kt
+++ b/hummingbird/androidApp/app/src/test/java/net/acumenus/hummingbird/data/SharedDtoFixtureDecodeTest.kt
@@ -143,6 +143,27 @@ class SharedDtoFixtureDecodeTest {
         assertEquals(null, api.mobileIdempotencyKey("POST", "/api/auth/token", "{}",))
     }
 
+    @Test
+    fun decodesCanonicalStaffingCandidateSafetyState() {
+        val candidate = api.parseStaffingCandidate(JSONObject("""
+            {
+              "staff_member_id": 42,
+              "display_name": "Avery Adams",
+              "role_label": "Staff Nurse",
+              "eligible": false,
+              "eligibility_state": "conflicted",
+              "reason_codes": ["overlapping_shift_assignment"],
+              "overlapping_assignments": 1
+            }
+        """.trimIndent()))
+
+        assertEquals(42, candidate.staffMemberId)
+        assertEquals("Avery Adams", candidate.displayName)
+        assertEquals("conflicted", candidate.eligibilityState)
+        assertEquals(listOf("overlapping_shift_assignment"), candidate.reasonCodes)
+        assertEquals(1, candidate.overlappingAssignments)
+    }
+
     private fun fixture(filename: String): JSONObject =
         JSONObject(File(repoRoot(), "docs/hummingbird/api-contract/fixtures/$filename").readText())
 

--- a/hummingbird/iosApp/Hummingbird/Features/Staffing/StaffingView.swift
+++ b/hummingbird/iosApp/Hummingbird/Features/Staffing/StaffingView.swift
@@ -1,14 +1,13 @@
 import SwiftUI
 
 /// P10 — the staffing coordinator's home: coverage metrics, units below minimum-safe, and the
-/// open-request queue with an inline Fill (assign from the float pool). Backed by
-/// GET /staffing/overview; fill posts to /staffing/requests/{id}/fill.
+/// open-request queue with governed person-level fulfillment. Backed by
+/// GET /staffing/overview and the canonical candidate/fill endpoints.
 @MainActor
 final class StaffingViewModel: ObservableObject {
     @Published var overview: StaffingOverview?
     @Published var isLoading = false
     @Published var errorMessage: String?
-    @Published var working: Set<Int> = []
     @Published var needsReauth = false
 
     let api: APIClient
@@ -25,13 +24,59 @@ final class StaffingViewModel: ObservableObject {
             errorMessage = error.message
         } catch { errorMessage = error.localizedDescription }
     }
+}
 
-    func fill(_ r: StaffingReq, bearer: String) async {
-        working.insert(r.id)
-        defer { working.remove(r.id) }
-        do { try await api.staffingFill(id: r.id, source: "Float Pool", bearer: bearer); await load(bearer: bearer) }
-        catch let e as APIError { errorMessage = e.message }
-        catch { errorMessage = error.localizedDescription }
+@MainActor
+final class StaffingFulfillmentViewModel: ObservableObject {
+    @Published var candidates: [StaffingCandidate] = []
+    @Published var selectedStaffMemberId: Int?
+    @Published var source = "float_pool"
+    @Published var isLoading = false
+    @Published var isWorking = false
+    @Published var errorMessage: String?
+    @Published var needsReauth = false
+
+    private let api: APIClient
+    init(api: APIClient) { self.api = api }
+
+    func load(request: StaffingReq, bearer: String) async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            candidates = try await api.staffingCandidates(id: request.id, bearer: bearer).data
+            selectedStaffMemberId = candidates.first(where: \.eligible)?.staffMemberId
+            errorMessage = nil
+        } catch let error as APIError {
+            if error.statusCode == 401 { needsReauth = true }
+            errorMessage = error.message
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func fill(request: StaffingReq, bearer: String) async -> Bool {
+        guard let selectedStaffMemberId else {
+            errorMessage = "Select a qualified, available staff member."
+            return false
+        }
+        isWorking = true
+        defer { isWorking = false }
+        do {
+            try await api.staffingFill(
+                id: request.id,
+                staffMemberId: selectedStaffMemberId,
+                source: source,
+                bearer: bearer
+            )
+            errorMessage = nil
+            return true
+        } catch let error as APIError {
+            if error.statusCode == 401 { needsReauth = true }
+            errorMessage = error.message
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        return false
     }
 }
 
@@ -160,18 +205,20 @@ struct StaffingView: View {
                         .foregroundStyle(Z.primary)
                 }
                 .buttonStyle(.plain)
-                Button {
-                    Task { await vm.fill(r, bearer: auth.accessToken ?? "") }
+                NavigationLink {
+                    StaffingFulfillmentView(request: r) {
+                        Task { await vm.load(bearer: auth.accessToken ?? "") }
+                    }
                 } label: {
                     HStack(spacing: Z.s2) {
-                        if vm.working.contains(r.id) { ProgressView().controlSize(.small).tint(.white) }
-                        Text("Fill from float pool").font(.system(size: 15, weight: .semibold))
+                        Image(systemName: "person.badge.plus")
+                        Text("Choose qualified staff").font(.system(size: 15, weight: .semibold))
                     }
                     .frame(maxWidth: .infinity).padding(.vertical, Z.s2)
                     .foregroundStyle(.white)
                     .background(RoundedRectangle(cornerRadius: 10).fill(Z.primary))
                 }
-                .disabled(vm.working.contains(r.id))
+                .buttonStyle(.plain)
             }
         }
     }
@@ -189,5 +236,124 @@ struct StaffingView: View {
 
     private func sectionLabel(_ t: String) -> some View {
         Text(t).font(.system(size: 11, weight: .semibold)).tracking(0.5).foregroundStyle(Z.inkMuted).padding(.top, Z.s2)
+    }
+}
+
+private struct StaffingFulfillmentView: View {
+    @EnvironmentObject private var auth: AuthStore
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var vm = StaffingFulfillmentViewModel(
+        api: APIClient(baseURL: URL(string: AppConfig.baseURL)!)
+    )
+
+    let request: StaffingReq
+    let onFilled: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Z.s4) {
+                Panel {
+                    VStack(alignment: .leading, spacing: Z.s2) {
+                        Text("\(request.roleLabel ?? "Staff") · \(request.unitLabel ?? "—")")
+                            .font(.system(size: 18, weight: .semibold))
+                            .foregroundStyle(Z.ink)
+                        Text("Choose a person who passes role, qualification, availability, and overlap checks.")
+                            .font(.system(size: 13))
+                            .foregroundStyle(Z.inkMuted)
+                    }
+                }
+
+                if vm.isLoading {
+                    SkeletonRows()
+                } else if let error = vm.errorMessage {
+                    RetryableMessage(symbol: "exclamationmark.shield", title: "Staffing action unavailable",
+                                     message: error, tone: .warning) {
+                        Task { await vm.load(request: request, bearer: auth.accessToken ?? "") }
+                    }
+                }
+
+                if !vm.candidates.isEmpty {
+                    let blocked = vm.candidates.filter { !$0.eligible }
+                    if !blocked.isEmpty {
+                        Text("\(blocked.count) candidate\(blocked.count == 1 ? " is" : "s are") blocked by current safety checks.")
+                            .font(.system(size: 12))
+                            .foregroundStyle(Z.inkMuted)
+                    }
+                    ForEach(vm.candidates) { candidate in
+                        Button {
+                            if candidate.eligible { vm.selectedStaffMemberId = candidate.staffMemberId }
+                        } label: {
+                            HStack(spacing: Z.s3) {
+                                Image(systemName: vm.selectedStaffMemberId == candidate.staffMemberId ? "checkmark.circle.fill" : "circle")
+                                    .foregroundStyle(candidate.eligible ? Z.primary : Z.inkMuted)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(candidate.displayName).font(.system(size: 15, weight: .semibold))
+                                    Text(candidate.eligible
+                                         ? candidate.roleLabel
+                                         : candidate.reasonCodes.map(humanize).joined(separator: " · "))
+                                        .font(.system(size: 12))
+                                        .foregroundStyle(Z.inkMuted)
+                                }
+                                Spacer()
+                                if !candidate.eligible {
+                                    Text(candidate.eligibilityState).font(.system(size: 11, weight: .semibold))
+                                        .foregroundStyle(Z.status(.warning))
+                                }
+                            }
+                            .padding(Z.s3)
+                            .background(RoundedRectangle(cornerRadius: 12).fill(Z.surface))
+                            .overlay(RoundedRectangle(cornerRadius: 12).stroke(candidate.eligible ? Z.border : Z.status(.warning).opacity(0.4)))
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(!candidate.eligible)
+                    }
+
+                    Picker("Source", selection: $vm.source) {
+                        Text("Float pool").tag("float_pool")
+                        Text("Overtime").tag("overtime")
+                        Text("Agency").tag("agency")
+                        Text("On call").tag("on_call")
+                    }
+                    .pickerStyle(.menu)
+
+                    Button {
+                        Task {
+                            if await vm.fill(request: request, bearer: auth.accessToken ?? "") {
+                                onFilled()
+                                dismiss()
+                            }
+                        }
+                    } label: {
+                        HStack {
+                            if vm.isWorking { ProgressView().controlSize(.small).tint(.white) }
+                            Text(vm.isWorking ? "Filling shift" : "Fill with selected staff")
+                                .font(.system(size: 15, weight: .semibold))
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, Z.s3)
+                        .foregroundStyle(.white)
+                        .background(RoundedRectangle(cornerRadius: 10).fill(Z.primary))
+                    }
+                    .disabled(vm.isWorking || vm.selectedStaffMemberId == nil)
+                } else if !vm.isLoading && vm.errorMessage == nil {
+                    RetryableMessage(symbol: "person.crop.circle.badge.xmark", title: "No eligible staff",
+                                     message: "No candidate currently passes qualification, availability, unit, and overlap checks.", tone: .warning) {
+                        Task { await vm.load(request: request, bearer: auth.accessToken ?? "") }
+                    }
+                }
+            }
+            .padding(Z.s4)
+        }
+        .background { HummingbirdBackdrop(dim: 0.4) }
+        .navigationTitle("Fulfill shift")
+        .navigationBarTitleDisplayMode(.inline)
+        .task { await vm.load(request: request, bearer: auth.accessToken ?? "") }
+        .onChange(of: vm.needsReauth) { _, needsReauth in
+            if needsReauth { Task { await auth.logout() } }
+        }
+    }
+
+    private func humanize(_ value: String) -> String {
+        value.replacingOccurrences(of: "_", with: " ")
     }
 }

--- a/hummingbird/iosApp/Hummingbird/Networking/APIClient.swift
+++ b/hummingbird/iosApp/Hummingbird/Networking/APIClient.swift
@@ -213,10 +213,18 @@ struct APIClient {
         try await getEnvelope(path: "/api/mobile/v1/staffing/overview", bearer: bearer, as: StaffingOverview.self)
     }
 
-    /// POST …/staffing/requests/{id}/fill — assign a source and mark filled (mobile:act).
-    func staffingFill(id: Int, source: String, bearer: String) async throws {
+    func staffingCandidates(id: Int, bearer: String) async throws -> StaffingCandidatePage {
+        try await getEnvelope(
+            path: "/api/mobile/v1/staffing/requests/\(id)/candidates?persona=staffing_coordinator&per_page=100",
+            bearer: bearer,
+            as: StaffingCandidatePage.self
+        ).data
+    }
+
+    /// POST …/staffing/requests/{id}/fill — fill with a server-validated canonical person (mobile:act).
+    func staffingFill(id: Int, staffMemberId: Int, source: String, bearer: String) async throws {
         _ = try await send(path: "/api/mobile/v1/staffing/requests/\(id)/fill", method: "POST",
-                           body: ["assigned_source": source], bearer: bearer)
+                           body: ["staff_member_id": "\(staffMemberId)", "assigned_source": source], bearer: bearer)
     }
 
     func improvementPdsa(bearer: String) async throws -> [PdsaCycle] {

--- a/hummingbird/iosApp/Hummingbird/Networking/Models.swift
+++ b/hummingbird/iosApp/Hummingbird/Networking/Models.swift
@@ -475,6 +475,36 @@ struct StaffingReq: Decodable, Identifiable {
     }
 }
 
+struct StaffingCandidatePage: Decodable {
+    let data: [StaffingCandidate]
+    let meta: StaffingCandidateMeta
+    let shift: StaffingCandidateShift
+}
+
+struct StaffingCandidateMeta: Decodable {
+    let currentPage: Int
+    let lastPage: Int
+    let perPage: Int
+    let total: Int
+}
+
+struct StaffingCandidateShift: Decodable {
+    let startsAt: String
+    let endsAt: String
+    let timezone: String
+}
+
+struct StaffingCandidate: Decodable, Identifiable {
+    let staffMemberId: Int
+    let displayName: String
+    let roleLabel: String
+    let eligible: Bool
+    let eligibilityState: String
+    let reasonCodes: [String]
+    let overlappingAssignments: Int
+    var id: Int { staffMemberId }
+}
+
 // MARK: Improvement / PI (P8) — GET /improvement/pdsa + /improvement/opportunities
 
 struct PdsaCycle: Decodable, Identifiable {

--- a/resources/js/Pages/Staffing/StaffingOffice.tsx
+++ b/resources/js/Pages/Staffing/StaffingOffice.tsx
@@ -2,7 +2,7 @@ import DashboardLayout from '@/Components/Dashboard/DashboardLayout';
 import PageContentLayout from '@/Components/Common/PageContentLayout';
 import { OperationalDataError, SourceFreshnessBanner } from '@/Components/Operations/OperationalDataState';
 import { KpiTile, metric } from '@/Components/system';
-import { useAssignStaffingRequest, useStaffingOverview, useStaffingWorkforce, useUpdateStaffingStatus } from '@/features/staffing/hooks';
+import { useOfferStaffingFulfillment, useStaffingCandidates, useStaffingOverview, useStaffingWorkforce, useTransitionStaffingFulfillment } from '@/features/staffing/hooks';
 import type {
   StaffingAssignedSource,
   StaffingRequest,
@@ -115,11 +115,21 @@ function RoleGapBar({ row }: { row: StaffingRoleGap }) {
   );
 }
 
-function RequestRow({ request }: { request: StaffingRequest }) {
-  const assign = useAssignStaffingRequest();
-  const updateStatus = useUpdateStaffingStatus();
+function RequestRow({ request, canManage }: { request: StaffingRequest; canManage: boolean }) {
+  const [showCandidates, setShowCandidates] = useState(false);
+  const [staffMemberId, setStaffMemberId] = useState<number | null>(null);
+  const [source, setSource] = useState<StaffingAssignedSource>('float_pool');
+  const candidates = useStaffingCandidates(request.staffing_request_id, showCandidates && canManage);
+  const offer = useOfferStaffingFulfillment();
+  const transition = useTransitionStaffingFulfillment();
   const isActive = request.freshness_status !== 'expired' && !['filled', 'completed', 'canceled', 'unfilled'].includes(request.status);
-  const sources: StaffingAssignedSource[] = ['float_pool', 'overtime', 'agency', 'on_call'];
+  const latest = request.fulfillment.latest;
+  const visibleFulfillments = request.fulfillment.active.length > 0
+    ? request.fulfillment.active
+    : latest ? [latest] : [];
+  const hasPendingOffer = request.fulfillment.active.some((fulfillment) => fulfillment.status === 'offered');
+  const isPending = offer.isPending || transition.isPending;
+  const actionError = offer.error ?? transition.error;
   const slaLabel = request.sla.minutes_until_due === null
     ? request.sla.label
     : formatRelativeDurationMinutes(request.sla.minutes_until_due);
@@ -139,35 +149,67 @@ function RequestRow({ request }: { request: StaffingRequest }) {
           <div className="mt-0.5 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
             Need {request.headcount_needed} · {request.shift} shift · {slaLabel}
             {request.assigned_source ? ` · ${SOURCE_LABELS[request.assigned_source]}` : ''}
+            {request.fulfillment.available && ` · ${request.fulfillment.filled_count}/${request.headcount_needed} canonically filled`}
           </div>
         </div>
         <span className={CHIP}>{request.freshness_status === 'expired' ? 'expired demo' : request.status}</span>
       </div>
 
-      {isActive && (
-        <div className="mt-3 flex flex-wrap items-center gap-2">
-          {request.status !== 'assigned' &&
-            sources.map((source) => (
-              <button
-                key={source}
-                type="button"
-                disabled={assign.isPending}
-                onClick={() => assign.mutate({ id: request.staffing_request_id, input: { assigned_source: source, owner_name: 'Staffing office' } })}
-                className="rounded-md border border-healthcare-border px-2.5 py-1 text-xs font-medium text-healthcare-text-secondary hover:bg-healthcare-background disabled:opacity-60 dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark dark:hover:bg-white/5"
-              >
-                {SOURCE_LABELS[source]}
-              </button>
-            ))}
-          <button
-            type="button"
-            disabled={updateStatus.isPending}
-            onClick={() => updateStatus.mutate({ id: request.staffing_request_id, status: 'filled' })}
-            className="ml-auto inline-flex items-center gap-1 rounded-md bg-healthcare-primary px-3 py-1 text-xs font-semibold text-white hover:opacity-90 disabled:opacity-60"
-          >
-            <CheckCircle2 className="size-3.5" /> Mark filled
+      {visibleFulfillments.map((fulfillment) => (
+        <div key={fulfillment.fulfillment_uuid} className="mt-3 flex flex-wrap items-center gap-2 rounded-md bg-healthcare-background px-3 py-2 text-xs dark:bg-white/5">
+          <span className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+            {fulfillment.staff_member_name}
+          </span>
+          <span className={CHIP}>{fulfillment.status}</span>
+          {canManage && fulfillment.actions.can_accept && (
+            <button type="button" disabled={isPending} onClick={() => transition.mutate({ fulfillmentUuid: fulfillment.fulfillment_uuid, status: 'accepted' })} className="rounded-md bg-healthcare-primary px-2.5 py-1 font-semibold text-white disabled:opacity-60">Accept offer</button>
+          )}
+          {canManage && fulfillment.actions.can_fill && (
+            <button type="button" disabled={isPending} onClick={() => transition.mutate({ fulfillmentUuid: fulfillment.fulfillment_uuid, status: 'filled' })} className="inline-flex items-center gap-1 rounded-md bg-healthcare-primary px-2.5 py-1 font-semibold text-white disabled:opacity-60"><CheckCircle2 className="size-3.5" /> Fill shift</button>
+          )}
+          {canManage && fulfillment.actions.can_release && (
+            <button type="button" disabled={isPending} onClick={() => transition.mutate({ fulfillmentUuid: fulfillment.fulfillment_uuid, status: 'released' })} className="rounded-md border border-healthcare-border px-2.5 py-1 font-medium text-healthcare-text-secondary disabled:opacity-60 dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark">Release</button>
+          )}
+          {canManage && fulfillment.actions.can_cancel && fulfillment.status !== 'filled' && (
+            <button type="button" disabled={isPending} onClick={() => transition.mutate({ fulfillmentUuid: fulfillment.fulfillment_uuid, status: 'canceled' })} className="rounded-md border border-healthcare-border px-2.5 py-1 font-medium text-healthcare-text-secondary disabled:opacity-60 dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark">Cancel offer</button>
+          )}
+        </div>
+      ))}
+
+      {isActive && canManage && request.fulfillment.actions.can_offer && !hasPendingOffer && (
+        <div className="mt-3 space-y-2">
+          <button type="button" onClick={() => setShowCandidates((value) => !value)} className="rounded-md border border-healthcare-border px-2.5 py-1 text-xs font-medium text-healthcare-text-secondary hover:bg-healthcare-background dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark dark:hover:bg-white/5">
+            {showCandidates ? 'Hide candidates' : 'Find qualified, available staff'}
           </button>
+          {showCandidates && (
+            <div className="flex flex-wrap items-center gap-2">
+              <select value={staffMemberId ?? ''} onChange={(event) => setStaffMemberId(event.target.value ? Number(event.target.value) : null)} aria-label="Qualified staffing candidate" className="h-9 min-w-64 rounded-md border border-healthcare-border bg-healthcare-surface px-2 text-sm text-healthcare-text-primary dark:border-healthcare-border-dark dark:bg-healthcare-surface-dark dark:text-healthcare-text-primary-dark">
+                <option value="">{candidates.isLoading ? 'Checking qualifications and availability...' : 'Select eligible staff member'}</option>
+                {candidates.data?.data.map((candidate) => (
+                  <option key={candidate.staff_member_id} value={candidate.staff_member_id} disabled={!candidate.eligible}>
+                    {candidate.display_name} · {candidate.role_label}{candidate.eligible ? '' : ` · ${candidate.eligibility_state}`}
+                  </option>
+                ))}
+              </select>
+              <select value={source} onChange={(event) => setSource(event.target.value as StaffingAssignedSource)} aria-label="Staffing fulfillment source" className="h-9 rounded-md border border-healthcare-border bg-healthcare-surface px-2 text-sm text-healthcare-text-primary dark:border-healthcare-border-dark dark:bg-healthcare-surface-dark dark:text-healthcare-text-primary-dark">
+                {(Object.keys(SOURCE_LABELS) as StaffingAssignedSource[]).map((key) => <option key={key} value={key}>{SOURCE_LABELS[key]}</option>)}
+              </select>
+              <button type="button" disabled={staffMemberId === null || isPending} onClick={() => staffMemberId !== null && offer.mutate({ id: request.staffing_request_id, input: { staff_member_id: staffMemberId, source } })} className="rounded-md bg-healthcare-primary px-3 py-2 text-xs font-semibold text-white disabled:opacity-60">Create governed offer</button>
+              {candidates.isError && <span className="text-xs text-healthcare-critical dark:text-healthcare-critical-dark">Candidate safety checks are unavailable; no offer can be created.</span>}
+              {!candidates.isLoading && candidates.data?.data.filter((candidate) => candidate.eligible).length === 0 && <span className="text-xs text-healthcare-warning dark:text-healthcare-warning-dark">No staff currently pass role, unit, qualification, availability, and conflict checks.</span>}
+            </div>
+          )}
+          {showCandidates && candidates.data && candidates.data.data.some((candidate) => !candidate.eligible) && (
+            <div className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+              Ineligible in this page: {(['unqualified', 'unavailable', 'conflicted'] as const).map((state) => {
+                const count = candidates.data.data.filter((candidate) => candidate.eligibility_state === state).length;
+                return count > 0 ? `${count} ${state}` : null;
+              }).filter(Boolean).join(' · ')}. Disabled candidates cannot be offered.
+            </div>
+          )}
         </div>
       )}
+      {actionError && <div className="mt-2 text-xs text-healthcare-critical dark:text-healthcare-critical-dark">The staffing action was rejected. Refresh the candidate check and try again.</div>}
     </div>
   );
 }
@@ -298,7 +340,7 @@ function WorkforceSection({ workforce }: { workforce: StaffingWorkforceSummary }
                   <tr><td colSpan={6} className="px-3 py-6 text-center text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">Loading workforce directory...</td></tr>
                 ) : directory.data?.data.length ? directory.data.data.map((member) => (
                   <tr key={`${member.staff_member_id}-${member.role_code}-${member.unit_id ?? 'hospital'}`} className="border-t border-healthcare-border dark:border-healthcare-border-dark">
-                    <td className="px-3 py-2"><div className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">{member.display_name}</div><div className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">{member.availability}{member.credential_status !== 'valid' ? ` · credential ${member.credential_status}` : ''}</div></td>
+                    <td className="px-3 py-2"><div className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">{member.display_name}</div><div className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">{member.availability}{!['valid', 'verified'].includes(member.credential_status) ? ` · credential ${member.credential_status}` : ''}</div></td>
                     <td className="px-3 py-2 text-healthcare-text-primary dark:text-healthcare-text-primary-dark">{member.role_label}</td>
                     <td className="px-3 py-2"><div className="text-healthcare-text-primary dark:text-healthcare-text-primary-dark">{member.unit_label}</div>{member.eligible_float_units.length > 1 && <div className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">{member.eligible_float_units.length} eligible units</div>}</td>
                     <td className="px-3 py-2 capitalize text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">{member.preferred_shift ?? 'Variable'}</td>
@@ -422,7 +464,7 @@ export default function StaffingOffice() {
               ) : (
                 <div className="space-y-3">
                   {data.queue.map((request) => (
-                    <RequestRow key={request.staffing_request_id} request={request} />
+                    <RequestRow key={request.staffing_request_id} request={request} canManage={data.permissions.manage} />
                   ))}
                 </div>
               )}

--- a/resources/js/features/staffing/api.ts
+++ b/resources/js/features/staffing/api.ts
@@ -4,6 +4,10 @@ import { sourceFreshnessSchema } from '@/features/operations/sourceFreshness';
 import type {
   AssignStaffingRequestInput,
   CreateStaffingRequestInput,
+  OfferStaffingFulfillmentInput,
+  StaffingCandidatePage,
+  StaffingFulfillment,
+  StaffingFulfillmentStatus,
   StaffingOverview,
   StaffingRequest,
   StaffingRequestStatus,
@@ -19,6 +23,31 @@ const slaSchema = z.object({
 
 const roleEnum = z.enum(['rn', 'lpn', 'tech', 'charge', 'provider', 'respiratory', 'unit_secretary']);
 const shiftEnum = z.enum(['day', 'evening', 'night']);
+const fulfillmentStatusEnum = z.enum(['offered', 'accepted', 'filled', 'released', 'canceled']);
+
+const fulfillmentSchema = z.object({
+  fulfillment_uuid: z.string().uuid(),
+  staffing_request_id: z.number(),
+  staff_member_id: z.number(),
+  staff_member_name: z.string(),
+  status: fulfillmentStatusEnum,
+  source: z.enum(['float_pool', 'overtime', 'agency', 'on_call']),
+  version: z.number(),
+  role_code: z.string().nullable(),
+  unit_id: z.number().nullable(),
+  starts_at: z.string().nullable(),
+  ends_at: z.string().nullable(),
+  timezone: z.string().nullable(),
+  validation: z.record(z.string(), z.unknown()),
+  offered_at: z.string().nullable(),
+  accepted_at: z.string().nullable(),
+  filled_at: z.string().nullable(),
+  released_at: z.string().nullable(),
+  canceled_at: z.string().nullable(),
+  actions: z.object({
+    can_accept: z.boolean(), can_fill: z.boolean(), can_release: z.boolean(), can_cancel: z.boolean(),
+  }),
+});
 
 const planSchema = z.object({
   staffing_plan_id: z.number(),
@@ -71,6 +100,17 @@ const requestSchema = z.object({
   is_synthetic: z.boolean(),
   freshness_status: z.enum(['current', 'stale', 'expired']),
   sla: slaSchema,
+  fulfillment: z.object({
+    available: z.boolean(),
+    state: z.enum(['unconfigured', 'unfilled', 'offer_pending', 'partially_fulfilled', 'filled']),
+    offered_count: z.number(),
+    accepted_count: z.number(),
+    filled_count: z.number(),
+    remaining_count: z.number(),
+    latest: fulfillmentSchema.nullable(),
+    active: z.array(fulfillmentSchema),
+    actions: z.object({ can_offer: z.boolean() }),
+  }),
 });
 
 const coverageSchema = z.object({
@@ -157,9 +197,11 @@ const workforceMemberSchema = z.object({
   eligible_float_units: z.array(z.string()),
   is_active: z.boolean(),
   is_synthetic: z.boolean(),
+  availability_source: z.string().nullable(),
 });
 
 const overviewSchema = z.object({
+  permissions: z.object({ manage: z.boolean() }),
   source: sourceFreshnessSchema,
   metrics: z.object({
     open_requests: z.number(),
@@ -218,4 +260,55 @@ export async function assignStaffingRequest(id: number, input: AssignStaffingReq
 export async function updateStaffingStatus(id: number, status: StaffingRequestStatus): Promise<StaffingRequest> {
   const res = await axios.post(`/api/staffing/requests/${id}/status`, { status });
   return envelope(requestSchema).parse(res.data).data;
+}
+
+const candidateSchema = z.object({
+  staff_member_id: z.number(),
+  display_name: z.string(),
+  role_code: z.string(),
+  role_label: z.string(),
+  unit_id: z.number().nullable(),
+  coverage_model: z.string().nullable(),
+  eligible: z.boolean(),
+  eligibility_state: z.enum(['eligible', 'unqualified', 'unavailable', 'conflicted']),
+  reason_codes: z.array(z.string()),
+  qualification_requirements: z.array(z.object({
+    qualification_code: z.string(), display_name: z.string(), verified: z.boolean(),
+  })),
+  availability: z.object({ covering_windows: z.number(), blocking_windows: z.number(), timezone: z.string() }),
+  overlapping_assignments: z.number(),
+  shift: z.object({ starts_at: z.string(), ends_at: z.string(), timezone: z.string() }),
+});
+
+export async function fetchStaffingCandidates(id: number): Promise<StaffingCandidatePage> {
+  const res = await axios.get(`/api/staffing/requests/${id}/candidates`, {
+    params: { per_page: 100 },
+  });
+  return z.object({
+    data: z.array(candidateSchema),
+    meta: z.object({ current_page: z.number(), last_page: z.number(), per_page: z.number(), total: z.number() }),
+    shift: z.object({ starts_at: z.string(), ends_at: z.string(), timezone: z.string() }),
+  }).parse(res.data);
+}
+
+export async function offerStaffingFulfillment(
+  id: number,
+  input: OfferStaffingFulfillmentInput,
+  idempotencyKey: string,
+): Promise<StaffingFulfillment> {
+  const res = await axios.post(`/api/staffing/requests/${id}/fulfillments`, input, {
+    headers: { 'Idempotency-Key': idempotencyKey },
+  });
+  return envelope(fulfillmentSchema).parse(res.data).data;
+}
+
+export async function transitionStaffingFulfillment(
+  fulfillmentUuid: string,
+  status: Exclude<StaffingFulfillmentStatus, 'offered'>,
+  idempotencyKey: string,
+): Promise<StaffingFulfillment> {
+  const res = await axios.post(`/api/staffing/fulfillments/${fulfillmentUuid}/transition`, { status }, {
+    headers: { 'Idempotency-Key': idempotencyKey },
+  });
+  return envelope(fulfillmentSchema).parse(res.data).data;
 }

--- a/resources/js/features/staffing/hooks.ts
+++ b/resources/js/features/staffing/hooks.ts
@@ -2,12 +2,15 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   assignStaffingRequest,
   createStaffingRequest,
+  fetchStaffingCandidates,
   fetchStaffingOverview,
   fetchStaffingRequests,
   fetchStaffingWorkforce,
+  offerStaffingFulfillment,
+  transitionStaffingFulfillment,
   updateStaffingStatus,
 } from './api';
-import type { AssignStaffingRequestInput, CreateStaffingRequestInput, StaffingRequestStatus, StaffingWorkforceFilters } from './types';
+import type { AssignStaffingRequestInput, CreateStaffingRequestInput, OfferStaffingFulfillmentInput, StaffingFulfillmentStatus, StaffingRequestStatus, StaffingWorkforceFilters } from './types';
 
 export function useStaffingOverview() {
   return useQuery({ queryKey: ['staffing', 'overview'], queryFn: fetchStaffingOverview });
@@ -24,6 +27,14 @@ export function useStaffingWorkforce(filters: StaffingWorkforceFilters = {}) {
   return useQuery({
     queryKey: ['staffing', 'workforce', filters],
     queryFn: () => fetchStaffingWorkforce(filters),
+  });
+}
+
+export function useStaffingCandidates(requestId: number, enabled: boolean) {
+  return useQuery({
+    queryKey: ['staffing', 'candidates', requestId],
+    queryFn: () => fetchStaffingCandidates(requestId),
+    enabled,
   });
 }
 
@@ -50,6 +61,30 @@ export function useUpdateStaffingStatus() {
 
   return useMutation({
     mutationFn: ({ id, status }: { id: number; status: StaffingRequestStatus }) => updateStaffingStatus(id, status),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['staffing'] }),
+  });
+}
+
+function commandKey(prefix: string): string {
+  return `${prefix}:${globalThis.crypto.randomUUID()}`;
+}
+
+export function useOfferStaffingFulfillment() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: number; input: OfferStaffingFulfillmentInput }) =>
+      offerStaffingFulfillment(id, input, commandKey('staffing-offer')),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['staffing'] }),
+  });
+}
+
+export function useTransitionStaffingFulfillment() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ fulfillmentUuid, status }: {
+      fulfillmentUuid: string;
+      status: Exclude<StaffingFulfillmentStatus, 'offered'>;
+    }) => transitionStaffingFulfillment(fulfillmentUuid, status, commandKey(`staffing-${status}`)),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['staffing'] }),
   });
 }

--- a/resources/js/features/staffing/types.ts
+++ b/resources/js/features/staffing/types.ts
@@ -15,6 +15,64 @@ export type StaffingRequestStatus =
   | 'escalated'
   | 'unfilled';
 export type StaffingAssignedSource = 'float_pool' | 'overtime' | 'agency' | 'on_call';
+export type StaffingFulfillmentStatus = 'offered' | 'accepted' | 'filled' | 'released' | 'canceled';
+
+export interface StaffingFulfillment {
+  fulfillment_uuid: string;
+  staffing_request_id: number;
+  staff_member_id: number;
+  staff_member_name: string;
+  status: StaffingFulfillmentStatus;
+  source: StaffingAssignedSource;
+  version: number;
+  role_code: string | null;
+  unit_id: number | null;
+  starts_at: string | null;
+  ends_at: string | null;
+  timezone: string | null;
+  validation: Record<string, unknown>;
+  offered_at: string | null;
+  accepted_at: string | null;
+  filled_at: string | null;
+  released_at: string | null;
+  canceled_at: string | null;
+  actions: {
+    can_accept: boolean;
+    can_fill: boolean;
+    can_release: boolean;
+    can_cancel: boolean;
+  };
+}
+
+export interface StaffingCandidate {
+  staff_member_id: number;
+  display_name: string;
+  role_code: string;
+  role_label: string;
+  unit_id: number | null;
+  coverage_model: string | null;
+  eligible: boolean;
+  eligibility_state: 'eligible' | 'unqualified' | 'unavailable' | 'conflicted';
+  reason_codes: string[];
+  qualification_requirements: Array<{
+    qualification_code: string;
+    display_name: string;
+    verified: boolean;
+  }>;
+  availability: {
+    covering_windows: number;
+    blocking_windows: number;
+    timezone: string;
+  };
+  overlapping_assignments: number;
+  shift: { starts_at: string; ends_at: string; timezone: string };
+}
+
+export interface StaffingCandidatePage {
+  data: StaffingCandidate[];
+  meta: { current_page: number; last_page: number; per_page: number; total: number };
+  shift: { starts_at: string; ends_at: string; timezone: string };
+}
 
 export interface StaffingSla {
   minutes_until_due: number | null;
@@ -73,6 +131,17 @@ export interface StaffingRequest {
   is_synthetic: boolean;
   freshness_status: 'current' | 'stale' | 'expired';
   sla: StaffingSla;
+  fulfillment: {
+    available: boolean;
+    state: 'unconfigured' | 'unfilled' | 'offer_pending' | 'partially_fulfilled' | 'filled';
+    offered_count: number;
+    accepted_count: number;
+    filled_count: number;
+    remaining_count: number;
+    latest: StaffingFulfillment | null;
+    active: StaffingFulfillment[];
+    actions: { can_offer: boolean };
+  };
 }
 
 export interface StaffingCoverage {
@@ -173,6 +242,7 @@ export interface StaffingWorkforceMember {
   coverage_model: string | null;
   preferred_shift: StaffingShift | null;
   availability: string;
+  availability_source: string | null;
   credential_status: string;
   credentials: string[];
   eligible_float_units: string[];
@@ -200,6 +270,7 @@ export interface StaffingWorkforceFilters {
 }
 
 export interface StaffingOverview {
+  permissions: { manage: boolean };
   source: SourceFreshness;
   metrics: {
     open_requests: number;
@@ -233,6 +304,10 @@ export interface CreateStaffingRequestInput {
 
 export interface AssignStaffingRequestInput {
   assigned_source: StaffingAssignedSource;
-  assigned_staff_ref?: string;
   owner_name?: string;
+}
+
+export interface OfferStaffingFulfillmentInput {
+  staff_member_id: number;
+  source: StaffingAssignedSource;
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -61,6 +61,7 @@ use App\Http\Controllers\Api\Rtdc\PredictionController;
 use App\Http\Controllers\Api\Rtdc\ReconciliationController;
 use App\Http\Controllers\Api\ServiceController;
 use App\Http\Controllers\Api\Staffing\StaffingController;
+use App\Http\Controllers\Api\Staffing\StaffingFulfillmentController;
 use App\Http\Controllers\Api\Transport\RegionalTransferController;
 use App\Http\Controllers\Api\Transport\TransportRequestController;
 use App\Http\Controllers\CommandCenterController;
@@ -254,11 +255,18 @@ Route::middleware(['web', 'auth', 'throttle:60,1'])->prefix('staffing')->group(f
     Route::get('/plans', [StaffingController::class, 'plans']);
     Route::get('/workforce', [StaffingController::class, 'workforce']);
     Route::get('/requests', [StaffingController::class, 'index']);
-    Route::post('/requests', [StaffingController::class, 'store']);
+    Route::post('/requests', [StaffingController::class, 'store'])->middleware('can:manageStaffingOperations');
+    Route::get('/requests/{staffingRequestId}/candidates', [StaffingFulfillmentController::class, 'candidates']);
+    Route::get('/requests/{staffingRequestId}/fulfillments', [StaffingFulfillmentController::class, 'index']);
+    Route::post('/requests/{staffingRequestId}/fulfillments', [StaffingFulfillmentController::class, 'store'])
+        ->middleware('can:manageStaffingOperations');
+    Route::post('/fulfillments/{fulfillmentUuid}/transition', [StaffingFulfillmentController::class, 'transition'])
+        ->middleware('can:manageStaffingOperations')
+        ->whereUuid('fulfillmentUuid');
     Route::get('/requests/{staffingRequestId}', [StaffingController::class, 'show']);
-    Route::post('/requests/{staffingRequestId}/assign', [StaffingController::class, 'assign']);
-    Route::post('/requests/{staffingRequestId}/status', [StaffingController::class, 'status']);
-    Route::post('/requests/{staffingRequestId}/cancel', [StaffingController::class, 'cancel']);
+    Route::post('/requests/{staffingRequestId}/assign', [StaffingController::class, 'assign'])->middleware('can:manageStaffingOperations');
+    Route::post('/requests/{staffingRequestId}/status', [StaffingController::class, 'status'])->middleware('can:manageStaffingOperations');
+    Route::post('/requests/{staffingRequestId}/cancel', [StaffingController::class, 'cancel'])->middleware('can:manageStaffingOperations');
     Route::get('/resources', [StaffingController::class, 'resources']);
 });
 
@@ -607,6 +615,7 @@ Route::middleware(['auth:sanctum', CheckForAnyAbility::class.':mobile:read', 'th
 
     // Staffing coordinator (P10) — gaps + open requests; the fill action is a mobile:act write.
     Route::get('/staffing/overview', [MobileStaffingController::class, 'overview']);
+    Route::get('/staffing/requests/{id}/candidates', [MobileStaffingController::class, 'candidates']);
     Route::post('/staffing/requests/{id}/fill', [MobileStaffingController::class, 'fill'])
         ->middleware(CheckForAnyAbility::class.':mobile:act');
 

--- a/tests/Feature/Mobile/MobileBackendSafetyTest.php
+++ b/tests/Feature/Mobile/MobileBackendSafetyTest.php
@@ -9,11 +9,14 @@ use App\Models\Ops\Approval;
 use App\Models\Ops\OperationalAction;
 use App\Models\Ops\OperationalEvent;
 use App\Models\Ops\Recommendation;
+use App\Models\Org\StaffAssignment;
+use App\Models\Org\StaffMember;
 use App\Models\Staffing\StaffingRequest;
 use App\Models\Transport\TransportRequest;
 use App\Models\User;
 use App\Services\Mobile\MobilePatientContextService;
 use App\Services\Mobile\OperationalActivityLedger;
+use App\Services\Staffing\StaffingShiftWindowService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -146,12 +149,16 @@ class MobileBackendSafetyTest extends TestCase
         ]);
         $staffingPath = "/api/mobile/v1/staffing/requests/{$staffing->staffing_request_id}/fill?persona=staffing_coordinator";
         $staffingHeaders = ['Idempotency-Key' => 'mobile-replay-staffing-fill-1'];
-        $staffingBody = ['assigned_source' => 'float_pool', 'owner_name' => 'Float pool lead'];
+        $staffMemberId = $this->eligibleStaffingCandidate($staffing);
+        $staffingBody = ['staff_member_id' => $staffMemberId, 'assigned_source' => 'float_pool', 'owner_name' => 'Float pool lead'];
 
         $this->withHeaders($staffingHeaders)->postJson($staffingPath, $staffingBody)->assertOk();
         $this->withHeaders($staffingHeaders)->postJson($staffingPath, $staffingBody)->assertOk();
 
-        $this->assertSame(2, DB::table('prod.staffing_events')
+        $this->assertSame(1, DB::table('prod.staffing_events')
+            ->where('staffing_request_id', $staffing->staffing_request_id)
+            ->count());
+        $this->assertSame(3, DB::table('prod.staffing_fulfillment_events')
             ->where('staffing_request_id', $staffing->staffing_request_id)
             ->count());
         $this->assertSame(1, OperationalEvent::query()->where('event_type', 'staffing.request_filled')->count());
@@ -329,11 +336,14 @@ class MobileBackendSafetyTest extends TestCase
             'headcount_needed' => 1,
             'is_deleted' => false,
         ]);
+        $staffMemberId = $this->eligibleStaffingCandidate($staffing);
 
-        $this->postJson("/api/mobile/v1/staffing/requests/{$staffing->staffing_request_id}/fill?persona=staffing_coordinator", [
-            'assigned_source' => 'float_pool',
-            'owner_name' => 'Float pool lead',
-        ])->assertOk();
+        $this->withHeader('Idempotency-Key', 'mobile-staffing-fill-event-1')
+            ->postJson("/api/mobile/v1/staffing/requests/{$staffing->staffing_request_id}/fill?persona=staffing_coordinator", [
+                'staff_member_id' => $staffMemberId,
+                'assigned_source' => 'float_pool',
+                'owner_name' => 'Float pool lead',
+            ])->assertOk();
 
         $this->assertOneOperationalEvent('staffing.request_filled', $user, 'staffing_coordinator', 'staffing_request');
     }
@@ -701,6 +711,82 @@ class MobileBackendSafetyTest extends TestCase
         Sanctum::actingAs($user, $abilities);
 
         return $user;
+    }
+
+    private function eligibleStaffingCandidate(StaffingRequest $request): int
+    {
+        $this->artisan('deployment:seed-registry');
+        $this->artisan('deployment:seed-staff-roles');
+        $member = StaffMember::create([
+            'staff_key' => 'MOBILE:'.Str::uuid(),
+            'source_system' => 'MOBILE_TEST',
+            'external_id' => (string) Str::uuid(),
+            'display_name' => 'Mobile Float Nurse',
+            'employment_status' => 'active',
+            'is_active' => true,
+            'metadata' => [],
+        ]);
+        StaffAssignment::create([
+            'staff_member_id' => $member->staff_member_id,
+            'facility_key' => 'SUMMIT_REGIONAL',
+            'service_line_code' => 'hospital_medicine',
+            'role_code' => 'staff_nurse',
+            'unit_id' => $request->unit_id,
+            'primary_flag' => false,
+            'coverage_model' => 'float',
+            'fte' => 1,
+            'review_status' => 'source_verified',
+            'effective_start' => now()->subYear()->toDateString(),
+            'is_active' => true,
+        ]);
+        DB::table('hosp_ref.staff_qualifications')->updateOrInsert(
+            ['qualification_code' => 'role.staff_nurse'],
+            [
+                'display_name' => 'Staff Nurse role qualification',
+                'qualification_type' => 'role',
+                'metadata' => '{}',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        );
+        DB::table('hosp_ref.staff_role_qualification_requirements')->updateOrInsert(
+            [
+                'facility_key' => null,
+                'unit_id' => null,
+                'service_line_code' => null,
+                'role_code' => 'staff_nurse',
+                'qualification_code' => 'role.staff_nurse',
+                'effective_start' => null,
+            ],
+            ['is_required' => true, 'metadata' => '{}', 'created_at' => now(), 'updated_at' => now()],
+        );
+        DB::table('hosp_org.staff_member_qualifications')->insert([
+            'qualification_uuid' => (string) Str::uuid(),
+            'staff_member_id' => $member->staff_member_id,
+            'qualification_code' => 'role.staff_nurse',
+            'status' => 'verified',
+            'source' => 'mobile-test',
+            'verified_at' => now(),
+            'effective_start' => now()->subYear(),
+            'metadata' => '{}',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $window = app(StaffingShiftWindowService::class)->forRequest($request);
+        DB::table('prod.staff_availability_windows')->insert([
+            'availability_uuid' => (string) Str::uuid(),
+            'staff_member_id' => $member->staff_member_id,
+            'window_type' => 'available',
+            'starts_at' => $window['starts_at'],
+            'ends_at' => $window['ends_at'],
+            'timezone' => $window['timezone'],
+            'source' => 'mobile-test',
+            'metadata' => '{}',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return (int) $member->staff_member_id;
     }
 
     private function transportRequest(array $attributes = []): TransportRequest

--- a/tests/Feature/MobileBffTest.php
+++ b/tests/Feature/MobileBffTest.php
@@ -43,7 +43,7 @@ class MobileBffTest extends TestCase
         ['POST', '/api/mobile/v1/transport/requests/1/handoff', ['handoff_to' => '3 West']],
         ['POST', '/api/mobile/v1/evs/requests/1/status', ['status' => 'assigned']],
         ['POST', '/api/mobile/v1/ops/approvals/00000000-0000-0000-0000-000000000000/decision', ['decision' => 'approved']],
-        ['POST', '/api/mobile/v1/staffing/requests/1/fill', ['assigned_source' => 'float_pool']],
+        ['POST', '/api/mobile/v1/staffing/requests/1/fill', ['staff_member_id' => 1, 'assigned_source' => 'float_pool']],
         ['POST', '/api/mobile/v1/eddy/approvals/00000000-0000-0000-0000-000000000000/decision', ['decision' => 'approved']],
     ];
 
@@ -323,6 +323,18 @@ class MobileBffTest extends TestCase
             'origin' => 'hummingbird',
             'pinned_context' => [],
         ]);
+        $staffingRequest = StaffingRequest::create([
+            'request_uuid' => (string) Str::uuid(),
+            'unit_label' => '3 West',
+            'role' => 'rn',
+            'shift_date' => now()->toDateString(),
+            'shift' => 'day',
+            'request_type' => 'fill_gap',
+            'priority' => 'urgent',
+            'status' => 'requested',
+            'headcount_needed' => 1,
+            'is_deleted' => false,
+        ]);
 
         return [
             '/activity' => '/api/mobile/v1/activity?persona=bed_manager',
@@ -354,6 +366,7 @@ class MobileBffTest extends TestCase
             '/rtdc/census' => '/api/mobile/v1/rtdc/census',
             '/rtdc/house' => '/api/mobile/v1/rtdc/house',
             '/staffing/overview' => '/api/mobile/v1/staffing/overview',
+            '/staffing/requests/{id}/candidates' => "/api/mobile/v1/staffing/requests/{$staffingRequest->staffing_request_id}/candidates?persona=staffing_coordinator",
             '/transport/queue' => '/api/mobile/v1/transport/queue',
         ];
     }

--- a/tests/Feature/MobileRoleCatalogParityTest.php
+++ b/tests/Feature/MobileRoleCatalogParityTest.php
@@ -578,17 +578,20 @@ class MobileRoleCatalogParityTest extends TestCase
         $staffingViewModel = file_get_contents(base_path(self::ANDROID_STAFFING_VIEW_MODEL));
         $staffingController = file_get_contents(base_path(self::MOBILE_STAFFING_CONTROLLER));
 
-        foreach (['StaffingOverview', 'StaffingMetrics', 'UnitAtRisk', 'StaffingReq'] as $dto) {
+        foreach (['StaffingOverview', 'StaffingMetrics', 'UnitAtRisk', 'StaffingReq', 'StaffingCandidate'] as $dto) {
             $this->assertStringContainsString("data class {$dto}", $models);
         }
 
-        foreach (['staffingOverview', 'fillStaffingRequest', 'parseStaffingOverview', 'parseStaffingMetrics', 'parseUnitAtRisk', 'parseStaffingReq'] as $method) {
+        foreach (['staffingOverview', 'staffingCandidates', 'fillStaffingRequest', 'parseStaffingOverview', 'parseStaffingMetrics', 'parseUnitAtRisk', 'parseStaffingReq', 'parseStaffingCandidate'] as $method) {
             $this->assertStringContainsString("fun {$method}", $apiClient);
         }
 
         $this->assertStringContainsString('class StaffingViewModel(app: Application) : AndroidViewModel(app)', $staffingViewModel);
         $this->assertStringContainsString('overview = api.staffingOverview(bearer)', $staffingViewModel);
-        $this->assertStringContainsString('api.fillStaffingRequest(bearer, request.staffingRequestId, "Float Pool")', $staffingViewModel);
+        $this->assertStringContainsString('val candidates = api.staffingCandidates(bearer, request.staffingRequestId)', $staffingViewModel);
+        $this->assertStringContainsString('selectedCandidateByRequest[request.staffingRequestId]', $staffingViewModel);
+        $this->assertStringContainsString('api.fillStaffingRequest(', $staffingViewModel);
+        $this->assertStringContainsString('staffMemberId,', $staffingViewModel);
         $this->assertStringContainsString('workingRequestIds = workingRequestIds + request.staffingRequestId', $staffingViewModel);
 
         $this->assertStringContainsString('import net.acumenus.hummingbird.ui.staffing.StaffingScreen', $mainScreen);
@@ -601,12 +604,13 @@ class MobileRoleCatalogParityTest extends TestCase
             $this->assertStringContainsString($symbol, $staffingScreen);
         }
 
-        foreach (['Staffing', 'BELOW MINIMUM-SAFE', 'OPEN REQUESTS', 'below safe', 'Fill from float pool', 'Open in Zephyrus'] as $copy) {
+        foreach (['Staffing', 'BELOW MINIMUM-SAFE', 'OPEN REQUESTS', 'below safe', 'Choose qualified staff', 'Fill with selected staff', 'Open in Zephyrus'] as $copy) {
             $this->assertStringContainsString($copy, $staffingScreen);
         }
 
         $this->assertStringContainsString('onOpenRequest(request, overview.webLink)', $staffingScreen);
-        $this->assertStringContainsString('vm.fillFromFloatPool(bearer, request)', $staffingScreen);
+        $this->assertStringContainsString('vm.loadCandidates(bearer, request)', $staffingScreen);
+        $this->assertStringContainsString('vm.fillSelected(bearer, request, onBack)', $staffingScreen);
         $this->assertStringContainsString('GET /api/mobile/v1/staffing/overview', $staffingController);
         $this->assertStringContainsString("links: ['web' => url('/staffing')]", $staffingController);
         $this->assertStringContainsString("\$this->ledger->record('staffing.request_filled'", $staffingController);
@@ -682,7 +686,8 @@ class MobileRoleCatalogParityTest extends TestCase
         $this->assertStringContainsString('fun resolveBarrier(bearer: String, id: Int)', $apiClient);
         $this->assertStringContainsString('fun opsDecision(bearer: String, approvalUuid: String, decision: String)', $apiClient);
         $this->assertStringContainsString('/api/mobile/v1/ops/approvals/${urlPart(approvalUuid)}/decision', $apiClient);
-        $this->assertStringContainsString('fun fillStaffingRequest(bearer: String, id: Int, assignedSource: String)', $apiClient);
+        $this->assertStringContainsString('suspend fun staffingCandidates(bearer: String, id: Int)', $apiClient);
+        $this->assertStringContainsString('staffMemberId: Int,', $apiClient);
         $this->assertStringContainsString('/api/mobile/v1/staffing/requests/$id/fill', $apiClient);
 
         $this->assertStringContainsString('fun load(bearer: String, role: MobileRole)', $viewModel);
@@ -696,9 +701,8 @@ class MobileRoleCatalogParityTest extends TestCase
         $this->assertStringContainsString('fun claimEvsTurn(bearer: String, item: ForYouItem, role: MobileRole)', $viewModel);
         $this->assertStringContainsString('fun approveOpsAction(bearer: String, item: ForYouItem, role: MobileRole)', $viewModel);
         $this->assertStringContainsString('fun rejectOpsAction(bearer: String, item: ForYouItem, role: MobileRole)', $viewModel);
-        $this->assertStringContainsString('fun fillStaffingRequest(bearer: String, item: ForYouItem, role: MobileRole)', $viewModel);
         $this->assertStringContainsString('api.opsDecision(bearer, approvalUuid, decision)', $viewModel);
-        $this->assertStringContainsString('api.fillStaffingRequest(bearer, id, role.title)', $viewModel);
+        $this->assertStringNotContainsString('api.fillStaffingRequest', $viewModel);
 
         $this->assertStringContainsString('selectedRole: MobileRole = MobileRoleCatalog.default', $screen);
         $this->assertStringContainsString('selectedUnitName: String? = null', $screen);
@@ -713,7 +717,8 @@ class MobileRoleCatalogParityTest extends TestCase
         $this->assertStringContainsString('vm.claimEvsTurn(bearer, item, role)', $screen);
         $this->assertStringContainsString('ForYouAction("Approve", CapacityStatus.SUCCESS) { vm.approveOpsAction(bearer, item, role) }', $screen);
         $this->assertStringContainsString('ForYouAction("Reject", CapacityStatus.WARNING) { vm.rejectOpsAction(bearer, item, role) }', $screen);
-        $this->assertStringContainsString('ForYouAction("Fill") { vm.fillStaffingRequest(bearer, item, role) }', $screen);
+        $this->assertStringContainsString('id.startsWith("staffing-")', $screen);
+        $this->assertStringNotContainsString('ForYouAction("Fill")', $screen);
         $this->assertStringContainsString('actions.forEach { action ->', $screen);
         $this->assertStringContainsString('title = "Can\'t load your queue"', $screen);
         $this->assertStringContainsString('title = "Loading your queue"', $screen);

--- a/tests/Feature/Staffing/CanonicalStaffingFulfillmentTest.php
+++ b/tests/Feature/Staffing/CanonicalStaffingFulfillmentTest.php
@@ -1,0 +1,515 @@
+<?php
+
+namespace Tests\Feature\Staffing;
+
+use App\Models\Org\StaffAssignment;
+use App\Models\Org\StaffMember;
+use App\Models\Staffing\StaffingRequest;
+use App\Models\Staffing\StaffShiftAssignment;
+use App\Models\User;
+use App\Services\Staffing\StaffingShiftWindowService;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class CanonicalStaffingFulfillmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2026-10-31 12:00:00 America/New_York');
+        $this->artisan('deployment:seed-registry');
+        $this->artisan('deployment:seed-staff-roles');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_candidate_pagination_exposes_qualification_availability_and_conflict_states(): void
+    {
+        [$request, $unitId] = $this->staffingRequest();
+        $eligible = $this->staffMember('A Eligible', $unitId);
+        $unqualified = $this->staffMember('B Unqualified', $unitId);
+        $unavailable = $this->staffMember('C Leave', $unitId);
+        $conflicted = $this->staffMember('D Conflict', $unitId);
+        $outsideFacility = $this->staffMember('E Other Facility', $unitId, [], 'OTHER_HOSPITAL');
+
+        $this->requireRoleQualification();
+        $this->qualify($eligible);
+        $this->qualify($unavailable);
+        $this->qualify($conflicted);
+        $this->qualify($outsideFacility);
+        $this->availability($eligible, $request, 'available');
+        $this->availability($unqualified, $request, 'available');
+        $this->availability($unavailable, $request, 'leave');
+        $this->availability($conflicted, $request, 'available');
+        $this->availability($outsideFacility, $request, 'available');
+        $window = app(StaffingShiftWindowService::class)->forRequest($request);
+        StaffShiftAssignment::create([
+            'shift_assignment_uuid' => (string) Str::uuid(),
+            'staff_member_id' => $conflicted->staff_member_id,
+            'unit_id' => $unitId,
+            'facility_key' => 'SUMMIT_REGIONAL',
+            'service_line_code' => 'hospital_medicine',
+            'role_code' => 'staff_nurse',
+            'starts_at' => $window['starts_at'],
+            'ends_at' => $window['ends_at'],
+            'timezone' => $window['timezone'],
+            'status' => 'accepted',
+        ]);
+
+        $user = User::factory()->create(['role' => 'user']);
+        $first = $this->actingAs($user)
+            ->getJson("/api/staffing/requests/{$request->staffing_request_id}/candidates?per_page=2")
+            ->assertOk()
+            ->assertJsonPath('meta.total', 4)
+            ->assertJsonPath('meta.last_page', 2)
+            ->assertJsonPath('data.0.display_name', 'A Eligible')
+            ->assertJsonPath('data.0.eligibility_state', 'eligible')
+            ->json();
+        $second = $this->actingAs($user)
+            ->getJson("/api/staffing/requests/{$request->staffing_request_id}/candidates?per_page=2&page=2")
+            ->assertOk()
+            ->json();
+        $this->assertSame([], array_intersect(
+            array_column($first['data'], 'staff_member_id'),
+            array_column($second['data'], 'staff_member_id'),
+        ));
+
+        $all = collect($this->actingAs($user)
+            ->getJson("/api/staffing/requests/{$request->staffing_request_id}/candidates?per_page=100")
+            ->assertOk()
+            ->json('data'))
+            ->keyBy('display_name');
+        $this->assertSame('unqualified', $all['B Unqualified']['eligibility_state']);
+        $this->assertContains('missing_required_qualification', $all['B Unqualified']['reason_codes']);
+        $this->assertSame('unavailable', $all['C Leave']['eligibility_state']);
+        $this->assertContains('unavailable_or_on_leave', $all['C Leave']['reason_codes']);
+        $this->assertSame('conflicted', $all['D Conflict']['eligibility_state']);
+        $this->assertContains('overlapping_shift_assignment', $all['D Conflict']['reason_codes']);
+    }
+
+    public function test_fulfillment_lifecycle_is_authorized_idempotent_and_append_only(): void
+    {
+        [$request, $unitId] = $this->staffingRequest();
+        $member = $this->staffMember('Eligible Nurse', $unitId);
+        $this->requireRoleQualification();
+        $this->qualify($member);
+        $this->availability($member, $request, 'available');
+        $path = "/api/staffing/requests/{$request->staffing_request_id}/fulfillments";
+        $payload = ['staff_member_id' => $member->staff_member_id, 'source' => 'float_pool'];
+
+        $this->actingAs(User::factory()->create(['role' => 'user']))
+            ->withHeader('Idempotency-Key', 'staffing-offer-forbidden')
+            ->postJson($path, $payload)
+            ->assertForbidden();
+        $this->flushHeaders();
+        $this->assertTrue(Gate::forUser(User::factory()->create(['role' => 'admin']))
+            ->allows('manageStaffingOperations'));
+
+        $coordinator = User::factory()->create(['role' => 'staffing_coordinator']);
+        $this->actingAs($coordinator)->postJson($path, $payload)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('idempotency_key');
+
+        $headers = ['Idempotency-Key' => 'staffing-offer-eligible-1'];
+        $offered = $this->actingAs($coordinator)->withHeaders($headers)->postJson($path, $payload)
+            ->assertCreated()
+            ->assertJsonPath('data.status', 'offered')
+            ->json('data');
+        $this->actingAs($coordinator)->withHeaders($headers)->postJson($path, $payload)
+            ->assertCreated()
+            ->assertJsonPath('data.fulfillment_uuid', $offered['fulfillment_uuid']);
+        $this->assertNull($request->fresh()->assigned_staff_ref);
+        $this->assertNull($request->fresh()->assigned_at);
+        $this->assertSame(1, DB::table('prod.staffing_request_fulfillments')->count());
+        $this->assertSame(1, DB::table('prod.staffing_fulfillment_commands')->count());
+        $this->assertSame(1, DB::table('prod.staffing_fulfillment_events')->count());
+
+        $this->actingAs($coordinator)->withHeaders($headers)->postJson($path, [
+            ...$payload,
+            'source' => 'agency',
+        ])->assertConflict();
+
+        $transitionPath = "/api/staffing/fulfillments/{$offered['fulfillment_uuid']}/transition";
+        $this->actingAs($coordinator)
+            ->withHeader('Idempotency-Key', 'staffing-illegal-fill-1')
+            ->postJson($transitionPath, ['status' => 'filled'])
+            ->assertUnprocessable();
+
+        $accepted = $this->actingAs($coordinator)
+            ->withHeader('Idempotency-Key', 'staffing-accept-1')
+            ->postJson($transitionPath, ['status' => 'accepted'])
+            ->assertOk()
+            ->assertJsonPath('data.status', 'accepted')
+            ->json('data');
+        $this->actingAs($coordinator)
+            ->withHeader('Idempotency-Key', 'staffing-accept-1')
+            ->postJson($transitionPath, ['status' => 'accepted'])
+            ->assertOk()
+            ->assertJsonPath('data.version', $accepted['version']);
+
+        $this->actingAs($coordinator)
+            ->withHeader('Idempotency-Key', 'staffing-fill-1')
+            ->postJson($transitionPath, ['status' => 'filled'])
+            ->assertOk()
+            ->assertJsonPath('data.status', 'filled');
+        $this->assertSame('filled', $request->fresh()->status);
+        $this->assertSame("staff:{$member->staff_member_id}", $request->fresh()->assigned_staff_ref);
+        $this->assertSame(3, DB::table('prod.staffing_fulfillment_events')->count());
+        $this->assertSame(3, DB::table('prod.staffing_fulfillment_commands')->count());
+        $this->assertSame(1, DB::table('prod.staff_shift_assignments')->where('status', 'filled')->count());
+
+        $this->actingAs($coordinator)
+            ->postJson("/api/staffing/requests/{$request->staffing_request_id}/cancel", ['reason' => 'unsafe bypass'])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('status');
+
+        $this->actingAs($coordinator)
+            ->withHeader('Idempotency-Key', 'staffing-release-1')
+            ->postJson($transitionPath, ['status' => 'released'])
+            ->assertOk()
+            ->assertJsonPath('data.status', 'released');
+        $this->assertSame('open', $request->fresh()->status);
+        $this->assertNull($request->fresh()->filled_at);
+        $this->assertNull($request->fresh()->assigned_at);
+        $this->assertNull($request->fresh()->assigned_staff_ref);
+        $this->assertNull($request->fresh()->assigned_source);
+
+        $eventId = DB::table('prod.staffing_fulfillment_events')->value('staffing_fulfillment_event_id');
+        try {
+            DB::table('prod.staffing_fulfillment_events')->where('staffing_fulfillment_event_id', $eventId)->update(['event_type' => 'tampered']);
+            $this->fail('Expected the fulfillment activity ledger to reject mutation.');
+        } catch (QueryException $exception) {
+            $this->assertStringContainsString('append-only', $exception->getMessage());
+        }
+    }
+
+    public function test_acceptance_revalidates_leave_and_preserves_the_offer(): void
+    {
+        [$request, $unitId] = $this->staffingRequest();
+        $member = $this->staffMember('Callout Nurse', $unitId);
+        $this->requireRoleQualification();
+        $this->qualify($member);
+        $this->availability($member, $request, 'available');
+        $coordinator = User::factory()->create(['role' => 'staffing_coordinator']);
+        $offered = $this->actingAs($coordinator)
+            ->withHeader('Idempotency-Key', 'staffing-callout-offer')
+            ->postJson("/api/staffing/requests/{$request->staffing_request_id}/fulfillments", [
+                'staff_member_id' => $member->staff_member_id,
+                'source' => 'on_call',
+            ])->assertCreated()->json('data');
+        $this->availability($member, $request, 'leave', priority: 1);
+
+        $this->actingAs($coordinator)
+            ->withHeader('Idempotency-Key', 'staffing-callout-accept')
+            ->postJson("/api/staffing/fulfillments/{$offered['fulfillment_uuid']}/transition", [
+                'status' => 'accepted',
+            ])->assertUnprocessable()
+            ->assertJsonValidationErrors('staff_member_id');
+        $this->assertDatabaseHas('prod.staffing_request_fulfillments', [
+            'fulfillment_uuid' => $offered['fulfillment_uuid'],
+            'status' => 'offered',
+        ]);
+        $this->assertSame(1, DB::table('prod.staffing_fulfillment_events')->count());
+    }
+
+    public function test_locked_headcount_capacity_prevents_over_acceptance_after_competing_offers(): void
+    {
+        [$request, $unitId] = $this->staffingRequest();
+        $request->update(['headcount_needed' => 2]);
+        $this->requireRoleQualification();
+        $members = collect(['First Nurse', 'Second Nurse', 'Third Nurse'])->map(function (string $name) use ($request, $unitId): StaffMember {
+            $member = $this->staffMember($name, $unitId);
+            $this->qualify($member);
+            $this->availability($member, $request, 'available');
+
+            return $member;
+        });
+        $coordinator = User::factory()->create(['role' => 'staffing_coordinator']);
+        $offers = $members->values()->map(function (StaffMember $member, int $index) use ($coordinator, $request): array {
+            return $this->actingAs($coordinator)
+                ->withHeader('Idempotency-Key', "capacity-offer-{$index}")
+                ->postJson("/api/staffing/requests/{$request->staffing_request_id}/fulfillments", [
+                    'staff_member_id' => $member->staff_member_id,
+                    'source' => 'float_pool',
+                ])->assertCreated()->json('data');
+        });
+
+        $fulfillments = $offers->take(2)->values()->map(function (array $offered, int $index) use ($coordinator): array {
+            return $this->actingAs($coordinator)
+                ->withHeader('Idempotency-Key', "capacity-accept-{$index}")
+                ->postJson("/api/staffing/fulfillments/{$offered['fulfillment_uuid']}/transition", [
+                    'status' => 'accepted',
+                ])->assertOk()->json('data');
+        });
+        $third = $offers->last();
+        $this->actingAs($coordinator)
+            ->withHeader('Idempotency-Key', 'capacity-accept-third')
+            ->postJson("/api/staffing/fulfillments/{$third['fulfillment_uuid']}/transition", [
+                'status' => 'accepted',
+            ])->assertUnprocessable()
+            ->assertJsonValidationErrors('request');
+        $this->assertDatabaseHas('prod.staffing_request_fulfillments', [
+            'fulfillment_uuid' => $third['fulfillment_uuid'],
+            'status' => 'offered',
+        ]);
+
+        foreach ($fulfillments as $index => $fulfillment) {
+            $this->actingAs($coordinator)
+                ->withHeader('Idempotency-Key', "capacity-fill-{$index}")
+                ->postJson("/api/staffing/fulfillments/{$fulfillment['fulfillment_uuid']}/transition", [
+                    'status' => 'filled',
+                ])->assertOk();
+        }
+        $this->assertSame('filled', $request->fresh()->status);
+        $this->assertSame(2, DB::table('prod.staffing_request_fulfillments')->where('status', 'filled')->count());
+    }
+
+    public function test_shift_windows_are_dst_safe_and_materialization_is_idempotent(): void
+    {
+        $this->artisan('schedule:list')
+            ->expectsOutputToContain('staffing:materialize-canonical')
+            ->assertSuccessful();
+        $windows = app(StaffingShiftWindowService::class);
+        $spring = $windows->forDateAndShift('2026-03-07', 'night', 'America/New_York');
+        $fall = $windows->forDateAndShift('2026-10-31', 'night', 'America/New_York');
+        $this->assertEquals(7 * 3600, $spring['starts_at']->diffInSeconds($spring['ends_at']));
+        $this->assertEquals(9 * 3600, $fall['starts_at']->diffInSeconds($fall['ends_at']));
+
+        [, $unitId] = $this->staffingRequest();
+        $materialized = $this->staffMember('Materialized Nurse', $unitId, [
+            'availability' => 'available',
+            'preferred_shift' => 'day',
+            'data_origin' => 'synthetic',
+        ]);
+        $outsideFacility = $this->staffMember('Other Facility Nurse', $unitId, [
+            'availability' => 'available',
+            'preferred_shift' => 'day',
+            'data_origin' => 'synthetic',
+        ], 'OTHER_HOSPITAL');
+        $arguments = ['--from' => '2026-10-31', '--days' => 2];
+        $this->artisan('staffing:materialize-canonical', [...$arguments, '--dry-run' => true])
+            ->expectsOutputToContain('dry run')
+            ->assertSuccessful();
+        $this->assertSame(0, DB::table('hosp_org.staff_member_qualifications')->count());
+        $this->assertSame(0, DB::table('prod.staff_availability_windows')->count());
+        $this->artisan('staffing:materialize-canonical', $arguments)->assertSuccessful();
+        $counts = [
+            DB::table('hosp_org.staff_member_qualifications')->count(),
+            DB::table('prod.staff_availability_windows')->count(),
+        ];
+        $this->artisan('staffing:materialize-canonical', $arguments)->assertSuccessful();
+        $this->assertSame($counts, [
+            DB::table('hosp_org.staff_member_qualifications')->count(),
+            DB::table('prod.staff_availability_windows')->count(),
+        ]);
+        $this->assertGreaterThan(0, $counts[0]);
+        $this->assertSame(2, $counts[1]);
+        $this->assertSame(0, DB::table('prod.staff_availability_windows')
+            ->where('staff_member_id', $outsideFacility->staff_member_id)
+            ->count());
+
+        $this->artisan('staffing:materialize-canonical', ['--from' => '2026-10-31', '--days' => 1])
+            ->assertSuccessful();
+        $this->assertSame(1, DB::table('prod.staff_availability_windows')
+            ->where('staff_member_id', $materialized->staff_member_id)
+            ->count());
+
+        DB::table('hosp_org.staff_assignments')
+            ->where('staff_member_id', $materialized->staff_member_id)
+            ->update(['is_active' => false, 'updated_at' => now()]);
+        $this->artisan('staffing:materialize-canonical', $arguments)->assertSuccessful();
+        $this->assertDatabaseHas('hosp_org.staff_member_qualifications', [
+            'staff_member_id' => $materialized->staff_member_id,
+            'status' => 'expired',
+        ]);
+        $this->assertSame(0, DB::table('prod.staff_availability_windows')
+            ->where('staff_member_id', $materialized->staff_member_id)
+            ->count());
+    }
+
+    public function test_legacy_fill_is_blocked_and_mobile_uses_the_same_canonical_idempotent_fulfillment(): void
+    {
+        [$request, $unitId] = $this->staffingRequest();
+        $member = $this->staffMember('Mobile Nurse', $unitId);
+        $this->requireRoleQualification();
+        $this->qualify($member);
+        $this->availability($member, $request, 'available');
+        $coordinator = User::factory()->create(['role' => 'staffing_coordinator']);
+
+        $this->actingAs($coordinator)->postJson("/api/staffing/requests/{$request->staffing_request_id}/assign", [
+            'assigned_source' => 'float_pool',
+        ])->assertOk()->assertJsonPath('data.status', 'sourcing');
+        $this->assertSame(0, DB::table('prod.staff_shift_assignments')->count());
+        $this->actingAs($coordinator)->postJson("/api/staffing/requests/{$request->staffing_request_id}/status", [
+            'status' => 'filled',
+        ])->assertUnprocessable();
+
+        Sanctum::actingAs($coordinator, ['mobile:read', 'mobile:act']);
+        $path = "/api/mobile/v1/staffing/requests/{$request->staffing_request_id}/fill?persona=staffing_coordinator";
+        $payload = ['staff_member_id' => $member->staff_member_id, 'assigned_source' => 'float_pool'];
+        $this->getJson("/api/mobile/v1/staffing/requests/{$request->staffing_request_id}/candidates?persona=staffing_coordinator")
+            ->assertOk()
+            ->assertJsonPath('data.data.0.staff_member_id', $member->staff_member_id)
+            ->assertJsonPath('data.data.0.eligibility_state', 'eligible')
+            ->assertJsonPath('data.meta.total', 1);
+        $this->withHeader('Idempotency-Key', str_repeat('x', 201))
+            ->postJson($path, $payload)
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors('idempotency_key');
+        $headers = ['Idempotency-Key' => 'staffing-mobile-fill-1'];
+        $first = $this->withHeaders($headers)->postJson($path, $payload)
+            ->assertOk()
+            ->assertJsonPath('data.status', 'filled')
+            ->assertJsonPath('data.canonical_fulfillment.staff_member_id', $member->staff_member_id)
+            ->json('data.canonical_fulfillment');
+        $second = $this->withHeaders($headers)->postJson($path, $payload)
+            ->assertOk()
+            ->json('data.canonical_fulfillment');
+        $this->assertEquals($first, $second);
+
+        $this->assertSame(1, DB::table('prod.staffing_request_fulfillments')->count());
+        $this->assertSame(3, DB::table('prod.staffing_fulfillment_events')->count());
+        $this->assertSame(1, DB::table('ops.operational_events')->where('event_type', 'staffing.request_filled')->count());
+    }
+
+    /** @return array{StaffingRequest,int} */
+    private function staffingRequest(): array
+    {
+        $unitId = (int) DB::table('prod.units')->insertGetId([
+            'name' => '3 West',
+            'abbreviation' => '3W',
+            'type' => 'med_surg',
+            'staffed_bed_count' => 24,
+            'ratio_floor' => 4,
+            'access_standard_minutes' => 120,
+            'is_deleted' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], 'unit_id');
+        $request = StaffingRequest::create([
+            'request_uuid' => (string) Str::uuid(),
+            'unit_id' => $unitId,
+            'unit_label' => '3 West',
+            'role' => 'rn',
+            'shift_date' => '2026-10-31',
+            'shift' => 'day',
+            'request_type' => 'fill_gap',
+            'priority' => 'urgent',
+            'status' => 'requested',
+            'headcount_needed' => 1,
+            'metadata' => ['timezone' => 'America/New_York', 'service_line_code' => 'hospital_medicine'],
+            'is_deleted' => false,
+        ]);
+
+        return [$request, $unitId];
+    }
+
+    private function staffMember(
+        string $name,
+        int $unitId,
+        array $metadata = [],
+        string $facilityKey = 'SUMMIT_REGIONAL',
+    ): StaffMember {
+        $member = StaffMember::create([
+            'staff_key' => 'TEST:'.Str::slug($name).':'.Str::uuid(),
+            'source_system' => 'TEST',
+            'external_id' => (string) Str::uuid(),
+            'display_name' => $name,
+            'employment_status' => 'active',
+            'is_active' => true,
+            'metadata' => $metadata,
+        ]);
+        StaffAssignment::create([
+            'staff_member_id' => $member->staff_member_id,
+            'facility_key' => $facilityKey,
+            'service_line_code' => 'hospital_medicine',
+            'role_code' => 'staff_nurse',
+            'unit_id' => $unitId,
+            'primary_flag' => false,
+            'coverage_model' => 'in_house',
+            'fte' => 1,
+            'review_status' => 'source_verified',
+            'effective_start' => '2026-01-01',
+            'is_active' => true,
+        ]);
+
+        return $member;
+    }
+
+    private function requireRoleQualification(): void
+    {
+        DB::table('hosp_ref.staff_qualifications')->updateOrInsert(
+            ['qualification_code' => 'role.staff_nurse'],
+            [
+                'display_name' => 'Staff Nurse role qualification',
+                'qualification_type' => 'role',
+                'is_regulated' => false,
+                'metadata' => '{}',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        );
+        DB::table('hosp_ref.staff_role_qualification_requirements')->updateOrInsert(
+            [
+                'facility_key' => null,
+                'unit_id' => null,
+                'service_line_code' => null,
+                'role_code' => 'staff_nurse',
+                'qualification_code' => 'role.staff_nurse',
+                'effective_start' => null,
+            ],
+            [
+                'is_required' => true,
+                'metadata' => '{}',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        );
+    }
+
+    private function qualify(StaffMember $member): void
+    {
+        DB::table('hosp_org.staff_member_qualifications')->insert([
+            'qualification_uuid' => (string) Str::uuid(),
+            'staff_member_id' => $member->staff_member_id,
+            'qualification_code' => 'role.staff_nurse',
+            'status' => 'verified',
+            'source' => 'test',
+            'verified_at' => now(),
+            'effective_start' => Carbon::parse('2026-01-01', 'America/New_York')->utc(),
+            'metadata' => '{}',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function availability(StaffMember $member, StaffingRequest $request, string $type, int $priority = 100): void
+    {
+        $window = app(StaffingShiftWindowService::class)->forRequest($request);
+        DB::table('prod.staff_availability_windows')->insert([
+            'availability_uuid' => (string) Str::uuid(),
+            'staff_member_id' => $member->staff_member_id,
+            'window_type' => $type,
+            'starts_at' => $window['starts_at'],
+            'ends_at' => $window['ends_at'],
+            'timezone' => $window['timezone'],
+            'source' => 'test',
+            'priority' => $priority,
+            'metadata' => '{}',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/tests/Feature/Staffing/StaffingApiTest.php
+++ b/tests/Feature/Staffing/StaffingApiTest.php
@@ -18,9 +18,9 @@ class StaffingApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_create_assign_and_fill_staffing_request(): void
+    public function test_create_and_source_selection_cannot_bypass_canonical_fulfillment(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['role' => 'staffing_coordinator']);
         $unitId = $this->seedUnit('7 West', '7W');
 
         $created = $this->actingAs($user)->postJson('/api/staffing/requests', [
@@ -49,21 +49,22 @@ class StaffingApiTest extends TestCase
 
         $this->actingAs($user)->postJson("/api/staffing/requests/{$created['staffing_request_id']}/assign", [
             'assigned_source' => 'float_pool',
-            'assigned_staff_ref' => 'float-rn-12',
             'owner_name' => 'House Supervisor',
         ])->assertOk()
-            ->assertJsonPath('data.status', 'assigned')
+            ->assertJsonPath('data.status', 'sourcing')
             ->assertJsonPath('data.assigned_source', 'float_pool');
 
         $this->actingAs($user)->postJson("/api/staffing/requests/{$created['staffing_request_id']}/status", [
             'status' => 'filled',
             'payload' => ['filled_by' => 'float-rn-12'],
             'note' => 'Float pool RN accepted the shift.',
-        ])->assertOk()
-            ->assertJsonPath('data.status', 'filled')
-            ->assertJsonPath('data.resolution_payload.filled_by', 'float-rn-12');
+        ])->assertUnprocessable();
 
         $this->assertDatabaseHas('prod.staffing_events', [
+            'staffing_request_id' => $created['staffing_request_id'],
+            'event_type' => 'staffing.sourcing',
+        ]);
+        $this->assertDatabaseMissing('prod.staffing_events', [
             'staffing_request_id' => $created['staffing_request_id'],
             'event_type' => 'staffing.filled',
         ]);
@@ -94,7 +95,7 @@ class StaffingApiTest extends TestCase
         Carbon::setTestNow('2026-07-09T16:00:00Z');
 
         try {
-            $user = User::factory()->create();
+            $user = User::factory()->create(['role' => 'staffing_coordinator']);
             $unitId = $this->seedUnit('7 West', '7W');
 
             $this->actingAs($user)->postJson('/api/staffing/requests', [
@@ -115,7 +116,7 @@ class StaffingApiTest extends TestCase
 
     public function test_plans_endpoint_returns_unit_risk_rollup(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['role' => 'staffing_coordinator']);
         $unitId = $this->seedUnit('5 South', '5S');
         $this->seedPlan($unitId, '5 South', 'rn', required: 5, scheduled: 3, actual: 3, minimumSafe: 4, status: 'critical_gap');
 
@@ -133,7 +134,7 @@ class StaffingApiTest extends TestCase
 
     public function test_create_rejects_invalid_role(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['role' => 'staffing_coordinator']);
 
         $this->actingAs($user)->postJson('/api/staffing/requests', [
             'unit_label' => '7 West',
@@ -147,7 +148,7 @@ class StaffingApiTest extends TestCase
 
     public function test_empty_staffing_maps_are_json_objects_and_missing_coverage_is_unknown(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['role' => 'staffing_coordinator']);
 
         $response = $this->actingAs($user)->postJson('/api/staffing/requests', [
             'unit_label' => '7 West',

--- a/tests/js/staffing/StaffingOffice.test.tsx
+++ b/tests/js/staffing/StaffingOffice.test.tsx
@@ -2,10 +2,11 @@ import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import StaffingOffice from '@/Pages/Staffing/StaffingOffice';
 import {
-  useAssignStaffingRequest,
+  useOfferStaffingFulfillment,
+  useStaffingCandidates,
   useStaffingOverview,
   useStaffingWorkforce,
-  useUpdateStaffingStatus,
+  useTransitionStaffingFulfillment,
 } from '@/features/staffing/hooks';
 
 vi.mock('@/Components/Dashboard/DashboardLayout', () => ({ default: ({ children }: { children: React.ReactNode }) => <div>{children}</div> }));
@@ -52,6 +53,7 @@ const workforce = {
 } as const;
 
 const overview = {
+  permissions: { manage: true },
   source: {},
   metrics: { open_requests: 0, at_risk_units: 0, critical_gaps: 0, unfilled_requests: 0, total_gap_headcount: 0, coverage_pct: 98, stat_requests: 0 },
   coverage: { required_count: 100, available_count: 98, total_gap_headcount: 2, coverage_pct: 98, below_minimum_safe: 0 },
@@ -83,6 +85,7 @@ describe('Staffing Office workforce roster', () => {
           coverage_model: 'in_house',
           preferred_shift: 'night',
           availability: 'available',
+          availability_source: 'canonical-materializer',
           credential_status: 'valid',
           credentials: ['RN', 'BLS'],
           eligible_float_units: ['Medical ICU', 'Surgical ICU'],
@@ -96,8 +99,9 @@ describe('Staffing Office workforce roster', () => {
       isFetching: false,
       refetch: vi.fn(),
     } as never);
-    vi.mocked(useAssignStaffingRequest).mockReturnValue({ isPending: false, mutate: vi.fn() } as never);
-    vi.mocked(useUpdateStaffingStatus).mockReturnValue({ isPending: false, mutate: vi.fn() } as never);
+    vi.mocked(useStaffingCandidates).mockReturnValue({ data: undefined, isLoading: false, isError: false } as never);
+    vi.mocked(useOfferStaffingFulfillment).mockReturnValue({ isPending: false, mutate: vi.fn(), error: null } as never);
+    vi.mocked(useTransitionStaffingFulfillment).mockReturnValue({ isPending: false, mutate: vi.fn(), error: null } as never);
   });
 
   it('renders roster posture, directory controls, and truthful unknown pool capacity', () => {
@@ -161,6 +165,17 @@ describe('Staffing Office workforce roster', () => {
             minutes_until_due: 61.516666666666666,
             at_risk: false,
             label: '61.516666666666666m remaining',
+          },
+          fulfillment: {
+            available: true,
+            state: 'unfilled',
+            offered_count: 0,
+            accepted_count: 0,
+            filled_count: 0,
+            remaining_count: 2,
+            latest: null,
+            active: [],
+            actions: { can_offer: true },
           },
         }],
       },

--- a/tests/js/staffing/api.test.ts
+++ b/tests/js/staffing/api.test.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fetchStaffingOverview, fetchStaffingRequests, fetchStaffingWorkforce } from '@/features/staffing/api';
+import { fetchStaffingCandidates, fetchStaffingOverview, fetchStaffingRequests, fetchStaffingWorkforce, offerStaffingFulfillment, transitionStaffingFulfillment } from '@/features/staffing/api';
 
 vi.mock('axios');
 const mocked = vi.mocked(axios, true);
@@ -47,6 +47,39 @@ const request = {
   is_synthetic: true,
   freshness_status: 'expired',
   sla: { minutes_until_due: null, at_risk: false, label: 'Expired synthetic request' },
+  fulfillment: {
+    available: true,
+    state: 'unfilled',
+    offered_count: 0,
+    accepted_count: 0,
+    filled_count: 0,
+    remaining_count: 2,
+    latest: null,
+    active: [],
+    actions: { can_offer: true },
+  },
+} as const;
+
+const fulfillment = {
+  fulfillment_uuid: 'b49d0c07-b5cc-4ab1-ad77-00cbab6ef576',
+  staffing_request_id: 1,
+  staff_member_id: 42,
+  staff_member_name: 'Avery A. Adams',
+  status: 'offered',
+  source: 'float_pool',
+  version: 1,
+  role_code: 'critical_care_nurse',
+  unit_id: 3,
+  starts_at: '2026-07-10T11:00:00Z',
+  ends_at: '2026-07-10T19:00:00Z',
+  timezone: 'America/New_York',
+  validation: {},
+  offered_at: '2026-07-10T10:00:00Z',
+  accepted_at: null,
+  filled_at: null,
+  released_at: null,
+  canceled_at: null,
+  actions: { can_accept: true, can_fill: false, can_release: false, can_cancel: true },
 } as const;
 
 describe('staffing operational API contract', () => {
@@ -56,6 +89,7 @@ describe('staffing operational API contract', () => {
     mocked.get.mockResolvedValue({
       data: {
         data: {
+          permissions: { manage: true },
           source,
           metrics: {
             open_requests: 1,
@@ -130,6 +164,7 @@ describe('staffing operational API contract', () => {
           coverage_model: 'in_house',
           preferred_shift: 'night',
           availability: 'available',
+          availability_source: 'canonical-materializer',
           credential_status: 'valid',
           credentials: ['RN', 'BLS'],
           eligible_float_units: ['Medical ICU', 'Surgical ICU'],
@@ -150,5 +185,46 @@ describe('staffing operational API contract', () => {
     mocked.get.mockResolvedValue({ data: { data: [{ ...request, metadata: [] }] } });
 
     await expect(fetchStaffingRequests()).rejects.toThrow();
+  });
+
+  it('parses eligibility evidence and sends idempotency keys on lifecycle writes', async () => {
+    mocked.get.mockResolvedValueOnce({
+      data: {
+        data: [{
+          staff_member_id: 42,
+          display_name: 'Avery A. Adams',
+          role_code: 'critical_care_nurse',
+          role_label: 'Critical Care Nurse',
+          unit_id: 3,
+          coverage_model: 'float',
+          eligible: true,
+          eligibility_state: 'eligible',
+          reason_codes: [],
+          qualification_requirements: [{ qualification_code: 'role.critical_care_nurse', display_name: 'Critical Care Nurse role qualification', verified: true }],
+          availability: { covering_windows: 1, blocking_windows: 0, timezone: 'America/New_York' },
+          overlapping_assignments: 0,
+          shift: { starts_at: '2026-07-10T11:00:00Z', ends_at: '2026-07-10T19:00:00Z', timezone: 'America/New_York' },
+        }],
+        meta: { current_page: 1, last_page: 1, per_page: 100, total: 1 },
+        shift: { starts_at: '2026-07-10T11:00:00Z', ends_at: '2026-07-10T19:00:00Z', timezone: 'America/New_York' },
+      },
+    });
+    expect((await fetchStaffingCandidates(1)).data[0].eligible).toBe(true);
+
+    mocked.post.mockResolvedValueOnce({ data: { data: fulfillment } });
+    await offerStaffingFulfillment(1, { staff_member_id: 42, source: 'float_pool' }, 'offer-key-1');
+    expect(mocked.post).toHaveBeenLastCalledWith(
+      '/api/staffing/requests/1/fulfillments',
+      { staff_member_id: 42, source: 'float_pool' },
+      { headers: { 'Idempotency-Key': 'offer-key-1' } },
+    );
+
+    mocked.post.mockResolvedValueOnce({ data: { data: { ...fulfillment, status: 'accepted', version: 2, actions: { can_accept: false, can_fill: true, can_release: true, can_cancel: true } } } });
+    await transitionStaffingFulfillment(fulfillment.fulfillment_uuid, 'accepted', 'accept-key-1');
+    expect(mocked.post).toHaveBeenLastCalledWith(
+      `/api/staffing/fulfillments/${fulfillment.fulfillment_uuid}/transition`,
+      { status: 'accepted' },
+      { headers: { 'Idempotency-Key': 'accept-key-1' } },
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add effective-dated canonical qualifications, availability windows, shift assignments, request fulfillments, and immutable command/event ledgers
- materialize deterministic, timezone-safe staffing projections with dry-run, batching, deactivation, and horizon reconciliation
- enforce facility scope, qualifications, availability, leave/conflicts, overlapping assignments, headcount reservation, authorization, and idempotency on every fulfillment transition
- close legacy assignment and direct-fill bypasses while preserving the existing source-selection workflow
- give Staffing Office and Hummingbird Android/iOS the same named-candidate lifecycle and explicit blocked states
- document production materialization, verification, rollback, and operating procedures

## Safety and compatibility

- the migration is additive and uses guarded column creation for existing environments
- accepted and filled fulfillments reserve request headcount under row locks
- transition commands use advisory idempotency locks and return the original result on exact replays
- mobile fill records offer, accept, fill, and operational activity in one transaction
- regulated qualifications remain provisional unless the source or client marks them verified

## Validation

- `php artisan test`: 43 passed plus 697 warning-class passes, 9,593 assertions
- `./vendor/bin/pint --test`: 901 files
- `npx vitest run --coverage`: 82 files, 346 tests
- `npx tsc --noEmit`: passed
- `npm run build`: passed
- Android `testDebugUnitTest` under JDK 17: passed
- Arena Python 3.12 sidecar: 17 tests passed
- native iOS compilation is unavailable on the Linux development host; shared contract and parity guards pass

`check-ui-canon.sh` names no staffing file. It currently fails on Arena UI files introduced by existing `main` commit `025139f` for font weight, arbitrary text sizes, and raw palette ratchet; those unrelated files are intentionally outside this PR.

## Deployment

After exact-head CI and merge, deploy manually from clean `main` with migrations enabled. Run the canonical staffing materializer in dry-run mode first, inspect projected counts, run it for the configured horizon, rerun to prove stable counts, and verify the scheduled daily projection plus web/mobile authorization boundaries.