### PR TITLE
fix(deploy): publish immutable main snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
 
+      - name: Verify immutable release snapshots
+        run: bash tests/Deployment/immutable-release-snapshot.sh
+
       - name: Copy .env and generate key
         run: cp .env.example .env && php artisan key:generate
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
 
+      - name: Verify immutable release snapshots
+        run: bash tests/Deployment/immutable-release-snapshot.sh
+
       - name: Copy .env and generate key
         run: cp .env.example .env && php artisan key:generate
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,51 +1,111 @@
 #!/bin/bash
 # Deploy script for Zephyrus
 
-# Exit on error
-set -e
+set -Eeuo pipefail
 
-# Check if we're in the development directory
-if [[ "$(pwd)" != "/home/smudoshi/Github/Zephyrus"* ]]; then
-    echo "❌ Error: This script must be run from the development directory"
-    echo "📂 Current directory: $(pwd)"
-    echo "📂 Expected directory: /home/smudoshi/Github/Zephyrus"
+EXPECTED_REPOSITORY_ROOT="/home/smudoshi/Github/Zephyrus"
+REPOSITORY_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+# Production releases must originate from the canonical main checkout. Other
+# worktrees are useful for development, but are not release sources.
+if [[ "$REPOSITORY_ROOT" != "$EXPECTED_REPOSITORY_ROOT" ]]; then
+    echo "❌ Error: This script must be run from the canonical development checkout"
+    echo "📂 Current repository: ${REPOSITORY_ROOT:-not a Git worktree}"
+    echo "📂 Expected repository: $EXPECTED_REPOSITORY_ROOT"
+    exit 1
+fi
+cd "$REPOSITORY_ROOT"
+
+CURRENT_BRANCH="$(git branch --show-current)"
+UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+if [[ "$CURRENT_BRANCH" != "main" || "$UPSTREAM" != "origin/main" ]]; then
+    echo "❌ Error: Production deployments must come from main tracking origin/main"
+    echo "🌿 Current branch: ${CURRENT_BRANCH:-detached HEAD}"
+    echo "📡 Current upstream: ${UPSTREAM:-none}"
     exit 1
 fi
 
-# Check for uncommitted changes
-if [[ -n $(git status -s) ]]; then
+# Check for uncommitted or untracked source before resolving the release.
+if [[ -n "$(git status --porcelain=v1 --untracked-files=normal)" ]]; then
     echo "❌ Error: You have uncommitted changes"
     echo "💡 Please commit or stash your changes before deploying"
     git status
     exit 1
 fi
 
-# Check if we're behind the remote
 echo "📡 Checking remote status..."
-git fetch origin
-LOCAL=$(git rev-parse @)
-REMOTE=$(git rev-parse @{u})
-BASE=$(git merge-base @ @{u})
+git fetch --quiet origin main
+RELEASE_COMMIT="$(git rev-parse HEAD)"
+REMOTE_COMMIT="$(git rev-parse origin/main)"
 
-if [ $LOCAL = $REMOTE ]; then
-    echo "✅ Local branch is up to date"
-elif [ $LOCAL = $BASE ]; then
-    echo "❌ Error: Your local branch is behind the remote"
-    echo "💡 Please pull the latest changes before deploying"
+if [[ "$RELEASE_COMMIT" != "$REMOTE_COMMIT" ]]; then
+    echo "❌ Error: main must exactly match origin/main before deploying"
+    echo "🏠 Local main:  $RELEASE_COMMIT"
+    echo "📡 Origin main: $REMOTE_COMMIT"
+    exit 1
+fi
+echo "✅ main is current at $RELEASE_COMMIT"
+
+if [[ ! -f "$REPOSITORY_ROOT/vendor/autoload.php" ]]; then
+    echo "❌ Error: Composer dependencies are missing; run composer install"
+    exit 1
+fi
+if [[ ! -d "$REPOSITORY_ROOT/node_modules" ]]; then
+    echo "❌ Error: Node dependencies are missing; run npm install"
     exit 1
 fi
 
+RELEASE_TEMP="$(mktemp -d "${TMPDIR:-/tmp}/zephyrus-release.XXXXXX")"
+RELEASE_ROOT="$RELEASE_TEMP/release"
+IMMUTABLE_HELPER="$RELEASE_TEMP/create-release-snapshot.sh"
+
+cleanup_release() {
+    rm -rf "$RELEASE_TEMP"
+}
+trap cleanup_release EXIT
+
+# Load the snapshot helper from the release commit itself, then archive that
+# same commit. A concurrent writer may change the checkout after this point,
+# but rsync and the asset build only read from RELEASE_ROOT.
+git show "$RELEASE_COMMIT:scripts/deployment/create-release-snapshot.sh" > "$IMMUTABLE_HELPER"
+chmod 0700 "$IMMUTABLE_HELPER"
+"$IMMUTABLE_HELPER" "$REPOSITORY_ROOT" "$RELEASE_COMMIT" "$RELEASE_ROOT"
+
+# Composer dependencies are not tracked. Freeze the currently installed,
+# lockfile-backed dependency tree into the otherwise commit-only release tree.
+echo "📦 Freezing Composer dependencies into the release snapshot..."
+mkdir -p "$RELEASE_ROOT/vendor"
+rsync -a --delete "$REPOSITORY_ROOT/vendor/" "$RELEASE_ROOT/vendor/"
+
 echo "🚀 Starting deployment process..."
-
-# Switch to the project directory
-cd "$(dirname "$0")"
-
 echo "Building assets..."
-# Build assets
-NODE_ENV=production npm run build
+
+# Reuse the installed build toolchain without exposing the release payload to
+# mutable application source. The symlink is removed before publication.
+ln -s "$REPOSITORY_ROOT/node_modules" "$RELEASE_ROOT/node_modules"
+(
+    cd "$RELEASE_ROOT"
+    NODE_ENV=production npm run build
+)
+rm "$RELEASE_ROOT/node_modules"
+
+if [[ ! -f "$RELEASE_ROOT/public/build/manifest.json" ]]; then
+    echo "❌ Error: Production asset manifest was not generated"
+    exit 1
+fi
+
+# Do not publish an older snapshot if main advanced while assets were building.
+echo "📡 Revalidating release commit before publication..."
+git fetch --quiet origin main
+REMOTE_COMMIT="$(git rev-parse origin/main)"
+if [[ "$RELEASE_COMMIT" != "$REMOTE_COMMIT" ]]; then
+    echo "❌ Error: origin/main advanced while the release was building"
+    echo "📦 Prepared commit: $RELEASE_COMMIT"
+    echo "📡 Origin main:     $REMOTE_COMMIT"
+    exit 1
+fi
 
 echo "Syncing to production..."
-# Sync to production (excluding node_modules, .git, etc)
 sudo rsync -av --exclude 'node_modules' \
             --exclude '.git' \
             --exclude '.env' \
@@ -57,13 +117,21 @@ sudo rsync -av --exclude 'node_modules' \
             --exclude 'arena/.venv' \
             --exclude '__pycache__' \
             --exclude '.pytest_cache' \
-            /home/smudoshi/Github/Zephyrus/ /var/www/Zephyrus/
+            "$RELEASE_ROOT/" /var/www/Zephyrus/
 
 echo "Setting permissions..."
 # rsync -a preserves dev (smudoshi) ownership, but Apache/PHP-FPM runs as www-data.
 # The ENTIRE tree must be www-data-owned or vendor/autoload reads fail with a
 # site-wide 500 (e.g. "Permission denied" on vendor/.../functions_include.php).
 sudo chown -R www-data:www-data /var/www/Zephyrus
+
+DEPLOYED_COMMIT="$(sudo cat /var/www/Zephyrus/.release-commit)"
+if [[ "$DEPLOYED_COMMIT" != "$RELEASE_COMMIT" ]]; then
+    echo "❌ Error: Deployed commit marker does not match the prepared release"
+    echo "📦 Prepared commit: $RELEASE_COMMIT"
+    echo "🚀 Deployed marker: $DEPLOYED_COMMIT"
+    exit 1
+fi
 
 echo "Clearing Laravel caches..."
 # Clear Laravel caches
@@ -194,7 +262,7 @@ if ! sudo -u www-data test -w /var/www/Zephyrus/storage; then
 fi
 
 echo "✅ All checks passed!"
-echo "🎉 Deployment completed successfully!"
+echo "🎉 Deployment completed successfully at commit $RELEASE_COMMIT!"
 
 # Print helpful information
 echo "

--- a/scripts/deployment/create-release-snapshot.sh
+++ b/scripts/deployment/create-release-snapshot.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+usage() {
+    echo "Usage: $0 <repository-root> <commit> <empty-destination>" >&2
+}
+
+if [[ $# -ne 3 ]]; then
+    usage
+    exit 64
+fi
+
+REPOSITORY_ROOT="$1"
+COMMIT="$2"
+DESTINATION="$3"
+
+if [[ ! -d "$REPOSITORY_ROOT/.git" && ! -f "$REPOSITORY_ROOT/.git" ]]; then
+    echo "Error: repository root is not a Git worktree: $REPOSITORY_ROOT" >&2
+    exit 1
+fi
+
+RESOLVED_COMMIT="$(git -C "$REPOSITORY_ROOT" rev-parse --verify "${COMMIT}^{commit}")"
+
+if [[ -L "$DESTINATION" ]]; then
+    echo "Error: snapshot destination must not be a symbolic link: $DESTINATION" >&2
+    exit 1
+fi
+
+if [[ -e "$DESTINATION" && ! -d "$DESTINATION" ]]; then
+    echo "Error: snapshot destination is not a directory: $DESTINATION" >&2
+    exit 1
+fi
+
+mkdir -p "$DESTINATION"
+
+if [[ -n "$(find "$DESTINATION" -mindepth 1 -print -quit)" ]]; then
+    echo "Error: snapshot destination is not empty: $DESTINATION" >&2
+    exit 1
+fi
+
+# Read only committed Git objects. Untracked files and worktree edits cannot
+# enter this payload, even if another process changes the checkout concurrently.
+git -C "$REPOSITORY_ROOT" archive --format=tar "$RESOLVED_COMMIT" \
+    | tar -xf - -C "$DESTINATION"
+
+printf '%s\n' "$RESOLVED_COMMIT" > "$DESTINATION/.release-commit"

--- a/tests/Deployment/immutable-release-snapshot.sh
+++ b/tests/Deployment/immutable-release-snapshot.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SNAPSHOT_HELPER="$PROJECT_ROOT/scripts/deployment/create-release-snapshot.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/zephyrus-release-test.XXXXXX")"
+WRITER_PID=""
+
+cleanup() {
+    touch "$TEST_ROOT/stop-writer" 2>/dev/null || true
+    if [[ -n "$WRITER_PID" ]]; then
+        kill "$WRITER_PID" 2>/dev/null || true
+        wait "$WRITER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+assert_file_equals() {
+    local expected="$1"
+    local path="$2"
+    local actual
+
+    [[ -f "$path" ]] || fail "expected file is missing: $path"
+    actual="$(cat "$path")"
+    [[ "$actual" == "$expected" ]] \
+        || fail "$path contained '$actual'; expected '$expected'"
+}
+
+REPOSITORY="$TEST_ROOT/repository"
+SNAPSHOT="$TEST_ROOT/snapshot"
+
+git init --quiet --initial-branch=main "$REPOSITORY"
+git -C "$REPOSITORY" config user.name "Zephyrus CI"
+git -C "$REPOSITORY" config user.email "ci@zephyrus.invalid"
+printf 'committed source\n' > "$REPOSITORY/tracked.txt"
+mkdir -p "$REPOSITORY/nested"
+printf 'committed nested source\n' > "$REPOSITORY/nested/tracked.txt"
+git -C "$REPOSITORY" add tracked.txt nested/tracked.txt
+git -C "$REPOSITORY" commit --quiet -m "fixture"
+COMMIT="$(git -C "$REPOSITORY" rev-parse HEAD)"
+
+# Keep changing tracked and untracked worktree files until the immutable
+# snapshot has been created. This reproduces the deploy time-of-check/time-of-
+# use window without allowing the writer to modify committed Git objects.
+(
+    touch "$TEST_ROOT/writer-ready"
+    mutation=0
+    while [[ ! -f "$TEST_ROOT/stop-writer" ]]; do
+        mutation=$((mutation + 1))
+        printf 'concurrent mutation %s\n' "$mutation" > "$REPOSITORY/tracked.txt"
+        printf 'untracked mutation %s\n' "$mutation" > "$REPOSITORY/rogue.php"
+    done
+) &
+WRITER_PID=$!
+
+while [[ ! -f "$TEST_ROOT/writer-ready" ]]; do
+    sleep 0.01
+done
+
+"$SNAPSHOT_HELPER" "$REPOSITORY" "$COMMIT" "$SNAPSHOT"
+touch "$TEST_ROOT/stop-writer"
+wait "$WRITER_PID"
+WRITER_PID=""
+
+assert_file_equals "committed source" "$SNAPSHOT/tracked.txt"
+assert_file_equals "committed nested source" "$SNAPSHOT/nested/tracked.txt"
+assert_file_equals "$COMMIT" "$SNAPSHOT/.release-commit"
+[[ ! -e "$SNAPSHOT/rogue.php" ]] \
+    || fail "an untracked concurrent write entered the release snapshot"
+
+OCCUPIED="$TEST_ROOT/occupied"
+mkdir -p "$OCCUPIED"
+touch "$OCCUPIED/existing-file"
+if "$SNAPSHOT_HELPER" "$REPOSITORY" "$COMMIT" "$OCCUPIED" >/dev/null 2>&1; then
+    fail "helper accepted a non-empty snapshot destination"
+fi
+
+echo "Immutable release snapshot regression test passed."


### PR DESCRIPTION
## Summary
- require the canonical main checkout to match origin/main exactly
- archive the selected commit into an isolated release tree and build assets there
- freeze Composer dependencies into that release tree and publish only from the snapshot
- revalidate origin/main before rsync and write a deployed commit marker
- add a concurrent worktree mutation regression test to both CI workflows

## R0.10 acceptance checklist
- [x] Concurrent tracked edits cannot enter the release payload
- [x] Concurrent untracked files cannot enter the release payload
- [x] Non-empty snapshot destinations are rejected
- [x] Asset build runs against the exact committed snapshot
- [x] Local shell syntax, repeated race tests, normal build, and exact-commit rehearsal pass
- [x] Full GitHub CI passes
- [x] PR merges to main
- [x] Merged main is deployed with deploy.sh
- [x] Production commit marker, web vhost, queue worker, and Arena sidecar are verified

## Validation
- bash -n deploy.sh scripts/deployment/create-release-snapshot.sh tests/Deployment/immutable-release-snapshot.sh
- bash tests/Deployment/immutable-release-snapshot.sh (repeated)
- npm run build
- exact-commit snapshot plus dependency freeze plus production build rehearsal
- git diff --check
- five exact-head GitHub checks passed at 784e895

## Production evidence
- merged normally as 1d3b4d5
- first hardened deployment published 1d3b4d5 from clean/current main
- local HEAD, origin/main, and the production release marker matched
- Apache, queue worker, and Arena were active
- forced vhost/public boundaries returned 301/302 and Arena health returned 200
- the deployed helper hash matched Git, the manifest was present, and storage was writable

No GitHub Actions deployment was introduced; release remained manual through the canonical deploy.sh path.