### PR TITLE
Fix ModSecurity chain semantics

### DIFF
--- a/deploy/apache/zephyrus-edge-security.conf
+++ b/deploy/apache/zephyrus-edge-security.conf
@@ -39,8 +39,8 @@ SecRule REQUEST_URI "@rx (?i)^/(?:artisan|composer\\.(?:json|lock)|package(?:-lo
 # oversized API bodies before PHP allocates or parses them; the staffing import
 # route retains the vhost-wide 10 MiB ceiling.
 SecRule REQUEST_URI "@beginsWith /api/" \
-    "id:1000005,phase:1,pass,nolog,chain"
+    "id:1000005,phase:1,deny,status:413,log,msg:'Zephyrus rejected oversized API request body',chain"
     SecRule REQUEST_URI "!@streq /api/deployment/staffing/imports" \
         "chain"
         SecRule REQUEST_HEADERS:Content-Length "@gt 1048576" \
-            "deny,status:413,log,msg:'Zephyrus rejected oversized API request body'"
+            "t:none"


### PR DESCRIPTION
## What changed

- Move the HTTP 413 disruptive action to the ModSecurity chain starter.
- Leave the terminal content-length predicate non-disruptive, as required by ModSecurity 2.9 chain semantics.

## Why

The production edge preflight found that Apache rejected the original rule with `Disruptive actions can only be specified by chain starter rules`. This blocked the repository-approved deployment before any reload occurred.

## Impact

The Zephyrus vhost can now load the pinned ModSecurity/OWASP CRS policy while preserving the intended behavior: non-exempt API requests declaring bodies larger than 1 MiB receive HTTP 413.

## Validation

- `apache2ctl -t`
- `php scripts/security/verify-edge-security.php --contract --apache`
- `php artisan test --filter=EdgeSecurityContractTest`
- Live edge smoke: login 200, sensitive path 404, TRACE 405, oversized API request 413
