### PR TITLE
feat(rounds): auto-refresh demo rounds on 6h pipeline + queue/task/idempotency hardening

### DIFF
--- a/app/Console/Commands/RoundsSeedDemoCommand.php
+++ b/app/Console/Commands/RoundsSeedDemoCommand.php
@@ -16,16 +16,23 @@ use Illuminate\Console\Command;
  * Synthetic round generator tied to the demo census (plan §15 Phase 1).
  * Creates today's run for a unit with active encounters, starts it, and
  * submits a plausible nursing note on the first patients so the board
- * demonstrates the full contribution → review workflow. Idempotent per
- * unit/day: an open run for the unit is reused, never duplicated.
+ * demonstrates the full contribution → review workflow.
+ *
+ * Idempotent per unit/day: an open run for the unit is reused, never
+ * duplicated — UNLESS --refresh is passed, in which case the stale open run is
+ * cancelled and a fresh cohort is built against the CURRENT census. The 6-hourly
+ * demo refresh calls this with --units + --refresh so a walkthrough always opens
+ * onto a live board re-anchored to "now".
  */
 class RoundsSeedDemoCommand extends Command
 {
     protected $signature = 'rounds:seed-demo
         {unit? : Unit abbreviation or id (default: the busiest unit)}
+        {--units= : Comma-separated units (abbreviation or id); overrides the positional arg}
+        {--refresh : Cancel the unit'."'".'s existing open run and rebuild against the current census}
         {--template= : Template name (default: Unit Multidisciplinary Round)}';
 
-    protected $description = 'Create a demo Virtual Rounds run over the current active census';
+    protected $description = 'Create (or refresh) demo Virtual Rounds runs over the current active census';
 
     public function handle(RoundCommandService $commands, RoundContributionService $contributions): int
     {
@@ -35,14 +42,6 @@ class RoundsSeedDemoCommand extends Command
 
         if (RoundTemplate::query()->count() === 0) {
             $this->call('db:seed', ['--class' => RoundTemplateSeeder::class, '--force' => true]);
-        }
-
-        $unit = $this->resolveUnit();
-
-        if ($unit === null) {
-            $this->error('No unit with active encounters found. Seed demo data first (php artisan db:seed).');
-
-            return self::FAILURE;
         }
 
         $templateName = $this->option('template') ?: 'Unit Multidisciplinary Round';
@@ -57,6 +56,36 @@ class RoundsSeedDemoCommand extends Command
         $actor = User::query()->where('role', 'admin')->orderBy('id')->first()
             ?? User::query()->orderBy('id')->firstOrFail();
 
+        $units = $this->resolveUnits();
+
+        if ($units === []) {
+            $this->error('No unit with active encounters found. Seed demo data first (php artisan db:seed).');
+
+            return self::FAILURE;
+        }
+
+        $refresh = (bool) $this->option('refresh');
+        $seeded = 0;
+
+        foreach ($units as $unit) {
+            if ($this->seedUnit($unit, $template, $actor, $commands, $contributions, $refresh)) {
+                $seeded++;
+            }
+        }
+
+        $this->info("Rounds demo: processed {$seeded}/".count($units).' unit(s).');
+
+        return self::SUCCESS;
+    }
+
+    private function seedUnit(
+        Unit $unit,
+        RoundTemplate $template,
+        User $actor,
+        RoundCommandService $commands,
+        RoundContributionService $contributions,
+        bool $refresh,
+    ): bool {
         $existing = RoundRun::query()
             ->open()
             ->where('scope_type', 'unit')
@@ -64,10 +93,16 @@ class RoundsSeedDemoCommand extends Command
             ->whereDate('created_at', now()->toDateString())
             ->first();
 
-        if ($existing !== null) {
+        if ($existing !== null && ! $refresh) {
             $this->info("Open run already exists for {$unit->name} today: {$existing->run_uuid}");
 
-            return self::SUCCESS;
+            return false;
+        }
+
+        // --refresh: retire the stale open run so the new one re-anchors to the
+        // current census (the demo refresh shifts every encounter to "now").
+        if ($existing !== null) {
+            $commands->cancel($actor, $existing, ['reason' => 'demo-refresh rebuild']);
         }
 
         $run = $commands->createRun($actor, [
@@ -75,11 +110,10 @@ class RoundsSeedDemoCommand extends Command
             'scope_type' => 'unit',
             'scope_key' => (string) $unit->unit_id,
         ]);
-
         $run = $commands->start($actor, $run);
 
-        // A nursing note on the first two patients makes the board tell a
-        // story: partial inputs, one patient nudged into in_progress.
+        // A nursing note on the first two patients makes the board tell a story:
+        // partial inputs, one patient nudged into in_progress.
         $notes = [
             'Comfortable overnight; ambulating with assist. Family visiting this morning.',
             'Intermittent pain overnight, controlled with PRN. Asking about discharge timing.',
@@ -97,21 +131,42 @@ class RoundsSeedDemoCommand extends Command
 
         $this->info("Demo run created for {$unit->name}: {$run->run_uuid} ({$run->patients()->count()} patients)");
 
-        return self::SUCCESS;
+        return true;
     }
 
-    private function resolveUnit(): ?Unit
+    /** @return list<Unit> */
+    private function resolveUnits(): array
     {
-        $argument = $this->argument('unit');
+        $list = (string) $this->option('units');
+        if ($list !== '') {
+            $tokens = array_values(array_filter(array_map('trim', explode(',', $list))));
 
-        if ($argument) {
-            $query = Unit::query()->where('is_deleted', false);
-
-            return ctype_digit((string) $argument)
-                ? $query->where('unit_id', (int) $argument)->first()
-                : $query->whereRaw('LOWER(abbreviation) = ?', [strtolower((string) $argument)])->first();
+            return array_values(array_filter(array_map(fn ($t) => $this->resolveUnit($t), $tokens)));
         }
 
+        $argument = $this->argument('unit');
+        if ($argument) {
+            $unit = $this->resolveUnit((string) $argument);
+
+            return $unit ? [$unit] : [];
+        }
+
+        $unit = $this->busiestUnit();
+
+        return $unit ? [$unit] : [];
+    }
+
+    private function resolveUnit(string $token): ?Unit
+    {
+        $query = Unit::query()->where('is_deleted', false);
+
+        return ctype_digit($token)
+            ? $query->where('unit_id', (int) $token)->first()
+            : $query->whereRaw('LOWER(abbreviation) = ?', [strtolower($token)])->first();
+    }
+
+    private function busiestUnit(): ?Unit
+    {
         $unitId = Encounter::query()
             ->active()
             ->selectRaw('unit_id, count(*) as census')

--- a/app/Http/Controllers/Api/Rounds/RoundQuestionController.php
+++ b/app/Http/Controllers/Api/Rounds/RoundQuestionController.php
@@ -51,6 +51,8 @@ class RoundQuestionController extends RoundsController
         $question = RoundQuestion::query()->where('question_uuid', $questionUuid)->firstOrFail();
         $patient = $question->patient;
         $this->authorization->assertCanContribute($request->user(), $patient->run);
+        // Resolving belongs to the question's target/raiser or a run leader.
+        abort_unless($this->authorization->canResolveQuestion($request->user(), $question, $patient->run), 403);
 
         $status = $request->input('status', 'answered');
         abort_unless(in_array($status, ['answered', 'dismissed'], true), 422);

--- a/app/Http/Controllers/Api/Rounds/RoundTaskController.php
+++ b/app/Http/Controllers/Api/Rounds/RoundTaskController.php
@@ -52,6 +52,9 @@ class RoundTaskController extends RoundsController
         $run = $task->run;
 
         $this->authorization->assertCanContribute($request->user(), $run);
+        // Only the task's owner/creator or a run leader may move it — a shared
+        // board must not let one discipline close another's task.
+        abort_unless($this->authorization->canManageTask($request->user(), $task), 403);
 
         $status = (string) $request->input('status');
         abort_unless(in_array($status, ['in_progress', 'completed', 'cancelled'], true), 422);

--- a/app/Http/Requests/Rounds/CreateRunRequest.php
+++ b/app/Http/Requests/Rounds/CreateRunRequest.php
@@ -14,11 +14,19 @@ class CreateRunRequest extends FormRequest
     /** @return array<string, mixed> */
     public function rules(): array
     {
+        // eddy_assisted is a valid DB/template mode; only offer it to clients
+        // when the Eddy sub-feature is on (the DB CHECK and templates already
+        // permit it — this keeps the request surface consistent with the flag).
+        $modes = ['async', 'live', 'hybrid'];
+        if (config('rounds.eddy_enabled')) {
+            $modes[] = 'eddy_assisted';
+        }
+
         return [
             'template_uuid' => 'required|uuid',
             'scope_type' => 'required|in:unit',
             'scope_key' => 'required|string|max:100',
-            'mode' => 'nullable|in:async,live,hybrid',
+            'mode' => 'nullable|in:'.implode(',', $modes),
             'planned_start_at' => 'nullable|date',
             'window_end_at' => 'nullable|date|after:planned_start_at',
         ];

--- a/app/Services/Demo/DemoRefreshCoordinator.php
+++ b/app/Services/Demo/DemoRefreshCoordinator.php
@@ -62,6 +62,16 @@ final class DemoRefreshCoordinator
             $domains[] = $this->step('flow', fn () => Artisan::call('patient-flow:rebase-synthetic', ['--anchor' => $clock->key()]));
             $domains[] = $this->step('operational', fn () => Artisan::call('db:seed', ['--class' => 'CommandCenterDemoSeeder', '--force' => true]));
             $domains[] = $this->step('tuning', fn () => Artisan::call('db:seed', ['--class' => 'DemoTuningSeeder', '--force' => true]));
+            // Re-anchor Virtual Rounds onto the freshly-rebased census so a
+            // walkthrough always opens onto a live board. --refresh retires the
+            // stale open run and rebuilds the cohort at the new cutoff. Gated on
+            // the feature flag; absent entirely when Virtual Rounds is off.
+            if (config('rounds.enabled') && config('rounds.demo_units') !== []) {
+                $domains[] = $this->step('rounds', fn () => Artisan::call('rounds:seed-demo', [
+                    '--units' => implode(',', (array) config('rounds.demo_units')),
+                    '--refresh' => true,
+                ]));
+            }
             // NB: no flow:snapshot --backfill here. The rebase already shifts the fixture
             // occupancy_snapshots to cover the trailing window; --backfill is an initial-seed
             // helper ("history on day one") and re-running it every cycle appends off-hour

--- a/app/Services/Rounds/RoundAuthorizationService.php
+++ b/app/Services/Rounds/RoundAuthorizationService.php
@@ -2,7 +2,9 @@
 
 namespace App\Services\Rounds;
 
+use App\Models\Rounds\RoundQuestion;
 use App\Models\Rounds\RoundRun;
+use App\Models\Rounds\RoundTask;
 use App\Models\Unit;
 use App\Models\User;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -118,6 +120,43 @@ class RoundAuthorizationService
     public function canManageTemplates(User $user): bool
     {
         return $this->isBroadAccess($user);
+    }
+
+    /**
+     * Closing or reassigning a task belongs to its owner (by user or mapped
+     * role), its creator, or a run leader — not to any unit-sharing contributor.
+     * Contributors can still CREATE tasks; only these actors may mutate one.
+     */
+    public function canManageTask(User $user, RoundTask $task): bool
+    {
+        if ($this->canLead($user, $task->run)) {
+            return true;
+        }
+
+        if ((int) $task->owner_user_id === (int) $user->id || (int) $task->created_by === (int) $user->id) {
+            return true;
+        }
+
+        return $task->owner_role !== null
+            && $task->owner_role === $this->contributorRoleFor($user, $task->run);
+    }
+
+    /**
+     * Resolving a question belongs to its target (by user or mapped role), the
+     * clinician who raised it, or a run leader.
+     */
+    public function canResolveQuestion(User $user, RoundQuestion $question, RoundRun $run): bool
+    {
+        if ($this->canLead($user, $run)) {
+            return true;
+        }
+
+        if ((int) $question->target_user_id === (int) $user->id || (int) $question->raised_by === (int) $user->id) {
+            return true;
+        }
+
+        return $question->target_role !== null
+            && $question->target_role === $this->contributorRoleFor($user, $run);
     }
 
     /**

--- a/app/Services/Rounds/RoundCommandService.php
+++ b/app/Services/Rounds/RoundCommandService.php
@@ -79,7 +79,7 @@ class RoundCommandService
         }
 
         $run = $this->execute(function () use ($actor, $input, $template, $unit): RoundRun {
-            if ($this->isReplay($input['idempotency_key'] ?? null)) {
+            if ($this->isReplay($input['idempotency_key'] ?? null, 'run')) {
                 $existing = $this->replayedRun($input['idempotency_key']);
                 if ($existing !== null) {
                     return $existing;
@@ -162,7 +162,7 @@ class RoundCommandService
         return $this->execute(function () use ($actor, $run, $opts): RoundRun {
             $locked = $this->lockRun($run);
 
-            if ($this->isReplay($opts['idempotency_key'] ?? null)) {
+            if ($this->isReplay($opts['idempotency_key'] ?? null, 'run', $locked->run_id)) {
                 return $locked;
             }
 
@@ -228,7 +228,7 @@ class RoundCommandService
             $this->lockRun($run);
             $locked = RoundPatient::query()->lockForUpdate()->findOrFail($patient->round_patient_id);
 
-            if ($this->isReplay($opts['idempotency_key'] ?? null)) {
+            if ($this->isReplay($opts['idempotency_key'] ?? null, 'round_patient', $locked->round_patient_id)) {
                 return $locked;
             }
 
@@ -316,7 +316,7 @@ class RoundCommandService
         return $this->execute(function () use ($actor, $run, $orderedUuids, $expectedQueueVersion, $opts): RoundRun {
             $locked = $this->lockRun($run);
 
-            if ($this->isReplay($opts['idempotency_key'] ?? null)) {
+            if ($this->isReplay($opts['idempotency_key'] ?? null, 'run', $locked->run_id)) {
                 return $locked;
             }
 
@@ -385,7 +385,9 @@ class RoundCommandService
         return $this->execute(function () use ($actor, $patient, $run, $pinned, $reason, $expectedQueueVersion, $opts): RoundRun {
             $locked = $this->lockRun($run);
 
-            if ($this->isReplay($opts['idempotency_key'] ?? null)) {
+            // Pin records its idempotency event against the patient (see below),
+            // so the replay check must scope to the same aggregate.
+            if ($this->isReplay($opts['idempotency_key'] ?? null, 'round_patient', $patient->round_patient_id)) {
                 return $locked;
             }
 
@@ -429,7 +431,7 @@ class RoundCommandService
         return $this->execute(function () use ($actor, $run, $apply): RoundRun {
             $locked = $this->lockRun($run);
 
-            if ($this->isReplay($apply['idempotency_key'] ?? null)) {
+            if ($this->isReplay($apply['idempotency_key'] ?? null, 'run', $locked->run_id)) {
                 return $locked;
             }
 
@@ -521,14 +523,21 @@ class RoundCommandService
             $patient->priority_reasons = $priority['reasons'];
         }
 
+        // The queue_version is the optimistic-lock token for pin/reorder. Only
+        // bump it when the ORDER actually changes — otherwise a plain status
+        // change (e.g. mark-ready, which never reorders) would invalidate a
+        // teammate's in-flight pin/reorder with a spurious 409 on a busy board.
+        // Score/band updates still propagate via the post-mutation board refetch.
+        $before = $patients->sortBy('queue_position')->pluck('round_patient_id')->values()->all();
         $ordered = $this->queue->orderQueue($patients);
+        $after = $ordered->pluck('round_patient_id')->values()->all();
         $this->eta->assignWindows($run, $ordered, (array) $template?->eta_policy);
 
         foreach ($ordered as $patient) {
             $patient->save();
         }
 
-        if ($bumpVersion) {
+        if ($bumpVersion && $before !== $after) {
             $run->queue_version = $run->queue_version + 1;
             $run->save();
         }
@@ -548,7 +557,7 @@ class RoundCommandService
         return $this->execute(function () use ($actor, $run, $to, $eventType, $opts, $mutate): RoundRun {
             $locked = $this->lockRun($run);
 
-            if ($this->isReplay($opts['idempotency_key'] ?? null)) {
+            if ($this->isReplay($opts['idempotency_key'] ?? null, 'run', $locked->run_id)) {
                 return $locked;
             }
 
@@ -627,13 +636,28 @@ class RoundCommandService
         }
     }
 
-    private function isReplay(?string $idempotencyKey): bool
+    /**
+     * A replay is the SAME key seen on the SAME aggregate this command records
+     * against — not merely the key existing anywhere. Scoping by aggregate
+     * prevents a key reused across different aggregates (or aggregate types)
+     * from short-circuiting an unrelated command with stale state. Pass a null
+     * $aggregateId to scope by type only (create, before the id exists).
+     */
+    private function isReplay(?string $idempotencyKey, string $aggregateType, int|string|null $aggregateId = null): bool
     {
         if ($idempotencyKey === null || $idempotencyKey === '') {
             return false;
         }
 
-        return RoundEvent::query()->where('idempotency_key', $idempotencyKey)->exists();
+        $query = RoundEvent::query()
+            ->where('idempotency_key', $idempotencyKey)
+            ->where('aggregate_type', $aggregateType);
+
+        if ($aggregateId !== null) {
+            $query->where('aggregate_id', $aggregateId);
+        }
+
+        return $query->exists();
     }
 
     private function replayedRun(string $idempotencyKey): ?RoundRun

--- a/config/rounds.php
+++ b/config/rounds.php
@@ -24,6 +24,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Demo units
+    |--------------------------------------------------------------------------
+    | Units (abbreviation or id) the 6-hourly demo refresh re-anchors a Virtual
+    | Rounds run for, so a walkthrough always opens onto a live board. Keep the
+    | first accessible unit here — the board auto-selects scopes[0].
+    */
+    'demo_units' => array_values(array_filter(array_map(
+        'trim',
+        explode(',', (string) env('VIRTUAL_ROUNDS_DEMO_UNITS', 'BMT,ONC,AIR'))
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
     | Contributor roles
     |--------------------------------------------------------------------------
     | role_code => display label. prod.user_unit pivot roles map onto these

--- a/tests/Feature/Rounds/RoundHardeningTest.php
+++ b/tests/Feature/Rounds/RoundHardeningTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature\Rounds;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\SeedsRoundsStory;
+use Tests\TestCase;
+
+/**
+ * Guards for the 2026-07-11 rounds hardening pass:
+ *  - queue_version bumps ONLY when the order changes (no spurious 409s);
+ *  - task mutation is owner/leader-gated (not any unit-sharing contributor);
+ *  - eddy_assisted mode is offered only when the Eddy sub-feature is on.
+ */
+class RoundHardeningTest extends TestCase
+{
+    use RefreshDatabase, SeedsRoundsStory;
+
+    private string $runUuid;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seedRoundsStory();
+
+        $board = $this->createRoundsRun();
+        $this->runUuid = $board['data']['run']['run_uuid'];
+        $this->actingAs($this->chargeNurse)->postJson("/api/rounds/runs/{$this->runUuid}/start")->assertOk();
+    }
+
+    public function test_non_reordering_transition_does_not_bump_queue_version_but_settling_does(): void
+    {
+        // A nurse note nudges ROUTINE queued -> in_progress (patient version only).
+        $routine = $this->boardRowFor($this->board(), 'ROUNDS-PAT-ROUTINE');
+        $this->submitNurseNote($routine['round_patient_uuid']);
+
+        $before = $this->board()['meta']['version'];
+
+        // in_progress -> ready_for_review keeps the patient in the active
+        // partition at the same band: the order is unchanged, so the queue
+        // version must NOT move (else concurrent pin/reorder would 409).
+        $this->actingAs($this->bedsideNurse)
+            ->postJson("/api/rounds/patients/{$routine['round_patient_uuid']}/mark-ready")
+            ->assertOk();
+
+        $this->assertSame($before, $this->board()['meta']['version'], 'mark-ready must not bump the queue version');
+
+        // Deferring the ACUTE patient settles it out of the active queue: the
+        // order genuinely changes, so the version SHOULD advance by exactly one.
+        $acute = $this->boardRowFor($this->board(), 'ROUNDS-PAT-ACUTE');
+        $this->actingAs($this->chargeNurse)
+            ->postJson("/api/rounds/patients/{$acute['round_patient_uuid']}/defer", ['reason' => 'Awaiting imaging.'])
+            ->assertOk();
+
+        $this->assertSame($before + 1, $this->board()['meta']['version'], 'a settling transition must bump the queue version once');
+    }
+
+    public function test_task_transition_is_owner_or_leader_gated(): void
+    {
+        $routine = $this->boardRowFor($this->board(), 'ROUNDS-PAT-ROUTINE');
+
+        // The charge nurse opens a pharmacy-owned task.
+        $detail = $this->actingAs($this->chargeNurse)
+            ->postJson("/api/rounds/patients/{$routine['round_patient_uuid']}/tasks", [
+                'title' => 'Reconcile discharge meds',
+                'owner_role' => 'pharmacist',
+            ])->assertCreated()->json();
+
+        $taskUuid = $detail['data']['tasks'][0]['task_uuid'];
+
+        // A bedside nurse is a contributor but neither the owner, the creator,
+        // nor a leader — they must not be able to close another discipline's task.
+        $this->actingAs($this->bedsideNurse)
+            ->postJson("/api/rounds/tasks/{$taskUuid}/transition", ['status' => 'completed'])
+            ->assertStatus(403);
+
+        // The charge nurse leads the run and may transition it.
+        $this->actingAs($this->chargeNurse)
+            ->postJson("/api/rounds/tasks/{$taskUuid}/transition", ['status' => 'completed'])
+            ->assertOk();
+    }
+
+    public function test_eddy_assisted_mode_is_gated_by_the_eddy_flag(): void
+    {
+        $payload = [
+            'template_uuid' => $this->roundsTemplate->template_uuid,
+            'scope_type' => 'unit',
+            'scope_key' => (string) $this->roundsUnit->unit_id,
+            'mode' => 'eddy_assisted',
+        ];
+
+        // Eddy off (default): the request surface rejects the mode.
+        config(['rounds.eddy_enabled' => false]);
+        $this->actingAs($this->chargeNurse)->postJson('/api/rounds/runs', $payload)->assertStatus(422);
+
+        // Eddy on: the mode is accepted (DB CHECK + templates already permit it).
+        config(['rounds.eddy_enabled' => true]);
+        $this->actingAs($this->chargeNurse)->postJson('/api/rounds/runs', $payload)->assertCreated();
+    }
+
+    /** @return array<string, mixed> current board payload */
+    private function board(): array
+    {
+        return $this->actingAs($this->chargeNurse)
+            ->getJson("/api/rounds/runs/{$this->runUuid}/board")
+            ->assertOk()
+            ->json();
+    }
+
+    private function submitNurseNote(string $roundPatientUuid): void
+    {
+        $this->actingAs($this->bedsideNurse)
+            ->postJson("/api/rounds/patients/{$roundPatientUuid}/contributions", [
+                'section_code' => 'overnight_events',
+                'author_role' => 'bedside_nurse',
+                'structured_data' => ['events' => 'Comfortable overnight.'],
+                'submit' => true,
+            ])->assertCreated();
+    }
+}

--- a/tests/Feature/Rounds/RoundsSeedDemoCommandTest.php
+++ b/tests/Feature/Rounds/RoundsSeedDemoCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Rounds;
+
+use App\Models\Rounds\RoundRun;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\Support\SeedsRoundsStory;
+use Tests\TestCase;
+
+/**
+ * The demo seeder feeds the 6-hourly demo refresh: it must create one open run
+ * per unit, idempotently skip an existing one, and — with --refresh — retire
+ * the stale run and rebuild a fresh cohort against the current census.
+ */
+class RoundsSeedDemoCommandTest extends TestCase
+{
+    use RefreshDatabase, SeedsRoundsStory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seedRoundsStory();
+    }
+
+    private function runSeeder(array $opts = []): int
+    {
+        return Artisan::call('rounds:seed-demo', array_merge([
+            '--units' => (string) $this->roundsUnit->unit_id,
+            '--template' => $this->roundsTemplate->name,
+        ], $opts));
+    }
+
+    public function test_creates_one_open_run_then_idempotently_skips(): void
+    {
+        $this->runSeeder();
+        $first = RoundRun::query()->open()->where('scope_key', (string) $this->roundsUnit->unit_id)->sole();
+
+        // Without --refresh a second pass reuses the same open run.
+        $this->runSeeder();
+        $this->assertSame(1, RoundRun::query()->open()->where('scope_key', (string) $this->roundsUnit->unit_id)->count());
+        $this->assertSame($first->run_uuid, RoundRun::query()->open()->where('scope_key', (string) $this->roundsUnit->unit_id)->sole()->run_uuid);
+    }
+
+    public function test_refresh_cancels_the_stale_run_and_rebuilds(): void
+    {
+        $this->runSeeder();
+        $original = RoundRun::query()->open()->where('scope_key', (string) $this->roundsUnit->unit_id)->sole();
+
+        $this->runSeeder(['--refresh' => true]);
+
+        // Exactly one open run remains, and it is a fresh one; the original is cancelled.
+        $current = RoundRun::query()->open()->where('scope_key', (string) $this->roundsUnit->unit_id)->sole();
+        $this->assertNotSame($original->run_uuid, $current->run_uuid);
+        $this->assertSame('cancelled', $original->fresh()->status);
+        $this->assertGreaterThan(0, $current->patients()->count());
+    }
+}


### PR DESCRIPTION
Follow-up to #27 — does both asks: (A) keep the demo rounds fresh, (B) the deferred fixes.

## Part A — demo rounds stay fresh
- `rounds:seed-demo` gains `--units=<csv>` and `--refresh` (cancel the stale open run and rebuild the cohort at the current cutoff). New `config('rounds.demo_units')` (env `VIRTUAL_ROUNDS_DEMO_UNITS`, default `BMT,ONC,AIR`).
- `DemoRefreshCoordinator::refresh` adds a **flag-gated `rounds` step** after the census rebase, so the 6-hourly demo refresh re-anchors Virtual Rounds and a walkthrough always opens onto a live board. No-op when the feature is off.

## Part B — deferred fixes from #27
- **queue_version bumps only when the order changes.** `recomputeQueue` compares the before/after order; a plain status change (mark-ready) no longer invalidates a teammate's in-flight pin/reorder with a spurious 409. A settling transition (defer/skip/round) still bumps exactly once.
- **task/question mutation is owner/leader-gated.** New `canManageTask` / `canResolveQuestion`: only the owner (by user or mapped role), the creator/raiser, or a run leader may close a task or resolve a question — a shared board no longer lets one discipline close another's.
- **idempotency `isReplay` is scoped** to `(idempotency_key, aggregate_type, aggregate_id)`, so a key reused across aggregates can't short-circuit an unrelated command with stale state.
- **`eddy_assisted` mode** is accepted by `CreateRunRequest` when `rounds.eddy_enabled` (the DB CHECK and templates already permit it).

## Tests
- `RoundHardeningTest` — no-bump vs settling-bump queue version; task owner/leader gate (403 for a non-owner contributor, 200 for the leader); eddy_assisted gated by the flag.
- `RoundsSeedDemoCommandTest` — `--refresh` cancels + rebuilds; idempotent skip without it.
- **48 rounds tests green, Pint clean.** Part A also runtime-verified in dev (`--units=7W,6E --refresh` cancelled the stale run and rebuilt both).