### PR TITLE
fix(cockpit): perioperative service-line face routes to periop drill (not a 0% census card)

### DIFF
--- a/app/Services/Cockpit/ScopedFaceBuilder.php
+++ b/app/Services/Cockpit/ScopedFaceBuilder.php
@@ -143,10 +143,23 @@ class ScopedFaceBuilder
      */
     private function serviceLineFace(CockpitScope $scope): array
     {
+        $lineUnits = $this->manifest->unitsByServiceLine((string) $scope->key);
+
+        // Procedural platforms (ED, periop) are not census wards — their live face
+        // IS the domain drill, never a bed-census card. Exclude them from the
+        // rollup so a single-platform line (emergency → ED, perioperative → OR)
+        // routes to its drill even when the platform unit still carries staffed
+        // bed rows (prod keeps OR beds, so the periop line would otherwise degrade
+        // to an honest-but-useless "0% occupancy" card). Same reuse rule as unitFace.
+        $censusUnits = array_filter(
+            $lineUnits,
+            fn (array $u): bool => ! in_array($u['type'] ?? null, ['ed', 'periop'], true),
+        );
+
         // Census rows may be keyed by either the branded abbr or the CAD join key
         // (prod.units.abbreviation differs by which importer wrote it) — roll up both.
         $abbrSet = [];
-        foreach ($this->manifest->unitsByServiceLine((string) $scope->key) as $u) {
+        foreach ($censusUnits as $u) {
             foreach ($this->unitNameCandidates($u, (string) $u['abbr']) as $candidate) {
                 $abbrSet[$candidate] = true;
             }
@@ -158,10 +171,9 @@ class ScopedFaceBuilder
         ));
 
         if ($rows === []) {
-            // A single-platform line (emergency → ED, perioperative → OR) may have
-            // no census wards at all — its live face is that platform's domain
-            // drill, same reuse rule as the unit/department mounts.
-            $types = array_column($this->manifest->unitsByServiceLine((string) $scope->key), 'type');
+            // No census wards → this line's live face is its platform domain drill,
+            // same reuse rule as the unit/department mounts.
+            $types = array_column($lineUnits, 'type');
             $domain = in_array('ed', $types, true) ? 'ed' : (in_array('periop', $types, true) ? 'periop' : null);
             if ($domain !== null) {
                 $drill = $this->drills->build($domain);

--- a/tests/Feature/Cockpit/ScopedFaceBuilderTest.php
+++ b/tests/Feature/Cockpit/ScopedFaceBuilderTest.php
@@ -250,6 +250,23 @@ class ScopedFaceBuilderTest extends TestCase
         $this->assertNotEmpty($face['kpis']);
     }
 
+    public function test_perioperative_service_line_routes_to_periop_drill_despite_or_bed_rows(): void
+    {
+        // RtdcSeeder seeds the OR unit AND its staffed beds, so the perioperative
+        // line carries a live (0-occupancy) census row. It must STILL render the
+        // periop domain drill — never a useless "0% occupancy" census card (the
+        // prod defect: emergency worked only because ED had no bed rows).
+        $this->seed(RtdcSeeder::class);
+
+        $face = $this->faces()->build(CockpitScope::serviceLine('perioperative', 'Perioperative Services'));
+
+        $this->assertSame('face', $face['render']);
+        $this->assertSame('service_line:perioperative', $face['scope']['token']);
+        $this->assertSame('periop', $face['domain']);
+        // Not the degenerate census rollup: no sl.* census KPI leaked through.
+        $this->assertNotContains('sl.occupancy', array_column($face['kpis'], 'key'));
+    }
+
     public function test_service_line_face_rolls_up_its_units(): void
     {
         $this->seed(RtdcSeeder::class);


### PR DESCRIPTION
## Symptom
The Cockpit scope picker showed the **perioperative** service line as `1 units — 0% occupancy — 0 patients` — an honest-but-useless census card. Audited all **44 picker scopes on prod** (16 service lines / 3 departments / 25 units): perioperative was the **only** degenerate face; ED/OR units and the emergency line all render correctly.

## Root cause
`ScopedFaceBuilder::serviceLineFace` only fell back to the platform domain drill when there were **zero** census rows. Emergency worked because prod prunes ED bed rows, but the OR unit keeps staffed bed rows, so the perioperative line rolled them into a 0%-occupancy card instead of the periop drill. `unitFace` already guards this (it checks `type === 'periop'` first); the service-line path didn't.

## Fix
ED/periop are procedural platforms, not census wards — exclude them from the census rollup so a single-platform line routes to its domain drill even when the platform unit still carries beds. Mixed lines still roll up their real census wards (and now correctly ignore a procedural member's degenerate row).

## Test
`test_perioperative_service_line_routes_to_periop_drill_despite_or_bed_rows` seeds the OR unit + beds (RtdcSeeder) and asserts the line renders the periop drill (`domain=periop`, no `sl.occupancy` leak). 14 ScopedFaceBuilder tests green, Pint clean.