### PR TITLE
docs(ops): close immutable deploy gate

### DIFF
--- a/docs/superpowers/plans/2026-07-09-operational-platform-remediation-plan.md
+++ b/docs/superpowers/plans/2026-07-09-operational-platform-remediation-plan.md
@@ -54,22 +54,23 @@ The core remediation sequence is merged through normal pull requests, reachable 
 | Integrations operational runtime | [PR #17](https://github.com/sudoshi/Zephyrus/pull/17), merge `3b41fe241359d3041bb1ab12ab3af5a294b54f0c` | Database queues, supervised workers, protocol health, bounded replay/dead-letter controls, Epic FHIR R4/SMART discovery, and governed HL7 ADT machinery are deployed. |
 | Canonical staffing fulfillment | [PR #18](https://github.com/sudoshi/Zephyrus/pull/18), merge `9f2795f80edc5e222d0be7f53287aefca281a139` | Qualifications, availability windows, shift assignments, governed fulfillment, web/Hummingbird parity, and the materialization schedule are deployed. |
 | Governed transport lifecycle | [PR #19](https://github.com/sudoshi/Zephyrus/pull/19), merge `12e1a12d686c85598bd5f6cfbd9bddad5b990a1a` | Server transition rules, immutable idempotency receipts/events/evidence, resource capacity, handoff enforcement, web/mobile parity, and cursor pagination are deployed. |
+| Immutable release source | [PR #25](https://github.com/sudoshi/Zephyrus/pull/25), merge `1d3b4d5020080350127ce6357641faf60c4f9789` | The canonical deploy path archives, builds, and publishes the exact `origin/main` commit from an isolated release tree, revalidates the remote before rsync, and records the deployed SHA. |
 
-All six pull requests passed the same five required checks: two Laravel/PHPUnit jobs, Node/Vite, Vitest/Vite, and Arena pytest. Final live evidence includes:
+All seven implementation pull requests passed the same five required checks: two Laravel/PHPUnit jobs, Node/Vite, Vitest/Vite, and Arena pytest. Final live evidence includes:
 
 - July foundation migrations `2026_07_04_000110` through `000170` are recorded; 23 active inpatient units and 500 active beds are mapped, and 1,150 occupancy snapshots span 23 spaces through 2026-07-10 19:00 EDT.
 - Integration migration `000200` is production batch 23. The database worker is enabled/active, scheduled health/poll dispatchers are registered, 117 protocol-health jobs completed, and the queue had zero pending/failed jobs at reconciliation. Epic discovery is healthy against three active `fhir.epic.com` endpoints; the synthetic HL7 file source is truthfully degraded because no machine-ingress identity is configured. Credentialed Epic polling remains activation-gated and therefore has no clinical watermark.
 - Staffing migration `000300` is production batch 25. The runtime contains 4,529 canonical members/assignments, 4,517 verified qualifications, and 124,275 future materializer windows, with zero overfilled requests and zero overlapping active shift assignments.
 - Transport migration `000400` is production batch 26. The runtime contains 202 requests, 10 resources, 20 active assignments, and 144 explicitly grandfathered terminal records; every runbook capacity, assignment, handoff, idempotency, version, and escalation invariant returns zero violations.
 - Apache and `zephyrus-queue-worker.service` are active, the public login boundary is intact, and deploy-eligible tracked production files match merged `main` byte-for-byte.
+- Release-source hardening merged through PR #25 and was exercised by its first `main` deployment. Local `HEAD`, `origin/main`, and the production `.release-commit` marker matched merge `1d3b4d5020080350127ce6357641faf60c4f9789`; Apache, the queue worker, and Arena were active, and the public authentication boundary remained intact.
 
 The remaining gates are deliberately narrower than the original production gate:
 
-1. Harden `deploy.sh` against concurrent writes between its initial clean-tree check and rsync by publishing an immutable release snapshot or rechecking immediately before sync.
-2. Supply approved Epic non-production backend credentials outside Git, complete a live token exchange and bounded Encounter/Location poll, and advance a clinical watermark.
-3. Complete interface governance for the first production HL7 v2 ADT sender, issue a bounded machine token, and prove one test ADT through raw, canonical, Patient Flow, and provenance records.
-4. Exercise credential rotation, failure/dead-letter recovery, staleness, worker restart, and rollback after real Epic/HL7 activation.
-5. Continue the explicitly unchecked extended-roadmap items in Sections 9 and 13; shipped core behavior must not be relabeled incomplete because optional later depth remains open.
+1. Supply approved Epic non-production backend credentials outside Git, complete a live token exchange and bounded Encounter/Location poll, and advance a clinical watermark.
+2. Complete interface governance for the first production HL7 v2 ADT sender, issue a bounded machine token, and prove one test ADT through raw, canonical, Patient Flow, and provenance records.
+3. Exercise credential rotation, failure/dead-letter recovery, staleness, worker restart, and rollback after real Epic/HL7 activation.
+4. Continue the explicitly unchecked extended-roadmap items in Sections 9 and 13; shipped core behavior must not be relabeled incomplete because optional later depth remains open.
 
 ## 2. Executive Verdict
 
@@ -1287,11 +1288,10 @@ The audit originally recommended a narrow truthfulness-only first pull request. 
 
 The next release backlog is now bounded to work that is actually still open:
 
-1. Harden `deploy.sh` so rsync can only read an immutable release snapshot (or revalidates immediately before sync), with a regression test for concurrent worktree mutation.
-2. Provide approved Epic non-production client/key references outside Git, complete token exchange plus bounded Encounter/Location polling, verify raw/FHIR/provenance retention, and advance the first clinical watermark.
-3. Complete contract/BAA/PHI/sender governance for the first production HL7 v2 ADT source, issue an exact-ability expiring machine token, and prove one test ADT through raw -> canonical -> Patient Flow -> provenance.
-4. After real source activation, execute the production failure/dead-letter, staleness, credential-rotation, worker-restart, and rollback drills.
-5. Continue only the explicitly unchecked extended-roadmap items: production-clone evidence for the older foundation chain, advanced staffing rule/forecast/FHIR depth, pre-transport equipment/vendor-event depth, FHIR Bulk Data, remaining transactional connector families, and governed outbound transmission.
-6. Re-audit open Patient Flow PR #13 and either extract unique work into a bounded current branch or close it as superseded; do not merge its stale branch wholesale.
+1. Provide approved Epic non-production client/key references outside Git, complete token exchange plus bounded Encounter/Location polling, verify raw/FHIR/provenance retention, and advance the first clinical watermark.
+2. Complete contract/BAA/PHI/sender governance for the first production HL7 v2 ADT source, issue an exact-ability expiring machine token, and prove one test ADT through raw -> canonical -> Patient Flow -> provenance.
+3. After real source activation, execute the production failure/dead-letter, staleness, credential-rotation, worker-restart, and rollback drills.
+4. Continue only the explicitly unchecked extended-roadmap items: production-clone evidence for the older foundation chain, advanced staffing rule/forecast/FHIR depth, pre-transport equipment/vendor-event depth, FHIR Bulk Data, remaining transactional connector families, and governed outbound transmission.
+5. Re-audit open Patient Flow PR #13 and either extract unique work into a bounded current branch or close it as superseded; do not merge its stale branch wholesale.
 
-The production migrations and operational runtimes described in Section 1.2 are shipped. Real clinical connector activation remains deliberately gated on external credentials, privacy/interface approval, and post-activation operational evidence; it must not be inferred from a healthy discovery endpoint alone.
+The production migrations, operational runtimes, and immutable release-source path described in Section 1.2 are shipped. Real clinical connector activation remains deliberately gated on external credentials, privacy/interface approval, and post-activation operational evidence; it must not be inferred from a healthy discovery endpoint alone.

--- a/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
+++ b/docs/superpowers/plans/2026-07-10-operational-platform-closure-checklist.md
@@ -1,6 +1,6 @@
 # Operational Platform Closure Checklist
 
-**Status:** Core closure tranches shipped; external connector activation and deploy-source hardening remain
+**Status:** Core closure tranches and deploy-source hardening shipped; external connector activation remains
 
 **Opened:** 2026-07-10
 
@@ -17,7 +17,7 @@
 - [x] R0.7 Verify Apache, the forced Zephyrus vhost, the public login boundary, runtime file parity, and current release migrations.
 - [x] R0.8 Restore all pre-existing local worktree changes without including them in the release PR.
 - [x] R0.9 Keep each implementation tranche on a separate branch and PR; PRs #15 through #19 each passed all five required checks, merged normally, and were deployed from the resulting `main` history before the next production tranche.
-- [ ] R0.10 Make `deploy.sh` publish an immutable release snapshot, or revalidate and abort immediately before rsync, so concurrent writes cannot enter a release after the initial clean-tree check. The transport deployment exposed this time-of-check/time-of-use race; the correction record below is the acceptance baseline.
+- [x] R0.10 Make `deploy.sh` publish an immutable release snapshot, or revalidate and abort immediately before rsync, so concurrent writes cannot enter a release after the initial clean-tree check. PR #25 archives the exact `origin/main` commit, builds and syncs only from that snapshot, revalidates the remote before publication, records the deployed commit, and is covered by a concurrent-writer regression test in both CI workflows.
 
 ## Patient Flow authorization and ingress hotfix
 
@@ -192,6 +192,14 @@ Production release evidence:
 - The first transport deployment run that passed the initial guard exposed R0.10: a concurrent worktree writer changed files after `deploy.sh`'s initial clean check but before rsync, causing an unrelated unmerged audit migration to run. The single generated audit row was preserved in a restricted backup, a detached clean snapshot of merged `main` was redeployed through `deploy.sh`, only the unrelated migration was rolled back, and its source files were removed. The transport migration was never rolled back.
 - After correction, Apache and the queue worker were active, the login boundary returned 302, the worker completed scheduled jobs, and every deploy-eligible tracked regular file compared byte-for-byte with merged `main` (zero mismatches; nested test trees are intentionally excluded by `deploy.sh`). The unrelated audit migration row/table are absent.
 
+## Immutable release-source hardening
+
+- PR [#25](https://github.com/sudoshi/Zephyrus/pull/25) passed all five exact-head checks at `784e895bd0d3f95d2b32d4339bdb2349c0340ca1` and merged normally as `1d3b4d5020080350127ce6357641faf60c4f9789`.
+- `deploy.sh` now refuses non-canonical worktrees, branches other than `main`, missing `origin/main` tracking, dirty source, and any local/remote SHA mismatch. It extracts the helper from the selected commit, archives only committed Git objects, freezes Composer dependencies into the temporary release tree, builds assets there, and revalidates `origin/main` immediately before rsync.
+- `tests/Deployment/immutable-release-snapshot.sh` keeps a background process changing both tracked and untracked fixture files while the snapshot is created. The test proves the release contains the committed bytes and release marker, excludes the rogue file, and rejects a non-empty destination; it passed in both backend CI matrices.
+- The first post-merge deployment exercised the hardened path from clean/current `main`. Local `HEAD`, `origin/main`, and `/var/www/Zephyrus/.release-commit` all resolved to `1d3b4d5020080350127ce6357641faf60c4f9789`; the deployed helper hash matched Git, the production manifest was present, and storage remained writable.
+- Apache, `zephyrus-queue-worker.service`, and `zephyrus-arena.service` were active after deployment. The forced Zephyrus vhost returned its canonical redirect, the public HTTPS boundary returned 302, and Arena health returned 200. The unrelated five-file Rounds/navigation worktree tranche was preserved before deployment and restored unchanged afterward.
+
 ## Canonical documentation reconciliation
 
 - [x] D1.1 Re-audit code, migrations, tests, exact-head CI, deployed runtime, and open PR state before changing completion claims.
@@ -204,14 +212,13 @@ Production release evidence:
 
 | Gate | Owner | Current evidence | Acceptance and release tracking |
 | --- | --- | --- | --- |
-| R0.10 immutable deploy source | Release engineering | The transport correction above proves the clean-check/rsync race and the clean-snapshot recovery. | A separate PR must add an immutable snapshot or pre-rsync recheck, test concurrent mutation/abort behavior, pass full CI, merge, and be exercised by the next `main` deployment. |
 | I1.5b credentialed Epic poll | Integrations + Security | Discovery is healthy against the configured Epic FHIR R4 sandbox; status is `activation_required`, with zero clinical watermarks and no secret reference. | A bounded activation change must provide an approved non-production client ID/private-key reference outside Git, pass live token/Encounter/Location poll and lineage checks, advance a watermark, pass CI, and deploy from `main`. No schema migration is expected. |
 | I1.6b production HL7 v2 ADT | Integrations + Privacy/Interface Operations | The machine-authenticated raw → canonical → Patient Flow path is deployed; only the synthetic non-PHI source is active. | After contract/BAA/PHI approval and sender identity, a bounded activation change must configure a production/live source and exact-ability token, deliver one test ADT with lineage/provenance, pass security smoke, and record deployment evidence. No new migration is expected unless sender-specific state requires one. |
 | I1.7b live failure/rotation drill | Integrations + Operations | Queue supervision, health jobs, replay controls, and runbooks are deployed; no live credential/feed exists to rotate or fail safely yet. | Exercise token/poll failure, dead-letter recovery, staleness, credential overlap rotation, worker restart, and rollback after I1.5b/I1.6b. Track it in the same activation PR or a dedicated operations-evidence PR. |
 | Extended staffing/transport roadmap | Staffing + Transport | Canonical qualification/availability/fulfillment and governed transport lifecycle are deployed with green invariants. | Future bounded PRs retain the still-unchecked July 9 items: versioned staffing rule approvals/forecast UX/FHIR mapping, and explicit pre-transport equipment checklist plus resource-shift/vendor-event depth. Each schema-bearing slice requires rehearsal, focused/full tests, CI, migration, and `main` deployment evidence. |
 | Open Patient Flow PR #13 | Patient Flow | GitHub still reports `feat/patient-flow-4d-barrier-eddy` open at `413f31fdbbb9c37f3979e324fd1be2abbeed7b2f`; it overlaps substantial later Patient Flow work already in `main`. | Re-audit unique commits and either rebase into a bounded non-duplicate PR or close it as superseded. Do not merge the stale branch wholesale. |
 
-## Definition of done for completed implementation tranches #14-#19
+## Definition of done for completed implementation tranches #14-#19 and #25
 
 - [x] The branch contains only the intended tranche and preserves unrelated local work.
 - [x] Focused tests and relevant static/build checks pass locally.


### PR DESCRIPTION
## Summary
- mark R0.10 complete after the shipped PR #25 release-safety tranche
- record exact-head CI, merge, first hardened deployment, commit marker, and runtime evidence
- remove deploy-source hardening from the remaining-gates table and executable backlog
- retain external Epic, production HL7, live drill, extended roadmap, and stale PR #13 gates

## Completion checklist
- [x] Documentation claims reconciled against GitHub, Git, deploy output, and live runtime evidence
- [x] All five exact-head GitHub checks passed at 39e0760
- [x] PR merged normally as 1a5a670
- [x] Final merged main deployed through the hardened deploy.sh path
- [x] Production release marker and runtime health verified
- [x] Concurrent Rounds branch restored to its exact clean head

## Evidence
- PR #25 head 784e895 passed all five required checks and merged as 1d3b4d5
- the first hardened deployment published 1d3b4d5
- this reconciliation passed all five checks and merged as 1a5a670
- final local main, origin/main, and production release marker matched 1a5a670
- Apache, queue worker, and Arena were active
- forced vhost/public boundary returned 301/302 and Arena health returned 200
- production manifest was present and storage was writable
- canonical checkout returned to fix/virtual-rounds-nplus1-nav-gate at b54dc78

No automated deployment was introduced; both releases used the canonical manual main path.