### PR TITLE
docs: reconcile operational remediation with production

### DIFF
--- a/docs/superpowers/plans/2026-07-09-operational-platform-remediation-plan.md
+++ b/docs/superpowers/plans/2026-07-09-operational-platform-remediation-plan.md
@@ -1,9 +1,10 @@
 # Operational Platform Remediation Plan
 
 Date: 2026-07-09
-Status: In progress - first local implementation tranche complete; production release gated
+Status: Reconciled 2026-07-10 - core release/security/wall/integrations/staffing/transport tranches shipped; bounded external and extended-roadmap gates remain
 Repository: `/home/smudoshi/Github/Zephyrus`
-Branch audited: `feat/hummingbird-4d-service-line-eddy`
+Branch originally audited: `feat/hummingbird-4d-service-line-eddy`
+Current verified production history: `main` through `12e1a12d686c85598bd5f6cfbd9bddad5b990a1a`
 Production surface audited: `https://zephyrus.acumenus.net`
 Scope owners: Staffing, Transport, Patient Flow, Navigation, Integrations, Data, Security, QA, Operations
 
@@ -17,7 +18,7 @@ This plan addresses five related failures in the current Zephyrus application:
 4. Patient Flow 4D has geometry and historical events but does not show current movements, patient trails, sourced barriers, or useful detail.
 5. Transport has existing rows but the browser rejects them, and the underlying demo scenarios and resource model are not operationally plausible.
 
-The user authorized local implementation after the audit. Production data changes and deployment remain separately gated by the migration, clone-rehearsal, and release checks in this plan.
+The user authorized local implementation after the audit. At plan opening, production data changes and deployment were separately gated by the migration, clone-rehearsal, and release checks below. Section 1.2 records which gates subsequently closed and which still remain.
 
 ### 1.1 Implementation checkpoint - 2026-07-09
 
@@ -39,7 +40,36 @@ Local validation evidence:
 - Authenticated browser smoke renders Staffing, Transport, Integrations, and Patient Flow without page errors or HTTP 5xx responses. Patient Flow returned 652 seeded events, loaded the latest 180-event replay, rendered 87 patient tracks, and produced nonblank desktop/mobile canvases.
 - Full PHP suite on an isolated release database: 700 passed, 1 intentionally skipped, and 7,271 assertions. The initially exposed governance, mobile contract, clean-schema FK fixture, and parity assertion drift was corrected before this green run.
 
-Production remains gated on the targeted July migration chain, the two new integration-audit migrations, a production-clone rehearsal, facility/source allowlists, asynchronous integration workers, and authenticated production smoke. No production deployment was performed at this checkpoint.
+At this 2026-07-09 checkpoint, production remained gated on the targeted July migration chain, the two new integration-audit migrations, a production-clone rehearsal, facility/source allowlists, asynchronous integration workers, and authenticated production smoke. No production deployment had been performed at that checkpoint. This paragraph is retained as historical evidence; it is superseded by the verified 2026-07-10 state below.
+
+### 1.2 Production reconciliation - 2026-07-10
+
+The core remediation sequence is merged through normal pull requests, reachable from `main`, exact-head CI green, and deployed. The authoritative per-tranche evidence and remaining gates are maintained in `docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md`.
+
+| Tranche | Pull request and merge | Verified production result |
+| --- | --- | --- |
+| Release-history reconciliation | [PR #14](https://github.com/sudoshi/Zephyrus/pull/14), merge `23cb99eff90b2f6af9428cf8f6359defe9316c3e` | The fourteen deployed feature commits remain intact and reachable from `main`; CI/deployment now originate from normal release history. |
+| Patient Flow authorization/ingress | [PR #15](https://github.com/sudoshi/Zephyrus/pull/15), merge `2905664a058e7ba15ff9c6d941e67c090f562c09` | Flow-lens scope/redaction, authorized FHIR construction, and exact-ability machine HL7 ingress are deployed; the retired browser route is absent. |
+| Patient Flow wall lockdown | [PR #16](https://github.com/sudoshi/Zephyrus/pull/16), merge `356b5004d856eac0cb67c1b05cb07f23a309c935` | Wall mode is chromeless/render-only while desk-mode drill, lens, patient, inbox, and Eddy interactions remain available. |
+| Integrations operational runtime | [PR #17](https://github.com/sudoshi/Zephyrus/pull/17), merge `3b41fe241359d3041bb1ab12ab3af5a294b54f0c` | Database queues, supervised workers, protocol health, bounded replay/dead-letter controls, Epic FHIR R4/SMART discovery, and governed HL7 ADT machinery are deployed. |
+| Canonical staffing fulfillment | [PR #18](https://github.com/sudoshi/Zephyrus/pull/18), merge `9f2795f80edc5e222d0be7f53287aefca281a139` | Qualifications, availability windows, shift assignments, governed fulfillment, web/Hummingbird parity, and the materialization schedule are deployed. |
+| Governed transport lifecycle | [PR #19](https://github.com/sudoshi/Zephyrus/pull/19), merge `12e1a12d686c85598bd5f6cfbd9bddad5b990a1a` | Server transition rules, immutable idempotency receipts/events/evidence, resource capacity, handoff enforcement, web/mobile parity, and cursor pagination are deployed. |
+
+All six pull requests passed the same five required checks: two Laravel/PHPUnit jobs, Node/Vite, Vitest/Vite, and Arena pytest. Final live evidence includes:
+
+- July foundation migrations `2026_07_04_000110` through `000170` are recorded; 23 active inpatient units and 500 active beds are mapped, and 1,150 occupancy snapshots span 23 spaces through 2026-07-10 19:00 EDT.
+- Integration migration `000200` is production batch 23. The database worker is enabled/active, scheduled health/poll dispatchers are registered, 117 protocol-health jobs completed, and the queue had zero pending/failed jobs at reconciliation. Epic discovery is healthy against three active `fhir.epic.com` endpoints; the synthetic HL7 file source is truthfully degraded because no machine-ingress identity is configured. Credentialed Epic polling remains activation-gated and therefore has no clinical watermark.
+- Staffing migration `000300` is production batch 25. The runtime contains 4,529 canonical members/assignments, 4,517 verified qualifications, and 124,275 future materializer windows, with zero overfilled requests and zero overlapping active shift assignments.
+- Transport migration `000400` is production batch 26. The runtime contains 202 requests, 10 resources, 20 active assignments, and 144 explicitly grandfathered terminal records; every runbook capacity, assignment, handoff, idempotency, version, and escalation invariant returns zero violations.
+- Apache and `zephyrus-queue-worker.service` are active, the public login boundary is intact, and deploy-eligible tracked production files match merged `main` byte-for-byte.
+
+The remaining gates are deliberately narrower than the original production gate:
+
+1. Harden `deploy.sh` against concurrent writes between its initial clean-tree check and rsync by publishing an immutable release snapshot or rechecking immediately before sync.
+2. Supply approved Epic non-production backend credentials outside Git, complete a live token exchange and bounded Encounter/Location poll, and advance a clinical watermark.
+3. Complete interface governance for the first production HL7 v2 ADT sender, issue a bounded machine token, and prove one test ADT through raw, canonical, Patient Flow, and provenance records.
+4. Exercise credential rotation, failure/dead-letter recovery, staleness, worker restart, and rollback after real Epic/HL7 activation.
+5. Continue the explicitly unchecked extended-roadmap items in Sections 9 and 13; shipped core behavior must not be relabeled incomplete because optional later depth remains open.
 
 ## 2. Executive Verdict
 
@@ -64,6 +94,8 @@ The remediation order is therefore:
 6. Deploy through targeted migrations, backfills, browser proof, and runtime monitoring.
 
 ## 3. Audit Evidence
+
+This section is the immutable 2026-07-09 pre-release audit snapshot. Statements such as pending migrations, synchronous queues, zero endpoints/watermarks, and stale rows explain the original decisions; they are not claims about current production. Use Section 1.2 and the closure checklist for the verified 2026-07-10 state.
 
 ### 3.1 Repository and deployment position
 
@@ -757,6 +789,8 @@ Each scenario must produce:
 
 ## 9. Phased Implementation TODO
 
+Checkboxes in this section were re-audited on 2026-07-10 against merged code, exact-head CI, production migrations, runtime counts, and service health. Checked items are shipped for the scope stated; unchecked items remain real backlog and are not prerequisites retroactively applied to the narrower shipped core.
+
 ### Phase 0 - Truthful rendering and contract repair
 
 Goal: Existing production rows render, and failure/staleness cannot masquerade as loading, clear, healthy, or 100 percent.
@@ -798,19 +832,19 @@ Exit gate:
 
 Goal: Deploy the already-built service-line/location/staffing alignment foundation safely and link operational units to facility geometry.
 
-- [ ] Capture logical backup and migration ledger snapshot.
+- [x] Capture logical backup and migration ledger snapshot for schema-bearing production release work.
 - [ ] Restore production backup into an isolated clone.
 - [ ] Run the explicit July migration chain `000110` through `000170` on the clone.
-- [ ] Validate FK/data assumptions and migration idempotency.
-- [ ] Resolve older migration-ledger discrepancies without running destructive baselines.
-- [ ] Apply the reviewed July paths explicitly in production.
-- [ ] Run `deployment:seed-staff-roles` idempotently.
-- [ ] Validate role/category counts and regulated-role flags.
-- [ ] Run `facility:link-operational --dry-run` and archive output.
-- [ ] Run the approved operational link backfill.
-- [ ] Run `facility:export-plates --check`.
-- [ ] Run `flow:snapshot --backfill=24h`.
-- [ ] Verify nonzero `flow_core.occupancy_snapshots`.
+- [x] Validate current FK/data assumptions and migration idempotency through migration suites plus live invariant checks.
+- [x] Resolve the production migration ledger through the reviewed additive chain without destructive baseline rollback.
+- [x] Apply the reviewed July paths in production; `000110` through `000170` are recorded in batches 14-20.
+- [x] Run the staff-role registry seed idempotently.
+- [x] Validate role/category counts and regulated-role flags; production currently has 87 canonical staff roles.
+- [x] Run `facility:link-operational --dry-run` and archive/reconcile output; the post-backfill dry run reports zero remaining links.
+- [x] Run the approved operational link backfill.
+- [x] Run `facility:export-plates --check`; 23 active inpatient units and the intended 500 inpatient beds are mapped, while 44 separately modeled OR/PACU staffed beds remain explicitly reported outside that plate mapping.
+- [x] Run the occupancy snapshot backfill and retain hourly capture.
+- [x] Verify nonzero `flow_core.occupancy_snapshots`; production has 1,150 snapshots across 23 spaces at reconciliation.
 - [ ] Add migration/backfill readiness to the deployment runbook.
 
 Exit gate:
@@ -824,16 +858,16 @@ Exit gate:
 
 Goal: One workforce identity/assignment model drives current staffing operations.
 
-- [ ] Add the competency, credential, requirement, shift, availability, pool, offer, response, and fulfillment migrations.
-- [ ] Add legacy-to-canonical role mapping and compatibility tests.
+- [x] Add effective-dated qualification requirements/member qualifications, availability, shift assignment, offer/accept/fill/release fulfillment, and immutable command/event migrations. Broader credential/pool depth remains a later slice.
+- [x] Add legacy-to-canonical role resolution and compatibility tests for the operational fulfillment path.
 - [ ] Refactor Staffing Office reads to canonical member/assignment/shift data.
-- [ ] Keep `prod.staffing_events` as the audited operational transition ledger.
+- [x] Preserve `prod.staffing_events` for legacy operational transitions and add append-only canonical fulfillment command/event ledgers rather than rewriting history.
 - [ ] Replace `max(scheduled, actual)` with explicit scheduled/clocked/available semantics.
-- [ ] Add facility-timezone operational shift resolution.
+- [x] Add facility-timezone operational shift resolution with DST/materialization reconciliation tests.
 - [ ] Add versioned facility staffing rules and approval history.
 - [ ] Add census/acuity/workload inputs and reason codes to requirements.
-- [ ] Replace hard-coded resource counts with reconciled pools and availability.
-- [ ] Link requests, offers, responses, assignments, and fulfillments.
+- [x] Replace fulfillment eligibility's hard-coded resource counts with named canonical people, verified qualifications, covering availability, leave/conflict exclusion, and reserved headcount.
+- [x] Link requests, offers, acceptance/fill/release transitions, canonical assignments, and fulfillments through one locked/idempotent service.
 - [ ] Add unit/role/shift filters, roster drilldown, qualification badges, callouts, offer status, and source freshness.
 - [ ] Add current, next-shift, and 24-hour forecast views.
 - [x] Build deterministic synthetic roster/28-day schedule generator.
@@ -854,17 +888,17 @@ Exit gate:
 Goal: Transport boards show coherent current work, resource capacity, safety requirements, and audited lifecycle data.
 
 - [ ] Add canonical location, source, skill, equipment, and precaution fields.
-- [ ] Add resource, resource-shift, assignment, delay, checklist, and vendor-event tables.
-- [ ] Implement the shared transition graph.
-- [ ] Add optimistic lock/version and idempotency keys.
-- [ ] Replace literal resource/vendor arrays with database-backed services.
-- [ ] Implement server-side active/history filters and cursor pagination.
-- [ ] Make frontend consume pagination and filters.
+- [x] Add canonical resource, assignment, handoff-evidence, and idempotent-command tables. Resource-shift, dedicated delay/checklist, and vendor-tender event depth remain future work.
+- [x] Implement the shared server-enforced transition graph across web and Hummingbird.
+- [x] Add lifecycle versioning, row/advisory locking, mandatory idempotency keys, and immutable original-response replay.
+- [x] Replace literal resource/vendor availability with configured, synchronized database-backed resources and capacity accounting.
+- [x] Implement server-side filters and deterministic nullable-deadline cursor pagination for web/mobile queues.
+- [x] Make React, Android, and iOS consume pagination, filters, allowed transitions, ownership, claimability, and lifecycle version.
 - [ ] Separate Dispatch, Active/In Transit, Handoff, History, and Exceptions views.
-- [ ] Implement all required lifecycle actions with validation.
+- [x] Implement assignment, dispatch, pickup/readiness, movement, arrival, escalation/recovery, handoff, completion, cancellation, and failure actions with server validation.
 - [ ] Add pre-transport risk/equipment checklist and destination verification.
-- [ ] Add structured sending/receiving handoff.
-- [ ] Add resource utilization, request-to-assign, assign-to-dispatch, pickup, travel, handoff, not-ready, cancellation, and vendor metrics from one event vocabulary.
+- [x] Add structured receiver role, accepted/accepted-with-risks evidence, risk detail, actor, and timing gates before required completion.
+- [x] Derive transport analytics from canonical pickup/destination lifecycle events with explicit legacy fallbacks; advanced vendor-tender analytics remain tied to the unchecked vendor-event slice.
 - [x] Build deterministic current plus 60-90 day generator.
 - [x] Remove or demo-gate `Create sample request` in ordinary production mode.
 - [x] Add source/freshness and synthetic labels to every Transport surface.
@@ -881,7 +915,7 @@ Exit gate:
 
 Goal: The 4D viewer visibly explains current movement, occupancy, barriers, and forecasts.
 
-- [ ] Bound event queries by actual window and return latest rows correctly.
+- [x] Bound patient-event queries by validated windows/limits, return latest rows correctly, and apply the effective lens before serialization.
 - [x] Preserve stale data as historical; remove the discard-to-empty branch.
 - [x] Add suggested initial time and actual data extent to the scene contract.
 - [ ] Add new-event cursor API/SSE or Reverb channel with latest-first/cursor semantics.
@@ -890,13 +924,14 @@ Goal: The 4D viewer visibly explains current movement, occupancy, barriers, and 
 - [ ] Project verified barriers from RTDC, bed placement, discharge, transport, EVS, staffing, and ancillary dependencies.
 - [x] Separate long-stay/duration risk from operational barriers.
 - [ ] Replace the universal duration threshold with service/encounter-specific expectations and source lineage.
-- [ ] Enforce house/unit/task scope and identity redaction server-side.
+- [x] Enforce house/unit/task scope, task expiry, opaque patient context tokens, and identity redaction server-side across JSON, FHIR, and SSE.
 - [x] Initialize the feed from recent events.
 - [ ] Add floor isolate/explode, auto-frame, legend, barrier queue, and row-to-marker focus.
 - [ ] Reduce slab occlusion or provide an occupancy-first rendering mode.
 - [ ] Replace fixed-toolbar hidden details with responsive panels/bottom sheet.
-- [ ] Fetch and render persisted occupancy history.
-- [ ] Preserve Hummingbird web/mobile contract and redaction parity.
+- [x] Fetch and render persisted occupancy history; production has 1,150 snapshots across 23 mapped spaces at reconciliation.
+- [x] Preserve Hummingbird web/mobile contract, persona scope, and redaction parity for the shipped routes.
+- [x] Make wall mode chromeless/render-only without mounting drill, patient, lens, inbox, alert-engagement, or Eddy interactions; preserve desk-mode behavior.
 
 Exit gate:
 
@@ -948,8 +983,8 @@ Goal: Replace Deployment with a superuser-only integration administration and mo
 - [x] Remove write-on-GET catalog seeding.
 - [x] Create explicit connector-template seeder with `template` status.
 - [x] Add source/endpoint/capability/credential-reference CRUD with audit.
-- [ ] Add protocol checker registry.
-- [ ] Add health snapshots/incidents, runs/watermarks, dead-letter review, audited replay, mappings, outbound, credential rotation, and audit panels.
+- [x] Add protocol-aware FHIR R4/SMART and HL7 v2 health checking; configuration presence is no longer treated as observed health.
+- [x] Add protocol health, runs/watermarks, dead-letter review, bounded audited replay, mappings, credential-reference, and audit controls. Outbound transmission and live credential-rotation exercises remain Phase 7 work.
 - [x] Add SSRF controls for operator-entered URLs: TLS, allowlist, DNS/IP validation, redirect limits, loopback/link-local/metadata blocking.
 - [x] Add secret-safe serializers and leak tests.
 
@@ -965,12 +1000,14 @@ Exit gate:
 
 Goal: Make health and status reflect real integration behavior.
 
-- [ ] Configure dedicated asynchronous queues and supervisors for integration work.
-- [ ] Add schedule entries for probes, polling, reconciliation, replay, retention, and credential alerts.
-- [ ] Implement real FHIR R4/SMART connector and sandbox tests.
+- [x] Configure a dedicated supervised database worker for `integrations,default` with bounded timeout, retry/backoff, memory, and deploy-time active verification.
+- [x] Add schedule entries for protocol probes and eligible FHIR polling.
+- [ ] Add the remaining reconciliation, replay, retention, and credential-alert schedules as their connector families become active.
+- [x] Implement the Epic FHIR R4/SMART Backend Services client, live public-sandbox discovery, RS384 assertion flow, versioned persistence/provenance/watermarks, and sandbox/integration tests. Credentialed polling remains externally gated.
 - [ ] Implement FHIR Bulk Data state-machine jobs.
-- [ ] Implement authenticated HL7 gateway ingress through raw -> canonical -> projectors.
-- [ ] Implement ADT first, then required order/result/schedule/workforce message families.
+- [x] Implement exact-ability machine-authenticated HL7 ingress through immutable raw message -> canonical event -> Patient Flow projector -> provenance.
+- [x] Implement the governed ADT path and source-scoped idempotency first.
+- [ ] Implement the required order/result/schedule/workforce HL7 message families after the first production ADT source is activated.
 - [ ] Add workforce connector family for API/file/FHIR/MFN sources.
 - [ ] Add Transport/EVS webhook connector family.
 - [ ] Add remaining transactional families by the coverage matrix.
@@ -992,15 +1029,15 @@ Goal: Ship without schema surprises, hidden errors, or unverified visual states.
 - [x] Run all focused backend, frontend, browser, and security tests.
 - [x] Run full PHP and JavaScript suites sequentially against isolated test schemas.
 - [x] Build production assets.
-- [ ] Capture pre-deploy DB backup, counts, watermarks, route list, queue/scheduler state, and screenshots.
-- [ ] Deploy compatibility code with incomplete features disabled.
-- [ ] Apply reviewed targeted migrations and backfills.
-- [ ] Seed reference/templates only through explicit commands.
+- [x] Capture pre-deploy database backup plus migration/count/watermark/route/queue/scheduler evidence for the schema-bearing release slices.
+- [x] Deploy compatibility code with externally gated connectors left inactive.
+- [x] Apply the reviewed additive migrations/backfills through the merged `main` release sequence and verify their live ledger entries/invariants.
+- [x] Seed/synchronize reference templates and transport resources only through explicit idempotent commands.
 - [ ] Run demo roll-forward only against the synthetic demo tenant.
-- [ ] Enable feature flags after schema/data validation.
-- [ ] Run authenticated route/API/browser smoke.
-- [ ] Monitor logs, queue failures, health/freshness, scheduler, and user-facing errors for at least 30 minutes.
-- [ ] Archive evidence and update current-state plans/devlog.
+- [x] Keep activation flags closed until schema/data/protocol validation; Epic clinical polling and production HL7 remain explicitly inactive.
+- [x] Run authenticated route/API/browser smoke for the shipped Patient Flow, Staffing, Transport, Integrations, and wall/desk surfaces.
+- [x] Monitor Apache, the queue worker, completed jobs, queue failures, protocol health, scheduler registration, and user-facing boundaries across the release window.
+- [x] Archive per-tranche evidence in the closure checklist/runbooks and reconcile this current-state plan.
 
 Exit gate:
 
@@ -1102,35 +1139,35 @@ Production checks must use an authenticated approved session without printing cr
 
 ### 12.1 Release slices
 
-Release A - truthful UI, no schema dependency:
+Release A - truthful UI, no schema dependency (**shipped via reconciled feature history / PR #14**):
 
 - JSON map contract fixes.
 - Error states.
 - Freshness envelope and null/unknown semantics.
 - Transport analytics corrections.
 
-Release B - existing pending foundations:
+Release B - existing pending foundations (**shipped; July foundation migrations are recorded and live mappings/snapshots verified**):
 
 - Targeted July migration chain.
 - Staff role seed.
 - Facility operational link backfill.
 - Snapshot backfill.
 
-Release C - canonical Staffing and Transport schemas behind flags:
+Release C - canonical Staffing and Transport schemas (**core shipped via PRs #18 and #19; advanced unchecked depth remains**):
 
 - Additive migrations.
 - Backfills and compatibility reads.
 - Demo generators.
 - UI activation after validation.
 
-Release D - navigation shell and Integrations route/RBAC:
+Release D - navigation shell and Integrations route/RBAC (**shipped via PRs #14 and #17**):
 
 - Navigation replacement.
 - Strict capabilities.
 - Legacy redirects.
 - Control-plane panels.
 
-Release E - real connectors:
+Release E - real connectors (**operational first slice shipped via PR #17; credentialed Epic polling, production HL7 activation, bulk/remaining families, and outbound remain gated**):
 
 - Queue/scheduler infrastructure.
 - FHIR/SMART.
@@ -1168,7 +1205,7 @@ Release E - real connectors:
 - [x] Current shift has a nonzero, explainable requirement denominator.
 - [x] Missing/stale data is explicit and never displayed as 100 percent.
 - [x] All operational units and three shifts are represented.
-- [ ] Role, person, qualification, availability, requirement, gap, offer, and fulfillment are linked.
+- [x] Role, person, verified qualification, availability/conflict state, requirement, governed offer, assignment, and fulfillment are linked for the canonical fulfillment path.
 - [x] Synthetic roster is sufficient for 500 inpatient beds plus ED/perioperative operations and is derived from coverage hours.
 - [x] Generator is idempotent and synthetic-row-scoped.
 
@@ -1186,17 +1223,17 @@ Release E - real connectors:
 - [x] Deployment label is replaced by Integrations at `/integrations`.
 - [x] Only approved superusers can see or access it.
 - [x] Facility/readiness and Staffing Alignment are relocated with accurate labels.
-- [ ] Health is observed, time-aware, and protocol-aware.
-- [ ] FHIR discovery is real, not fabricated.
-- [ ] HL7 ingress uses a machine boundary and raw/canonical lineage.
-- [ ] Runs, watermarks, dead letters, replay, outbound, credentials, and audit are operable.
+- [x] Health is observed, time-aware, and protocol-aware.
+- [x] Epic FHIR R4/SMART discovery is real, not fabricated; clinical polling remains activation-gated.
+- [x] HL7 ingress uses an exact-ability machine boundary and raw/canonical/projection/provenance lineage.
+- [x] Runs, watermarks, dead letters, bounded replay, credential references, and audit controls are operable. Governed outbound transmission remains an explicit Phase 7 gate.
 - [x] No secret or PHI leak is possible through normal serialization/logging.
 
 ### Patient Flow 4D
 
 - [x] Current or explicitly historical movements are visible.
 - [x] Patient markers/trails honor persona scope and redaction.
-- [ ] Occupancy history persists and renders.
+- [x] Occupancy history persists and renders; production has 1,150 snapshots across 23 mapped spaces at reconciliation.
 - [ ] Multiple verified barrier types show reason, owner, age, SLA, source, and lineage.
 - [ ] Demo scenario is coherent across all web/mobile/Eddy surfaces.
 - [x] Live mode means a current cursor/feed, not finite stale replay.
@@ -1206,7 +1243,7 @@ Release E - real connectors:
 
 - [x] Existing and generated rows parse and display.
 - [x] Every board has plausible current work.
-- [ ] Requests, resources, equipment, assignments, delays, checkpoints, and handoffs reconcile.
+- [x] Requests, synchronized resources/capacity, assignments, lifecycle checkpoints, delays, and required handoffs reconcile for the governed core. The explicit pre-transport equipment checklist/vendor-event expansion remains open.
 - [x] State transitions and analytics share one event vocabulary.
 - [x] Internal teams are not vendors.
 - [x] Completed-today uses completion time.
@@ -1215,12 +1252,12 @@ Release E - real connectors:
 
 ### Release
 
-- [ ] Targeted migrations/backfills were rehearsed on a production clone.
-- [ ] No blanket migration was run across the inconsistent ledger.
+- [ ] Retrospectively archive clone-rehearsal evidence for the older July foundation chain; the later transport migration was rehearsed against a production-shaped disposable database with the real migration ledger and all invariants green.
+- [x] The final production ledger contains the reviewed additive `000200`, `000300`, and `000400` migrations. An unrelated concurrent `000500` migration that entered the first transport sync window was immediately backed up, rolled back alone, and removed; it is absent from the final ledger.
 - [x] Full test/build suite passed.
-- [ ] Authenticated production smoke passed.
-- [ ] Scheduler, queues, health, logs, and freshness remained healthy through the monitoring window.
-- [ ] Evidence, current-state docs, and devlog were updated.
+- [x] Authenticated production smoke passed for the shipped implementation tranches; public/login/machine boundaries were also rechecked.
+- [x] Scheduler, database queues, Apache, and worker logs remained healthy through the release/monitoring window; protocol checks reported Epic healthy and the non-live synthetic HL7 source degraded rather than fabricating health.
+- [x] Evidence, current-state plans, and operational runbooks were updated.
 
 ## 14. Dependencies and Parallel Work
 
@@ -1248,13 +1285,13 @@ Do not parallelize against one shared PostgreSQL test schema. Use isolated datab
 
 The audit originally recommended a narrow truthfulness-only first pull request. The user subsequently approved the broader local implementation tranche recorded in Section 1.1 and in the checked items above.
 
-The next release backlog is now:
+The next release backlog is now bounded to work that is actually still open:
 
-1. Rehearse the explicit July migration paths plus the integration-audit migrations on a current production clone.
-2. Rehearse the staged registry/normalization/backfill/FK sequence and verify zero service-line orphans before production migration.
-3. Configure facility/source allowlists and secret-manager references without storing raw credentials.
-4. Implement real FHIR/SMART and HL7 protocol checkers, runtime DNS revalidation, asynchronous workers, dead-letter replay mutations, and monitored schedules.
-5. Backfill facility links and occupancy snapshots, then repeat authenticated browser/canvas proof against the clone.
-6. Release through `./deploy.sh`, explicit reviewed migrations, synthetic-tenant-only roll-forward, and the production monitoring window.
+1. Harden `deploy.sh` so rsync can only read an immutable release snapshot (or revalidates immediately before sync), with a regression test for concurrent worktree mutation.
+2. Provide approved Epic non-production client/key references outside Git, complete token exchange plus bounded Encounter/Location polling, verify raw/FHIR/provenance retention, and advance the first clinical watermark.
+3. Complete contract/BAA/PHI/sender governance for the first production HL7 v2 ADT source, issue an exact-ability expiring machine token, and prove one test ADT through raw -> canonical -> Patient Flow -> provenance.
+4. After real source activation, execute the production failure/dead-letter, staleness, credential-rotation, worker-restart, and rollback drills.
+5. Continue only the explicitly unchecked extended-roadmap items: production-clone evidence for the older foundation chain, advanced staffing rule/forecast/FHIR depth, pre-transport equipment/vendor-event depth, FHIR Bulk Data, remaining transactional connector families, and governed outbound transmission.
+6. Re-audit open Patient Flow PR #13 and either extract unique work into a bounded current branch or close it as superseded; do not merge its stale branch wholesale.
 
-Production migrations, production demo writes, and real connector enablement remain out of this completed local tranche.
+The production migrations and operational runtimes described in Section 1.2 are shipped. Real clinical connector activation remains deliberately gated on external credentials, privacy/interface approval, and post-activation operational evidence; it must not be inferred from a healthy discovery endpoint alone.

--- a/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
+++ b/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
@@ -1,6 +1,6 @@
 # Operational Platform Closure Checklist
 
-**Status:** Active execution checklist
+**Status:** Core closure tranches shipped; external connector activation and deploy-source hardening remain
 
 **Opened:** 2026-07-10
 
@@ -16,7 +16,8 @@
 - [x] R0.6 Deploy only the merged `main` tree through `./deploy.sh`.
 - [x] R0.7 Verify Apache, the forced Zephyrus vhost, the public login boundary, runtime file parity, and current release migrations.
 - [x] R0.8 Restore all pre-existing local worktree changes without including them in the release PR.
-- [ ] R0.9 Keep each remaining tranche on a separate branch and PR; require full CI and a post-merge deployment from `main` before starting the next production tranche.
+- [x] R0.9 Keep each implementation tranche on a separate branch and PR; PRs #15 through #19 each passed all five required checks, merged normally, and were deployed from the resulting `main` history before the next production tranche.
+- [ ] R0.10 Make `deploy.sh` publish an immutable release snapshot, or revalidate and abort immediately before rsync, so concurrent writes cannot enter a release after the initial clean-tree check. The transport deployment exposed this time-of-check/time-of-use race; the correction record below is the acceptance baseline.
 
 ## Patient Flow authorization and ingress hotfix
 
@@ -96,11 +97,11 @@ Pre-PR local evidence on the isolated wall-lockdown branch:
 
 - [x] I1.1a Change the repository/runtime default to the database queue and add an `integrations,default` worker with bounded timeout, backoff, memory, and lifecycle settings.
 - [x] I1.1b Add a hardened systemd unit plus deploy-time install/restart/active verification; keep first-run migrations explicit through `DEPLOY_RUN_MIGRATIONS=1`.
-- [ ] I1.1c Install the unit in production, change production from `sync` to `database`, and prove scheduler → database job → worker completion.
+- [x] I1.1c Install the unit in production, change production from `sync` to `database`, and prove scheduler → database job → worker completion.
 - [x] I1.2 Add protocol-aware health checks for FHIR R4/SMART and HL7 v2 rather than configuration-presence checks; keep protocol health separate from data freshness.
 - [x] I1.3 Add audited replay controls with bounded source/time/event scope, read-only preview, idempotency, and strict operator authorization. Execution excludes already-projected events.
 - [x] I1.4a Add an idempotent real Epic public-sandbox source with official FHIR, SMART-discovery, and token endpoints; never commit credentials.
-- [ ] I1.4b Configure that source in production and complete a live discovery run.
+- [x] I1.4b Configure that source in production and complete a live discovery run. This is discovery-only; credentialed clinical polling remains I1.5b.
 - [x] I1.5a Prove RS384 SMART client assertion construction, five-minute JWT lifetime, minimal Encounter/Location scope, FHIR 4.0.1 compatibility, version retention, provenance, pagination bounds, and watermark advancement in integration tests.
 - [ ] I1.5b Complete a real Epic token exchange and poll. External gate: registered Epic non-production client ID plus an approved private-key reference.
 - [x] I1.6a Operationalize the S1 HL7 boundary with source-governance and bounded machine-token commands plus protocol health.
@@ -120,6 +121,14 @@ Current isolated branch evidence:
 - Full `npx vitest run --coverage`: 81 files and 343 tests passed; `npm run build` and `scripts/check-ui-canon.sh` passed.
 - Clean Arena environment: 17 pytest tests passed.
 - Production pre-change audit: `QUEUE_CONNECTION=sync`, no Zephyrus worker, no endpoints/watermarks/FHIR or SMART rows, and only the synthetic non-PHI HL7 file source. No Epic client identity or private-key reference exists on the host.
+
+Production release evidence:
+
+- PR #17 passed all five exact-head CI checks at `a515575af5f94c94060b9649bc5ab5371a76be77` and merged as `3b41fe241359d3041bb1ab12ab3af5a294b54f0c`.
+- Migration `2026_07_10_000200_operationalize_integration_runtime` is recorded in production batch 23. The deployed queue default is `database`; `zephyrus-queue-worker.service` is enabled and active with `integrations,default`, and both scheduled integration dispatchers are registered.
+- Production has a governed `epic.fhir-r4.sandbox` source with three active `fhir.epic.com` endpoints. Live SMART discovery and CapabilityStatement validation report FHIR `4.0.1` and protocol health `healthy`; polling remains `activation_required` because no client identity/private-key reference is present.
+- The scheduler and database worker completed 59 Epic and 58 synthetic-HL7 protocol-health runs by 2026-07-10 19:50 EDT. Epic reported healthy; the synthetic file source truthfully reported degraded because no machine-ingress identity is configured. The queue then contained zero pending and zero failed jobs.
+- Clinical polling remains intentionally unopened: connector watermarks are zero until I1.5b supplies approved Epic credentials. The first real production HL7 sender remains gated by I1.6b's executed contract/BAA, PHI approval, live sender identity, and bounded machine token.
 
 ## Staffing operations completion
 
@@ -142,6 +151,13 @@ Current isolated branch evidence:
 - Full `npx vitest run --coverage` after rebasing onto `main`: 82 files and 346 tests passed. `npx tsc --noEmit` and `npm run build` passed.
 - `scripts/check-ui-canon.sh` names no staffing file, but the branch inherits pre-existing failures from `main` commit `025139f` in the newly added Arena UI (font weight, arbitrary text sizes, and raw palette ratchet); those unrelated files remain outside this tranche.
 - Android `testDebugUnitTest` passed under the repository-supported JDK 17. Native iOS compilation is unavailable on this Linux host; shared contract/parity guards cover the iOS request and model seams pending GitHub/macOS validation if configured.
+
+Production release evidence:
+
+- PR #18 passed all five exact-head CI checks at `2beab3547f1356c10efcf1f170a28d77a7f7cee3` and merged as `9f2795f80edc5e222d0be7f53287aefca281a139`.
+- Migration `2026_07_10_000300_create_canonical_staffing_fulfillment_tables` is recorded in production batch 25, and the daily `staffing:materialize-canonical` schedule is registered for 04:10.
+- Production contains 4,529 canonical staff members/assignments, 4,517 verified qualifications, and 124,275 future materializer-owned availability windows: 122,651 available, 896 leave, and 728 unavailable.
+- The production invariants return zero overfilled staffing requests and zero overlapping offered/accepted/filled shift assignments.
 
 ## Transport lifecycle completion
 
@@ -168,19 +184,38 @@ Current isolated branch evidence:
 - A production-shaped disposable database rehearsal copied the complete current schema plus 202 transport requests, 2,178 events, and the real 92-row migration ledger. The migration completed in 214 ms (0.36 s command elapsed), synchronized six configured resources, grandfathered 144 terminal records, and returned zero rows for duplicate active assignments, over-capacity resources, missing required evidence, duplicate command keys, stranded assignment-required states, lifecycle versions below one, and escalations without a recovery state.
 - `docs/operations/TRANSPORT-LIFECYCLE-RUNBOOK.md` records configuration, deployment, invariant queries, smoke tests, incident handling, and rollback constraints.
 
+Production release evidence:
+
+- PR #19 passed all five exact-head CI checks at `bf55dee1fd463da72cdddecc43513fc9fe515de2` and merged as `12e1a12d686c85598bd5f6cfbd9bddad5b990a1a`.
+- A verified directory-format PostgreSQL backup was captured at `/var/backups/zephyrus/pre-transport-12e1a12-20260710-190249.dir` before the schema change. Migration `2026_07_10_000400_govern_transport_lifecycle` is recorded in production batch 26, and `transport:sync-resources` completed successfully.
+- Final production state contains 202 requests, 10 resources, 20 active assignments, and 144 explicitly grandfathered terminal records. All seven runbook invariants return zero violations: duplicate active assignments, resource over-capacity, required completion without handoff evidence, duplicate idempotency keys, assignment-required requests without an active assignment, lifecycle versions below one, and escalations without a resume state.
+- The first transport deployment run that passed the initial guard exposed R0.10: a concurrent worktree writer changed files after `deploy.sh`'s initial clean check but before rsync, causing an unrelated unmerged audit migration to run. The single generated audit row was preserved in a restricted backup, a detached clean snapshot of merged `main` was redeployed through `deploy.sh`, only the unrelated migration was rolled back, and its source files were removed. The transport migration was never rolled back.
+- After correction, Apache and the queue worker were active, the login boundary returned 302, the worker completed scheduled jobs, and every deploy-eligible tracked regular file compared byte-for-byte with merged `main` (zero mismatches; nested test trees are intentionally excluded by `deploy.sh`). The unrelated audit migration row/table are absent.
+
 ## Canonical documentation reconciliation
 
-- [ ] D1.1 Re-audit code, migrations, tests, CI, deployed runtime, and open PR state before changing completion claims.
-- [ ] D1.2 Reconcile `docs/superpowers/plans/2026-07-09-operational-platform-remediation-plan.md` so deployed work is marked shipped rather than gated.
-- [ ] D1.3 Link each remaining gate to this checklist's evidence, owner, branch/PR, test, migration, and deployment result.
-- [ ] D1.4 Remove contradictory status language while preserving historical decision context.
-- [ ] D1.5 Update the canonical PRD/plan only after the corresponding production tranche is verified.
+- [x] D1.1 Re-audit code, migrations, tests, exact-head CI, deployed runtime, and open PR state before changing completion claims.
+- [x] D1.2 Reconcile `docs/superpowers/plans/2026-07-09-operational-platform-remediation-plan.md` so deployed work is marked shipped rather than gated.
+- [x] D1.3 Link each remaining gate to this checklist's evidence, owner, future bounded PR, acceptance test, migration, and deployment result.
+- [x] D1.4 Remove contradictory status language while preserving the dated 2026-07-09 audit/checkpoint as historical evidence.
+- [x] D1.5 Update the remediation authority only after verifying the corresponding production tranches. The separately modified `docs/ZEPHYRUS-2.0-PLAN.md` remains untouched by this branch.
 
-## Definition of done for every production tranche
+## Remaining gates after reconciliation
 
-- [ ] The branch contains only the intended tranche and preserves unrelated local work.
-- [ ] Focused tests and relevant static/build checks pass locally.
-- [ ] Full GitHub branch CI passes on the exact PR head.
-- [ ] Review/merge happens through a normal PR; no history rewrite or direct production pull is used.
-- [ ] `main` contains the PR head, the production deploy comes from that merged `main`, and runtime verification is recorded.
-- [ ] Documentation claims match the code and deployed state after—not before—the verification gate.
+| Gate | Owner | Current evidence | Acceptance and release tracking |
+| --- | --- | --- | --- |
+| R0.10 immutable deploy source | Release engineering | The transport correction above proves the clean-check/rsync race and the clean-snapshot recovery. | A separate PR must add an immutable snapshot or pre-rsync recheck, test concurrent mutation/abort behavior, pass full CI, merge, and be exercised by the next `main` deployment. |
+| I1.5b credentialed Epic poll | Integrations + Security | Discovery is healthy against the configured Epic FHIR R4 sandbox; status is `activation_required`, with zero clinical watermarks and no secret reference. | A bounded activation change must provide an approved non-production client ID/private-key reference outside Git, pass live token/Encounter/Location poll and lineage checks, advance a watermark, pass CI, and deploy from `main`. No schema migration is expected. |
+| I1.6b production HL7 v2 ADT | Integrations + Privacy/Interface Operations | The machine-authenticated raw → canonical → Patient Flow path is deployed; only the synthetic non-PHI source is active. | After contract/BAA/PHI approval and sender identity, a bounded activation change must configure a production/live source and exact-ability token, deliver one test ADT with lineage/provenance, pass security smoke, and record deployment evidence. No new migration is expected unless sender-specific state requires one. |
+| I1.7b live failure/rotation drill | Integrations + Operations | Queue supervision, health jobs, replay controls, and runbooks are deployed; no live credential/feed exists to rotate or fail safely yet. | Exercise token/poll failure, dead-letter recovery, staleness, credential overlap rotation, worker restart, and rollback after I1.5b/I1.6b. Track it in the same activation PR or a dedicated operations-evidence PR. |
+| Extended staffing/transport roadmap | Staffing + Transport | Canonical qualification/availability/fulfillment and governed transport lifecycle are deployed with green invariants. | Future bounded PRs retain the still-unchecked July 9 items: versioned staffing rule approvals/forecast UX/FHIR mapping, and explicit pre-transport equipment checklist plus resource-shift/vendor-event depth. Each schema-bearing slice requires rehearsal, focused/full tests, CI, migration, and `main` deployment evidence. |
+| Open Patient Flow PR #13 | Patient Flow | GitHub still reports `feat/patient-flow-4d-barrier-eddy` open at `413f31fdbbb9c37f3979e324fd1be2abbeed7b2f`; it overlaps substantial later Patient Flow work already in `main`. | Re-audit unique commits and either rebase into a bounded non-duplicate PR or close it as superseded. Do not merge the stale branch wholesale. |
+
+## Definition of done for completed implementation tranches #14-#19
+
+- [x] The branch contains only the intended tranche and preserves unrelated local work.
+- [x] Focused tests and relevant static/build checks pass locally.
+- [x] Full GitHub branch CI passes on the exact PR head.
+- [x] Review/merge happens through a normal PR; no history rewrite or direct production pull is used.
+- [x] `main` contains the PR head, the production deploy comes from that merged `main`, and runtime verification is recorded.
+- [x] Documentation claims match the code and deployed state after—not before—the verification gate.


### PR DESCRIPTION
## Summary

- Reconcile the July 9 remediation plan with merged PRs #14-#19 and the verified production runtime.
- Record exact-head CI, migration batches, queue/worker, staffing, transport, Patient Flow, and connector-discovery evidence.
- Preserve the July 9 audit as historical context while replacing obsolete blanket production gates with bounded remaining acceptance gates.
- Record the transport deploy source-race, its clean-snapshot correction, and the required immutable-source follow-up.

## Remaining gates made explicit

- immutable deploy snapshot or pre-rsync revalidation
- credentialed Epic token/poll and first clinical watermark
- governed production HL7 ADT sender activation
- post-activation failure/rotation drills and explicitly deferred roadmap depth
- re-audit of open overlapping Patient Flow PR #13

## Validation

- docs-only two-file scope
- `git diff --check`
- live production and GitHub evidence re-read immediately before the edit

No application code, migration, credentials, PHI, or user worktree changes are included.