### PR TITLE
fix(rounds): board N+1 (144→7) + gate Virtual Rounds nav on feature flag

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -69,6 +69,13 @@ class HandleInertiaRequests extends Middleware
             'arena' => [
                 'ai_enabled' => (bool) config('services.arena.ai_enabled'),
             ],
+            // Feature flags the frontend reads to gate nav + surfaces. Virtual
+            // Rounds ships disabled; the nav item stays hidden (never a dead
+            // link) until VIRTUAL_ROUNDS_ENABLED is on — matching the server
+            // route gate (EnsureRoundsEnabled) so nav and route never disagree.
+            'features' => [
+                'virtual_rounds' => (bool) config('rounds.enabled'),
+            ],
             'workflow' => $request->session()->get('workflow'),
             'flash' => [
                 'message' => fn () => $request->session()->get('message'),

--- a/app/Services/Rounds/RoundCompletionService.php
+++ b/app/Services/Rounds/RoundCompletionService.php
@@ -42,16 +42,27 @@ class RoundCompletionService
         $policy ??= $this->policyFor($patient->run);
         $freshnessHours = (int) ($policy['freshness_hours'] ?? 24);
 
-        $submitted = $patient->contributions()
+        // Prefer eager-loaded relations — the board projects 28+ patients at
+        // once, so a per-patient query here is an N+1 on the hot path. Single-
+        // patient callers (transitions) leave the relations unloaded and fall
+        // back to a scoped query. Status/round_patient filters run in-memory so
+        // the loaded collections need only the rows, not a re-query.
+        $submitted = ($patient->relationLoaded('contributions')
+            ? $patient->contributions
+            : $patient->contributions()->get(['round_patient_id', 'author_role', 'section_code', 'submitted_at', 'status']))
             ->where('status', 'submitted')
-            ->get(['author_role', 'section_code', 'submitted_at']);
+            ->values();
 
-        $waivedRoles = $patient->run->participants()
+        $run = $patient->run;
+        $participants = $run->relationLoaded('participants')
+            ? $run->participants
+            : $run->participants()->get(['round_patient_id', 'role_code', 'waived_by', 'waiver_reason', 'status']);
+
+        $waivedRoles = $participants
             ->where('status', 'waived')
-            ->where(function ($q) use ($patient) {
-                $q->whereNull('round_patient_id')->orWhere('round_patient_id', $patient->round_patient_id);
-            })
-            ->get(['role_code', 'waived_by', 'waiver_reason']);
+            ->filter(fn ($p) => $p->round_patient_id === null
+                || (int) $p->round_patient_id === (int) $patient->round_patient_id)
+            ->values();
 
         $waived = $waivedRoles->map(fn ($p) => [
             'role' => $p->role_code,
@@ -93,7 +104,9 @@ class RoundCompletionService
             }
         }
 
-        $openTasks = $patient->tasks()->whereIn('status', ['open', 'in_progress'])->count();
+        $openTasks = $patient->relationLoaded('tasks')
+            ? $patient->tasks->whereIn('status', ['open', 'in_progress'])->count()
+            : $patient->tasks()->whereIn('status', ['open', 'in_progress'])->count();
 
         $hardMissing = array_values(array_filter($missing, fn ($m) => $m['requirement'] === 'hard'));
         $blockedByTasks = ! empty($policy['block_on_open_tasks']) && $openTasks > 0;

--- a/app/Services/Rounds/RoundProjectionService.php
+++ b/app/Services/Rounds/RoundProjectionService.php
@@ -32,9 +32,20 @@ class RoundProjectionService
         $policy = $this->completion->policyFor($run);
 
         $patients = $run->patients()
-            ->with(['contributions' => fn ($q) => $q->whereIn('status', ['submitted', 'draft'])->orderByDesc('submitted_at')])
+            ->with([
+                'contributions' => fn ($q) => $q->whereIn('status', ['submitted', 'draft'])->orderByDesc('submitted_at'),
+                'questions' => fn ($q) => $q->where('status', 'open'),
+                'tasks',
+            ])
             ->orderBy('queue_position')
             ->get();
+
+        // Load the run's participants once and share the single run instance
+        // across every row, so evaluatePatient() (waiver + requirement checks)
+        // reads in-memory instead of re-querying run/participants per patient.
+        // This collapses a ~5-queries-per-patient N+1 into a flat handful.
+        $run->loadMissing('participants');
+        $patients->each(fn (RoundPatient $patient) => $patient->setRelation('run', $run));
 
         $rows = $patients->map(function (RoundPatient $patient) use ($detail, $policy) {
             $evaluation = $this->completion->evaluatePatient($patient, $policy);
@@ -63,7 +74,9 @@ class RoundProjectionService
                     'waived' => $evaluation['waived'],
                 ],
                 'open_task_count' => $evaluation['open_task_count'],
-                'open_question_count' => $patient->questions()->where('status', 'open')->count(),
+                'open_question_count' => $patient->relationLoaded('questions')
+                    ? $patient->questions->count()
+                    : $patient->questions()->where('status', 'open')->count(),
                 'rounded_at' => $patient->rounded_at?->toIso8601String(),
             ];
 

--- a/resources/js/Components/Navigation/TopNavbar.tsx
+++ b/resources/js/Components/Navigation/TopNavbar.tsx
@@ -20,7 +20,7 @@ export function TopNavbar({ isDarkMode, setIsDarkMode }: TopNavbarProps) {
   const page = usePage<PageProps>();
   const url = page.url ?? '';
   const isAdmin = Boolean(page.props.auth?.is_admin);
-  const access: NavigationAccess = { isAdmin, can: page.props.auth?.can };
+  const access: NavigationAccess = { isAdmin, can: page.props.auth?.can, features: page.props.features };
   const sections = visibleSections(access);
   const centeredSections = sections.filter((section) => ['cockpit', 'workspaces', 'study'].includes(section.key));
   const utilitySections = sections.filter((section) => !['cockpit', 'workspaces', 'study'].includes(section.key));

--- a/resources/js/Pages/Transport/TransportLayout.tsx
+++ b/resources/js/Pages/Transport/TransportLayout.tsx
@@ -34,6 +34,7 @@ export default function TransportLayout({ title, subtitle, current, children }: 
   const access: NavigationAccess = {
     isAdmin: Boolean(page.props.auth?.is_admin),
     can: page.props.auth?.can,
+    features: page.props.features,
   };
   const tabs: readonly LocalTab[] = [
     { label: 'Command', href: '/dashboard?drill=flow' },

--- a/resources/js/components/ui/CommandPalette.tsx
+++ b/resources/js/components/ui/CommandPalette.tsx
@@ -11,7 +11,7 @@ export function CommandPalette() {
   const setOpen = useUIStore((s) => s.setCommandPaletteOpen);
   const page = usePage<PageProps>();
   const isAdmin = Boolean(page.props.auth?.is_admin);
-  const access: NavigationAccess = { isAdmin, can: page.props.auth?.can };
+  const access: NavigationAccess = { isAdmin, can: page.props.auth?.can, features: page.props.features };
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {

--- a/resources/js/config/navigationConfig.ts
+++ b/resources/js/config/navigationConfig.ts
@@ -60,9 +60,16 @@ export interface NavigationCapabilities {
   readonly view_user_audit?: boolean;
 }
 
+/** Server-shared feature flags (Inertia `features` prop). A leaf gated on a
+ *  disabled feature is hidden — never rendered as a dead link that 404s. */
+export interface NavigationFeatures {
+  readonly virtual_rounds?: boolean;
+}
+
 export interface NavigationAccess {
   readonly isAdmin: boolean;
   readonly can?: NavigationCapabilities;
+  readonly features?: NavigationFeatures;
 }
 
 export interface NavLeaf {
@@ -72,6 +79,8 @@ export interface NavLeaf {
   readonly adminOnly?: boolean;
   readonly requiredCapability?: keyof NavigationCapabilities;
   readonly adminOrCapability?: keyof NavigationCapabilities;
+  /** Hidden unless this server-shared feature flag is on. */
+  readonly requiredFeature?: keyof NavigationFeatures;
 }
 
 export interface NavGroup {
@@ -124,7 +133,12 @@ const RTDC: NavDomain = {
       items: [
         { label: 'Bed Tracking', href: '/rtdc/bed-tracking', icon: Activity },
         { label: 'Patient Flow 4D', href: '/rtdc/patient-flow-navigator', icon: Workflow },
-        { label: 'Virtual Rounds', href: '/rtdc/virtual-rounds', icon: Stethoscope },
+        {
+          label: 'Virtual Rounds',
+          href: '/rtdc/virtual-rounds',
+          icon: Stethoscope,
+          requiredFeature: 'virtual_rounds',
+        },
         { label: 'Bed Placement', href: '/rtdc/bed-placement', icon: ClipboardList },
         { label: 'Ancillary Services', href: '/rtdc/ancillary-services', icon: Boxes },
         { label: 'Global Huddle', href: '/rtdc/global-huddle', icon: Users },
@@ -462,6 +476,7 @@ export function visibleDomains(access: NavigationAccess): readonly NavDomain[] {
 }
 
 export function isLeafVisible(item: NavLeaf, access: NavigationAccess): boolean {
+  if (item.requiredFeature && access.features?.[item.requiredFeature] !== true) return false;
   if (item.adminOnly && !access.isAdmin) return false;
   if (item.adminOrCapability) {
     return access.isAdmin || access.can?.[item.adminOrCapability] === true;

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -30,6 +30,9 @@ export interface PageProps {
   arena?: {
     ai_enabled: boolean;
   };
+  features?: {
+    virtual_rounds?: boolean;
+  };
   flash?: {
     message?: string;
     error?: string;


### PR DESCRIPTION
## Why
Debugging the **Virtual Rounds** feature surfaced two real defects. The feature (unit Rounds Board, plan phases 1-2) is fully built and passes its 43 tests, but is flag-disabled (`VIRTUAL_ROUNDS_ENABLED`) in dev + prod — yet the RTDC sidebar still links to it, so clicking **Virtual Rounds** hard-404s (`EnsureRoundsEnabled`). Separately, the board projection was pathologically N+1.

## Fixes
### 1. Board N+1: 144 → 7 queries (flat regardless of census)
`RoundProjectionService::board` eager-loaded contributions, but `RoundCompletionService::evaluatePatient` re-queried them and lazy-loaded `run`/`participants`/`tasks`/`questions` **per patient**. Measured **144 queries for a 28-patient board** — on the hot path (30 s auto-refetch + invalidate-after-every-mutation).

- `evaluatePatient` now reads eager-loaded relations when present, with `relationLoaded()` fallbacks so single-patient transition callers are unchanged.
- `board()` eager-loads `questions`/`tasks` and shares one `run` instance (`loadMissing('participants')` + `setRelation`).
- **Verified: 7 queries, board output byte-identical (md5 signature), 43 rounds tests green.**

### 2. Dead nav link → feature-gated nav
- Share `config('rounds.enabled')` as the `features.virtual_rounds` Inertia prop (mirrors the existing `eddy`/`arena` flag pattern).
- New `NavigationFeatures` + `requiredFeature` on `NavLeaf`; `isLeafVisible` hides a leaf when its feature flag is off. The "Virtual Rounds" leaf gets `requiredFeature: 'virtual_rounds'`, so the item is **hidden (never a dead 404 link) until the feature is on** — matching the server route gate.
- Threaded `features` through all 3 `NavigationAccess` construction sites (TopNavbar → mega-menus/mobile drawer, CommandPalette, TransportLayout).

## Verification
- `144 → 7` query proof + byte-identical board output (tinker, live 28-patient dev run).
- `php artisan test tests/Feature/Rounds tests/Unit/Rounds` → **43 passed**.
- `npx tsc --noEmit` clean · `npx vite build` clean · `vendor/bin/pint --test` clean.

## Not in this PR (found, reported)
Idempotency keys are regenerated per request (client sends fresh UUID → the idempotency layer provides no real double-submit protection; server `isReplay` is also globally unscoped); every patient transition bumps `queue_version` (spurious 409s for concurrent pin/reorder); task/question mutations have no owner/leader gate; `eddy_assisted` mode is accepted by DB/templates but rejected by `CreateRunRequest`.

## Enablement
Additive + reversible. Flipping `VIRTUAL_ROUNDS_ENABLED=true` shows the (working, complete) unit board; the family/writeback/eddy/notification sub-flags stay off.