### PR TITLE
Demo plausibility layer + runtime validation gate (grafted onto B1)

### DIFF
--- a/app/Console/Commands/DemoValidateCommand.php
+++ b/app/Console/Commands/DemoValidateCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\Demo\DemoClock;
+use App\Services\Demo\DemoInvariantService;
+use Illuminate\Console\Command;
+
+/**
+ * Read-only demo coherence + plausibility gate (a runtime companion to the B1 trust
+ * foundation, which validates only in PHPUnit).
+ *
+ * Runs App\Services\Demo\DemoInvariantService against the current database and reports
+ * temporal, capacity, freshness, and plausibility findings. SELECT-only — safe to run
+ * against the canonical demo host after a demo reset / zephyrus:demo-roll-forward, or in CI.
+ * Exit code:
+ *   0  no critical finding failed
+ *   1  a critical finding failed (or, with --strict, any finding failed)
+ *
+ *   php artisan zephyrus:demo-validate
+ *   php artisan zephyrus:demo-validate --anchor=now --json
+ */
+class DemoValidateCommand extends Command
+{
+    protected $signature = 'zephyrus:demo-validate
+        {--anchor=now : Anchor the checks to this moment (ISO-8601 or "now")}
+        {--window-hours=48 : Operational window width (±half around the anchor)}
+        {--strict : Treat warnings as failures too}
+        {--json : Emit machine-readable JSON for schedulers/monitors}';
+
+    protected $description = 'Validate demo-data coherence and plausibility (read-only). Non-zero exit on critical failure.';
+
+    public function handle(DemoInvariantService $invariants): int
+    {
+        $clock = DemoClock::fromOption((string) $this->option('anchor'), (int) $this->option('window-hours'));
+        $findings = $invariants->run($clock);
+
+        $criticalFail = array_filter($findings, fn ($f) => $f['severity'] === 'critical' && ! $f['passed']);
+        $warnFail = array_filter($findings, fn ($f) => $f['severity'] === 'warning' && ! $f['passed']);
+        $ok = $invariants->passed($findings) && (! $this->option('strict') || $warnFail === []);
+
+        if ($this->option('json')) {
+            $this->line((string) json_encode([
+                'anchor' => $clock->key(),
+                'windowStart' => $clock->windowStart()->toIso8601String(),
+                'windowEnd' => $clock->windowEnd()->toIso8601String(),
+                'ok' => $ok,
+                'counts' => [
+                    'total' => count($findings),
+                    'criticalFailed' => count($criticalFail),
+                    'warningFailed' => count($warnFail),
+                ],
+                'findings' => $findings,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return $ok ? self::SUCCESS : self::FAILURE;
+        }
+
+        $this->info("Demo validation @ {$clock->key()}  window {$clock->windowStart()->format('m-d H:i')} → {$clock->windowEnd()->format('m-d H:i')}");
+        $this->newLine();
+
+        $rows = [];
+        foreach ($findings as $f) {
+            $mark = $f['passed'] ? '<fg=green>PASS</>' : ($f['severity'] === 'critical' ? '<fg=red;options=bold>FAIL</>' : '<fg=yellow>WARN</>');
+            $rows[] = [$mark, $f['category'], $f['key'], $f['observed'], $f['expected']];
+        }
+        $this->table(['', 'category', 'invariant', 'observed', 'expected'], $rows);
+
+        $this->newLine();
+        foreach ($findings as $f) {
+            if (! $f['passed']) {
+                $tag = $f['severity'] === 'critical' ? '<fg=red>✗ critical</>' : '<fg=yellow>! warning</>';
+                $this->line("  {$tag} {$f['key']} — {$f['detail']}");
+            }
+        }
+
+        $this->newLine();
+        $summary = sprintf('%d checks · %d critical failures · %d warnings',
+            count($findings), count($criticalFail), count($warnFail));
+        $ok ? $this->info("✓ {$summary}") : $this->error("✗ {$summary}");
+
+        return $ok ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/app/Services/Demo/DemoClock.php
+++ b/app/Services/Demo/DemoClock.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Services\Demo;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * The one rolling demo clock (plan §4.1 / FEEDBACK Wave 1).
+ *
+ * Every rolling-demo refresh and every read-side invariant check must derive its
+ * sense of "now" from a SINGLE immutable anchor, not from ad-hoc `now()` /
+ * `today()` / `MAX(some_column)` scattered across services. Today the demo is
+ * incoherent precisely because different surfaces invent different anchors
+ * (TriageService advances to MAX(arrived_at); TreatmentService uses wall-clock;
+ * periop advances to MAX(surgery_date); staffing is strict today()) — see
+ * FEEDBACK §3.4b. This class is the antidote: construct it once per batch, pass
+ * it explicitly, and every timestamp in the batch shares the same frame.
+ *
+ * The operational window is [anchor - 24h, anchor + 24h]. Historical analytic
+ * cohorts may extend farther back but must never masquerade as current
+ * operational data (plan §4.1).
+ *
+ * Tests freeze the anchor by constructing with an explicit CarbonImmutable, so
+ * they never depend on wall-clock execution speed.
+ */
+final class DemoClock
+{
+    private readonly CarbonImmutable $anchor;
+
+    private readonly int $windowHours;
+
+    /**
+     * @param  CarbonImmutable|string|null  $anchor  Explicit anchor, an ISO-8601
+     *                                               string, the literal "now", or null (= now). Frozen at construction.
+     * @param  int  $windowHours  Full operational window width; split evenly
+     *                            around the anchor (default 48 → ±24h).
+     */
+    public function __construct(CarbonImmutable|string|null $anchor = null, int $windowHours = 48)
+    {
+        $this->anchor = match (true) {
+            $anchor instanceof CarbonImmutable => $anchor,
+            $anchor === null, $anchor === '', $anchor === 'now' => CarbonImmutable::now(),
+            default => CarbonImmutable::parse($anchor),
+        };
+        $this->windowHours = max(2, $windowHours);
+    }
+
+    /** Parse the conventional `--anchor` command option ("now" or ISO-8601). */
+    public static function fromOption(?string $anchor, int $windowHours = 48): self
+    {
+        return new self($anchor, $windowHours);
+    }
+
+    /** The single immutable moment the whole batch is anchored to. */
+    public function anchor(): CarbonImmutable
+    {
+        return $this->anchor;
+    }
+
+    /** Start of the operational window (anchor - windowHours/2). */
+    public function windowStart(): CarbonImmutable
+    {
+        return $this->anchor->subHours(intdiv($this->windowHours, 2));
+    }
+
+    /** End of the operational window (anchor + windowHours/2). Forecast horizon. */
+    public function windowEnd(): CarbonImmutable
+    {
+        return $this->anchor->addHours(intdiv($this->windowHours, 2));
+    }
+
+    /** Full window width in hours. */
+    public function windowHours(): int
+    {
+        return $this->windowHours;
+    }
+
+    /** True when $at falls inside [windowStart, windowEnd]. */
+    public function contains(CarbonImmutable $at): bool
+    {
+        return $at->greaterThanOrEqualTo($this->windowStart())
+            && $at->lessThanOrEqualTo($this->windowEnd());
+    }
+
+    /** ISO-8601 anchor — used as the ledger/refresh-run key and payload stamp. */
+    public function key(): string
+    {
+        return $this->anchor->toIso8601String();
+    }
+}

--- a/app/Services/Demo/DemoInvariantService.php
+++ b/app/Services/Demo/DemoInvariantService.php
@@ -1,0 +1,382 @@
+<?php
+
+namespace App\Services\Demo;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Read-only demo invariants (plan §11 / FEEDBACK Wave 6 + the Wave-0 pre-demo gate).
+ *
+ * Runs SELECT-only checks against prod.* and reports temporal, capacity/reconciliation,
+ * freshness, and plausibility findings. It NEVER writes — it is safe to run against the
+ * canonical demo database as a pre-demo gate and in CI. The regeneration pipeline (Wave 1/2)
+ * will publish a refreshed cockpit snapshot ONLY if the critical findings here all pass.
+ *
+ * Each finding: key, category, severity (critical|warning|info), passed, observed, expected,
+ * detail. A refresh/gate should fail iff any severity=critical finding has passed=false.
+ *
+ * The specific violations this was built to catch (measured 2026-07-10 on the live demo):
+ *   - 100 future-dated census snapshots, 3 future admits, 10 discharge-before-admit rows,
+ *     96 RTDC predictions dated in the past, 46 ED visits open older than the window;
+ *   - the house denominator silently including ED (148) + periop (44) beds;
+ *   - flat ~84.5% occupancy across every unit type, an ESI-2-heavy (not ESI-3) mix,
+ *     49.9% discharge-before-noon, and a STAT≈urgent transport queue.
+ */
+final class DemoInvariantService
+{
+    public function __construct(private readonly DistributionProfile $profile) {}
+
+    /**
+     * @return list<array{key:string,category:string,severity:string,passed:bool,observed:string,expected:string,detail:string}>
+     */
+    public function run(DemoClock $clock): array
+    {
+        return [
+            ...$this->temporal($clock),
+            ...$this->capacity($clock),
+            ...$this->freshness($clock),
+            ...$this->plausibility($clock),
+        ];
+    }
+
+    /** True iff no critical finding failed. */
+    public function passed(array $findings): bool
+    {
+        foreach ($findings as $f) {
+            if ($f['severity'] === 'critical' && $f['passed'] === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // ---- temporal coherence (plan §11.1) ----
+
+    private function temporal(DemoClock $clock): array
+    {
+        $anchor = $clock->anchor()->toDateTimeString();
+        $windowStart = $clock->windowStart()->toDateTimeString();
+        $anchorDate = $clock->anchor()->toDateString();
+        // The anchor is frozen at batch start, but the seeders write at live now(), which drifts
+        // forward while a batch runs. A small grace on the "not in future" upper-bound checks
+        // absorbs that batch duration — a genuinely-future row is hours/days ahead, far past this.
+        $ceiling = $clock->anchor()->addMinutes(15)->toDateTimeString();
+        $out = [];
+
+        $futureCensus = $this->scalar(
+            'SELECT count(*) FROM prod.census_snapshots WHERE captured_at > ?', [$ceiling]
+        );
+        $out[] = $this->finding('temporal.census_not_in_future', 'temporal', 'critical',
+            $futureCensus === 0, "{$futureCensus} snapshots after anchor", '0',
+            'census_snapshots.captured_at must not exceed the anchor (+15m batch grace)');
+
+        $futureAdmit = $this->scalar(
+            'SELECT count(*) FROM prod.encounters WHERE admitted_at > ? AND discharged_at IS NULL AND is_deleted = false', [$ceiling]
+        );
+        $out[] = $this->finding('temporal.admit_not_in_future', 'temporal', 'critical',
+            $futureAdmit === 0, "{$futureAdmit} active encounters admitted after anchor", '0',
+            'an active encounter cannot be admitted in the future');
+
+        $dcBeforeAdmit = $this->scalar(
+            'SELECT count(*) FROM prod.encounters
+             WHERE is_deleted = false AND expected_discharge_date IS NOT NULL
+               AND expected_discharge_date < admitted_at', []
+        );
+        $out[] = $this->finding('temporal.discharge_after_admit', 'temporal', 'critical',
+            $dcBeforeAdmit === 0, "{$dcBeforeAdmit} encounters discharge-before-admit", '0',
+            'expected_discharge_date must be >= admitted_at');
+
+        $staleForecast = $this->scalar(
+            'SELECT count(*) FROM prod.rtdc_predictions WHERE service_date < ?::date', [$anchorDate]
+        );
+        $totalForecast = $this->scalar('SELECT count(*) FROM prod.rtdc_predictions', []);
+        $out[] = $this->finding('temporal.forecasts_current', 'temporal', 'critical',
+            $staleForecast === 0, "{$staleForecast}/{$totalForecast} predictions before anchor date", '0 stale',
+            'RTDC predictions are forecasts — service_date must be >= the anchor date');
+
+        $agedEd = $this->scalar(
+            'SELECT count(*) FROM prod.ed_visits WHERE departed_at IS NULL AND is_deleted = false AND arrived_at < ?', [$windowStart]
+        );
+        $out[] = $this->finding('temporal.no_aged_active_ed', 'temporal', 'critical',
+            $agedEd === 0, "{$agedEd} open ED visits older than the 24h window", '0',
+            'an active ED visit older than anchor-24h is not a plausible current boarder');
+
+        $edOrder = $this->scalar(
+            'SELECT count(*) FROM prod.ed_visits
+             WHERE is_deleted = false AND (
+                 (triaged_at IS NOT NULL AND triaged_at < arrived_at) OR
+                 (provider_seen_at IS NOT NULL AND triaged_at IS NOT NULL AND provider_seen_at < triaged_at) OR
+                 (departed_at IS NOT NULL AND departed_at < arrived_at))', []
+        );
+        $out[] = $this->finding('temporal.ed_lifecycle_monotonic', 'temporal', 'critical',
+            $edOrder === 0, "{$edOrder} ED rows with out-of-order lifecycle", '0',
+            'arrived <= triaged <= provider_seen <= departed');
+
+        return $out;
+    }
+
+    // ---- capacity & reconciliation (plan §8.1 / §11.2) ----
+
+    private function capacity(DemoClock $clock): array
+    {
+        $out = [];
+        $inpatientTypes = $this->profile->inpatientUnitTypes();
+        $placeholders = implode(',', array_fill(0, count($inpatientTypes), '?'));
+
+        // Bed-board occupancy by unit type (deterministic, matches prod.beds ground truth).
+        $rows = DB::select(
+            "SELECT u.type,
+                    count(b.bed_id) AS inventory,
+                    count(b.bed_id) FILTER (WHERE b.status = 'occupied') AS occupied,
+                    count(b.bed_id) FILTER (WHERE b.status = 'available') AS available,
+                    count(b.bed_id) FILTER (WHERE b.status IN ('blocked','dirty')) AS blocked
+             FROM prod.units u
+             JOIN prod.beds b ON b.unit_id = u.unit_id AND b.is_deleted = false
+             WHERE u.is_deleted = false
+             GROUP BY u.type"
+        );
+
+        $inpatientInventory = 0;
+        $inpatientOccupied = 0;
+        $reconcileOk = true;
+        foreach ($rows as $r) {
+            if ((int) $r->occupied + (int) $r->available + (int) $r->blocked !== (int) $r->inventory) {
+                $reconcileOk = false;
+            }
+            if (in_array($r->type, $inpatientTypes, true)) {
+                $inpatientInventory += (int) $r->inventory;
+                $inpatientOccupied += (int) $r->occupied;
+            }
+        }
+
+        // The canonical house denominator (HouseCensusService::houseTotals) must be inpatient-only.
+        // ED + periop beds legitimately exist; the invariant is that the CODE excludes them, not
+        // that they are absent. We assert the returned denominator does not exceed the inpatient plant.
+        $licensed = $this->profile->licensedInpatientBeds();
+        $house = app(\App\Services\Rtdc\HouseCensusService::class)->houseTotals();
+        $houseStaffed = (int) ($house['staffedBeds'] ?? 0);
+        $ceiling = $licensed > 0 ? $licensed : $inpatientInventory;
+        $out[] = $this->finding('capacity.house_denominator_inpatient_only', 'capacity', 'critical',
+            $houseStaffed <= $ceiling,
+            "houseTotals staffedBeds {$houseStaffed}",
+            "<= inpatient plant {$ceiling} (ED + periop excluded)",
+            'HouseCensusService::houseTotals() must scope the denominator to inpatient unit types');
+
+        $licensed = $this->profile->licensedInpatientBeds();
+        $out[] = $this->finding('capacity.inpatient_matches_licensed', 'capacity', 'warning',
+            $licensed === 0 || $inpatientInventory === $licensed,
+            "inpatient inventory {$inpatientInventory}", "licensed {$licensed}",
+            'physical inpatient beds should equal the licensed count');
+
+        $out[] = $this->finding('capacity.bed_states_reconcile', 'capacity', 'critical',
+            $reconcileOk, $reconcileOk ? 'all units reconcile' : 'a unit does not reconcile',
+            'occupied + available + blocked = inventory', 'per-unit bed-state sum must equal inventory');
+
+        // Occupied inpatient beds vs active inpatient encounters.
+        $activeEnc = $this->scalar(
+            "SELECT count(*) FROM prod.encounters e JOIN prod.units u ON u.unit_id = e.unit_id
+             WHERE e.discharged_at IS NULL AND e.is_deleted = false AND u.type IN ($placeholders)",
+            $inpatientTypes
+        );
+        $diff = abs($activeEnc - $inpatientOccupied);
+        $out[] = $this->finding('capacity.encounters_match_occupied', 'capacity', 'warning',
+            $diff <= max(5, (int) round($inpatientOccupied * 0.05)),
+            "active inpatient encounters {$activeEnc} vs occupied inpatient beds {$inpatientOccupied}",
+            'within 5%', 'active encounters should track occupied inpatient beds');
+
+        return $out;
+    }
+
+    // ---- source freshness (plan §10.1 — read the ALREADY-EXISTING ops.source_freshness) ----
+
+    private function freshness(DemoClock $clock): array
+    {
+        $out = [];
+        $decisionCritical = ['ed_flow', 'encounters', 'capacity_census', 'bed_placement', 'rtdc_predictions'];
+
+        $rows = DB::select('SELECT source_key, source_label, status, latest_observed_at FROM ops.source_freshness');
+        $critical = [];
+        foreach ($rows as $r) {
+            if ($r->status === 'critical') {
+                $critical[] = $r->source_key;
+            }
+        }
+        $decisionStale = array_values(array_intersect($critical, $decisionCritical));
+
+        $out[] = $this->finding('freshness.decision_sources_current', 'freshness',
+            $decisionStale === [] ? 'info' : 'critical',
+            $decisionStale === [],
+            $decisionStale === [] ? 'all decision sources current' : implode(', ', $decisionStale).' = critical',
+            'no decision-critical source stale',
+            'ops.source_freshness marks these as stale against wall-clock now(); a green cockpit tile must not be built from them');
+
+        return $out;
+    }
+
+    // ---- plausibility bands (FEEDBACK §4 — the "deeply plausible" spec) ----
+
+    private function plausibility(DemoClock $clock): array
+    {
+        $out = [];
+
+        // 1. Occupancy by unit type — banded, and not suspiciously flat.
+        $bands = $this->profile->occupancyBands();
+        $rows = DB::select(
+            "SELECT u.type,
+                    count(b.bed_id) AS inventory,
+                    count(b.bed_id) FILTER (WHERE b.status = 'occupied') AS occupied
+             FROM prod.units u JOIN prod.beds b ON b.unit_id = u.unit_id AND b.is_deleted = false
+             WHERE u.is_deleted = false GROUP BY u.type"
+        );
+        $pcts = [];
+        foreach ($rows as $r) {
+            $type = (string) $r->type;
+            if (! isset($bands[$type]) || (int) $r->inventory === 0) {
+                continue;
+            }
+            $pct = (int) $r->occupied / (int) $r->inventory;
+            $pcts[$type] = $pct;
+            [$min, $max] = $bands[$type];
+            $out[] = $this->finding("plausibility.occupancy.$type", 'plausibility', 'warning',
+                $pct >= $min && $pct <= $max,
+                sprintf('%s %.1f%%', $type, $pct * 100),
+                sprintf('%.0f–%.0f%%', $min * 100, $max * 100),
+                'occupancy should sit inside the unit-type operating band');
+        }
+        if (count($pcts) >= 2) {
+            $spread = max($pcts) - min($pcts);
+            $out[] = $this->finding('plausibility.occupancy_differentiated', 'plausibility', 'warning',
+                $spread >= 0.03,
+                sprintf('spread %.1f points', $spread * 100), '>= 3 points',
+                'a flat occupancy across all unit types reads as a global target, not a real house (ICUs run hotter)');
+        }
+
+        // 2. ED acuity pyramid — ESI-3 modal, each level in band.
+        $esiRows = DB::select(
+            'SELECT esi_level, count(*) AS n FROM prod.ed_visits WHERE is_deleted = false AND esi_level IS NOT NULL GROUP BY esi_level'
+        );
+        $esiCounts = [];
+        $esiTotal = 0;
+        foreach ($esiRows as $r) {
+            $esiCounts[(int) $r->esi_level] = (int) $r->n;
+            $esiTotal += (int) $r->n;
+        }
+        if ($esiTotal > 0) {
+            $esiBands = $this->profile->esiBands();
+            $inBand = true;
+            $detail = [];
+            foreach ($esiBands as $level => [$min, $max]) {
+                $share = ($esiCounts[$level] ?? 0) / $esiTotal;
+                $detail[] = sprintf('ESI-%d %.0f%%', $level, $share * 100);
+                if ($share < $min || $share > $max) {
+                    $inBand = false;
+                }
+            }
+            $modal = array_keys($esiCounts, max($esiCounts))[0] ?? null;
+            $out[] = $this->finding('plausibility.esi_bands', 'plausibility', 'warning',
+                $inBand, implode(' · ', $detail), 'each level within band',
+                'a real ED presents as an ESI-3-dominant pyramid');
+            $out[] = $this->finding('plausibility.esi_modal_is_3', 'plausibility', 'warning',
+                $modal === 3, "modal class ESI-{$modal}", 'ESI-3',
+                'ESI-3 should be the largest presenting class');
+        }
+
+        // 3. Discharge-before-noon — realistic, not fantasy.
+        $dcRow = DB::selectOne(
+            'SELECT count(*) AS n, count(*) FILTER (WHERE extract(hour FROM discharged_at) < 12) AS before_noon
+             FROM prod.discharge_facts WHERE discharged_at IS NOT NULL'
+        );
+        if ($dcRow && (int) $dcRow->n > 0) {
+            $share = (int) $dcRow->before_noon / (int) $dcRow->n;
+            [$min, $max] = $this->profile->dischargeBeforeNoonBand();
+            $out[] = $this->finding('plausibility.discharge_before_noon', 'plausibility', 'warning',
+                $share >= $min && $share <= $max,
+                sprintf('%.1f%%', $share * 100), sprintf('%.0f–%.0f%%', $min * 100, $max * 100),
+                'discharge-before-noon > ~45% is not achievable in reality');
+        }
+
+        // 4. Transport priority mix + overdue share.
+        $tpRows = DB::select(
+            'SELECT priority, count(*) AS n, count(*) FILTER (WHERE completed_at IS NULL) AS active FROM prod.transport_requests GROUP BY priority'
+        );
+        $tpTotal = 0;
+        $tpCounts = [];
+        $activeTotal = 0;
+        foreach ($tpRows as $r) {
+            $tpCounts[(string) $r->priority] = (int) $r->n;
+            $tpTotal += (int) $r->n;
+            $activeTotal += (int) $r->active;
+        }
+        if ($tpTotal > 0) {
+            $tpBands = $this->profile->transportPriorityBands();
+            $inBand = true;
+            $detail = [];
+            foreach ($tpBands as $prio => [$min, $max]) {
+                $share = ($tpCounts[$prio] ?? 0) / $tpTotal;
+                $detail[] = sprintf('%s %.0f%%', $prio, $share * 100);
+                if ($share < $min || $share > $max) {
+                    $inBand = false;
+                }
+            }
+            $out[] = $this->finding('plausibility.transport_priority_mix', 'plausibility', 'warning',
+                $inBand, implode(' · ', $detail), 'routine dominant, stat a thin slice',
+                'STAT should not rival urgent or routine volume');
+        }
+        $activeOverdue = $this->scalar(
+            'SELECT count(*) FROM prod.transport_requests WHERE completed_at IS NULL AND needed_at < ?',
+            [$clock->anchor()->toDateTimeString()]
+        );
+        if ($activeTotal > 0) {
+            $share = $activeOverdue / $activeTotal;
+            $out[] = $this->finding('plausibility.transport_overdue_share', 'plausibility', 'warning',
+                $share <= $this->profile->transportOverdueShareMax(),
+                sprintf('%d/%d active overdue (%.0f%%)', $activeOverdue, $activeTotal, $share * 100),
+                sprintf('<= %.0f%%', $this->profile->transportOverdueShareMax() * 100),
+                'only a small intentional cohort should breach SLA');
+        }
+
+        // 5. OR physical rooms vs declared procedure spaces (identity consistency).
+        $physicalRooms = $this->scalar("SELECT count(*) FROM prod.rooms WHERE type = 'OR' AND is_deleted = false", []);
+        $declaredSpaces = 0;
+        foreach ($this->profile->unitRoster() as $u) {
+            if (($u['cadCode'] ?? null) === 'PERIOP') {
+                $declaredSpaces = (int) ($u['beds'] ?? 0);
+            }
+        }
+        if ($declaredSpaces > 0) {
+            $out[] = $this->finding('plausibility.or_room_scale', 'plausibility', 'warning',
+                $physicalRooms >= (int) round($declaredSpaces * 0.4),
+                "OR rooms {$physicalRooms}", "~{$declaredSpaces} declared procedure spaces",
+                'a Level I / 44-room identity backed by only a handful of rooms undercuts OR realism');
+        }
+
+        // 6. OR daily volume on the most-recent surgical day — a real suite runs many rooms.
+        $orDay = DB::selectOne('SELECT max(surgery_date)::date AS d FROM prod.or_cases WHERE is_deleted = false');
+        if ($orDay && $orDay->d !== null) {
+            $vol = $this->scalar('SELECT count(*) FROM prod.or_cases WHERE surgery_date::date = ?::date AND is_deleted = false', [$orDay->d]);
+            $roomsUsed = $this->scalar('SELECT count(DISTINCT room_id) FROM prod.or_cases WHERE surgery_date::date = ?::date AND is_deleted = false', [$orDay->d]);
+            $out[] = $this->finding('plausibility.or_daily_volume', 'plausibility', 'warning',
+                $vol >= 20 && $roomsUsed >= 8,
+                "{$vol} cases across {$roomsUsed} rooms on {$orDay->d}",
+                '>= 20 cases across >= 8 rooms',
+                'a Level I OR suite runs many rooms with meaningful daily volume');
+        }
+
+        return $out;
+    }
+
+    // ---- helpers ----
+
+    private function scalar(string $sql, array $bindings): int
+    {
+        $row = DB::selectOne($sql, $bindings);
+
+        return (int) ($row->count ?? array_values((array) $row)[0] ?? 0);
+    }
+
+    private function finding(string $key, string $category, string $severity, bool $passed, string $observed, string $expected, string $detail): array
+    {
+        return compact('key', 'category', 'severity', 'passed', 'observed', 'expected', 'detail');
+    }
+}

--- a/app/Services/Demo/DistributionProfile.php
+++ b/app/Services/Demo/DistributionProfile.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace App\Services\Demo;
+
+use RuntimeException;
+
+/**
+ * Typed accessor for a facility's VERIFIED distribution profile
+ * (config/hospital/hospital-1-distributions.json).
+ *
+ * This JSON is a rigorously derived, independently reproduced statistical
+ * profile of the synthetic MIMIC-IV / atlantic_health cohort — admission
+ * archetypes, careunit transition matrix, per-unit-type LOS, ICU LOS, ED
+ * throughput, service-line weights, disposition mix, geriatric demographics,
+ * and the acuity/procedure signature. Until this class existed it was cited
+ * only in a code COMMENT and never loaded at runtime, so the operational
+ * seeders fell back to hand-tuned constants and the data came out coherent but
+ * not distribution-true (flat per-unit occupancy, an over-acute ESI mix, a
+ * fantasy discharge-before-noon rate). See
+ * docs/DEMO-DATA-COHERENCE-FEEDBACK-AND-PLAN-2026-07-10.md §3.5 / §4.
+ *
+ * Two kinds of data are exposed:
+ *   1. SOURCE-DERIVED shapes read straight from the JSON (losByUnitType, esi
+ *      is NOT in the JSON, dispositionMix, transitionMatrix, …).
+ *   2. CLINICAL-BENCHMARK bands from config('hospital.plausibility_targets') —
+ *      realistic operating ranges the source cohort doesn't pin down (occupancy
+ *      by unit type, ESI pyramid, transport mix, discharge-before-noon).
+ *
+ * Mirrors App\Support\Hospital\HospitalManifest: facility-parameterized, loaded
+ * once, statically cached per facility_key.
+ */
+final class DistributionProfile
+{
+    /** @var array<string,array<string,mixed>> keyed by facility_key */
+    private static array $cache = [];
+
+    private readonly string $facilityKey;
+
+    public function __construct(?string $facilityKey = null)
+    {
+        $this->facilityKey = $facilityKey
+            ?? (string) config('hospital.default_facility', 'SUMMIT_REGIONAL');
+    }
+
+    public static function forFacility(string $facilityKey): self
+    {
+        return new self($facilityKey);
+    }
+
+    public function facilityKey(): string
+    {
+        return $this->facilityKey;
+    }
+
+    // ---- identity / capacity vocabulary (plan §8.1) ----
+
+    /** Licensed inpatient beds (Summit = 500). The only house denominator basis. */
+    public function licensedInpatientBeds(): int
+    {
+        return (int) ($this->data()['facility']['licensedBeds'] ?? 0);
+    }
+
+    /** prod.units.type values that roll into the inpatient house denominator. */
+    public function inpatientUnitTypes(): array
+    {
+        return (array) config('hospital.inpatient_unit_types', ['icu', 'step_down', 'med_surg']);
+    }
+
+    // ---- source-derived shapes (read straight from the JSON) ----
+
+    /** @return list<array<string,mixed>> the 23-unit CAD roster + ED + PERIOP. */
+    public function unitRoster(): array
+    {
+        return (array) ($this->data()['unitRoster'] ?? []);
+    }
+
+    /** Length-of-stay stats keyed by careunit unitType (median/p75/p90/max/mean days). */
+    public function losByUnitType(): array
+    {
+        $out = [];
+        foreach ((array) ($this->data()['losDistributionsByUnitType'] ?? []) as $row) {
+            $out[(string) $row['unitType']] = $row;
+        }
+
+        return $out;
+    }
+
+    /**
+     * True ICU bed LOS (icustays.los, median 4.07d) — NOT the sub-1-day MICU
+     * "transport unit" artifact in losByUnitType. The JSON flags this trap
+     * explicitly; use this for MICU3/SICU3/NSICU3/CVICU3/BURN3.
+     */
+    public function icuLos(): array
+    {
+        return (array) ($this->data()['icuLos'] ?? []);
+    }
+
+    /** ED door-to-disposition throughput hours (median 5.38h, p90 10.3h). */
+    public function edThroughputHours(): array
+    {
+        return (array) ($this->data()['edThroughputHours'] ?? []);
+    }
+
+    /** @return list<array{destination:string,probability:float}> verified disposition mix. */
+    public function dispositionMix(): array
+    {
+        return (array) ($this->data()['dispositionMix'] ?? []);
+    }
+
+    /** @return list<array{path:string,probability:float}> */
+    public function admissionArchetypes(): array
+    {
+        return (array) ($this->data()['admissionArchetypes'] ?? []);
+    }
+
+    /** @return list<array{from:string,to:string,probability:float}> careunit transitions. */
+    public function transitionMatrix(): array
+    {
+        return (array) ($this->data()['transitionMatrix'] ?? []);
+    }
+
+    /** @return list<array<string,mixed>> service-line weights (sum to 1.0). */
+    public function serviceLineWeights(): array
+    {
+        return (array) ($this->data()['serviceLineWeights'] ?? []);
+    }
+
+    public function demographics(): array
+    {
+        return (array) ($this->data()['demographics'] ?? []);
+    }
+
+    public function mortalityRate(): float
+    {
+        return (float) ($this->data()['mortalityRate'] ?? 0.0);
+    }
+
+    // ---- clinical-benchmark plausibility bands (config-driven; tuneable) ----
+
+    /** @return array<string,array{0:float,1:float}> unit_type => [minPct, maxPct] as fractions. */
+    public function occupancyBands(): array
+    {
+        return (array) config('hospital.plausibility_targets.occupancy_by_unit_type', []);
+    }
+
+    /** @return array<int,array{0:float,1:float}> esi level => [minShare, maxShare]. */
+    public function esiBands(): array
+    {
+        return (array) config('hospital.plausibility_targets.esi_share', []);
+    }
+
+    /** @return array{0:float,1:float} [min, max] share discharged before noon. */
+    public function dischargeBeforeNoonBand(): array
+    {
+        return (array) config('hospital.plausibility_targets.discharge_before_noon', [0.18, 0.42]);
+    }
+
+    /** @return array<string,array{0:float,1:float}> priority => [minShare, maxShare]. */
+    public function transportPriorityBands(): array
+    {
+        return (array) config('hospital.plausibility_targets.transport_priority_share', []);
+    }
+
+    public function transportOverdueShareMax(): float
+    {
+        return (float) config('hospital.plausibility_targets.transport_overdue_share_max', 0.20);
+    }
+
+    /** @return array{0:float,1:float} [min, max] cases per physical OR room per weekday. */
+    public function orCasesPerRoomWeekdayBand(): array
+    {
+        return (array) config('hospital.plausibility_targets.or_cases_per_room_weekday', [3.0, 12.0]);
+    }
+
+    // ---- loading (mirrors HospitalManifest) ----
+
+    /** @return array<string,mixed> */
+    private function data(): array
+    {
+        if (! isset(self::$cache[$this->facilityKey])) {
+            $path = base_path($this->configPath());
+            $raw = @file_get_contents($path);
+            if ($raw === false) {
+                throw new RuntimeException("Distribution profile file not readable: {$path}");
+            }
+            $decoded = json_decode($raw, true);
+            if (! is_array($decoded)) {
+                throw new RuntimeException("Distribution profile is not valid JSON: {$path}");
+            }
+            self::$cache[$this->facilityKey] = $decoded;
+        }
+
+        return self::$cache[$this->facilityKey];
+    }
+
+    private function configPath(): string
+    {
+        /** @var array<string,string> $map */
+        $map = (array) config('hospital.distributions', []);
+        $path = $map[$this->facilityKey] ?? null;
+        if (! is_string($path) || $path === '') {
+            throw new RuntimeException(
+                "No distribution profile registered for facility_key '{$this->facilityKey}'. ".
+                'Register it under config/hospital.php `distributions`.'
+            );
+        }
+
+        return $path;
+    }
+
+    /** Test helper: drop the static cache. */
+    public static function flush(): void
+    {
+        self::$cache = [];
+    }
+}

--- a/app/Services/Demo/DistributionSampler.php
+++ b/app/Services/Demo/DistributionSampler.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services\Demo;
+
+/**
+ * Deterministic weighted sampling for the demo generators (FEEDBACK Wave 2).
+ *
+ * The operational seeders were coherent but not distribution-true — flat occupancy across
+ * every unit type, an ESI-2-heavy ED mix, a ~50% (uniform-hour) discharge-before-noon rate,
+ * a STAT-heavy transport queue. This sampler lets the generators draw plausible values from
+ * weighted distributions / clinical bands (DistributionProfile) instead of flat constants,
+ * while staying fully deterministic (seed in → value out, no global mt_srand state), so
+ * repeated demo refreshes remain idempotent.
+ */
+final class DistributionSampler
+{
+    /** Deterministic pseudo-random float in [0,1) from an integer seed. */
+    public function unit(int $seed): float
+    {
+        return (crc32('ds:'.$seed) % 1_000_000) / 1_000_000;
+    }
+
+    /**
+     * Deterministic weighted choice. Returns the KEY of $weights.
+     *
+     * @template T of array-key
+     *
+     * @param  array<T,int|float>  $weights  value => weight
+     * @return T
+     */
+    public function weightedPick(array $weights, int $seed): int|string
+    {
+        $total = array_sum($weights);
+        if ($total <= 0) {
+            return array_key_first($weights);
+        }
+        $r = $this->unit($seed) * $total;
+        foreach ($weights as $value => $weight) {
+            $r -= $weight;
+            if ($r < 0) {
+                return $value;
+            }
+        }
+
+        return array_key_last($weights);
+    }
+
+    /**
+     * Deterministic value uniformly inside a [min,max] band.
+     *
+     * @param  array{0:float,1:float}  $band
+     */
+    public function valueInBand(array $band, int $seed): float
+    {
+        [$min, $max] = $band;
+
+        return $min + $this->unit($seed) * ($max - $min);
+    }
+
+    /** Deterministic integer in [min,max] inclusive. */
+    public function intBetween(int $min, int $max, int $seed): int
+    {
+        if ($max <= $min) {
+            return $min;
+        }
+
+        return $min + (int) floor($this->unit($seed) * ($max - $min + 1));
+    }
+}

--- a/app/Services/Rtdc/HouseCensusService.php
+++ b/app/Services/Rtdc/HouseCensusService.php
@@ -60,11 +60,20 @@ class HouseCensusService
     /**
      * House-wide totals from the same rows — the single occupancy formula.
      *
+     * The house denominator is INPATIENT ONLY: ED treatment spaces and periop
+     * procedure rooms are capacity in their own domains and must never inflate
+     * house occupancy (plan §8.1 capacity vocabulary). Per-unit consumers keep
+     * calling latestPerUnit() to see every unit; only the house TOTAL is scoped.
+     *
      * @return array{staffedBeds:int,occupied:int,available:int,blocked:int,occupancyPct:int}
      */
     public function houseTotals(): array
     {
-        $rows = $this->latestPerUnit();
+        $inpatientTypes = (array) config('hospital.inpatient_unit_types', ['icu', 'step_down', 'med_surg']);
+        $rows = array_filter(
+            $this->latestPerUnit(),
+            fn ($row): bool => in_array($row->unit_type ?? null, $inpatientTypes, true)
+        );
 
         $staffed = (int) array_sum(array_map(fn ($row): int => (int) $row->staffed_beds, $rows));
         $occupied = (int) array_sum(array_map(fn ($row): int => (int) $row->occupied, $rows));

--- a/config/hospital.php
+++ b/config/hospital.php
@@ -22,4 +22,53 @@ return [
     'manifests' => [
         'SUMMIT_REGIONAL' => 'config/hospital/hospital-1.php',
     ],
+
+    // facility_key => path (relative to base_path()) of the VERIFIED distribution profile
+    // (synthetic MIMIC-IV / atlantic_health provenance). Read by App\Services\Demo\DistributionProfile.
+    // Before this key existed the JSON was documentation only — cited in a code comment but never
+    // loaded at runtime, so the operational seeders used hand-tuned constants instead of these
+    // source-derived shapes. See docs/DEMO-DATA-COHERENCE-FEEDBACK-AND-PLAN-2026-07-10.md §3.5.
+    'distributions' => [
+        'SUMMIT_REGIONAL' => 'config/hospital/hospital-1-distributions.json',
+    ],
+
+    // Which prod.units.type values roll up into the licensed INPATIENT house denominator.
+    // ED treatment spaces and periop procedure rooms are capacity in their own domain but are
+    // NEVER part of house occupancy (plan §8.1 capacity vocabulary; FEEDBACK §3.4a/§5).
+    'inpatient_unit_types' => ['icu', 'step_down', 'med_surg'],
+
+    // Clinical-benchmark plausibility bands used by App\Services\Demo\DemoInvariantService (and,
+    // later, the regeneration sampler). These are NOT source-derived — they are realistic operating
+    // ranges for a busy academic medical center, kept here so they are tuneable per demo scenario.
+    // Rationale/citations live beside each band in FEEDBACK §4.
+    'plausibility_targets' => [
+        // Inpatient occupancy by unit type — ICUs run hotter than med/surg; a flat number across
+        // every unit type reads as a global target, not a real house. (min, max) as fractions.
+        'occupancy_by_unit_type' => [
+            'icu' => [0.80, 0.96],
+            'step_down' => [0.76, 0.93],
+            'med_surg' => [0.72, 0.90],
+        ],
+        // ED arrival acuity — a real ED is an ESI-3-dominant pyramid. Shares as (min, max) per level;
+        // ESI-3 must also be the modal (largest) class.
+        'esi_share' => [
+            1 => [0.005, 0.05],
+            2 => [0.12, 0.30],
+            3 => [0.35, 0.52],
+            4 => [0.14, 0.30],
+            5 => [0.02, 0.12],
+        ],
+        // Discharge-before-noon is a metric hospitals fight to hit; >45% is fantasy. (min, max).
+        'discharge_before_noon' => [0.18, 0.42],
+        // Transport priority mix — routine dominates, stat is a thin slice.
+        'transport_priority_share' => [
+            'routine' => [0.55, 0.85],
+            'urgent' => [0.10, 0.30],
+            'stat' => [0.02, 0.15],
+        ],
+        // Share of the ACTIVE transport queue allowed to be past its needed_by (SLA breach).
+        'transport_overdue_share_max' => 0.20,
+        // OR weekday volume sanity, expressed per physical OR room (cases per room per weekday).
+        'or_cases_per_room_weekday' => [3.0, 12.0],
+    ],
 ];

--- a/database/seeders/CommandCenterDemoSeeder.php
+++ b/database/seeders/CommandCenterDemoSeeder.php
@@ -857,6 +857,14 @@ class CommandCenterDemoSeeder extends Seeder
         $elapsedDays = max(1, (int) $monthStart->diffInDays(now()));
         $rows = [];
 
+        // Afternoon-peaked discharge hour (FEEDBACK Wave 2): a uniform 0–23h gave ~50%
+        // discharge-before-noon, which no hospital achieves. This lands ~30% before noon.
+        $sampler = new \App\Services\Demo\DistributionSampler;
+        $dischargeHourWeights = [
+            0 => 1, 1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 2, 6 => 3, 7 => 4, 8 => 6, 9 => 8, 10 => 9, 11 => 10,
+            12 => 14, 13 => 16, 14 => 16, 15 => 14, 16 => 12, 17 => 10, 18 => 8, 19 => 6, 20 => 5, 21 => 4, 22 => 2, 23 => 1,
+        ];
+
         for ($i = 1; $i <= 1284; $i++) {
             $seed = 70400 + $i;
             $isObs = $i <= 159; // ≈12.4%
@@ -864,7 +872,7 @@ class CommandCenterDemoSeeder extends Seeder
             $cost = 8000 + $this->seededRand($seed + 1, 0, 7800);            // mean ≈11,900
             $dischargedAt = $monthStart->copy()
                 ->addDays($this->seededRand($seed + 2, 0, $elapsedDays))
-                ->addHours($this->seededRand($seed + 3, 0, 23));
+                ->addHours((int) $sampler->weightedPick($dischargeHourWeights, $seed + 3));
             if ($dischargedAt->greaterThan(now())) {
                 $dischargedAt = now()->copy()->subHours(1);
             }
@@ -1170,9 +1178,14 @@ class CommandCenterDemoSeeder extends Seeder
             return;
         }
 
-        // Clearing the requests cascades their transport_events (FK cascadeOnDelete),
-        // so this stays idempotent for both tables.
-        DB::table('prod.transport_requests')->where('requested_by', 'demo-seeder')->delete();
+        // prod.transport_events is an append-only ledger (prod.reject_transport_ledger_mutation
+        // rejects DELETE/UPDATE), so demo transport is seeded ONCE and then left intact — deleting
+        // requests that already have events would cascade into the protected ledger and fail. On
+        // re-runs DemoTuningSeeder::refreshSlas() keeps active needed_at/needed_by near "now"
+        // without mutating the ledger, so the queue stays current.
+        if (DB::table('prod.transport_requests')->where('requested_by', 'demo-seeder')->exists()) {
+            return;
+        }
 
         $hasEvents = Schema::hasTable('prod.transport_events');
 
@@ -1391,7 +1404,9 @@ class CommandCenterDemoSeeder extends Seeder
         $dispositions = $this->deterministicShuffle($dispositions, 20260622);
 
         // ESI weight: mostly 2-4, rarely 1 or 5.
-        $esiWeights = [1 => 5, 2 => 25, 3 => 45, 4 => 20, 5 => 5];
+        // ESI-3-dominant pyramid (FEEDBACK Wave 2). ESI-1 is deliberately rare in walk-in
+        // throughput — the true ESI-1 resuscitations are the ventilated crowding cohort below.
+        $esiWeights = [1 => 1, 2 => 25, 3 => 46, 4 => 23, 5 => 5];
         $esiPool = [];
         foreach ($esiWeights as $level => $weight) {
             for ($w = 0; $w < $weight; $w++) {
@@ -1498,6 +1513,7 @@ class CommandCenterDemoSeeder extends Seeder
         // little and the crowding term must carry the score: 34 patients
         // currently in the department (none admitted → boarders unchanged),
         // 8 still waiting for a provider, 4 on ventilators.
+        $sampler = new \App\Services\Demo\DistributionSampler;
         for ($k = 1; $k <= 34; $k++) {
             $seed = 20260701 + $k * 17;
             $arrivedAt = now()->subMinutes($this->seededRand($seed, 20, 360));
@@ -1505,11 +1521,20 @@ class CommandCenterDemoSeeder extends Seeder
             $ventilated = $k <= 4; // 4 critical, on vents
             $triagedAt = $arrivedAt->copy()->addMinutes($this->seededRand($seed + 1, 3, 10));
 
+            // A boarding cohort skews higher-acuity but is not all ESI-2: vents are ESI-1,
+            // undifferentiated waiters are ESI-2/3, the rest sample an ESI-3-modal pyramid
+            // (FEEDBACK Wave 2 — keeps ESI-3 the modal class overall).
+            $esiLevelCrowd = $ventilated
+                ? 1
+                : ($waiting
+                    ? $sampler->weightedPick([2 => 2, 3 => 3], $seed + 5)
+                    : $sampler->weightedPick([2 => 30, 3 => 45, 4 => 20, 5 => 5], $seed + 5));
+
             EdVisit::create([
                 'patient_ref' => sprintf('sim-ed-crowd-%02d', $k),
                 'arrived_at' => $arrivedAt,
                 'triaged_at' => $triagedAt,
-                'esi_level' => $ventilated ? 1 : ($waiting ? 3 : 2),
+                'esi_level' => $esiLevelCrowd,
                 'is_ventilated' => $ventilated,
                 'provider_seen_at' => $waiting ? null : $triagedAt->copy()->addMinutes($this->seededRand($seed + 2, 5, 20)),
                 'disposition' => null, // still in ED, undispositioned
@@ -1659,8 +1684,16 @@ class CommandCenterDemoSeeder extends Seeder
             }
         }
 
-        // Rooms (4 ORs).
-        $roomNames = ['OR-1', 'OR-2', 'OR-3', 'OR-4'];
+        // Rooms — a Level I academic OR suite (FEEDBACK Wave 2: 4 ORs read as a community
+        // hospital, not the 44-space procedural platform in the manifest). 20 named ORs across
+        // the service lines; a block-schedule "active" pattern below keeps a realistic subset
+        // running each day so the board is full without every room being lit.
+        $roomNames = [
+            'GEN-OR-1', 'GEN-OR-2', 'GEN-OR-3', 'GEN-OR-4', 'GEN-OR-5', 'GEN-OR-6',
+            'CV-OR-1', 'CV-OR-2', 'NEURO-OR-1', 'NEURO-OR-2',
+            'ORTHO-OR-1', 'ORTHO-OR-2', 'ORTHO-OR-3', 'TRAUMA-OR-1', 'TRAUMA-OR-2',
+            'HYBRID-OR-1', 'HYBRID-OR-2', 'ROBOTIC-OR-1', 'ROBOTIC-OR-2', 'OB-OR-1',
+        ];
         $roomIds = [];
         foreach ($roomNames as $rn) {
             $existing = DB::table('prod.rooms')
@@ -1683,6 +1716,13 @@ class CommandCenterDemoSeeder extends Seeder
                 ], 'room_id');
             }
         }
+
+        // Retire seeder-owned ORs no longer in the roster (e.g. the old OR-1..OR-4) so they
+        // don't linger as orphaned idle rooms after the suite was expanded.
+        DB::table('prod.rooms')
+            ->where('created_by', 'seeder')->where('type', 'OR')
+            ->whereNotIn('name', $roomNames)
+            ->update(['is_deleted' => true, 'updated_at' => now()]);
 
         // Case statuses (idempotent via CaseManagementSeeder pattern).
         $this->ensureCaseStatuses();
@@ -1794,8 +1834,18 @@ class CommandCenterDemoSeeder extends Seeder
 
         foreach ($weekdays as $dayIdx => $day) {
             foreach ($roomIds as $roomIdx => $roomId) {
-                // ~5 cases per room per day.
-                $numCases = 5;
+                // Block schedule: ~70% of ORs are staffed on a given weekday; the rest are dark
+                // (they read 'available' in Room Status). The most-recent day forces the first 12
+                // rooms active so the live board is full even when the real anchor is a weekend.
+                $active = $this->seededRand($dayIdx * 100 + $roomIdx + 7, 0, 99) < 70;
+                if ($dayIdx === $anchorDayIdx && $roomIdx < 12) {
+                    $active = true;
+                }
+                if (! $active) {
+                    continue;
+                }
+                // 2–4 cases per active room (was a flat 5 across only 4 rooms).
+                $numCases = $this->seededRand($dayIdx * 7 + $roomIdx + 3, 2, 4);
                 $slotStart = $day->copy()->setTime(7, 30);
 
                 for ($cIdx = 0; $cIdx < $numCases; $cIdx++) {
@@ -1873,31 +1923,17 @@ class CommandCenterDemoSeeder extends Seeder
                         $procStartOffset = null; // reset each iteration to avoid cross-case leakage
 
                         if ($cIdx === 0) {
-                            // FCOTS target on the most recent OR day (dayIdx=4): exactly
-                            // 1 of 4 first-cases late → 3/4 = 75% on the latest day,
-                            // which is what CommandCenterDataService reports (it queries
-                            // only the max(surgery_date) day).
-                            // Hard-code late slots as (dayIdx, roomIdx) pairs for
-                            // determinism across re-runs. dayIdx=4 roomIdx=1 is the
-                            // designated late case on the latest OR day.
-                            $lateSlots = [[0, 3], [2, 1], [3, 0], [4, 1]]; // (dayIdx, roomIdx)
-                            $isLate = false;
-                            foreach ($lateSlots as $slot) {
-                                if ($slot[0] === $dayIdx && $slot[1] === $roomIdx) {
-                                    $isLate = true;
-                                    break;
-                                }
-                            }
-                            if (! $isLate) {
-                                // On-time: procedure_start_time = scheduledStart + (-2 to +13m)
-                                $procStartOffset = $this->seededRand($seed + 4, -2, 13);
-                            } else {
-                                // Late: procedure_start_time = scheduledStart + (16 to 40m)
-                                $procStartOffset = $this->seededRand($seed + 4, 16, 40);
-                            }
+                            // FCOTS ≈ 80% first-case on-time, generalised across N rooms (was
+                            // hardcoded (dayIdx,roomIdx) slots that only covered 4 rooms). A
+                            // deterministic 1-in-5 modulo keeps the late rate controlled and stable
+                            // (a random draw over few rooms can land on a fake-looking 100%).
+                            $isLate = (($dayIdx + $roomIdx) % 5 === 0);
+                            $procStartOffset = $isLate
+                                ? $this->seededRand($seed + 5, 16, 40)   // late: +16–40m
+                                : $this->seededRand($seed + 5, -2, 13);  // on-time: -2–+13m
                             $procStart = $scheduledStart->copy()->addMinutes($procStartOffset);
                             // OR-in 10–20m before procedure start.
-                            $orInTime = $procStart->copy()->subMinutes($this->seededRand($seed + 5, 10, 20));
+                            $orInTime = $procStart->copy()->subMinutes($this->seededRand($seed + 6, 10, 20));
                         } else {
                             // Non-first cases: standard OR-in jitter, then fixed prep.
                             $lateStartMin = $this->seededRand($seed + 4, -5, 20);
@@ -1999,7 +2035,9 @@ class CommandCenterDemoSeeder extends Seeder
             // Mild seasonality: slightly higher volume mid-week.
             $monthSeed = (int) $day->format('Ymd');
 
-            foreach ($roomIds as $roomIdx => $roomId) {
+            // History is carried by the sustained-volume general/CV ORs (specialty rooms run
+            // sparser elective schedules); keeps the ~6-month trend volume modest across 20 rooms.
+            foreach (array_slice($roomIds, 0, 6, true) as $roomIdx => $roomId) {
                 $numCases = $this->seededRand($monthSeed + $roomIdx, 3, 5);
                 $slotStart = $day->copy()->setTime(7, 30);
 

--- a/database/seeders/DemoTuningSeeder.php
+++ b/database/seeders/DemoTuningSeeder.php
@@ -23,7 +23,11 @@ use Illuminate\Support\Facades\DB;
  */
 class DemoTuningSeeder extends Seeder
 {
-    private const TARGET_OCCUPANCY = 0.85;
+    // Per-unit-type occupancy target: ICUs run hotter than med/surg — a flat number across
+    // every type reads as a global target, not a real house. Each value sits inside its
+    // config('hospital.plausibility_targets.occupancy_by_unit_type') band; populateOccupancy()
+    // only fills UP, so med/surg settles near ~85% while ICU and step-down are pulled higher.
+    private const OCCUPANCY_TARGET = ['icu' => 0.92, 'step_down' => 0.86, 'med_surg' => 0.84];
 
     /** Acuity mix by unit type: [tier => weight]. ICUs skew high, med/surg low. */
     private const ACUITY = [
@@ -34,12 +38,44 @@ class DemoTuningSeeder extends Seeder
 
     public function run(): void
     {
+        $this->clampTemporalLeaks();
         $this->fixEdBedInventory();
         $this->reconcileStrayEncounters();
         $this->populateOccupancy();
         $this->refreshSlas();
         $this->staffingToday();
         $this->varyOrSurgeons();
+    }
+
+    /**
+     * 0. Correct seed-owned temporal leaks in the NON-scenario domains (encounters / census /
+     *    predictions — the scenario's own staffing+transport are owned by OperationalDemoDataService)
+     *    so the current snapshot is coherent (enforced by zephyrus:demo-validate):
+     *      - purge expired forecasts once today/tomorrow replacements exist;
+     *      - drop future-dated census "actuals" (a snapshot cannot be in the future);
+     *      - pull active encounters admitted in the future back to a plausible recent admit;
+     *      - repair expected_discharge_date rows that precede admission.
+     *    Idempotent (no-ops once clean).
+     */
+    private function clampTemporalLeaks(): void
+    {
+        DB::delete("DELETE FROM prod.rtdc_predictions WHERE service_date < (now() AT TIME ZONE 'UTC')::date");
+
+        DB::delete("DELETE FROM prod.census_snapshots WHERE captured_at > (now() AT TIME ZONE 'UTC')");
+
+        DB::update("
+            UPDATE prod.encounters
+            SET admitted_at = (now() AT TIME ZONE 'UTC') - (floor(random()*72)||' hours')::interval,
+                updated_at = now()
+            WHERE admitted_at > (now() AT TIME ZONE 'UTC') AND discharged_at IS NULL AND is_deleted = false
+        ");
+
+        DB::update("
+            UPDATE prod.encounters
+            SET expected_discharge_date = (admitted_at + ((2 + floor(random()*4))||' days')::interval)::date,
+                updated_at = now()
+            WHERE is_deleted = false AND expected_discharge_date IS NOT NULL AND expected_discharge_date < admitted_at
+        ");
     }
 
     /** 1. Prune phantom "available" ED beds so the ED bed rows match its staffed count. */
@@ -86,9 +122,13 @@ class DemoTuningSeeder extends Seeder
             ORDER BY u.unit_id
         ");
 
+        $sampler = new \App\Services\Demo\DistributionSampler;
         $seq = 0;
         foreach ($units as $u) {
-            $goal = (int) round(self::TARGET_OCCUPANCY * (int) $u->staffed_bed_count);
+            // Per-type target + a small deterministic per-unit jitter so units within a type vary.
+            $base = self::OCCUPANCY_TARGET[$u->type] ?? 0.82;
+            $target = $base + $sampler->valueInBand([-0.02, 0.02], (int) $u->unit_id);
+            $goal = (int) round($target * (int) $u->staffed_bed_count);
             $delta = $goal - (int) $u->occ;
             if ($delta <= 0) {
                 continue;

--- a/docs/DEMO-DATA-COHERENCE-AND-REMEDIATION-PLAN-2026-07-10.md
+++ b/docs/DEMO-DATA-COHERENCE-AND-REMEDIATION-PLAN-2026-07-10.md
@@ -1,0 +1,577 @@
+# Zephyrus Demo Data Coherence and Application Remediation Plan
+
+**Date:** 2026-07-10  
+**Status:** Execution-ready remediation backlog  
+**Environment:** `zephyrus.acumenus.net` working demonstration environment  
+**Data policy:** Synthetic/seeded operational data is intentional. The goal is not to make the demo look like production data; the goal is to keep the synthetic story temporally current, internally coherent, visibly labeled, and safe to interpret.
+
+## 1. Outcome
+
+Zephyrus should present one continuously advancing synthetic hospital scenario across the command center, RTDC, ED, perioperative, staffing, transport, analytics, improvement, Arena, and administration surfaces.
+
+At the end of this plan:
+
+- every first-class route renders a useful page or an explicit, intentional unavailable state;
+- no page white-screens, throws an uncaught runtime error, or displays `undefined` in its title;
+- the central 48-hour operational window is always `[demo now - 24h, demo now + 24h]`;
+- past events, current state, and future forecasts share one canonical clock and refresh batch;
+- active waits and delays remain inside clinically and operationally plausible demo bounds;
+- cross-page counts reconcile because every surface consumes the same canonical domain summaries;
+- historical analytics remain available outside the 48-hour operational window, but are clearly labeled as historical synthetic cohorts;
+- the global header never calls synthetic or stale data simply `LIVE`;
+- demo refreshes never overwrite users, user-created records, approvals, or other non-seeder-owned data;
+- a scheduled health check fails loudly before implausible values reach the UI.
+
+## 2. Audit baseline
+
+The July 10 browser audit covered all 67 first-class routes exposed through the command palette, workspace menus, and superuser menu. Most routes existed and many contained substantial seeded data, but the demo was not operationally coherent.
+
+### 2.1 Highest-risk discrepancies
+
+| Area               | Observed disagreement                                                                                                                                    | Required correction                                                                                                                                  |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| House capacity     | Command Center and RTDC Utilization showed `423 / 692 staffed`; Bed Tracking showed `423 / 544`; the facility is labeled `500 licensed beds`             | Separate inpatient licensed/staffed beds from ED treatment capacity and perioperative spaces; use a single inpatient denominator for house occupancy |
+| Pending discharges | Command Center `0`; Bed Tracking `349`; Discharge Priorities `14`                                                                                        | Define one canonical pending-discharge cohort and reuse it everywhere                                                                                |
+| ED census          | Command Center `0`; Triage `41`; Treatment `38`; ED Analytics `46 / 20`; ED Resource Management `0 / 46`                                                 | Use one ED state projection and one simultaneous-capacity definition                                                                                 |
+| OR activity        | Command Center `0 cases today`; Case Management `20`; Room Status `4 / 4`; other resource views `15 / 20`                                                | Use the same service date, room scope, and case-state definitions                                                                                    |
+| Staffing           | Command Center `0 open shifts`; Staffing and RTDC Resources showed five requests and a nine-person gap                                                   | Derive the cockpit tile from the staffing gap/request service                                                                                        |
+| Freshness          | Command Center said `LIVE`; Transport was synthetic and about two hours old; Staffing was about eighteen hours old; Patient Flow was about 143 hours old | Compute freshness per source and aggregate it honestly                                                                                               |
+| ED timers          | ESI-1/2 patients and active alerts displayed roughly 141–151 hour ages                                                                                   | Re-anchor or regenerate seeder-owned active records and enforce duration bounds                                                                      |
+
+### 2.2 Broken or incomplete surfaces
+
+- `/improvement/bottlenecks` rendered blank.
+- `/analytics/turnover-times` threw `Cannot read properties of undefined (reading 'turnoverDistribution')`.
+- `/analytics/arena` reported an unavailable OCEL registry and OCPM sidecar.
+- `/admin/enterprise-setup` had no imported organizations.
+- `/rtdc/predictions/discharge` produced an `undefined` document title.
+- the Cockpit Service Line tab was disabled and marked `soon`.
+- Retrospective Review, Process Intelligence, Opportunity Portfolio, Predictive Planning, and Scenario Workbench were presented as planned/reference surfaces rather than finished analytic workflows.
+- raw formatting such as `56.400000000000006%` escaped to the UI.
+
+## 3. Root causes found in the repository
+
+### 3.1 There is no single demo refresh pipeline
+
+`app/Console/Commands/DemoSeedCommand.php` provisions the database, facility catalog, and fixed synthetic patient-flow fixture, but it does not subsequently keep all time-sensitive domains aligned.
+
+Useful pieces already exist:
+
+- `patient-flow:rebase-synthetic --anchor=now` shifts the fixed `flow_core` fixture to wall-clock time;
+- `rtdc:simulate --trailing` emits a trailing operational event story;
+- `flow:snapshot` creates hourly checkpoints;
+- `RefreshCockpitSnapshot` runs every minute;
+- OCEL and Arena jobs already have scheduled cadences;
+- `CommandCenterDemoSeeder` already generates most operational domains relative to `now()`.
+
+These pieces currently run at different times, or only when a full seed is performed. They need one coordinator, one anchor, one batch identifier, and post-refresh validation.
+
+### 3.2 Capacity concepts are mixed
+
+`config/hospital/hospital-1.php` defines exactly 500 inpatient beds, plus:
+
+- ED `staffed_bed_count = 148`, described as daily-throughput capacity, with separate `nedocs_bed_capacity = 50`;
+- perioperative `staffed_bed_count = 44`, representing procedural capacity.
+
+Adding all three produces 692, which is not a valid inpatient house denominator. `BedTrackingService` and census-snapshot consumers also use different inventories, producing 544, 692, or 500 depending on the page.
+
+### 3.3 Current-state queries do not share one state projection
+
+ED, RTDC, cockpit, staffing, and OR services independently query tables and apply different fallbacks, cutoffs, and capacity semantics. Examples include:
+
+- `TriageService::anchorNow()` advancing to the latest future arrival when seed rows drift ahead;
+- ED resource services alternating between census snapshots, physical beds, active visits, and hard fallbacks;
+- Bed Tracking summing `prod.beds`, while RTDC Utilization sums `prod.census_snapshots`;
+- cockpit metrics rebuilding from a separate command-center payload;
+- page-level authored demo fallbacks remaining in several React components.
+
+### 3.4 Active seeded rows age forever
+
+Several seeders generate active records relative to the time they were last run. If they are not reseeded or rebased, open visits, transport requests, alerts, barriers, and flow events continue to accumulate duration. Queries correctly calculate elapsed time; the source rows are simply no longer a plausible current scenario.
+
+### 3.5 Freshness is snapshot freshness, not source freshness
+
+Refreshing `cockpit.snapshot` every minute can make the outer payload look current even when an included domain's newest source event is hours or days old. The command center must report the oldest or most consequential source freshness, not merely the time the aggregate was recomputed.
+
+## 4. Target architecture: one rolling demo clock
+
+### 4.1 Canonical time model
+
+Create `App\Services\Demo\DemoClock` with these rules:
+
+- `anchor()` returns one immutable timestamp for the entire refresh batch;
+- the operational window is `anchor - 24 hours` through `anchor + 24 hours`;
+- historical analytic cohorts may extend farther back, but cannot masquerade as current operational data;
+- all timestamps in one refresh derive from the same `CarbonImmutable $anchor` passed explicitly to domain refreshers;
+- tests use `Carbon::setTestNow()` and never depend on wall-clock execution speed;
+- production/live connector mode bypasses `DemoClock` and uses source timestamps unchanged.
+
+Do not let individual services invent their own synthetic `now`. Remove the need for workarounds such as advancing ED's clock to a future arrival.
+
+### 4.2 Refresh ledger
+
+Add `ops.demo_refresh_runs`:
+
+```text
+refresh_id UUID primary key
+scenario_key text
+seed_version text
+anchor_at timestamptz
+window_start_at timestamptz
+window_end_at timestamptz
+started_at timestamptz
+completed_at timestamptz nullable
+status text: running|passed|failed
+domain_results jsonb
+invariant_results jsonb
+error_summary text nullable
+```
+
+This provides an auditable answer to “which synthetic moment produced this screen?” without attaching a new batch column to every existing table.
+
+### 4.3 Ownership rules
+
+The refresh pipeline may mutate only records it can prove are demo-owned:
+
+- `patient_ref LIKE 'sim-%'`;
+- request IDs/refs using `SYN-*` or `sim-*` conventions;
+- `created_by = 'seeder'` or `created_by = 'demo-seeder'`;
+- `requested_by = 'demo-seeder'`;
+- event `source = 'demo-seeder'` or the registered synthetic source key;
+- explicitly registered seed natural keys.
+
+It must never delete or rewrite:
+
+- users and credentials;
+- user-created transport/staffing requests;
+- approvals, audit history, or manually authored PDSA work;
+- imported live connector data;
+- facility configuration not owned by the Summit reference deployment.
+
+## 5. P0 — Immediate demo safety and honesty
+
+**Goal:** Stop misleading output before deeper reconciliation work.
+
+- [ ] Add `DEMO_MODE=true` and `DEMO_SCENARIO=summit-reference` configuration; refuse all rolling-demo mutations unless demo mode is explicitly enabled.
+- [ ] Replace the global `LIVE` badge with source-aware states:
+    - `DEMO · CURRENT` when all required synthetic sources meet freshness thresholds;
+    - `DEMO · AGING` when at least one source is nearing its threshold;
+    - `DEMO · STALE` when any decision-critical source is expired;
+    - `LIVE` only for connector-backed, non-synthetic sources.
+- [ ] Add a global demo banner showing scenario name, refresh anchor, oldest critical source, and “Synthetic data — not for clinical use.”
+- [ ] Change empty/no-observation metrics from reassuring zeroes to `—`/`No current observations` unless zero is an actual measured value.
+- [ ] Add source provenance and `observedAt` to every cockpit domain section, drill, and analytics payload.
+- [ ] Make stale domains incapable of producing green/normal operational statuses. Stale values should be neutral/unknown with an explicit warning.
+- [ ] Rotate the predictable superuser password. Keep one-click demo access behind an environment flag or external access control, not a public `admin/password` credential.
+- [ ] Add rate limiting, audit logging, and a visible demo-account marker to all superuser actions.
+
+**Acceptance:** A reviewer can distinguish synthetic-current, synthetic-stale, and live data without opening a drill-down.
+
+## 6. P1 — Build the canonical `zephyrus:demo-refresh` command
+
+Create:
+
+- `app/Console/Commands/DemoRefreshCommand.php`
+- `app/Services/Demo/DemoRefreshCoordinator.php`
+- `app/Services/Demo/DemoClock.php`
+- `app/Services/Demo/DemoInvariantService.php`
+- one small domain refresher per bounded data family.
+
+Suggested signature:
+
+```bash
+php artisan zephyrus:demo-refresh \
+  --anchor=now \
+  --window-hours=48 \
+  --scenario=summit-reference \
+  --domains=all \
+  --validate
+```
+
+Also support:
+
+- `--dry-run` — show proposed counts/time shifts without writes;
+- `--validate-only` — run invariants against the current database;
+- `--domains=flow,ed,rtdc,...` — targeted repair/testing;
+- `--force` — permitted only in demo mode and logged;
+- `--json` — machine-readable scheduler/monitor output.
+
+### 6.1 Execution order
+
+1. Acquire a cache lock and PostgreSQL advisory lock.
+2. Create the refresh ledger row and freeze one `anchor`.
+3. Refresh reference deployment prerequisites.
+4. Refresh the current operational domains.
+5. Rebuild derived snapshots, projections, and materialized views.
+6. Run invariants.
+7. Publish the cockpit snapshot only if critical invariants pass.
+8. Mark the refresh passed/failed and emit structured logs/metrics.
+
+### 6.2 Failure behavior
+
+- Never publish a partially refreshed cockpit snapshot as current.
+- Preserve the last-known-good snapshot and mark it stale if a refresh fails.
+- Record per-domain success/failure in `domain_results`.
+- Return non-zero when any critical invariant fails.
+- Alert after two consecutive refresh failures or when no successful refresh exists inside the source threshold.
+
+## 7. P2 — Keep every 48-hour window current
+
+### 7.1 Patient Flow 4D / `flow_core`
+
+- [ ] Invoke the existing `patient-flow:rebase-synthetic --anchor=<batch anchor>` from the coordinator.
+- [ ] Extend the rebase command to cover every timestamp family used by the navigator, ambient signals, encounter state, and projected events—not just `flow_events`, `encounters`, and `occupancy_snapshots`.
+- [ ] Rebuild trailing hourly checkpoints with `TimelineSnapshotService::rebuildTrailingWindow(24, $anchor)`.
+- [ ] Rebuild forward projections through `anchor + 24h`.
+- [ ] Run the OCEL incremental projection after rebasing so Arena and Flow never disagree about event time.
+- [ ] Verify the web navigator and mobile Flow Window report the same window bounds and newest event.
+
+### 7.2 RTDC
+
+- [ ] Refactor the time-sensitive portions of `CommandCenterDemoSeeder` into `RtdcDemoRefresher`; do not run the full database seeder every fifteen minutes.
+- [ ] Upsert today and tomorrow predictions using the batch anchor.
+- [ ] Generate a deterministic trailing 24-hour operational event stream using stable natural event keys; do not append duplicates on each run.
+- [ ] Rebuild current census snapshots and hourly history from the same unit state.
+- [ ] Reconcile predictions nightly, but keep the forward prediction rows present across midnight.
+- [ ] Remove expired seed-owned predictions and snapshots only after replacement rows pass validation.
+- [ ] Ensure Global Huddle reads the same current prediction day used by Demand Forecast and Resource Planning.
+
+### 7.3 Emergency Department
+
+- [ ] Extract `seedEdVisits()` into `EdDemoRefresher` accepting the immutable anchor.
+- [ ] Generate arrivals across the trailing 24 hours with deterministic 15-minute buckets.
+- [ ] Create a bounded active cohort rather than leaving all unfinished rows open forever.
+- [ ] Enforce temporal order:
+      `arrived <= triaged <= provider_seen <= admit_decision <= bed_assigned <= departed`.
+- [ ] Keep active clinical timers inside demo bounds:
+    - ESI-1 provider contact: immediate/within 5 minutes;
+    - ESI-2 door-to-provider: normally within 15 minutes;
+    - waiting-room maximum: configurable, default 180 minutes;
+    - treatment maximum: configurable, default 8 hours;
+    - active ED boarder maximum: configurable, default 4 hours;
+    - no active ED visit older than the operational window.
+- [ ] Make exceptional outliers deliberate and labeled `scenario stressor`; never create 100+ hour ED waits accidentally.
+- [ ] Remove `TriageService::anchorNow()`'s future-arrival workaround after seeds are guaranteed not to drift ahead.
+- [ ] Derive Triage, Treatment, Resource Management, Wait Time, Resource Analytics, NEDOCS, and cockpit ED tiles from one `EdCurrentStateService`.
+
+### 7.4 Transport
+
+- [ ] Extract `seedTransportBacklog()` into `TransportDemoRefresher`.
+- [ ] Re-anchor active requests to the current shift while preserving lifecycle order.
+- [ ] Keep completed history in the trailing 24 hours and active due times near the anchor.
+- [ ] Enforce priority-specific SLA bounds; create only a small, intentional overdue cohort.
+- [ ] Preserve user-created requests and user-driven status transitions.
+- [ ] Recompute `source_freshness` from the newest transport event, not the time the API response was assembled.
+
+### 7.5 Staffing
+
+- [ ] Refresh current and next shift plans, `needed_by`, and open demo requests from the same anchor.
+- [ ] Cover midnight and shift changes by seeding today and tomorrow, not only the current calendar date.
+- [ ] Keep the intended five-unit/nine-person shortage internally consistent with open request headcount.
+- [ ] Derive the cockpit open-shifts tile from `StaffingOperationsService`/the canonical gap summary.
+- [ ] Refresh synthetic source-freshness observations each cycle.
+
+### 7.6 Perioperative
+
+- [ ] Maintain three cohorts: yesterday's completed cases, today's current schedule, and tomorrow's forecast/schedule.
+- [ ] Use one service-date resolver for Room Status, Case Management, dashboard tiles, block schedule, and predictions.
+- [ ] Ensure `cases today`, in-progress, completed, delayed, room counts, turnover, and PACU holds reconcile.
+- [ ] Preserve the six-month historical analytic cohort; only rotate the operational 48-hour slice.
+- [ ] Ensure scheduled times never drift into the past while cases remain marked pre-op.
+
+### 7.7 Improvement, alerts, and agents
+
+- [ ] Re-anchor only demo-owned PDSA `updated_at`/measurement windows; do not rewrite user-authored cycles.
+- [ ] Close seed-owned alerts when their source condition clears.
+- [ ] Derive alert `opened_at` from the current scenario episode; do not retain alert ages across full scenario resets.
+- [ ] Keep inbox approvals, executive brief recommendations, and cockpit alerts on the same snapshot/refresh ID.
+- [ ] Cap demo episode duration or deliberately rotate scenario phases so no active alert silently ages past 24 hours.
+
+## 8. P3 — Reconcile capacity and counts
+
+### 8.1 Capacity vocabulary
+
+Adopt explicit measures:
+
+| Measure                        | Summit demo value/meaning                                              | Included units                                                                |
+| ------------------------------ | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `licensed_inpatient_beds`      | 500 licensed inpatient beds                                            | ICU, step-down, med/surg, behavioral health, rehab, inpatient specialty units |
+| `staffed_inpatient_beds`       | Current staffed subset of the 500                                      | Same inpatient units only                                                     |
+| `ed_treatment_spaces`          | Simultaneous ED treatment capacity; use a clearly named manifest value | ED only                                                                       |
+| `ed_daily_throughput_capacity` | Optional planning measure; not a bed denominator                       | ED only                                                                       |
+| `periop_procedure_spaces`      | OR/procedure/recovery capacity                                         | Perioperative only                                                            |
+| `physical_bed_inventory`       | Actual `prod.beds` rows by unit                                        | Display only within matching domain                                           |
+
+- [ ] Do not sum ED throughput capacity or perioperative spaces into house inpatient occupancy.
+- [ ] Add an explicit unit/reporting classification in the manifest or schema instead of inferring everything from `type`.
+- [ ] Make `HouseCensusService` the canonical inpatient denominator provider.
+- [ ] Make Bed Tracking and RTDC Utilization consume that canonical summary.
+- [ ] Reconcile each unit: `occupied + available + dirty + blocked = staffed/physical inventory` under one documented model.
+- [ ] Keep acuity-adjusted total capacity and remaining headroom as separate fields; never divide occupied beds by remaining headroom.
+
+### 8.2 Canonical operational summaries
+
+Create and reuse:
+
+- `HouseCensusService` — inpatient capacity and census;
+- `EdCurrentStateService` — ED cohort/capacity/timers;
+- `PeriopCurrentStateService` — current service-date cases and rooms;
+- `StaffingCurrentStateService` — gaps, requests, coverage;
+- `TransportCurrentStateService` — active queue, SLA risk, durations;
+- `DischargeCurrentStateService` — pending/ready/planned discharge cohorts.
+
+Every cockpit tile, detailed page, agent tool, and executive brief must consume these summaries or an explicitly versioned derivative. Do not duplicate SQL definitions in presentation-specific services.
+
+### 8.3 Pending discharge definition
+
+Choose one contract and name its variants:
+
+- `expected_discharge_24h`: active encounters with an expected discharge inside the next 24 hours;
+- `discharge_ready_now`: clinically and operationally ready now;
+- `priority_discharge_worklist`: the governed prioritized subset;
+- `discharged_before_noon`: completed historical outcome, never a current pending count.
+
+The dashboard label `Pending discharges` should use one of these named measures and link to the matching worklist.
+
+## 9. P4 — Repair specific broken and unfinished pages
+
+### 9.1 Demo blockers
+
+- [ ] `/improvement/bottlenecks`
+    - reproduce the production white-screen with browser console capture;
+    - add an error boundary and honest empty state;
+    - normalize `DashboardService::getBottleneckStats()` rows before rendering;
+    - add a feature route test and React render test using empty and populated payloads.
+- [ ] `/analytics/turnover-times`
+    - remove the hardcoded `MARH OR` fallback in `TurnoverTimesDashboard.jsx`;
+    - select the first actual site key or require an explicit selection;
+    - guard every view against missing `locationData` and `turnoverDistribution`;
+    - add a contract test for `TurnoverTimesService::build()` and a React test for empty, single-site, and multi-site payloads.
+- [ ] `/rtdc/predictions/discharge`
+    - provide a non-empty page title and route-level metadata;
+    - test the generated document title.
+- [ ] Format all percentages and durations through shared formatters; prohibit unrounded floating-point strings.
+
+### 9.2 Arena
+
+- [ ] Register/run `OcelProcessLandscapeSeeder` as part of initial demo provisioning.
+- [ ] Enable and health-check the OCPM sidecar when Arena is included in the demo profile.
+- [ ] Run `ocel:project` after every demo refresh and the full reconcile nightly.
+- [ ] If Arena is deliberately excluded, remove it from primary navigation or show an intentional feature-disabled page—not a failed integration diagnostic.
+
+### 9.3 Enterprise Setup
+
+- [ ] Include `deployment:seed-registry` and the Summit facility import in `zephyrus:demo-seed`.
+- [ ] Validate that organizations, facilities, spaces, capabilities, and transfer relationships exist before marking provisioning successful.
+- [ ] Show a guided demo empty state only when the feature is intentionally unprovisioned.
+
+### 9.4 Planned analytics
+
+For each of Retrospective Review, Process Intelligence, Opportunity Portfolio, Predictive Planning, and Scenario Workbench, choose one state:
+
+1. **Implemented:** real metrics, filters, evidence, empty/error states, and tests; or
+2. **Preview:** visibly labeled preview/reference page with no implication that the engine is operating; or
+3. **Hidden:** remove from primary demo navigation until ready.
+
+Do not label an architectural description `active` merely because the page route loads.
+
+### 9.5 Cockpit Service Line view
+
+- [ ] Either implement the Service Line face using the existing service-line registry and scoped cockpit APIs, or remove/disable the visible tab with a clear preview label.
+- [ ] Do not concatenate `Service Line` and `soon` into the accessible name.
+
+## 10. P5 — Freshness, observability, and scheduler reliability
+
+### 10.1 Source freshness contract
+
+Every domain payload should carry:
+
+```json
+{
+    "provenance": "synthetic|live|mixed",
+    "sourceKey": "synthetic-flow-ehr",
+    "observedAt": "ISO-8601",
+    "refreshedAt": "ISO-8601",
+    "refreshId": "UUID",
+    "ageSeconds": 0,
+    "freshness": "current|aging|stale|unavailable"
+}
+```
+
+Recommended initial demo thresholds:
+
+| Domain                |              Current |                      Aging |                                                 Stale |
+| --------------------- | -------------------: | -------------------------: | ----------------------------------------------------: |
+| Cockpit aggregate     |             <= 2 min |                    2–5 min |                                               > 5 min |
+| ED/RTDC current state |             <= 5 min |                   5–15 min |                                              > 15 min |
+| Transport             |            <= 10 min |                  10–30 min |                                              > 30 min |
+| Staffing              |            <= 30 min |                  30–90 min |                                              > 90 min |
+| Patient Flow events   |            <= 15 min |                  15–45 min |                                              > 45 min |
+| Forecasts             | current service date | next service-date boundary |                                  expired service date |
+| Historical analytics  |   labeled cohort end |                        n/a | end date unintentionally behind expected seed horizon |
+
+### 10.2 Scheduling
+
+Add to `bootstrap/app.php` in demo mode:
+
+- `zephyrus:demo-refresh --window-hours=48 --validate` every 15 minutes;
+- `withoutOverlapping()` and `onOneServer()`;
+- hourly flow snapshot/materialized-view refresh after a successful demo refresh;
+- nightly long-window reconciliation and retention;
+- a one-minute cockpit refresh may remain, but it must not upgrade stale source data to current.
+
+Production host requirements:
+
+- one reliable `schedule:run` cron or supervised `schedule:work` process;
+- queue workers for scheduled jobs;
+- monitor both last scheduler heartbeat and last successful demo refresh;
+- deploy only through `./deploy.sh`, per `AGENTS.md`;
+- initial deploy sequence: migrations, `zephyrus:demo-seed`, `zephyrus:demo-refresh --validate`, build/cache refresh, route smoke, browser smoke.
+
+### 10.3 Monitoring
+
+- [ ] Emit `demo_refresh_success`, `demo_refresh_duration_seconds`, `demo_refresh_age_seconds`, and invariant-failure counts.
+- [ ] Add `/up/demo` or an authenticated admin health endpoint returning last refresh, domain freshness, and invariant status.
+- [ ] Add an admin refresh-history panel with the last ten batches.
+- [ ] Alert on two failed refreshes, scheduler silence, stale critical data, or invariant failure.
+- [ ] Log query/source failures without exposing PHI or credentials.
+
+## 11. P6 — Automated invariants and test matrix
+
+### 11.1 Temporal invariants
+
+- [ ] No active operational event predates `anchor - 24h` unless explicitly marked a continuing encounter.
+- [ ] No historical event occurs after the anchor.
+- [ ] Only forecasts/plans may occur after the anchor, capped at `anchor + 24h` for the Flow Window.
+- [ ] All lifecycle timestamps are monotonically ordered.
+- [ ] All displayed durations are non-negative.
+- [ ] Active timers satisfy configured demo bounds or carry an explicit scenario-outlier label.
+
+### 11.2 Reconciliation invariants
+
+- [ ] Sum of current inpatient unit census equals house census.
+- [ ] Inpatient denominators exclude ED throughput and perioperative procedural capacity.
+- [ ] Per-unit bed states reconcile to inventory.
+- [ ] Active encounter count reconciles with occupied inpatient beds under documented exceptions.
+- [ ] ED current census and acuity mix match across ED services.
+- [ ] Pending admits/discharges/boarders match between cockpit and worklists.
+- [ ] OR cases-today, room status, and throughput counts match.
+- [ ] Staffing gap headcount equals open request headcount or documents the difference.
+- [ ] Transport queue and at-risk counts match between cockpit and transport APIs.
+- [ ] Agent Inbox and cockpit show the same pending-approval count for the same refresh ID.
+
+### 11.3 Plausibility invariants
+
+- [ ] Percentage values are finite and formatted to the defined precision.
+- [ ] Occupancy over 100% is allowed only where the metric explicitly represents patients per staffed treatment space and is labeled over-capacity.
+- [ ] NEDOCS cannot be zero when the ED is on diversion or has active boarders unless the metric is unavailable/stale.
+- [ ] An OR utilization KPI cannot be populated from a period with zero cases without an explicit historical-period label.
+- [ ] Green/normal status cannot be calculated from stale or missing sources.
+
+### 11.4 Tests to add
+
+- `tests/Feature/Demo/DemoRefreshCommandTest.php`
+- `tests/Feature/Demo/DemoRefreshIdempotencyTest.php`
+- `tests/Feature/Demo/DemoRefreshOwnershipTest.php`
+- `tests/Feature/Demo/DemoTemporalInvariantTest.php`
+- `tests/Feature/Demo/DemoCrossSurfaceParityTest.php`
+- `tests/Feature/Demo/DemoFreshnessTest.php`
+- ED current-state contract tests using a frozen anchor;
+- RTDC capacity vocabulary/reconciliation tests;
+- OR current-service-date parity tests;
+- browser route smoke asserting no blank root, no `Something went wrong`, no endless loading, and no `undefined` title;
+- React tests for all repaired error/empty states.
+
+Run the idempotency suite twice against the same anchor and assert:
+
+- counts do not grow;
+- natural keys remain stable;
+- no non-demo row changes;
+- the second run produces the same domain payload;
+- a later anchor advances timestamps without producing impossible lifecycle order.
+
+## 12. P7 — Demo runbook
+
+### 12.1 Initial provisioning
+
+```bash
+php artisan zephyrus:demo-seed --migrate
+php artisan zephyrus:demo-refresh --anchor=now --window-hours=48 --validate
+php artisan ocel:project --days=90 --reconcile
+php artisan facility:export-plates --check
+php artisan route:list
+npm run build
+php artisan test --testsuite=Feature
+```
+
+Use the supported `./deploy.sh` path for the production demo host; do not use direct production `git pull` or ad hoc SSH deployment commands.
+
+### 12.2 Pre-demo check
+
+```bash
+php artisan zephyrus:demo-refresh --validate
+php artisan zephyrus:demo-refresh --validate-only --json
+```
+
+Then verify:
+
+- global badge is `DEMO · CURRENT`;
+- newest ED/RTDC/transport/flow observation is inside its freshness threshold;
+- no active timer exceeds configured bounds;
+- cockpit and detailed-page parity checks pass;
+- Arena is healthy or intentionally hidden;
+- enterprise registry is populated;
+- all 67 command-palette/admin routes pass browser smoke.
+
+### 12.3 Recovery
+
+If validation fails:
+
+1. retain the last-known-good cockpit snapshot;
+2. show `DEMO · STALE`;
+3. run `--validate-only --json` and inspect the failed domain/invariant;
+4. refresh the bounded domain only;
+5. rerun full validation;
+6. do not clear user-created records or run `migrate:fresh` on the shared demo.
+
+## 13. Delivery sequence
+
+| Wave | Scope                                                       | Depends on | Exit gate                                          |
+| ---- | ----------------------------------------------------------- | ---------- | -------------------------------------------------- |
+| 0    | Demo label, stale semantics, credential hardening           | none       | Synthetic/stale data cannot appear as live/current |
+| 1    | DemoClock, refresh ledger, coordinator, locks               | Wave 0     | Dry run + repeatable frozen-anchor refresh         |
+| 2    | Flow, RTDC, ED, Transport, Staffing, OR refreshers          | Wave 1     | 48-hour invariants and ownership tests pass        |
+| 3    | Canonical capacity/state summaries                          | Wave 1–2   | Cross-page parity suite passes                     |
+| 4    | Blank/crash/title/Arena/enterprise/planned-page remediation | Wave 0     | All first-class routes render intentionally        |
+| 5    | Scheduler, freshness contract, health/monitoring            | Wave 1–3   | Refresh remains current unattended for 72 hours    |
+| 6    | Browser regression and release runbook                      | all        | Full browser audit has no critical discrepancy     |
+
+## 14. Definition of done
+
+- [ ] The demo runs unattended for 72 hours with a successful refresh at least every 15 minutes.
+- [ ] Every rolling `[now-24h, now+24h]` window contains coherent past, current, and forecast data.
+- [ ] No unintended active wait, delay, alert, or transport age exceeds 24 hours; tighter domain bounds pass.
+- [ ] No current operational page is backed by an expired service date.
+- [ ] House census, ED state, staffing gaps, transport queue, OR activity, and pending flow reconcile across all consuming surfaces.
+- [ ] Synthetic provenance and source age are visible globally and in detail.
+- [ ] All 67 audited routes render without blank pages, runtime errors, unresolved loading states, or undefined titles.
+- [ ] The Turnover Times console error is gone.
+- [ ] Bottlenecks renders populated or honest-empty content.
+- [ ] Arena and Enterprise Setup are either fully provisioned or intentionally excluded/labeled.
+- [ ] Planned analytics are implemented, clearly preview-labeled, or removed from primary demo navigation.
+- [ ] Default public superuser credentials are removed.
+- [ ] Refresh, parity, plausibility, ownership, and browser smoke tests run in CI.
+- [ ] Deployment and pre-demo runbooks are validated on the hosted demo.
+
+## 15. Recommended first implementation slice
+
+Start with a small vertical slice that proves the architecture:
+
+1. add `DemoClock`, the refresh ledger, and `zephyrus:demo-refresh` skeleton;
+2. integrate `patient-flow:rebase-synthetic` and ED regeneration with a frozen anchor;
+3. add temporal-order and maximum-active-age invariants;
+4. publish source freshness to the cockpit and replace `LIVE` with `DEMO · CURRENT/STALE`;
+5. run the command twice at one anchor, then once at `anchor + 15m`, and verify idempotency and advancing timers;
+6. add the cross-surface ED parity test before expanding to RTDC, staffing, transport, and OR.
+
+This slice directly eliminates the most visibly irrational timers while establishing the mechanism every remaining domain will reuse.

--- a/docs/DEMO-DATA-COHERENCE-FEEDBACK-AND-PLAN-2026-07-10.md
+++ b/docs/DEMO-DATA-COHERENCE-FEEDBACK-AND-PLAN-2026-07-10.md
@@ -1,0 +1,214 @@
+# Feedback & Refined Plan — Demo Data Coherence + Plausibility
+
+**Companion to:** `docs/DEMO-DATA-COHERENCE-AND-REMEDIATION-PLAN-2026-07-10.md`
+**Author review date:** 2026-07-10 (~20:14 EDT)
+**Backend inspected:** `pgsql.acumenus.net` / db `zephyrus` (Postgres 17), canonical `prod.*` schema
+**Verdict:** The plan is directionally excellent and its diagnosis is *empirically correct* — every number in its §2.1 discrepancy table reconciles to a real query. But it is **~90% about coherence and ~10% about plausibility**, and it over-invests in new architecture for a problem whose first 80% is "the refresh pipeline is simply never scheduled." This companion (a) validates the diagnosis with ground-truth measurements, (b) corrects/augments five points, and (c) re-sequences the work so the demo is *coherent within hours* and *deeply plausible within a couple of iterations*.
+
+---
+
+## 1. Ground truth — what the database actually contains (measured 2026-07-10)
+
+The last full operational seed ran **~2026-07-03/04**. Since then only *transport* and *census_snapshots* have advanced; everything else is frozen ~6 days in the past, while a few values leak into the *future*. This single fact explains the entire §2.1 table.
+
+| Domain | Table | Count | Newest observation | Staleness | Notes |
+|---|---|---|---|---|---|
+| ED | `prod.ed_visits` | 104 (46 active) | arrived 2026-07-04 21:32 | **142.7 h** | The "141–151 h timers" = these frozen active boarders |
+| Encounters | `prod.encounters` | 593 (**423 active**) | admitted → 2026-07-24 (future) | mixed | **423 active = the "423 occupied"**; 3 admitted in the future; 10 with `exp_dc < admitted` |
+| OR | `prod.or_cases` | 759 (**0 today**) | surgery_date 2026-07-03 | **188 h** | 20 on last day = the "Case Mgmt 20" |
+| RTDC forecasts | `prod.rtdc_predictions` | 96 | service_date 2026-07-05 | **140 h** | **All 96** have `service_date < today` |
+| Patient Flow 4D | `flow_core.flow_events` | 3,779 | occurred 2026-07-04 20:24 | **143.8 h** | Matches the plan's "143 h old" exactly |
+| Bed requests | `prod.bed_requests` | 18 | 2026-07-03 | **168 h** | |
+| Census | `prod.census_snapshots` | 3,674 | captured 2026-07-11 00:00 | fresh, **100 rows in the future** | Over-eager generator writes to tomorrow |
+| Transport | `prod.transport_requests` | 202 (22 active) | requested 2026-07-10 20:57 | **fresh** | but 21 of 22 active are overdue |
+
+**Beds decode (the 500 / 544 / 692 mystery, solved):** `prod.beds` = **692** physical rows = med_surg 340 + **ed 148** + icu 96 + step_down 64 + **periop 44**.
+- Inpatient (icu+step_down+med_surg) = **500** → licensed denominator ✅
+- +periop = **544** (Bed Tracking) ✅
+- +ED = **692** (RTDC Utilization / physical inventory) ✅
+- Occupied = **423** (entirely inpatient; ED & periop beds are all `available`), available = 269, 423+269 = 692. So the numerator is fine — **the bug is purely denominator hygiene.**
+
+**Pending-discharge decode (0 / 349 / 14):** 349 = active encounters with `expected_discharge_date ≤ now+24h`, and **all 349 are already overdue** because the data froze 6 days ago. It is a *staleness artifact*, not a real cohort.
+
+**`ops.source_freshness` already exists and already knows** (12 tracked sources): `ed_flow`, `encounters`, `bed_placement`, `rtdc_predictions` = **critical**; `transport_*`, `capacity_census` = success. The header just doesn't read it.
+
+---
+
+## 2. What the plan gets right (keep all of this)
+
+- **Root-cause framing** (§3): no single refresh pipeline; mixed capacity concepts; no shared state projection; rows age forever; snapshot-freshness ≠ source-freshness. All confirmed.
+- **One rolling clock + explicit anchor + 48 h window** (§4.1). Correct and necessary.
+- **Capacity vocabulary** (§8.1) and the **named pending-discharge variants** (§8.3). These are exactly the right abstractions; I've supplied the concrete Summit values in §5 below.
+- **Temporal / reconciliation / plausibility invariants** (§11) as executable gates. This is the plan's best idea — it just needs to *run now* (see §4), because the DB currently violates several.
+- **Honest freshness badge + provenance** (§5, §10.1). Right instinct.
+- **Ownership discipline** (§4.3) — don't clobber users/approvals/PDSA.
+
+---
+
+## 3. Corrections & additions (what to change)
+
+### 3.1 Re-weight the effort: the first fix is "schedule the pipeline," not "build the architecture"
+None of the demo's time-advancing commands are scheduled. `bootstrap/app.php` schedules `flow:snapshot` (hourly — but it only checkpoints the *frozen* census), `RefreshCockpitSnapshot` (**every minute** — this is *why* the header says LIVE: it re-wraps 6-day-old data with a fresh timestamp), MV refresh, OCEL, Arena, and a nightly RTDC reconcile. It does **not** schedule `patient-flow:rebase-synthetic`, `rtdc:simulate --trailing`, `db:seed`, or `zephyrus:demo-seed`. `CommandCenterDemoSeeder` is already `now()`-relative and idempotent with tagged deletes — **re-running it moves everything to "today."** So the highest-leverage action is a few hours of work, not the full DemoClock build. Sequence it first (Wave 0 below).
+
+### 3.2 Don't reinvent `ops.source_freshness` — consume and schedule it
+The plan's §10.1 "source freshness contract" is ~80% already built: `ops.source_freshness` stores `source_key / latest_observed_at / expected_lag_minutes / warning_lag_minutes / status(success|warning|critical) / metadata(route,scope)`, computed by `MetricLineageService::materializeSourceFreshness()`. The gaps are only: (1) it is **request-driven, not scheduled** — a row updates lazily when someone opens an analytics page; (2) the global header/badge doesn't read it. Fix those two things instead of designing a parallel contract.
+
+### 3.3 The ownership model already exists in code — formalize, don't re-derive
+`CommandCenterDemoSeeder`/`DemoTuningSeeder` already scope their deletes by `created_by IN ('seeder','demo-seeder')`, `patient_ref` prefixes (`sim-*`, `sim-hx/ra`, `sim-occ-*`), and note tags (`demo-tuning`, `notes='demo-today'`). §4.3 should reference these *actual* predicates as the ownership contract rather than proposing new ones.
+
+### 3.4 Fix service references — most named services don't exist; `HouseCensusService` does (and is already canonical)
+Both `TriageService` and `BedTrackingService` **do** exist (`app/Services/Ed/TriageService.php`, `app/Services/Rtdc/BedTrackingService.php`) — the plan's references are accurate. But of the six proposed canonical services, only **`HouseCensusService` already exists** (`app/Services/Rtdc/HouseCensusService.php`) and is *already* the single house-census read that Cockpit delegates to. The other five are just renames of existing split logic — do **not** create parallel classes; consolidate onto the real ones:
+- ED → currently split across `Ed/{TriageService, TreatmentService, ResourceManagementService, WaitTimeService, NedocsService, ResourceAnalyticsService}` + `Dashboard/EdDashboardService` (there is no `EdCurrentStateService`).
+- Periop → `Operations/{CaseManagementService, RoomStatusService}` + `Dashboard/PerioperativeMetricsService`.
+- Staffing → `Staffing/StaffingOperationsService`; Transport → `Transport/TransportOperationsService`; Discharge → `Rtdc/DischargePrioritiesService`.
+
+`DemoClock`/`DemoRefreshCoordinator` are genuinely greenfield. Confirm: app reads only `prod.*` (`config/database.php` → `search_path=prod,public`); the empty `emergency|perioperative|rtdc` schemas are read by **no** PHP (the `rtdc.*` strings in code are Cockpit *metric-key* namespaces, not tables).
+
+### 3.4a The house-denominator bug is real and localized to ONE place
+`HouseCensusService` sums `staffed_beds` across **all** non-deleted units with **no unit-type filter**, so any ED/OR unit carrying census rows is folded straight into the inpatient occupancy % that drives the RTDC dashboard and Cockpit strain tiles. This — not six scattered queries — is the single fix locus for §8.1: add a unit-classification filter here and everything downstream inherits it (Cockpit already delegates to it).
+
+### 3.4b The incoherence mechanism is *divergent forward-anchoring*, not just divergent queries
+Different surfaces of the same domain invent a different "now," which is why Triage/Treatment/Analytics disagree even off identical rows:
+- `TriageService::anchorNow()` advances "now" to `MAX(arrived_at)` (so it sees the future-dated cohort); but `TreatmentService`, `WaitTimeService`, `ResourceManagementService`, `NedocsService` use plain `now()`/`today()` (so they *under*-populate the same cohort).
+- Periop advances to the latest **day**: `CaseManagementService::activeDate()` and `RoomStatusService` anchor on `MAX(surgery_date)`, and `RoomStatusService::simulatedClock()` clamps to 10:30 off-hours.
+- `StaffingOperationsService::todaysPlans()` is strict `whereDate(shift_date, today())` — empty whenever the seed day ≠ today.
+
+Once DemoClock guarantees seeds never drift ahead of the anchor (Wave 1), **delete every one of these forward-anchor workarounds** — they exist only to paper over drift and actively cause the disagreement.
+
+### 3.5 The biggest gap for "deeply plausible values": the plausibility model is disconnected
+`config/hospital/hospital-1-distributions.json` is a rigorously derived, independently-verified statistical profile (admission archetypes, careunit transition matrix, per-unit-type LOS, ICU LOS, ED throughput hours, service-line weights, disposition mix, geriatric demographics, acuity/procedure signature). **It is never loaded at runtime** — it appears only in a code *comment* as provenance. The operational seeders use `mt_srand(20260622)` with hand-tuned constants. Consequence: the data is *coherent* but not *distribution-true*. This is the workstream the plan is missing, and it's exactly what "deeply plausible across the entire spectrum" requires. See §6.
+
+### 3.6 Kill the empty legacy schemas (a footgun)
+`emergency.*`, `perioperative.*`, and `rtdc.*` schemas exist with full table sets but are **completely empty** — the app reads the parallel `prod.*` tables. Anyone "fixing ED data" could seed the wrong schema. Either drop these schemas or document them as dead, and add an invariant that they stay empty.
+
+### 3.7 Run the temporal invariants as a *pre-demo gate today* — the DB is already violating them
+Current violations: **100** future-dated census snapshots, **3** encounters admitted in the future, **10** encounters with discharge-before-admit, **96** RTDC predictions dated in the past. §11's invariants should block a refresh from publishing (they'd catch all four right now).
+
+### 3.8 Several surfaces render client-side *mocks*, not data — no amount of seeding fixes these
+The plan's §3.3 mentions "page-level authored demo fallbacks" but doesn't enumerate them; they matter because a coherent, plausible database still won't reach these screens. Inventory to hunt down (React):
+- **Fully client-mock, no backend props at all:** `RTDC/UnitHuddle` and `RTDC/GlobalHuddle` (their controller actions render with no service). §7.2's "Global Huddle reads the same prediction day" is currently impossible — there's nothing to read.
+- **Hardcoded numeric fallbacks that leak stale/round values:** `RTDC/BedTracking.tsx` (`TOTAL=500`, `OCCUPIED=425` — this is where a stray "425" comes from), `ED/Analytics/WaitTime.jsx` (`DEFAULT_KPI` zeros).
+- **`DEMO_*` block fallbacks:** `ED/Predictions/Resources.jsx` (`DEMO_AVAILABLE/FORECAST/KPIS/RECOMMENDATIONS/ACUITY_MIX`), `RTDC/Predictions/ResourcePlanning.jsx` (`DEMO_KPIS/DEMAND_VS_CAPACITY/RECOMMENDATIONS`), `Operations/RoomStatus.jsx` (12-room `mockRooms`), `Operations/BlockSchedule.jsx`, `RTDC/DischargePriorities.jsx` (`generateMockDischargeData()`), `Analytics.jsx` (`fallbackIntelligence/ActionQueue/SourceMap`), `Improvement/*` (`mockCycles`, `MOCK_BOTTLENECK_DATA`, `MOCK_RESOURCE_DATA`).
+
+Decision per surface: wire to the canonical service (Wave 3) **or** convert the fallback into an honest empty/unavailable state (Wave 4). A silent mock is the worst outcome — it looks live and reconciles with nothing.
+
+---
+
+## 4. The plausibility problem, quantified (this is the heart of "deeply plausible")
+
+Coherence makes the numbers *agree*; plausibility makes them *believable*. Current specifics that fail a clinician's smell test:
+
+| Signal | Measured now | Realistic target | Why it's off |
+|---|---|---|---|
+| Inpatient occupancy by unit type | **flat 84.4–84.7%** across ICU / step-down / med-surg | ICU 85–95%, step-down 80–90%, med-surg 78–88%, differentiated | A single global occupancy target applied uniformly, not a per-unit model |
+| ED acuity (ESI) mix | 1:8 / **2:45** / 3:37 / 4:9 / 5:5 (ESI-2 = 43%) | pyramid: ESI-3 largest (~40–45%), then 2 & 4 (~20–25% each), ESI-1 ~2%, ESI-5 ~5–10% | Over-acute arrival mix; ESI-2 shouldn't exceed ESI-3 |
+| Discharge-before-noon | **49.9%** | 25–35% (a metric hospitals *struggle* to hit) | Implausibly rosy — undercuts the improvement narrative |
+| Discharge volume | 1,284 over 4 days ≈ **321/day** | ~90–120/day for 500 staffed beds | ~3× too high; also only a 4-day span, not the "6-month cohort" §7.6 assumes |
+| Transport priority mix | routine 101 / **urgent 51 / stat 50** | routine ≫ urgent ≫ stat (stat a few %) | STAT ≈ urgent is not real; over-weighted to high priority |
+| Active transport overdue | **21 of 22** overdue | a small, intentional overdue cohort (≤ ~15%) | `needed_at` anchored to an old shift |
+| OR scale | 4 rooms, **15–20 cases/day**, no weekend cases | Level I / 44 procedural rooms → 35–60 weekday cases, a light weekend emergent tail | Volume & room count contradict the stated "Level I Trauma Academic" identity |
+| ED door-to-provider | median 19 m / p90 25 m / **max 27 m** | median plausible, but needs a real long tail (p90 45–90 m, occasional 2–4 h) | Intervals too tight — no variance |
+
+Note the recurring pattern: **over-acuity** (ED ESI, transport priority) and **flat distributions** (occupancy, OR/day, door-to-provider). Both are symptoms of hand-tuned constants instead of sampling from `distributions.json`.
+
+---
+
+## 5. Concrete Summit capacity constants (drop-in for §8.1)
+
+Author these into the manifest and assert them as invariants:
+
+```
+licensed_inpatient_beds   = 500   # icu 96 + step_down 64 + med_surg 340
+staffed_inpatient_beds    = <=500 # current staffed subset; the ONLY house denominator
+ed_treatment_spaces       = 148   # ED only — never in the inpatient denominator
+periop_procedure_spaces   = 44    # OR/procedure/PACU — never in the inpatient denominator
+physical_bed_inventory    = 692   # display only, per matching domain
+```
+Reconciliation invariant per unit: `occupied + available + dirty + blocked = staffed/physical inventory`. House invariant: `Σ inpatient-unit occupied = house occupied`, and the house denominator excludes ED + periop.
+
+Pending-discharge named measures (pick one per surface, link to its worklist): `expected_discharge_24h`, `discharge_ready_now`, `priority_discharge_worklist`, `discharged_before_noon` (historical outcome only — never a current pending count).
+
+---
+
+## 6. Refined delivery plan
+
+The plan's Waves 0–6 are good; I re-order and add a **Plausibility** wave, and pull the "just schedule it" win to the front.
+
+### Wave 0 — Coherent + honest *today* (hours, no new architecture)
+1. Run one manual re-anchored batch at a single frozen anchor: `db:seed --class=CommandCenterDemoSeeder` → `db:seed --class=DemoTuningSeeder` → `patient-flow:rebase-synthetic --anchor=now` → `flow:snapshot --backfill=24h` → `rtdc:simulate --trailing`. (These already exist; they've just never been run together on a cron.)
+2. Fix the future-leak: cap census generation at `anchor`; correct the 3 future admits + 10 discharge-before-admit rows.
+3. Wire the global badge to `ops.source_freshness` → `DEMO · CURRENT / AGING / STALE`; add the "Synthetic — not for clinical use" banner with anchor + oldest critical source. Stale sources cannot render green.
+4. Rotate the superuser password behind an env flag.
+**Exit:** header can't call stale data LIVE; no active timer > 24 h; the four temporal violations are gone.
+
+### Wave 1 — Formalize the clock (DemoClock, ledger, coordinator, locks)
+Wrap the Wave 0 commands in `zephyrus:demo-refresh` (one anchor, advisory lock, `ops.demo_refresh_runs` ledger, publish-only-if-invariants-pass). Build **on** the existing ownership tags (§3.3) and `ops.source_freshness` (§3.2). Schedule it every 15 min with `withoutOverlapping()->onOneServer()`. Requires a real `schedule:work` + queue worker on the host.
+**Exit:** dry-run + repeatable frozen-anchor refresh; idempotency suite green.
+
+### Wave 2 — Plausibility engine (**new — the "deeply plausible" core**)
+1. Load `hospital-1-distributions.json` at runtime behind a `DistributionProfile` service (`DistributionSampler`).
+2. Replace hand-tuned constants in the domain refreshers with sampling: per-unit-type LOS (use `icuLos` for ICU beds, *not* the MICU transport-unit artifact — the JSON flags this), admission archetypes + transition matrix for encounter journeys, disposition mix, geriatric age/gender skew.
+3. Domain calibrations from §4: per-unit occupancy targets (ICU hot, med-surg cooler); ED **ESI pyramid** on arrivals with realistic door-to-provider tails; **scale OR** to the 44-room / Level-I identity (or explicitly down-scope the identity) with weekday shape + weekend emergent tail; transport priority mix routine≫urgent≫stat with a small overdue cohort; discharge-before-noon to 25–35%.
+4. Add **distributional invariants** (§8): assert sampled cohorts fall within target bands, not just that counts reconcile.
+**Exit:** each domain's headline distribution is within its realistic band; a clinician reviewer can't point to an "off" number.
+
+### Wave 3 — Canonical state consolidation + reconciliation
+Do **not** create six new `*CurrentStateService` classes. Instead: (a) add the unit-classification filter to the existing `HouseCensusService` so it stops mixing ED/OR into the inpatient denominator (§3.4a) — Cockpit already delegates to it, so this fix propagates for free; (b) collapse the ED read-path onto one entry point and the periop read-path onto one service-date resolver (§3.4); (c) delete the divergent forward-anchor workarounds now that Wave 1 guarantees no drift (§3.4b); (d) point the fully-mock and `DEMO_*` React surfaces (§3.8) at the real services. Cross-surface parity suite (§11.2) is the gate.
+
+### Wave 4 — Page repairs (parallel with Wave 0)
+`/improvement/bottlenecks` (error boundary + honest empty), `/analytics/turnover-times` (`turnoverDistribution` guard, drop the `MARH OR` fallback), `/rtdc/predictions/discharge` (title), shared formatters (kill `56.400000000000006%`), Arena (seed OCEL + health-check sidecar or hide intentionally), Enterprise Setup (registry import), planned analytics (implement / preview-label / hide), Cockpit Service Line tab.
+
+### Wave 5 — Freshness, scheduler, monitoring
+Schedule the `source_freshness` recompute (don't leave it request-driven); `/up/demo` health endpoint; admin refresh-history panel; alert on 2 failed refreshes / scheduler silence / stale-critical / invariant failure.
+
+### Wave 6 — Invariants in CI + browser regression
+Full temporal + reconciliation + **plausibility/distributional** invariant suites, idempotency (run twice at one anchor, once at +15m), 67-route browser smoke (no blank root, no error boundary, no endless loading, no `undefined` title).
+
+---
+
+## 7. Do-this-in-the-next-hour checklist
+- [ ] Run the Wave 0 re-anchor batch against a frozen anchor; confirm ED/OR/RTDC/flow newest observation moves inside threshold.
+- [ ] Delete/repair the 100 future census snapshots, 3 future admits, 10 discharge-before-admit rows.
+- [ ] Point the header badge at `ops.source_freshness`; ship the synthetic banner.
+- [ ] Add a `--validate-only` invariant pass that fails on the four current violations, and run it as the pre-demo gate.
+- [ ] File the two footguns: drop/annotate empty `emergency|perioperative|rtdc` schemas; note that `distributions.json` is currently unused at runtime.
+
+---
+
+## 7a. Build status — 2026-07-10 (read-only foundation landed)
+
+Shipped (all SELECT-only / additive; nothing written to the canonical demo DB yet):
+- `config/hospital.php` — registered the previously-unused `distributions` profile + `inpatient_unit_types` + tuneable `plausibility_targets` bands.
+- `App\Services\Demo\DemoClock` — the one immutable anchor + 48h window (replaces the divergent per-service "now").
+- `App\Services\Demo\DistributionProfile` — finally loads `hospital-1-distributions.json` at runtime with typed accessors + the clinical bands.
+- `App\Services\Demo\DemoInvariantService` — read-only temporal / capacity / freshness / plausibility invariants.
+- `zephyrus:demo-validate` — the `--validate-only` pre-demo gate (non-zero exit on critical failure; `--json` for monitors). Safe to run on the canonical host.
+- `tests/Unit/Demo/*` — 8 PHPUnit tests (DemoClock, DistributionProfile, gate logic), green.
+
+Verified against the live DB (read-only): the gate initially reported **6 critical failures** (3 future admits, 10 discharge-before-admit, 96 stale forecasts, 46 aged ED boarders, house-denominator contamination, 4 stale decision sources) and 6 plausibility warnings.
+
+**Wave 0 EXECUTED on the canonical demo DB (2026-07-10) — all 6 criticals cleared.** After a full `prod`-schema backup, ran `patient-flow:rebase-synthetic --anchor=now` (window shifted +6d), `db:seed CommandCenterDemoSeeder`, `db:seed DemoTuningSeeder`, `flow:snapshot --backfill=24h`, and republished the cockpit snapshot. Two seeder bugs were found and fixed in the process:
+- `DemoTuningSeeder::staffingToday()` collided on `uniq_staffing_plan_slot` because its `DELETE` only cleared `notes='demo-today'` while `CommandCenterDemoSeeder` now owns today's slots → made the insert `ON CONFLICT … DO UPDATE` (takes ownership, idempotent).
+- Added `DemoTuningSeeder::clampTemporalLeaks()` (runs first, idempotent): purge expired forecasts, drop future-dated census actuals, pull future-admitted active encounters back to a recent admit, repair discharge-before-admit rows.
+- Fixed `HouseCensusService::houseTotals()` to scope the house denominator to `config('hospital.inpatient_unit_types')` (excludes ED + periop); `latestPerUnit()` still returns all units for per-unit consumers.
+
+Result: **0 critical failures, 6 plausibility warnings.** Domains re-anchored — ED aged boarders 46→0, OR cases today 0→20, forecasts 07-04→07-11/12, flow 144h→0.2h; census and bed-board reconcile at 423/500 = 85%.
+
+**Wave 1 EXECUTED (2026-07-10) — the demo now stays current unattended.** Built `config/demo.php` (DEMO_MODE gate), the `ops.demo_refresh_runs` ledger (migration), `App\Services\Demo\DemoRefreshCoordinator`, and `zephyrus:demo-refresh` (`--validate`/`--validate-only`/`--dry-run`/`--json`/`--force`). One anchor per batch, a PostgreSQL advisory lock, ledger row, the refresher batch (rebase → CommandCenterDemoSeeder → DemoTuningSeeder), `ops.source_freshness` recompute, invariants, and cockpit publish **only if critical invariants pass**. Scheduled `*/15 * * * *` (gated on `demo.enabled`, `withoutOverlapping(10)`). Verified: repeated runs are idempotent (every domain table stable across runs — 0 growth), each writes a ledger row, and a forced failure preserves last-known-good (cockpit not published). Two more re-runnability bugs fixed: `CommandCenterDemoSeeder::seedTransportBacklog()` was deleting `transport_requests` → cascade into the **append-only** `transport_events` ledger (now seed-once; `DemoTuningSeeder::refreshSlas()` keeps SLAs near-now); and the coordinator no longer calls `flow:snapshot --backfill` every cycle (it appended off-hour duplicate `occupancy_snapshots` because the rebase nudges prior rows off their upsert key).
+
+**Wave 2 EXECUTED (2026-07-10) — deeply plausible values, 0 warnings.** Added `App\Services\Demo\DistributionSampler` (deterministic weighted / in-band sampling) and wired it into the generators so values are distribution-true, not flat constants:
+- **Occupancy differentiated** — `DemoTuningSeeder` per-unit-type targets (ICU 92 / step-down 86 / med-surg ~85), pulled up only, so ICU runs hotter (spread 5.3 pts, was 0.3).
+- **ESI pyramid** — `CommandCenterDemoSeeder`: throughput ESI-1 made rare (walk-in ESI-1 is not real; the vent crowding cohort carries ESI-1) and the crowding cohort samples a pyramid instead of hard-coding ESI-2 → ESI-3 modal (5/30/43/14/8).
+- **Discharge-before-noon** — afternoon-peaked discharge-hour distribution (was uniform 0–23h → ~50%) → 37.5%.
+- **Transport** — re-weighted synthetic sources to routine 70 / urgent 20 / stat 10 (stable per request id) and tightened the SLA spread to ~9% overdue (was 73%); user-created requests preserved.
+
+Verified idempotent across repeated refreshes (every table stable, deterministic sampler). Tests: `tests/Unit/Demo/DistributionSamplerTest` (+ suite = 13 green). Result: **0 critical, 0 warnings.**
+
+**OR scale-up + Wave 5 EXECUTED (2026-07-11).** OR expanded to a 20-room Level I suite with a block-schedule active pattern (~70% staffed/day; anchor day forces 12 rooms) and 2–4 cases/active room → ~48 cases across 16 rooms on the anchor day; FCOTS generalised off hardcoded room-index slots to a deterministic ~80% (measured 81%), turnover (~29m) and PACU holds (4) preserved; new `plausibility.or_daily_volume` invariant. A 15-minute batch-drift grace was added to the "not in future" checks (the anchor is frozen at start but seeders write at live now()). Wave 5: `zephyrus:demo-prune` (nightly retention for occupancy/census snapshots + the ledger) and `GET /up/demo` (health endpoint — last refresh, source freshness, scheduler liveness; 200/503) for uptime monitors.
+
+Result across everything: **22 checks, 0 critical / 0 warnings, idempotent.**
+
+Genuinely remaining (follow-ups): the admin refresh-history **panel** (frontend) is not built (the `/up/demo` endpoint + ledger back it); the full PHPUnit suite should run in **CI** against `zephyrus_test` (Demo unit suite is green; app behavior verified directly against canonical); the demo **host** needs a `schedule:run` cron + queue worker + `DEMO_MODE=true`; and the app relies on the DB server session timezone being **UTC** (standard for servers — `config/database.php` doesn't pin it).
+
+## 8. One-line summary
+The plan's diagnosis is right and its architecture is sound, but (a) the fastest 80% of coherence is "schedule the seeders + rebase you already have," (b) build on the `ops.source_freshness` + seeder-ownership machinery that already exists rather than re-deriving it, and (c) add the missing **plausibility wave** that finally wires the verified `distributions.json` into the generators — because *coherent* and *deeply plausible* are two different bars, and only the first is currently in scope.

--- a/tests/Unit/Demo/DemoClockTest.php
+++ b/tests/Unit/Demo/DemoClockTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Unit\Demo;
+
+use App\Services\Demo\DemoClock;
+use Carbon\CarbonImmutable;
+use PHPUnit\Framework\TestCase;
+
+class DemoClockTest extends TestCase
+{
+    public function test_freezes_explicit_anchor_and_derives_symmetric_window(): void
+    {
+        $anchor = CarbonImmutable::parse('2026-07-10 12:00:00');
+        $clock = new DemoClock($anchor, 48);
+
+        $this->assertTrue($clock->anchor()->equalTo($anchor));
+        $this->assertSame('2026-07-09 12:00:00', $clock->windowStart()->toDateTimeString());
+        $this->assertSame('2026-07-11 12:00:00', $clock->windowEnd()->toDateTimeString());
+        $this->assertSame(48, $clock->windowHours());
+    }
+
+    public function test_parses_now_null_and_iso_option_forms(): void
+    {
+        $this->assertInstanceOf(CarbonImmutable::class, DemoClock::fromOption('now')->anchor());
+        $this->assertInstanceOf(CarbonImmutable::class, DemoClock::fromOption(null)->anchor());
+        $this->assertSame('2026-01-02 03:04:05', DemoClock::fromOption('2026-01-02 03:04:05')->anchor()->toDateTimeString());
+    }
+
+    public function test_knows_whether_a_timestamp_is_inside_the_window(): void
+    {
+        $clock = new DemoClock(CarbonImmutable::parse('2026-07-10 12:00:00'), 48);
+
+        $this->assertTrue($clock->contains(CarbonImmutable::parse('2026-07-10 12:00:00')));
+        $this->assertTrue($clock->contains(CarbonImmutable::parse('2026-07-09 12:00:00')));
+        $this->assertTrue($clock->contains(CarbonImmutable::parse('2026-07-11 12:00:00')));
+        $this->assertFalse($clock->contains(CarbonImmutable::parse('2026-07-08 23:59:59')));
+        $this->assertFalse($clock->contains(CarbonImmutable::parse('2026-07-11 12:00:01')));
+    }
+}

--- a/tests/Unit/Demo/DemoInvariantGateTest.php
+++ b/tests/Unit/Demo/DemoInvariantGateTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit\Demo;
+
+use App\Services\Demo\DemoInvariantService;
+use App\Services\Demo\DistributionProfile;
+use Tests\TestCase;
+
+class DemoInvariantGateTest extends TestCase
+{
+    /** passed() is the gate the refresh pipeline uses; it must fail iff a critical finding fails. */
+    public function test_gates_on_critical_failures_only(): void
+    {
+        $svc = new DemoInvariantService(new DistributionProfile);
+
+        $this->assertTrue($svc->passed([$this->f('critical', true), $this->f('warning', true)]));
+        $this->assertTrue($svc->passed([$this->f('critical', true), $this->f('warning', false)]));
+        $this->assertFalse($svc->passed([$this->f('critical', false), $this->f('warning', true)]));
+        $this->assertTrue($svc->passed([]));
+    }
+
+    private function f(string $severity, bool $passed): array
+    {
+        return ['key' => 'x', 'category' => 'c', 'severity' => $severity, 'passed' => $passed,
+            'observed' => '', 'expected' => '', 'detail' => ''];
+    }
+}

--- a/tests/Unit/Demo/DistributionProfileTest.php
+++ b/tests/Unit/Demo/DistributionProfileTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Demo;
+
+use App\Services\Demo\DistributionProfile;
+use RuntimeException;
+use Tests\TestCase;
+
+class DistributionProfileTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        DistributionProfile::flush();
+    }
+
+    public function test_loads_verified_distribution_json_previously_unused_at_runtime(): void
+    {
+        $p = new DistributionProfile;
+
+        $this->assertSame(500, $p->licensedInpatientBeds());
+        $this->assertEqualsCanonicalizing(
+            ['icu', 'step_down', 'med_surg'],
+            $p->inpatientUnitTypes()
+        );
+        $this->assertArrayHasKey('EMERGENCY', $p->losByUnitType());
+        $this->assertArrayHasKey('INPATIENT', $p->losByUnitType());
+        $this->assertSame(4.07, $p->icuLos()['medianDays'] ?? null);
+        $this->assertGreaterThan(5.0, $p->edThroughputHours()['median'] ?? 0);
+        $this->assertGreaterThan(0.0, $p->mortalityRate());
+    }
+
+    public function test_exposes_verified_disposition_mix_in_order(): void
+    {
+        $mix = (new DistributionProfile)->dispositionMix();
+
+        $this->assertNotEmpty($mix);
+        $this->assertSame('Home/Self Care', $mix[0]['destination']);
+        $this->assertGreaterThan(0.7, $mix[0]['probability']);
+    }
+
+    public function test_exposes_tuneable_clinical_plausibility_bands_from_config(): void
+    {
+        $p = new DistributionProfile;
+
+        $this->assertArrayHasKey('icu', $p->occupancyBands());
+        $this->assertArrayHasKey(3, $p->esiBands());
+        $this->assertCount(2, $p->dischargeBeforeNoonBand());
+        $this->assertArrayHasKey('routine', $p->transportPriorityBands());
+        $this->assertLessThan(0.5, $p->transportOverdueShareMax());
+    }
+
+    public function test_throws_a_clear_error_for_an_unregistered_facility(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No distribution profile registered');
+
+        (new DistributionProfile('NO_SUCH_FACILITY'))->licensedInpatientBeds();
+    }
+}

--- a/tests/Unit/Demo/DistributionSamplerTest.php
+++ b/tests/Unit/Demo/DistributionSamplerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Demo;
+
+use App\Services\Demo\DistributionSampler;
+use PHPUnit\Framework\TestCase;
+
+class DistributionSamplerTest extends TestCase
+{
+    public function test_weighted_pick_is_deterministic_for_a_seed(): void
+    {
+        $s = new DistributionSampler;
+        $weights = [1 => 1, 2 => 25, 3 => 46, 4 => 23, 5 => 5];
+
+        $this->assertSame($s->weightedPick($weights, 12345), $s->weightedPick($weights, 12345));
+        $this->assertContains($s->weightedPick($weights, 999), array_keys($weights));
+    }
+
+    public function test_weighted_pick_roughly_matches_weights_and_keeps_the_mode(): void
+    {
+        $s = new DistributionSampler;
+        $weights = [1 => 1, 2 => 25, 3 => 46, 4 => 23, 5 => 5]; // ESI pyramid, mode = 3
+        $counts = array_fill_keys(array_keys($weights), 0);
+        for ($seed = 0; $seed < 4000; $seed++) {
+            $counts[$s->weightedPick($weights, $seed)]++;
+        }
+
+        // ESI-3 must be the modal draw, and rare classes stay rare.
+        arsort($counts);
+        $this->assertSame(3, array_key_first($counts));
+        $this->assertLessThan($counts[2], $counts[1]); // ESI-1 rarer than ESI-2
+    }
+
+    public function test_value_in_band_stays_inside_the_band_and_is_deterministic(): void
+    {
+        $s = new DistributionSampler;
+        for ($seed = 0; $seed < 500; $seed++) {
+            $v = $s->valueInBand([0.80, 0.96], $seed);
+            $this->assertGreaterThanOrEqual(0.80, $v);
+            $this->assertLessThanOrEqual(0.96, $v);
+        }
+        $this->assertSame($s->valueInBand([0.1, 0.2], 7), $s->valueInBand([0.1, 0.2], 7));
+    }
+
+    public function test_int_between_is_bounded(): void
+    {
+        $s = new DistributionSampler;
+        for ($seed = 0; $seed < 500; $seed++) {
+            $v = $s->intBetween(0, 23, $seed);
+            $this->assertGreaterThanOrEqual(0, $v);
+            $this->assertLessThanOrEqual(23, $v);
+        }
+    }
+}


### PR DESCRIPTION
Grafts the **net-new value** from the demo-coherence work onto the team's **B1 demo-data trust foundation** (`OperationalDemoDataService` / `zephyrus:demo-roll-forward`), adding what B1 doesn't cover while staying entirely **out of the staffing/transport/workforce domains B1 owns** (writing those would trip its `OWNER` collision guard and abort the roll).

Supersedes #21 (which was the full standalone system, built before B1 landed on main and now architecturally redundant with it).

### Added (net-new, additive)
- **`DistributionProfile` + `DistributionSampler`** — load the verified `hospital-1-distributions.json` and sample deterministically; `config/hospital.php` gains the profile registration, `inpatient_unit_types`, and clinical plausibility bands.
- **`zephyrus:demo-validate`** (`DemoClock` + `DemoInvariantService`) — a **read-only runtime** coherence + plausibility gate (temporal / capacity / freshness / plausibility / OR). B1 has equivalents only as PHPUnit assertions; this runs against the live demo after a reset/roll-forward, or in CI. Non-zero exit on critical failure.
- **`HouseCensusService` denominator fix** — house occupancy scoped to inpatient unit types (ED + periop no longer inflate it).
- **Plausibility in domains B1 does not own** (re-applied onto the current seeders): ESI-3-modal ED pyramid, afternoon-peaked discharge hour, a 20-room Level I OR suite (block schedule, generalised FCOTS), and differentiated per-unit-type occupancy + `clampTemporalLeaks` (encounters/census/predictions only). B1's OWNER-scoped staffing/transport refresh is untouched.

### Deliberately dropped (superseded by B1, or would conflict)
- My `DemoRefreshCoordinator` / `zephyrus:demo-refresh` / `config/demo.php` / `ops.demo_refresh_runs` ledger / `/up/demo` / `zephyrus:demo-prune` — B1's roll-forward, `config/demo_data`, and reset runbook cover this.
- My staffing/transport seeder writes and `created_by='seeder'`/`demo-seeder`/`sim-*` tags for those tables — B1 owns them via `OperationalDemoDataService::OWNER`.

### Verification
Pint + `php -l` pass; the Demo unit suite is included; CI runs the full suite. **Runtime `zephyrus:demo-validate` should be run on the deploy host** — the graft branch couldn't be exercised locally (no composer/Postgres/docker in this environment). The same plausibility logic was verified **0-critical / 0-warning** against canonical earlier in its original form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)