### PR TITLE
fix(rounds): demo --refresh retires all open runs (no straggler leak)

### DIFF
--- a/app/Console/Commands/RoundsSeedDemoCommand.php
+++ b/app/Console/Commands/RoundsSeedDemoCommand.php
@@ -86,23 +86,26 @@ class RoundsSeedDemoCommand extends Command
         RoundContributionService $contributions,
         bool $refresh,
     ): bool {
-        $existing = RoundRun::query()
+        $openRuns = RoundRun::query()
             ->open()
             ->where('scope_type', 'unit')
             ->where('scope_key', (string) $unit->unit_id)
-            ->whereDate('created_at', now()->toDateString())
-            ->first();
+            ->get();
 
-        if ($existing !== null && ! $refresh) {
-            $this->info("Open run already exists for {$unit->name} today: {$existing->run_uuid}");
+        if (! $refresh) {
+            $today = $openRuns->first(fn (RoundRun $r) => $r->created_at?->isToday() ?? false);
+            if ($today !== null) {
+                $this->info("Open run already exists for {$unit->name} today: {$today->run_uuid}");
 
-            return false;
-        }
-
-        // --refresh: retire the stale open run so the new one re-anchors to the
-        // current census (the demo refresh shifts every encounter to "now").
-        if ($existing !== null) {
-            $commands->cancel($actor, $existing, ['reason' => 'demo-refresh rebuild']);
+                return false;
+            }
+        } else {
+            // Retire EVERY open run for this unit (any date) so the fresh cohort
+            // is the only board — the census shifts to "now", and cancelling only
+            // today's run would leak yesterday's straggler on each daily refresh.
+            foreach ($openRuns as $stale) {
+                $commands->cancel($actor, $stale, ['reason' => 'demo-refresh rebuild']);
+            }
         }
 
         $run = $commands->createRun($actor, [

--- a/tests/Feature/Rounds/RoundsSeedDemoCommandTest.php
+++ b/tests/Feature/Rounds/RoundsSeedDemoCommandTest.php
@@ -55,4 +55,24 @@ class RoundsSeedDemoCommandTest extends TestCase
         $this->assertSame('cancelled', $original->fresh()->status);
         $this->assertGreaterThan(0, $current->patients()->count());
     }
+
+    public function test_refresh_retires_every_open_run_so_a_daily_pass_never_leaks_stragglers(): void
+    {
+        $commands = app(\App\Services\Rounds\RoundCommandService::class);
+        $make = fn () => $commands->createRun($this->admin, [
+            'template_uuid' => $this->roundsTemplate->template_uuid,
+            'scope_type' => 'unit',
+            'scope_key' => (string) $this->roundsUnit->unit_id,
+        ]);
+        $a = $make();
+        $b = $make();
+        $this->assertSame(2, RoundRun::query()->open()->where('scope_key', (string) $this->roundsUnit->unit_id)->count());
+
+        $this->runSeeder(['--refresh' => true]);
+
+        // Both prior open runs are retired; the fresh cohort is the only board.
+        $this->assertSame(1, RoundRun::query()->open()->where('scope_key', (string) $this->roundsUnit->unit_id)->count());
+        $this->assertSame('cancelled', $a->fresh()->status);
+        $this->assertSame('cancelled', $b->fresh()->status);
+    }
 }


### PR DESCRIPTION
Follow-up to #29. `rounds:seed-demo --refresh` (the 6h demo pipeline's rounds step) only cancelled the *first* open run created *today*, so a daily pass leaked one open run per unit (yesterday's never matched `whereDate(today)`) and a same-day re-run left two open boards. Now `--refresh` retires **every** open run for the unit before rebuilding; the non-refresh idempotent skip still keys on a run created today. Regression test asserts two pre-existing open runs are both retired by one `--refresh`. Verified on prod (isolation run left two open BMT boards — this is the fix).