### PR TITLE
Harden synthetic-source and production-asset boundaries

### DIFF
--- a/app/Services/PatientFlow/SyntheticFlowImporter.php
+++ b/app/Services/PatientFlow/SyntheticFlowImporter.php
@@ -144,6 +144,11 @@ class SyntheticFlowImporter
 
     private function upsertSource(string $sourceKey, string $facilityCode): Source
     {
+        $existingMetadata = Source::query()
+            ->where('source_key', $sourceKey)
+            ->first(['metadata'])
+            ?->metadata ?? [];
+
         return $this->sources->ensureSource([
             'source_key' => $sourceKey,
             'tenant_key' => 'default',
@@ -153,12 +158,15 @@ class SyntheticFlowImporter
             'system_class' => 'ehr',
             'environment' => 'sandbox',
             'interface_type' => 'hl7v2_file',
-            'active_status' => 'active',
+            'active_status' => 'testing',
             'contract_status' => 'not_required',
             'baa_status' => 'not_required',
             'phi_allowed' => false,
-            'go_live_status' => 'demo',
-            'metadata' => ['purpose' => 'patient-flow-4d-navigator-demo'],
+            'go_live_status' => 'testing',
+            'metadata' => [
+                ...$existingMetadata,
+                'purpose' => 'patient-flow-4d-navigator-demo',
+            ],
         ]);
     }
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -129,6 +129,16 @@ sudo rsync -av --exclude 'node_modules' \
             --exclude '.pytest_cache' \
             "$RELEASE_ROOT/" /var/www/Zephyrus/
 
+# Vite's ignored hot marker is intentionally absent from immutable release
+# snapshots, but rsync does not delete destination-only runtime files. Remove
+# any marker left by an older development-era deployment so production pages
+# resolve assets from the generated manifest instead of localhost:5176.
+sudo rm -f /var/www/Zephyrus/public/hot
+if sudo test -e /var/www/Zephyrus/public/hot; then
+    echo "❌ Error: Production Vite hot marker could not be removed"
+    exit 1
+fi
+
 echo "Setting permissions..."
 # rsync -a preserves dev (smudoshi) ownership, but Apache/PHP-FPM runs as www-data.
 # The ENTIRE tree must be www-data-owned or vendor/autoload reads fail with a
@@ -261,6 +271,19 @@ fi
 if ! curl -s -o /dev/null -w "%{http_code}" -H "Host: zephyrus.acumenus.net" http://localhost | grep -q "^[23]"; then
     echo "❌ Error: Site is not responding correctly"
     echo "💡 Check the Laravel logs: tail -f /var/www/Zephyrus/storage/logs/laravel.log"
+    exit 1
+fi
+
+# A 200 response can still be a blank application shell when a stale Vite hot
+# marker sends the browser to a development server. Prove that the live login
+# document references production assets before declaring the release healthy.
+LOGIN_HTML="$(curl --fail --silent --show-error https://zephyrus.acumenus.net/login)"
+if grep -Eq 'https?://(localhost|127\.0\.0\.1):[0-9]+/(@vite|@react-refresh|resources/)' <<< "$LOGIN_HTML"; then
+    echo "❌ Error: Live production HTML references a development Vite server"
+    exit 1
+fi
+if ! grep -Eq '/build/assets/' <<< "$LOGIN_HTML"; then
+    echo "❌ Error: Live production HTML does not reference built assets"
     exit 1
 fi
 

--- a/tests/Feature/PatientFlow/SyntheticFlowImporterTest.php
+++ b/tests/Feature/PatientFlow/SyntheticFlowImporterTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Feature\PatientFlow;
+
+use App\Integrations\Healthcare\Services\SourceRegistryService;
+use App\Models\Integration\Source;
+use App\Services\PatientFlow\SyntheticFlowImporter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SyntheticFlowImporterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_synthetic_import_provisions_an_unscoped_source_in_a_non_live_state(): void
+    {
+        $this->runEmptyImport();
+
+        $source = Source::query()->where('source_key', 'synthetic-flow-ehr')->sole();
+
+        $this->assertNull($source->organization_id);
+        $this->assertNull($source->facility_id);
+        $this->assertSame('testing', $source->active_status);
+        $this->assertSame('testing', $source->go_live_status);
+        $this->assertSame('validating', $source->lifecycle_state);
+        $this->assertFalse($source->phi_allowed);
+        $this->assertSame('patient-flow-4d-navigator-demo', $source->metadata['purpose']);
+    }
+
+    public function test_synthetic_refresh_preserves_governance_metadata_and_non_live_state(): void
+    {
+        app(SourceRegistryService::class)->ensureSource([
+            'source_key' => 'synthetic-flow-ehr',
+            'tenant_key' => 'default',
+            'facility_key' => 'ZEPHYRUS-500',
+            'source_name' => 'Synthetic Flow EHR',
+            'vendor' => 'synthetic',
+            'system_class' => 'ehr',
+            'environment' => 'sandbox',
+            'interface_type' => 'hl7v2_file',
+            'active_status' => 'testing',
+            'contract_status' => 'not_required',
+            'baa_status' => 'not_required',
+            'phi_allowed' => false,
+            'go_live_status' => 'testing',
+            'metadata' => [
+                'purpose' => 'patient-flow-4d-navigator-demo',
+                'enterprise_scope_cutover' => [
+                    'reason' => 'Synthetic demo sources stay non-live until canonical scope is selected.',
+                ],
+            ],
+        ]);
+
+        $this->runEmptyImport();
+
+        $source = Source::query()->where('source_key', 'synthetic-flow-ehr')->sole();
+
+        $this->assertSame('testing', $source->active_status);
+        $this->assertSame('testing', $source->go_live_status);
+        $this->assertSame('validating', $source->lifecycle_state);
+        $this->assertSame(
+            'Synthetic demo sources stay non-live until canonical scope is selected.',
+            $source->metadata['enterprise_scope_cutover']['reason'],
+        );
+    }
+
+    private function runEmptyImport(): void
+    {
+        $path = tempnam(sys_get_temp_dir(), 'zephyrus-synthetic-flow-');
+        $this->assertNotFalse($path);
+
+        try {
+            app(SyntheticFlowImporter::class)->import($path);
+        } finally {
+            @unlink($path);
+        }
+    }
+}

--- a/tests/Unit/Deployment/ProductionAssetBoundaryTest.php
+++ b/tests/Unit/Deployment/ProductionAssetBoundaryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Unit\Deployment;
+
+use PHPUnit\Framework\TestCase;
+
+final class ProductionAssetBoundaryTest extends TestCase
+{
+    public function test_deploy_removes_the_vite_hot_marker_before_restarting_apache(): void
+    {
+        $script = file_get_contents(dirname(__DIR__, 3).'/deploy.sh');
+        $this->assertIsString($script);
+
+        $publication = strpos($script, '"$RELEASE_ROOT/" /var/www/Zephyrus/');
+        $hotMarkerRemoval = strpos($script, 'sudo rm -f /var/www/Zephyrus/public/hot');
+        $apacheRestart = strpos($script, 'sudo systemctl restart apache2');
+
+        $this->assertIsInt($publication);
+        $this->assertIsInt($hotMarkerRemoval);
+        $this->assertIsInt($apacheRestart);
+        $this->assertGreaterThan($publication, $hotMarkerRemoval);
+        $this->assertLessThan($apacheRestart, $hotMarkerRemoval);
+    }
+
+    public function test_deploy_rejects_live_html_that_references_a_development_vite_server(): void
+    {
+        $script = file_get_contents(dirname(__DIR__, 3).'/deploy.sh');
+        $this->assertIsString($script);
+
+        $this->assertStringContainsString(
+            'https?://(localhost|127\\.0\\.0\\.1):[0-9]+/(@vite|@react-refresh|resources/)',
+            $script,
+        );
+        $this->assertStringContainsString("grep -Eq '/build/assets/'", $script);
+    }
+}


### PR DESCRIPTION
## Summary
- keep the unscoped synthetic Patient Flow source in testing/validating instead of implicitly promoting it live
- preserve existing governance metadata during scheduled demo refreshes
- remove stale Vite hot markers during release publication
- fail deployment if live HTML references a development server or lacks built assets
- cover fresh provisioning, post-cutover refresh behavior, and production asset boundaries with regression tests

## Validation
- php artisan test tests/Feature/PatientFlow tests/Feature/Integrations/IntegrationOperationalRuntimeTest.php
- php artisan test tests/Unit/Deployment/ProductionAssetBoundaryTest.php tests/Feature/PatientFlow/SyntheticFlowImporterTest.php
- targeted Laravel Pint checks
- bash -n deploy.sh
- git diff --check
- live Playwright smoke of https://zephyrus.acumenus.net/admin authentication boundary and rendered login assets