### PR TITLE
feat: Home Hospital module — acute Hospital-at-Home, RPM & transitions of care (ACUM-PRD-HAH-001, Phases 0–3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -331,6 +331,13 @@ VIRTUAL_ROUNDS_FAMILY_ENABLED=false        # Phase 5: guest RSVP/questions surfa
 VIRTUAL_ROUNDS_WRITEBACK_ENABLED=false     # Phase 7: EHR writeback adapter
 VIRTUAL_ROUNDS_EDDY_ENABLED=false          # Phase 6: Eddy rounds tour (shadow mode)
 VIRTUAL_ROUNDS_EXTERNAL_NOTIFICATIONS_ENABLED=false  # Phases 4-5: outbound channels
+
+# Home Hospital (HOME) — acute Hospital-at-Home virtual ward (ACUM-PRD-HAH-001,
+# docs/home-hospital/). Flags gate routes/nav/seeds; off = 404 invisible,
+# existing episode/audit data is never deleted. Later-phase flags ship off.
+HOME_HOSPITAL_ENABLED=false
+HOME_HOSPITAL_RPM_INGEST_ENABLED=false     # Phase 1: RPM vitals ingestion pipeline
+HOME_HOSPITAL_EDDY_ENABLED=false           # Phase 3: Eddy home action catalog
 EDDY_ALLOW_CLOUD=false                      # master kill-switch for any frontier egress
 EDDY_DEFAULT_PROVIDER_MODE=local_first
 EDDY_PHI_DETECTION_ENABLED=true

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -15,3 +15,13 @@ paths = [
   '''(^|/)artifacts/''',
 ]
 
+[[allowlists]]
+# Public diversion-model scenario identifier ('critical-care-surge-v1') used as
+# both modelVersionKey and version_key in the seeded regional network — a
+# display label, not a credential. Pre-dates this policy on main; AND-scoped to
+# the one file + exact string so nothing else in the file is exempted.
+description = "RegionalTransferService seeded model-version identifiers (public labels)"
+condition = "AND"
+paths = ['''^app/Services/Transport/RegionalTransferService\.php$''']
+regexes = ['''critical-care-surge-v1''']
+

--- a/app/Console/Commands/HomeCmsExportCommand.php
+++ b/app/Console/Commands/HomeCmsExportCommand.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * CMS AHCAH waiver + 2028-study export (ACUM-PRD-HAH-001 §8).
+ *
+ * The Consolidated Appropriations Act, 2026 directs HHS to report by
+ * 2028-09-30 on home vs brick-and-mortar inpatient care: readmissions,
+ * mortality, escalations/transfers, LOS, staffing, patient experience,
+ * conditions, cost, and EQUITY (explicitly addressing selection bias).
+ * Because the module captures those variables as first-class operational
+ * data, this export is a byproduct — every number is computed from the
+ * prod.home_* tables, pseudonymous throughout, with the national benchmarks
+ * (Levine 2024 / CMS waiver floor) attached for comparison.
+ */
+class HomeCmsExportCommand extends Command
+{
+    protected $signature = 'home:cms-export
+        {--from= : Window start (default: first day of last month)}
+        {--to= : Window end (default: now)}
+        {--output= : Write JSON to this path instead of stdout}';
+
+    protected $description = 'Export CMS AHCAH waiver + 2028-study measures from the Home Hospital operational tables';
+
+    public function handle(): int
+    {
+        if (! (bool) config('home_hospital.enabled')) {
+            $this->error('Home Hospital is not enabled (HOME_HOSPITAL_ENABLED).');
+
+            return self::FAILURE;
+        }
+
+        $from = $this->option('from') ? now()->parse((string) $this->option('from')) : now()->subMonth()->startOfMonth();
+        $to = $this->option('to') ? now()->parse((string) $this->option('to')) : now();
+
+        $report = [
+            'report' => 'ACUM-PRD-HAH-001 CMS AHCAH waiver / 2028-study export',
+            'window' => ['from' => $from->toIso8601String(), 'to' => $to->toIso8601String()],
+            'generated_at' => now()->toIso8601String(),
+            'episodes' => $this->episodes($from, $to),
+            'escalations' => $this->escalations($from, $to),
+            'visit_compliance' => $this->visitCompliance($from, $to),
+            'monitoring' => $this->monitoring($from, $to),
+            'equity_selection_bias' => $this->equity($from, $to),
+            'benchmarks' => [
+                'escalation_rate_pct' => ['value' => 6.2, 'source' => 'Levine et al. 2024'],
+                'in_episode_mortality_pct' => ['value' => 0.5, 'source' => 'Levine et al. 2024'],
+                'readmission_30d_pct' => ['value' => 15.6, 'source' => 'Levine et al. 2024'],
+                'mean_los_days' => ['value' => 6.3, 'source' => 'Levine et al. 2024'],
+                'emergency_response_minutes' => ['value' => 30, 'source' => 'CMS waiver / MedPAC 2024'],
+                'visits_per_day_floor' => ['value' => 2, 'source' => 'CMS waiver / MedPAC 2024'],
+            ],
+        ];
+
+        $json = json_encode($report, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+
+        if ($this->option('output')) {
+            file_put_contents((string) $this->option('output'), $json.PHP_EOL);
+            $this->info('Wrote '.$this->option('output'));
+        } else {
+            $this->line($json);
+        }
+
+        return self::SUCCESS;
+    }
+
+    /** @return array<string, mixed> */
+    private function episodes($from, $to): array
+    {
+        $row = DB::selectOne("
+            SELECT count(*) AS started,
+                   count(*) FILTER (WHERE e.status = 'completed') AS completed,
+                   ROUND(AVG(EXTRACT(EPOCH FROM (e.ended_at - e.started_at)) / 86400.0)
+                       FILTER (WHERE e.ended_at IS NOT NULL)::numeric, 2) AS mean_los_days,
+                   count(*) FILTER (WHERE e.disposition = 'deceased') AS deaths,
+                   count(*) FILTER (WHERE e.disposition IN ('ed_return', 'readmitted')) AS returns_to_hospital
+            FROM prod.home_episodes e
+            JOIN prod.home_programs p ON p.home_program_id = e.home_program_id
+            WHERE e.is_deleted = false AND p.program_type = 'ahcah_acute'
+              AND e.started_at BETWEEN ? AND ?
+        ", [$from, $to]);
+
+        $started = (int) ($row->started ?? 0);
+
+        $conditions = DB::table('prod.home_episodes as e')
+            ->join('prod.home_programs as p', 'p.home_program_id', '=', 'e.home_program_id')
+            ->where('e.is_deleted', false)
+            ->where('p.program_type', 'ahcah_acute')
+            ->whereBetween('e.started_at', [$from, $to])
+            ->selectRaw('e.condition_code, count(*) AS n')
+            ->groupBy('e.condition_code')
+            ->orderByDesc('n')
+            ->pluck('n', 'condition_code');
+
+        return [
+            'started' => $started,
+            'completed' => (int) $row->completed,
+            'mean_los_days' => $row->mean_los_days !== null ? (float) $row->mean_los_days : null,
+            'in_episode_mortality_pct' => $started > 0 ? round(100.0 * (int) $row->deaths / $started, 2) : null,
+            'return_to_hospital_pct' => $started > 0 ? round(100.0 * (int) $row->returns_to_hospital / $started, 2) : null,
+            'by_condition' => $conditions,
+            'note' => 'return_to_hospital counts ed_return + readmitted dispositions; index-linked 30-day readmission requires cross-encounter linkage (Phase Later).',
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function escalations($from, $to): array
+    {
+        $row = DB::selectOne('
+            SELECT count(*) AS total,
+                   percentile_cont(0.9) WITHIN GROUP (ORDER BY response_minutes) AS response_p90,
+                   count(*) FILTER (WHERE response_minutes <= 30) AS within_floor,
+                   count(*) FILTER (WHERE response_minutes IS NOT NULL) AS with_response
+            FROM prod.home_escalations
+            WHERE is_deleted = false AND initiated_at BETWEEN ? AND ?
+        ', [$from, $to]);
+
+        $outcomes = DB::table('prod.home_escalations')
+            ->where('is_deleted', false)
+            ->whereBetween('initiated_at', [$from, $to])
+            ->whereNotNull('outcome')
+            ->selectRaw('outcome, count(*) AS n')
+            ->groupBy('outcome')
+            ->pluck('n', 'outcome');
+
+        $withResponse = (int) ($row->with_response ?? 0);
+
+        return [
+            'total' => (int) ($row->total ?? 0),
+            'response_p90_minutes' => $row->response_p90 !== null ? round((float) $row->response_p90, 1) : null,
+            'within_30min_floor_pct' => $withResponse > 0 ? round(100.0 * (int) $row->within_floor / $withResponse, 1) : null,
+            'outcomes' => $outcomes,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function visitCompliance($from, $to): array
+    {
+        $row = DB::selectOne("
+            SELECT count(*) FILTER (WHERE is_waiver_required AND status = 'completed') AS waiver_completed,
+                   count(*) FILTER (WHERE is_waiver_required AND status IN ('completed', 'missed')) AS waiver_due,
+                   count(*) FILTER (WHERE is_waiver_required AND status = 'completed' AND on_time) AS waiver_on_time
+            FROM prod.home_visits
+            WHERE is_deleted = false AND scheduled_start BETWEEN ? AND ?
+        ", [$from, $to]);
+
+        $due = (int) ($row->waiver_due ?? 0);
+        $completed = (int) ($row->waiver_completed ?? 0);
+
+        return [
+            'waiver_visits_due' => $due,
+            'waiver_visits_completed' => $completed,
+            'compliance_pct' => $due > 0 ? round(100.0 * $completed / $due, 1) : null,
+            'on_time_pct' => $completed > 0 ? round(100.0 * (int) $row->waiver_on_time / $completed, 1) : null,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function monitoring($from, $to): array
+    {
+        $row = DB::selectOne("
+            SELECT count(*) AS observations,
+                   count(*) FILTER (WHERE quality_flag <> 'ok') AS flagged,
+                   count(*) FILTER (WHERE is_breach) AS breaches
+            FROM prod.rpm_observations
+            WHERE is_deleted = false AND observed_at BETWEEN ? AND ?
+        ", [$from, $to]);
+
+        $alerts = DB::selectOne('
+            SELECT count(*) AS total,
+                   ROUND(AVG(EXTRACT(EPOCH FROM (acknowledged_at - opened_at)) / 60.0)
+                       FILTER (WHERE acknowledged_at IS NOT NULL)::numeric, 1) AS mean_ack_minutes
+            FROM prod.rpm_alerts
+            WHERE is_deleted = false AND opened_at BETWEEN ? AND ?
+        ', [$from, $to]);
+
+        return [
+            'observations' => (int) ($row->observations ?? 0),
+            'quality_flagged' => (int) ($row->flagged ?? 0),
+            'breaches' => (int) ($row->breaches ?? 0),
+            'patient_alerts' => (int) ($alerts->total ?? 0),
+            'mean_acknowledge_minutes' => $alerts->mean_ack_minutes !== null ? (float) $alerts->mean_ack_minutes : null,
+        ];
+    }
+
+    /**
+     * The equity block the 2028 study explicitly demands: who is screened out
+     * and why, by payer and zone — selection bias surfaced before it becomes
+     * a federal finding.
+     *
+     * @return array<string, mixed>
+     */
+    private function equity($from, $to): array
+    {
+        $base = DB::table('prod.home_referrals')
+            ->where('is_deleted', false)
+            ->whereBetween('referred_at', [$from, $to]);
+
+        return [
+            'referrals' => (clone $base)->count(),
+            'decline_reasons' => (clone $base)->where('status', 'declined')
+                ->selectRaw('decline_reason, count(*) AS n')
+                ->groupBy('decline_reason')->pluck('n', 'decline_reason'),
+            'by_payer_class' => (clone $base)
+                ->selectRaw("COALESCE(payer_class, 'unknown') AS payer, count(*) AS n")
+                ->groupBy('payer')->pluck('n', 'payer'),
+            'activation_rate_by_payer' => (clone $base)
+                ->selectRaw("COALESCE(payer_class, 'unknown') AS payer,
+                    ROUND(100.0 * count(*) FILTER (WHERE status = 'activated') / count(*), 1) AS pct")
+                ->groupBy('payer')->pluck('pct', 'payer'),
+            'by_service_zone' => (clone $base)
+                ->selectRaw("COALESCE(service_zone, 'unknown') AS zone, count(*) AS n")
+                ->groupBy('zone')->pluck('n', 'zone'),
+        ];
+    }
+}

--- a/app/Domain/Arena/ArenaCopilotService.php
+++ b/app/Domain/Arena/ArenaCopilotService.php
@@ -312,7 +312,7 @@ class ArenaCopilotService
             ];
         }
 
-        $pathway = in_array($focus, ['sepsis', 'surgical_safety'], true) ? $focus : null;
+        $pathway = in_array($focus, ['sepsis', 'surgical_safety', 'home_hospital'], true) ? $focus : null;
         if ($pathway === null) {
             return null;
         }

--- a/app/Domain/Arena/FlowReviewComposer.php
+++ b/app/Domain/Arena/FlowReviewComposer.php
@@ -55,6 +55,9 @@ final class FlowReviewComposer
     private const PATHWAY_FOCUS = [
         'sepsis' => ['nodes' => ['ed_arrival'], 'edges' => []],
         'surgical_safety' => ['nodes' => ['or_case_start', 'timeout'], 'edges' => []],
+        // Home Hospital (ACUM-PRD-HAH-001 §6.3) — lit only when the home
+        // activities appear in the window's discovered map (guard below).
+        'home_hospital' => ['nodes' => ['home-activate', 'home-escalation-open'], 'edges' => []],
     ];
 
     private const CATEGORY_FOCUS = [

--- a/app/Domain/Cockpit/Metrics/HomeMetrics.php
+++ b/app/Domain/Cockpit/Metrics/HomeMetrics.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace App\Domain\Cockpit\Metrics;
+
+use App\Domain\Cockpit\SnapshotContext;
+use App\Support\Cockpit\MetricValue;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Home Hospital domain provider (ACUM-PRD-HAH-001 §9) — the virtual ward on
+ * the same instrument as ED and RTDC. Emits nothing while the module flag is
+ * off, so the cockpit is byte-identical on deployments without the module.
+ *
+ * Every value is a cheap aggregate over the prod.home_* / prod.rpm_* tables;
+ * alert candidacy is governed entirely by which seeded definitions carry an
+ * alert_template (the Earned-Red ration — four alerting rows, no per-vital
+ * noise at house altitude).
+ */
+class HomeMetrics extends BaseMetrics
+{
+    private const OFFLINE_GAP_MINUTES = 60;
+
+    public function domain(): string
+    {
+        return 'home';
+    }
+
+    /** @return list<MetricValue> */
+    public function metrics(SnapshotContext $ctx): array
+    {
+        if (! (bool) config('home_hospital.enabled')) {
+            return [];
+        }
+
+        $ward = $this->wardCensus();
+
+        return $this->compact([
+            $ward === null ? null : $this->fromKey($ctx, 'home.census_occupancy', $ward['pct'], [
+                'sub' => "{$ward['occupied']} of {$ward['capacity']} slots",
+            ]),
+            $this->fromKey($ctx, 'home.unacked_critical_vitals', $this->unackedCriticalVitals($ctx)),
+            $this->fromKey($ctx, 'home.escalation_response_p90', $this->escalationResponseP90()),
+            $this->fromKey($ctx, 'home.visit_compliance_today', $this->visitComplianceToday()),
+            $this->fromKey($ctx, 'home.device_offline_pct', $this->deviceOfflinePct()),
+            $this->fromKey($ctx, 'home.rpm_adherence', $this->rpmAdherence()),
+            $this->fromKey($ctx, 'home.escalation_rate_7d', $this->escalationRate7d()),
+            $this->fromKey($ctx, 'home.referral_conversion_7d', $this->referralConversion7d()),
+            $this->fromKey($ctx, 'home.avoided_bed_days_mtd', $this->avoidedBedDaysMtd()),
+        ]);
+    }
+
+    /** @return array{occupied:int,capacity:int,pct:float}|null */
+    private function wardCensus(): ?array
+    {
+        $row = DB::selectOne("
+            SELECT count(*) FILTER (WHERE b.status = 'occupied') AS occupied, count(*) AS capacity
+            FROM prod.beds b
+            JOIN prod.units u ON u.unit_id = b.unit_id
+            WHERE u.type = 'virtual_home' AND u.is_deleted = false AND b.is_deleted = false
+        ");
+
+        $capacity = (int) ($row->capacity ?? 0);
+        if ($capacity === 0) {
+            return null;
+        }
+
+        $occupied = (int) $row->occupied;
+
+        return ['occupied' => $occupied, 'capacity' => $capacity, 'pct' => round(100.0 * $occupied / $capacity, 1)];
+    }
+
+    private function unackedCriticalVitals(SnapshotContext $ctx): float
+    {
+        return (float) DB::table('prod.rpm_alerts')
+            ->where('status', 'open')
+            ->where('severity', 'critical')
+            ->where('is_deleted', false)
+            ->count();
+    }
+
+    private function escalationResponseP90(): ?float
+    {
+        $row = DB::selectOne("
+            SELECT percentile_cont(0.9) WITHIN GROUP (ORDER BY response_minutes) AS p90
+            FROM prod.home_escalations
+            WHERE response_minutes IS NOT NULL AND is_deleted = false
+              AND initiated_at >= ?::timestamptz
+        ", [now()->subDays(7)->toIso8601String()]);
+
+        return $row->p90 !== null ? round((float) $row->p90, 1) : null;
+    }
+
+    /** Percent of DUE waiver-required visits completed today (future visits are not yet non-compliant). */
+    private function visitComplianceToday(): ?float
+    {
+        $row = DB::selectOne("
+            SELECT count(*) FILTER (WHERE status = 'completed') AS done, count(*) AS due
+            FROM prod.home_visits
+            WHERE is_waiver_required = true AND is_deleted = false
+              AND scheduled_start >= date_trunc('day', now())
+              AND scheduled_start <= now()
+              AND status NOT IN ('cancelled')
+        ");
+
+        $due = (int) ($row->due ?? 0);
+
+        return $due > 0 ? round(100.0 * (int) $row->done / $due, 1) : null;
+    }
+
+    private function deviceOfflinePct(): ?float
+    {
+        $row = DB::selectOne('
+            SELECT count(*) FILTER (WHERE last_seen_at IS NULL OR last_seen_at < ?::timestamptz) AS offline,
+                   count(*) AS assigned
+            FROM prod.rpm_kits
+            WHERE status = ? AND is_deleted = false
+        ', [now()->subMinutes(self::OFFLINE_GAP_MINUTES)->toIso8601String(), 'assigned']);
+
+        $assigned = (int) ($row->assigned ?? 0);
+
+        return $assigned > 0 ? round(100.0 * (int) $row->offline / $assigned, 1) : null;
+    }
+
+    /** Received vs expected readings across active enrollments over the 6h adherence window. */
+    private function rpmAdherence(): ?float
+    {
+        $enrollments = DB::table('prod.rpm_enrollments')
+            ->where('status', 'active')
+            ->where('is_deleted', false)
+            ->get(['rpm_enrollment_id', 'monitoring_plan']);
+
+        if ($enrollments->isEmpty()) {
+            return null;
+        }
+
+        $windowHours = (int) config('home_hospital.hews.adherence_window_hours', 6);
+        $since = now()->subHours($windowHours);
+
+        $received = DB::table('prod.rpm_observations')
+            ->whereIn('rpm_enrollment_id', $enrollments->pluck('rpm_enrollment_id'))
+            ->where('observed_at', '>=', $since)
+            ->where('is_deleted', false)
+            ->selectRaw('rpm_enrollment_id, count(*) AS n')
+            ->groupBy('rpm_enrollment_id')
+            ->pluck('n', 'rpm_enrollment_id');
+
+        $expectedTotal = 0;
+        $receivedTotal = 0;
+        foreach ($enrollments as $enrollment) {
+            $plan = json_decode((string) $enrollment->monitoring_plan, true) ?: [];
+            foreach ((array) ($plan['cadence_minutes'] ?? []) as $minutes) {
+                $minutes = (int) $minutes;
+                if ($minutes > 0) {
+                    $expectedTotal += (int) floor(($windowHours * 60) / $minutes);
+                }
+            }
+            $receivedTotal += (int) ($received[$enrollment->rpm_enrollment_id] ?? 0);
+        }
+
+        return $expectedTotal > 0 ? round(min(100.0, 100.0 * $receivedTotal / $expectedTotal), 1) : null;
+    }
+
+    private function escalationRate7d(): ?float
+    {
+        $episodeDays = DB::selectOne("
+            SELECT COALESCE(SUM(
+                EXTRACT(EPOCH FROM (LEAST(COALESCE(ended_at, now()), now()) - GREATEST(started_at, now() - interval '7 days')))
+            ) / 86400.0, 0) AS days
+            FROM prod.home_episodes
+            WHERE is_deleted = false AND started_at IS NOT NULL
+              AND started_at <= now()
+              AND COALESCE(ended_at, now()) >= now() - interval '7 days'
+        ");
+
+        $days = (float) ($episodeDays->days ?? 0);
+        if ($days <= 0) {
+            return null;
+        }
+
+        $escalations = (int) DB::table('prod.home_escalations')
+            ->where('is_deleted', false)
+            ->where('initiated_at', '>=', now()->subDays(7))
+            ->count();
+
+        return round(100.0 * $escalations / $days, 1);
+    }
+
+    private function referralConversion7d(): ?float
+    {
+        $row = DB::selectOne("
+            SELECT count(*) FILTER (WHERE status = 'activated') AS activated, count(*) AS total
+            FROM prod.home_referrals
+            WHERE is_deleted = false AND referred_at >= now() - interval '7 days'
+        ");
+
+        $total = (int) ($row->total ?? 0);
+
+        return $total > 0 ? round(100.0 * (int) $row->activated / $total, 1) : null;
+    }
+
+    /** Every active home episode-day this month is an avoided occupied bed-day (§6.2). */
+    private function avoidedBedDaysMtd(): float
+    {
+        $row = DB::selectOne("
+            SELECT COALESCE(SUM(
+                EXTRACT(EPOCH FROM (LEAST(COALESCE(ended_at, now()), now()) - GREATEST(started_at, date_trunc('month', now())))) / 86400.0
+            ), 0) AS days
+            FROM prod.home_episodes
+            WHERE is_deleted = false AND started_at IS NOT NULL
+              AND started_at <= now()
+              AND COALESCE(ended_at, now()) >= date_trunc('month', now())
+        ");
+
+        return round((float) ($row->days ?? 0), 1);
+    }
+}

--- a/app/Domain/Cockpit/Metrics/HomeMetrics.php
+++ b/app/Domain/Cockpit/Metrics/HomeMetrics.php
@@ -80,12 +80,12 @@ class HomeMetrics extends BaseMetrics
 
     private function escalationResponseP90(): ?float
     {
-        $row = DB::selectOne("
+        $row = DB::selectOne('
             SELECT percentile_cont(0.9) WITHIN GROUP (ORDER BY response_minutes) AS p90
             FROM prod.home_escalations
             WHERE response_minutes IS NOT NULL AND is_deleted = false
               AND initiated_at >= ?::timestamptz
-        ", [now()->subDays(7)->toIso8601String()]);
+        ', [now()->subDays(7)->toIso8601String()]);
 
         return $row->p90 !== null ? round((float) $row->p90, 1) : null;
     }

--- a/app/Domain/Ocel/EmissionMap.php
+++ b/app/Domain/Ocel/EmissionMap.php
@@ -369,6 +369,19 @@ final class EmissionMap
         ], fn ($v) => $v !== null);
 
         $events = [];
+        if (! empty($row->referred_at)) {
+            // The referral moment anchors the time-to-activation SLA check.
+            $events[] = new EmittedEvent(
+                id: 'home-ep-'.$row->home_episode_id.'-refer',
+                activity: 'home-refer',
+                timestamp: Carbon::parse($row->referred_at),
+                sourceSystem: 'prod.home_episodes',
+                sourceRef: (string) $row->home_episode_id,
+                objects: $objects,
+                o2o: $o2o,
+                attrs: $attrs,
+            );
+        }
         if (! empty($row->started_at)) {
             $events[] = new EmittedEvent(
                 id: 'home-ep-'.$row->home_episode_id.'-activate',

--- a/app/Domain/Ocel/EmissionMap.php
+++ b/app/Domain/Ocel/EmissionMap.php
@@ -336,6 +336,159 @@ final class EmissionMap
     }
 
     /**
+     * prod.home_episodes (joined with program + kit) → home-activate /
+     * home-discharge over a first-class Home Episode object, with the RPM Kit
+     * as a linked resource (ACUM-PRD-HAH-001 §6.3). PHI-safe: patient travels
+     * only as a hashed ref attr; program/condition/zone are operational.
+     *
+     * @return list<EmittedEvent>
+     */
+    public static function forHomeEpisode(object $row): array
+    {
+        if (empty($row->home_episode_id)) {
+            return [];
+        }
+
+        $epId = 'home-ep-'.$row->home_episode_id;
+        $objects = [['id' => $epId, 'type' => 'Home Episode', 'qualifier' => 'subject']];
+        $o2o = [];
+
+        if (! empty($row->kit_code)) {
+            $kitId = 'rpm-kit-'.self::slug((string) $row->kit_code);
+            $objects[] = ['id' => $kitId, 'type' => 'RPM Kit', 'qualifier' => 'device'];
+            $o2o[] = ['from' => $epId, 'to' => $kitId, 'qualifier' => 'monitored_by'];
+        }
+
+        $attrs = array_filter([
+            'program' => $row->program_type ?? null,
+            'condition' => $row->condition_code ?? null,
+            'admission_source' => $row->admission_source ?? null,
+            'service_zone' => $row->service_zone ?? null,
+            'disposition' => $row->disposition ?? null,
+            'patient_ref' => ! empty($row->patient_ref) ? self::hashRef((string) $row->patient_ref) : null,
+        ], fn ($v) => $v !== null);
+
+        $events = [];
+        if (! empty($row->started_at)) {
+            $events[] = new EmittedEvent(
+                id: 'home-ep-'.$row->home_episode_id.'-activate',
+                activity: 'home-activate',
+                timestamp: Carbon::parse($row->started_at),
+                sourceSystem: 'prod.home_episodes',
+                sourceRef: (string) $row->home_episode_id,
+                objects: $objects,
+                o2o: $o2o,
+                attrs: $attrs,
+            );
+        }
+        if (! empty($row->ended_at)) {
+            $events[] = new EmittedEvent(
+                id: 'home-ep-'.$row->home_episode_id.'-discharge',
+                activity: 'home-discharge',
+                timestamp: Carbon::parse($row->ended_at),
+                sourceSystem: 'prod.home_episodes',
+                sourceRef: (string) $row->home_episode_id,
+                objects: $objects,
+                o2o: $o2o,
+                attrs: $attrs,
+            );
+        }
+
+        return $events;
+    }
+
+    /**
+     * prod.home_visits (completed) → home-visit-complete over the Home Visit +
+     * its Home Episode; waiver flag + on-time telemetry ride as attrs — the
+     * raw material for the visit-cadence conformance check.
+     *
+     * @return list<EmittedEvent>
+     */
+    public static function forHomeVisit(object $row): array
+    {
+        if (empty($row->home_visit_id) || empty($row->completed_at)) {
+            return [];
+        }
+
+        $epId = 'home-ep-'.$row->home_episode_id;
+        $visitId = 'home-visit-'.$row->home_visit_id;
+
+        return [new EmittedEvent(
+            id: $visitId.'-complete',
+            activity: 'home-visit-complete',
+            timestamp: Carbon::parse($row->completed_at),
+            sourceSystem: 'prod.home_visits',
+            sourceRef: (string) $row->home_visit_id,
+            objects: [
+                ['id' => $visitId, 'type' => 'Home Visit', 'qualifier' => 'subject'],
+                ['id' => $epId, 'type' => 'Home Episode', 'qualifier' => 'episode'],
+            ],
+            o2o: [['from' => $visitId, 'to' => $epId, 'qualifier' => 'for']],
+            attrs: array_filter([
+                'visit_type' => $row->visit_type ?? null,
+                'waiver_required' => isset($row->is_waiver_required) ? (bool) $row->is_waiver_required : null,
+                'on_time' => $row->on_time ?? null,
+            ], fn ($v) => $v !== null),
+        )];
+    }
+
+    /**
+     * prod.home_escalations → home-escalation-open / home-escalation-resolve
+     * over a first-class Escalation object; the timing chain + outcome ride as
+     * attrs — the escalation-protocol conformance corpus.
+     *
+     * @return list<EmittedEvent>
+     */
+    public static function forHomeEscalation(object $row): array
+    {
+        if (empty($row->home_escalation_id)) {
+            return [];
+        }
+
+        $epId = 'home-ep-'.$row->home_episode_id;
+        $escId = 'home-esc-'.$row->home_escalation_id;
+        $objects = [
+            ['id' => $escId, 'type' => 'Escalation', 'qualifier' => 'subject'],
+            ['id' => $epId, 'type' => 'Home Episode', 'qualifier' => 'episode'],
+        ];
+        $o2o = [['from' => $escId, 'to' => $epId, 'qualifier' => 'for']];
+        $attrs = array_filter([
+            'trigger_type' => $row->trigger_type ?? null,
+            'response_mode' => $row->response_mode ?? null,
+            'response_minutes' => $row->response_minutes ?? null,
+            'outcome' => $row->outcome ?? null,
+        ], fn ($v) => $v !== null);
+
+        $events = [];
+        if (! empty($row->initiated_at)) {
+            $events[] = new EmittedEvent(
+                id: $escId.'-open',
+                activity: 'home-escalation-open',
+                timestamp: Carbon::parse($row->initiated_at),
+                sourceSystem: 'prod.home_escalations',
+                sourceRef: (string) $row->home_escalation_id,
+                objects: $objects,
+                o2o: $o2o,
+                attrs: $attrs,
+            );
+        }
+        if (! empty($row->resolved_at)) {
+            $events[] = new EmittedEvent(
+                id: $escId.'-resolve',
+                activity: 'home-escalation-resolve',
+                timestamp: Carbon::parse($row->resolved_at),
+                sourceSystem: 'prod.home_escalations',
+                sourceRef: (string) $row->home_escalation_id,
+                objects: $objects,
+                o2o: $o2o,
+                attrs: $attrs,
+            );
+        }
+
+        return $events;
+    }
+
+    /**
      * prod.barriers → up to two OCEL events (barrier_opened → barrier_resolved)
      * over one first-class Barrier object, carrying the barrier's status as a
      * time-varying object_change — the raw material for "how long do placement

--- a/app/Domain/Ocel/OcelCatalog.php
+++ b/app/Domain/Ocel/OcelCatalog.php
@@ -147,6 +147,7 @@ final class OcelCatalog
             'barrier_resolved' => 'flow',
             // Home Hospital (ACUM-PRD-HAH-001 §6.3) — the virtual-ward pathway:
             // activation cadence, waiver visits, escalation protocol, discharge.
+            'home-refer' => 'home',
             'home-activate' => 'home',
             'home-visit-complete' => 'home',
             'home-escalation-open' => 'home',

--- a/app/Domain/Ocel/OcelCatalog.php
+++ b/app/Domain/Ocel/OcelCatalog.php
@@ -62,6 +62,11 @@ final class OcelCatalog
             'Pharmacy Work' => ['lens' => 'medication', 'source_system' => 'prod.ancillary_milestones', 'emitted' => true],
             'Medication Dose' => ['lens' => 'medication', 'source_system' => 'prod.ancillary_milestones', 'emitted' => true],
             'Medication Resource' => ['lens' => 'resource', 'source_system' => 'prod.ancillary_milestones', 'emitted' => true],
+            // Home Hospital (ACUM-PRD-HAH-001 §6.3) — the virtual-ward pathway.
+            'Home Episode' => ['lens' => 'clinical', 'source_system' => 'prod.home_episodes', 'emitted' => true],
+            'RPM Kit' => ['lens' => 'resource', 'source_system' => 'prod.rpm_kits', 'emitted' => true],
+            'Home Visit' => ['lens' => 'logistics', 'source_system' => 'prod.home_visits', 'emitted' => true],
+            'Escalation' => ['lens' => 'clinical', 'source_system' => 'prod.home_escalations', 'emitted' => true],
             // Declared for the catalog; emitted by later Arena phases.
             'Order' => ['lens' => 'clinical', 'source_system' => 'flow_core.flow_events', 'emitted' => false],
             'EVS Task' => ['lens' => 'logistics', 'source_system' => 'prod.evs_tasks', 'emitted' => false],
@@ -140,6 +145,13 @@ final class OcelCatalog
             // Barriers (RTDC operational impediments → the flow-reconciliation loop)
             'barrier_opened' => 'flow',
             'barrier_resolved' => 'flow',
+            // Home Hospital (ACUM-PRD-HAH-001 §6.3) — the virtual-ward pathway:
+            // activation cadence, waiver visits, escalation protocol, discharge.
+            'home-activate' => 'home',
+            'home-visit-complete' => 'home',
+            'home-escalation-open' => 'home',
+            'home-escalation-resolve' => 'home',
+            'home-discharge' => 'home',
         ];
     }
 }

--- a/app/Domain/Ocel/OcelProjector.php
+++ b/app/Domain/Ocel/OcelProjector.php
@@ -58,6 +58,7 @@ class OcelProjector
             'prod.transport_requests' => $this->collectTransport($since, $until),
             'prod.barriers' => $this->collectBarriers($since, $until),
             'prod.ancillary_milestones' => $this->collectAncillaryMilestones($since, $until),
+            'prod.home_episodes' => $this->collectHomeEpisodes($since, $until),
         ];
 
         $this->flush();
@@ -209,6 +210,76 @@ class OcelProjector
             ->chunk(1000, function ($rows) use (&$n) {
                 foreach ($rows as $row) {
                     foreach (EmissionMap::forTransport($row) as $e) {
+                        $this->absorb($e);
+                        $n++;
+                    }
+                }
+            });
+
+        return $n;
+    }
+
+    /**
+     * Home Hospital pathway (ACUM-PRD-HAH-001 §6.3): episodes (activate →
+     * discharge, with the RPM kit as a linked resource), completed waiver
+     * visits, and the escalation open→resolve chains — the corpus the
+     * time-to-activation / visit-cadence / escalation-protocol conformance
+     * checks read. Gated on the module flag: zero rows when off.
+     */
+    private function collectHomeEpisodes(CarbonInterface $since, CarbonInterface $until): int
+    {
+        if (! (bool) config('home_hospital.enabled')) {
+            return 0;
+        }
+
+        $n = 0;
+
+        DB::table('prod.home_episodes as e')
+            ->join('prod.home_programs as p', 'p.home_program_id', '=', 'e.home_program_id')
+            ->leftJoin('prod.rpm_enrollments as en', function ($join): void {
+                $join->on('en.home_episode_id', '=', 'e.home_episode_id')
+                    ->where('en.is_deleted', '=', false);
+            })
+            ->leftJoin('prod.rpm_kits as k', 'k.rpm_kit_id', '=', 'en.rpm_kit_id')
+            ->where('e.is_deleted', false)
+            ->whereBetween('e.started_at', [$since, $until])
+            ->select([
+                'e.home_episode_id', 'e.patient_ref', 'e.condition_code', 'e.admission_source',
+                'e.service_zone', 'e.disposition', 'e.started_at', 'e.ended_at',
+                'p.program_type', 'k.kit_code',
+            ])
+            ->distinct()
+            ->orderBy('e.home_episode_id')
+            ->chunk(500, function ($rows) use (&$n): void {
+                foreach ($rows as $row) {
+                    foreach (EmissionMap::forHomeEpisode($row) as $e) {
+                        $this->absorb($e);
+                        $n++;
+                    }
+                }
+            });
+
+        DB::table('prod.home_visits')
+            ->where('is_deleted', false)
+            ->whereNotNull('completed_at')
+            ->whereBetween('completed_at', [$since, $until])
+            ->orderBy('home_visit_id')
+            ->chunk(1000, function ($rows) use (&$n): void {
+                foreach ($rows as $row) {
+                    foreach (EmissionMap::forHomeVisit($row) as $e) {
+                        $this->absorb($e);
+                        $n++;
+                    }
+                }
+            });
+
+        DB::table('prod.home_escalations')
+            ->where('is_deleted', false)
+            ->whereBetween('initiated_at', [$since, $until])
+            ->orderBy('home_escalation_id')
+            ->chunk(1000, function ($rows) use (&$n): void {
+                foreach ($rows as $row) {
+                    foreach (EmissionMap::forHomeEscalation($row) as $e) {
                         $this->absorb($e);
                         $n++;
                     }

--- a/app/Domain/Ocel/OcelProjector.php
+++ b/app/Domain/Ocel/OcelProjector.php
@@ -236,6 +236,7 @@ class OcelProjector
 
         DB::table('prod.home_episodes as e')
             ->join('prod.home_programs as p', 'p.home_program_id', '=', 'e.home_program_id')
+            ->leftJoin('prod.home_referrals as r', 'r.home_referral_id', '=', 'e.home_referral_id')
             ->leftJoin('prod.rpm_enrollments as en', function ($join): void {
                 $join->on('en.home_episode_id', '=', 'e.home_episode_id')
                     ->where('en.is_deleted', '=', false);
@@ -246,7 +247,7 @@ class OcelProjector
             ->select([
                 'e.home_episode_id', 'e.patient_ref', 'e.condition_code', 'e.admission_source',
                 'e.service_zone', 'e.disposition', 'e.started_at', 'e.ended_at',
-                'p.program_type', 'k.kit_code',
+                'p.program_type', 'k.kit_code', 'r.referred_at',
             ])
             ->distinct()
             ->orderBy('e.home_episode_id')

--- a/app/Http/Controllers/Api/Home/HomeCensusController.php
+++ b/app/Http/Controllers/Api/Home/HomeCensusController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api\Home;
+
+use App\Http\Controllers\Controller;
+use App\Services\Home\HomeCensusService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Live census payload for the Virtual Bed Board. Same builder as the Inertia
+ * page, fetched over the authenticated API (invalidate-on-ping doctrine —
+ * public channels never carry patient-level data).
+ */
+class HomeCensusController extends Controller
+{
+    public function index(HomeCensusService $census): JsonResponse
+    {
+        return response()->json($census->build());
+    }
+}

--- a/app/Http/Controllers/Api/Home/HomeCommandController.php
+++ b/app/Http/Controllers/Api/Home/HomeCommandController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Api\Home;
+
+use App\Http\Controllers\Controller;
+use App\Services\Home\HomeCommandService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Live Virtual Ward Command payload — same builder as the Inertia page,
+ * fetched over the authenticated API (invalidate-on-ping doctrine).
+ */
+class HomeCommandController extends Controller
+{
+    public function index(HomeCommandService $command): JsonResponse
+    {
+        return response()->json($command->build());
+    }
+}

--- a/app/Http/Controllers/Api/Home/HomeDecantController.php
+++ b/app/Http/Controllers/Api/Home/HomeDecantController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Api\Home;
+
+use App\Http\Controllers\Controller;
+use App\Services\Home\HomeCapacityService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * The decant line (ACUM-PRD-HAH-001 §6.2): home-eligible counts + free-slot
+ * forecast for the RTDC global huddle. Also refreshes the home rows in
+ * prod.rtdc_predictions so the forecast lives alongside physical capacity.
+ */
+class HomeDecantController extends Controller
+{
+    public function index(HomeCapacityService $capacity): JsonResponse
+    {
+        $capacity->writePredictions();
+
+        return response()->json($capacity->decant());
+    }
+}

--- a/app/Http/Controllers/Api/Home/HomeEscalationController.php
+++ b/app/Http/Controllers/Api/Home/HomeEscalationController.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Http\Controllers\Api\Home;
+
+use App\Http\Controllers\Controller;
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeEscalation;
+use App\Models\Home\RpmAlert;
+use App\Services\Home\HomeEscalationService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Escalation workflow endpoints (ACUM-PRD-HAH-001 §4.2). Every transition is
+ * a human action over the authenticated session; response timers derive from
+ * the stored timing chain, never from the client.
+ */
+class HomeEscalationController extends Controller
+{
+    public function __construct(private readonly HomeEscalationService $escalations) {}
+
+    public function index(): JsonResponse
+    {
+        $open = HomeEscalation::query()
+            ->with('episode:home_episode_id,patient_ref,condition_label')
+            ->whereIn('status', ['open', 'responding'])
+            ->where('is_deleted', false)
+            ->orderBy('initiated_at')
+            ->get()
+            ->map(fn (HomeEscalation $e): array => $this->present($e));
+
+        return response()->json(['escalations' => $open]);
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'episode_uuid' => ['required', 'string'],
+            'trigger_type' => ['required', Rule::in(['critical_vital', 'clinical_deterioration', 'patient_request', 'caregiver_request', 'device_failure', 'other'])],
+            'alert_uuid' => ['nullable', 'string'],
+            'response_mode' => ['nullable', Rule::in(['tele_assessment', 'field_dispatch', 'ems', 'ed_return'])],
+        ]);
+
+        $episode = HomeEpisode::query()
+            ->where('episode_uuid', $validated['episode_uuid'])
+            ->where('is_deleted', false)
+            ->firstOrFail();
+
+        $alert = isset($validated['alert_uuid'])
+            ? RpmAlert::query()->where('alert_uuid', $validated['alert_uuid'])->where('is_deleted', false)->first()
+            : null;
+
+        $escalation = $this->escalations->open(
+            $episode,
+            $validated['trigger_type'],
+            $alert,
+            $validated['response_mode'] ?? null,
+        );
+
+        return response()->json(['escalation' => $this->present($escalation)], 201);
+    }
+
+    public function dispatchResponse(Request $request, string $escalationUuid): JsonResponse
+    {
+        $validated = $request->validate([
+            'response_mode' => ['required', Rule::in(['tele_assessment', 'field_dispatch', 'ems', 'ed_return'])],
+        ]);
+
+        $escalation = $this->openEscalation($escalationUuid);
+
+        return response()->json([
+            'escalation' => $this->present($this->escalations->markDispatched($escalation, $validated['response_mode'])),
+        ]);
+    }
+
+    public function arrive(string $escalationUuid): JsonResponse
+    {
+        $escalation = $this->openEscalation($escalationUuid);
+
+        return response()->json([
+            'escalation' => $this->present($this->escalations->markArrived($escalation)),
+        ]);
+    }
+
+    public function resolve(Request $request, string $escalationUuid): JsonResponse
+    {
+        $validated = $request->validate([
+            'outcome' => ['required', Rule::in(['managed_at_home', 'ed_return', 'readmitted', 'deceased', 'other'])],
+        ]);
+
+        $escalation = $this->openEscalation($escalationUuid);
+
+        return response()->json([
+            'escalation' => $this->present($this->escalations->resolve($escalation, $validated['outcome'])),
+        ]);
+    }
+
+    private function openEscalation(string $escalationUuid): HomeEscalation
+    {
+        return HomeEscalation::query()
+            ->where('escalation_uuid', $escalationUuid)
+            ->whereIn('status', ['open', 'responding'])
+            ->where('is_deleted', false)
+            ->firstOrFail();
+    }
+
+    /** @return array<string, mixed> */
+    private function present(HomeEscalation $e): array
+    {
+        return [
+            'escalationUuid' => $e->escalation_uuid,
+            'patientRef' => $e->patient_ref,
+            'conditionLabel' => $e->episode?->condition_label,
+            'triggerType' => $e->trigger_type,
+            'responseMode' => $e->response_mode,
+            'status' => $e->status,
+            'initiatedAt' => $e->initiated_at?->toIso8601String(),
+            'dispatchedAt' => $e->dispatched_at?->toIso8601String(),
+            'arrivedAt' => $e->arrived_at?->toIso8601String(),
+            'resolvedAt' => $e->resolved_at?->toIso8601String(),
+            'responseMinutes' => $e->response_minutes,
+            // Live timer input: minutes since initiation while unresolved.
+            'elapsedMinutes' => $e->status === 'resolved' || $e->initiated_at === null
+                ? null
+                : max(0, (int) round($e->initiated_at->diffInMinutes(now()))),
+            'outcome' => $e->outcome,
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/Home/HomeLogisticsController.php
+++ b/app/Http/Controllers/Api/Home/HomeLogisticsController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\Api\Home;
+
+use App\Http\Controllers\Controller;
+use App\Services\Home\HomeLogisticsService;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * Field operations & logistics payload — the ONE surface where a patient's
+ * physical address is permitted (ACUM-PRD-HAH-001 §4.2 / build brief §8.4).
+ */
+class HomeLogisticsController extends Controller
+{
+    public function index(HomeLogisticsService $logistics): JsonResponse
+    {
+        return response()->json($logistics->build());
+    }
+}

--- a/app/Http/Controllers/Api/Home/HomeReferralController.php
+++ b/app/Http/Controllers/Api/Home/HomeReferralController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers\Api\Home;
+
+use App\Http\Controllers\Controller;
+use App\Models\Home\HomeReferral;
+use App\Services\Home\HomeReferralService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Referral funnel + eligibility worklists (ACUM-PRD-HAH-001 §4.2). Funnel
+ * transitions are human actions; declines always carry a coded reason
+ * (selection-bias analytics, §11).
+ */
+class HomeReferralController extends Controller
+{
+    public function __construct(private readonly HomeReferralService $referrals) {}
+
+    public function index(): JsonResponse
+    {
+        return response()->json($this->referrals->build());
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'patient_ref' => ['required', 'string', 'max:190'],
+            'source' => ['required', Rule::in(['ed_diversion', 'inpatient_stepdown', 'direct', 'ambulatory'])],
+            'encounter_id' => ['nullable', 'integer'],
+            'program_code' => ['nullable', 'string', 'max:60'],
+            'payer_class' => ['nullable', 'string', 'max:40'],
+            'service_zone' => ['nullable', 'string', 'max:60'],
+            'screening' => ['nullable', 'array'],
+        ]);
+
+        $validated['referred_by'] = (string) ($request->user()?->email ?? 'unknown');
+
+        $referral = $this->referrals->create($validated);
+
+        return response()->json(['referral' => ['referralUuid' => $referral->referral_uuid, 'status' => $referral->status]], 201);
+    }
+
+    public function advance(string $referralUuid): JsonResponse
+    {
+        $referral = $this->find($referralUuid);
+        $advanced = $this->referrals->advance($referral);
+
+        return response()->json(['referral' => [
+            'referralUuid' => $advanced->referral_uuid,
+            'status' => $advanced->status,
+            'activatedAt' => $advanced->activated_at?->toIso8601String(),
+        ]]);
+    }
+
+    public function decline(Request $request, string $referralUuid): JsonResponse
+    {
+        $validated = $request->validate([
+            'reason' => ['required', 'string', 'max:60'],
+            'note' => ['nullable', 'string', 'max:2000'],
+        ]);
+
+        $referral = $this->find($referralUuid);
+        $declined = $this->referrals->decline($referral, $validated['reason'], $validated['note'] ?? null);
+
+        return response()->json(['referral' => [
+            'referralUuid' => $declined->referral_uuid,
+            'status' => $declined->status,
+            'declineReason' => $declined->decline_reason,
+        ]]);
+    }
+
+    private function find(string $referralUuid): HomeReferral
+    {
+        return HomeReferral::query()
+            ->where('referral_uuid', $referralUuid)
+            ->where('is_deleted', false)
+            ->firstOrFail();
+    }
+}

--- a/app/Http/Controllers/Api/Home/HomeTransitionController.php
+++ b/app/Http/Controllers/Api/Home/HomeTransitionController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers\Api\Home;
+
+use App\Http\Controllers\Controller;
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeTransition;
+use App\Services\Home\HomeTransitionService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+
+/**
+ * Transitions board endpoints: inbound activation checklists, outbound
+ * governed handoffs (care_transition transport + regional decision), episode
+ * discharge → 30-day post-discharge cohort (ACUM-PRD-HAH-001 §7).
+ */
+class HomeTransitionController extends Controller
+{
+    public function __construct(private readonly HomeTransitionService $transitions) {}
+
+    public function index(): JsonResponse
+    {
+        return response()->json($this->transitions->build());
+    }
+
+    public function completeChecklistItem(Request $request, string $transitionUuid): JsonResponse
+    {
+        $validated = $request->validate(['item' => ['required', 'string', 'max:60']]);
+
+        $transition = HomeTransition::query()
+            ->where('transition_uuid', $transitionUuid)
+            ->where('is_deleted', false)
+            ->firstOrFail();
+
+        $updated = $this->transitions->completeChecklistItem($transition, $validated['item']);
+
+        return response()->json(['transition' => [
+            'transitionUuid' => $updated->transition_uuid,
+            'status' => $updated->status,
+            'checklist' => (array) $updated->checklist,
+        ]]);
+    }
+
+    public function startOutbound(Request $request, string $episodeUuid): JsonResponse
+    {
+        $validated = $request->validate([
+            'receiving_entity_type' => ['required', Rule::in(['pcp', 'home_health', 'snf', 'other'])],
+            'handoff_owner' => ['nullable', 'string', 'max:190'],
+        ]);
+
+        $episode = $this->episode($episodeUuid);
+
+        $result = $this->transitions->startOutbound(
+            $episode,
+            $validated['receiving_entity_type'],
+            $validated['handoff_owner'] ?? (string) ($request->user()?->email ?? 'unknown'),
+            $request->user()?->id,
+        );
+
+        return response()->json([
+            'transition' => [
+                'transitionUuid' => $result['transition']->transition_uuid,
+                'status' => $result['transition']->status,
+            ],
+            'transportRequestId' => $result['transportRequestId'],
+            'decisionId' => $result['decisionId'],
+        ], 201);
+    }
+
+    public function discharge(Request $request, string $episodeUuid): JsonResponse
+    {
+        $validated = $request->validate([
+            'disposition' => ['required', Rule::in(['routine_discharge', 'ed_return', 'readmitted', 'transferred', 'deceased', 'other'])],
+        ]);
+
+        $episode = $this->episode($episodeUuid);
+        $discharged = $this->transitions->discharge($episode, $validated['disposition']);
+
+        return response()->json(['episode' => [
+            'episodeUuid' => $discharged->episode_uuid,
+            'status' => $discharged->status,
+            'disposition' => $discharged->disposition,
+        ]]);
+    }
+
+    private function episode(string $episodeUuid): HomeEpisode
+    {
+        return HomeEpisode::query()
+            ->where('episode_uuid', $episodeUuid)
+            ->where('is_deleted', false)
+            ->firstOrFail();
+    }
+}

--- a/app/Http/Controllers/Api/Home/RpmAlertController.php
+++ b/app/Http/Controllers/Api/Home/RpmAlertController.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Controllers\Api\Home;
+
+use App\Http\Controllers\Controller;
+use App\Models\Home\RpmAlert;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Patient-alert acknowledgement workflow (ACUM-PRD-HAH-001 §4.2 / Phase 1
+ * DoD). Acknowledge and resolve are HUMAN actions recorded with the acting
+ * user — mirroring the Eddy doctrine that consequential loops keep a person
+ * in them. Alerts are never deleted; resolution closes the row in place.
+ */
+class RpmAlertController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $alerts = RpmAlert::query()
+            ->with('episode:home_episode_id,patient_ref,condition_label')
+            ->where('is_deleted', false)
+            ->whereIn('status', ['open', 'acknowledged'])
+            ->orderByRaw("CASE severity WHEN 'critical' THEN 0 WHEN 'warning' THEN 1 ELSE 2 END")
+            ->orderByDesc('opened_at')
+            ->limit(100)
+            ->get()
+            ->map(fn (RpmAlert $alert): array => $this->present($alert));
+
+        return response()->json(['alerts' => $alerts]);
+    }
+
+    public function acknowledge(Request $request, string $alertUuid): JsonResponse
+    {
+        $alert = RpmAlert::query()
+            ->where('alert_uuid', $alertUuid)
+            ->where('is_deleted', false)
+            ->firstOrFail();
+
+        if ($alert->status === 'open') {
+            $alert->update([
+                'status' => 'acknowledged',
+                'acknowledged_at' => now(),
+                'acknowledged_by' => (string) ($request->user()?->email ?? $request->user()?->name ?? 'unknown'),
+            ]);
+        }
+
+        return response()->json(['alert' => $this->present($alert->fresh())]);
+    }
+
+    public function resolve(Request $request, string $alertUuid): JsonResponse
+    {
+        $alert = RpmAlert::query()
+            ->where('alert_uuid', $alertUuid)
+            ->where('is_deleted', false)
+            ->firstOrFail();
+
+        if (in_array($alert->status, ['open', 'acknowledged'], true)) {
+            $alert->update([
+                'status' => 'resolved',
+                // An unacked alert resolved directly still records the human.
+                'acknowledged_at' => $alert->acknowledged_at ?? now(),
+                'acknowledged_by' => $alert->acknowledged_by
+                    ?? (string) ($request->user()?->email ?? $request->user()?->name ?? 'unknown'),
+                'resolved_at' => now(),
+                'resolved_by' => (string) ($request->user()?->email ?? $request->user()?->name ?? 'unknown'),
+            ]);
+        }
+
+        return response()->json(['alert' => $this->present($alert->fresh())]);
+    }
+
+    /** @return array<string, mixed> */
+    private function present(RpmAlert $alert): array
+    {
+        return [
+            'alertUuid' => $alert->alert_uuid,
+            'patientRef' => $alert->patient_ref,
+            'conditionLabel' => $alert->episode?->condition_label,
+            'ruleKey' => $alert->rule_key,
+            'severity' => $alert->severity,
+            'status' => $alert->status,
+            'openedAt' => $alert->opened_at?->toIso8601String(),
+            'acknowledgedAt' => $alert->acknowledged_at?->toIso8601String(),
+            'acknowledgedBy' => $alert->acknowledged_by,
+            'resolvedAt' => $alert->resolved_at?->toIso8601String(),
+            'value' => $alert->metadata['value'] ?? $alert->metadata['last_value'] ?? null,
+            'unit' => $alert->metadata['unit'] ?? null,
+            'display' => $alert->metadata['display'] ?? null,
+            'breachCount' => $alert->metadata['breach_count'] ?? 1,
+            'thresholdSource' => $alert->metadata['threshold_source'] ?? null,
+        ];
+    }
+}

--- a/app/Http/Controllers/HomeDashboardController.php
+++ b/app/Http/Controllers/HomeDashboardController.php
@@ -16,4 +16,9 @@ class HomeDashboardController extends Controller
     {
         return Inertia::render('Home/Census', $census->build());
     }
+
+    public function command(\App\Services\Home\HomeCommandService $command): InertiaResponse
+    {
+        return Inertia::render('Home/Command', $command->build());
+    }
 }

--- a/app/Http/Controllers/HomeDashboardController.php
+++ b/app/Http/Controllers/HomeDashboardController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\Home\HomeCensusService;
+use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
+
+/**
+ * Home Hospital (HOME) workspace pages (ACUM-PRD-HAH-001 §4.2).
+ * All routes are gated by EnsureHomeHospitalEnabled (404 when the flag is off).
+ */
+class HomeDashboardController extends Controller
+{
+    public function census(HomeCensusService $census): InertiaResponse
+    {
+        return Inertia::render('Home/Census', $census->build());
+    }
+}

--- a/app/Http/Controllers/HomeDashboardController.php
+++ b/app/Http/Controllers/HomeDashboardController.php
@@ -21,4 +21,19 @@ class HomeDashboardController extends Controller
     {
         return Inertia::render('Home/Command', $command->build());
     }
+
+    public function referrals(\App\Services\Home\HomeReferralService $referrals): InertiaResponse
+    {
+        return Inertia::render('Home/Referrals', $referrals->build());
+    }
+
+    public function transitions(\App\Services\Home\HomeTransitionService $transitions): InertiaResponse
+    {
+        return Inertia::render('Home/Transitions', $transitions->build());
+    }
+
+    public function logistics(\App\Services\Home\HomeLogisticsService $logistics): InertiaResponse
+    {
+        return Inertia::render('Home/Logistics', $logistics->build());
+    }
 }

--- a/app/Http/Middleware/EnsureHomeHospitalEnabled.php
+++ b/app/Http/Middleware/EnsureHomeHospitalEnabled.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Feature gate for the Home Hospital module (HOME_HOSPITAL_ENABLED).
+ * A 404 (not 403) keeps the module invisible when off; disabling the flag
+ * stops new work without deleting existing episode or audit records.
+ */
+class EnsureHomeHospitalEnabled
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        abort_unless((bool) config('home_hospital.enabled'), 404);
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -95,6 +95,10 @@ class HandleInertiaRequests extends Middleware
             // route gate (EnsureRoundsEnabled) so nav and route never disagree.
             'features' => [
                 'virtual_rounds' => (bool) config('rounds.enabled'),
+                // Home Hospital ships disabled; nav stays hidden (never a dead
+                // link) until HOME_HOSPITAL_ENABLED is on — matching the server
+                // route gate (EnsureHomeHospitalEnabled).
+                'home_hospital' => (bool) config('home_hospital.enabled'),
             ],
             'workflow' => $request->session()->get('workflow'),
             'flash' => [

--- a/app/Integrations/Healthcare/Rpm/RpmEventVocabulary.php
+++ b/app/Integrations/Healthcare/Rpm/RpmEventVocabulary.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Integrations\Healthcare\Rpm;
+
+/**
+ * Canonical event types for remote-patient-monitoring feeds
+ * (ACUM-PRD-HAH-001 §5.2). PascalCase values match the RTDC canonical
+ * vocabulary (App\Rtdc\Events\CanonicalEvent).
+ */
+final class RpmEventVocabulary
+{
+    public const OBSERVATION_RECORDED = 'ObservationRecorded';
+
+    public const DEVICE_STATUS_CHANGED = 'DeviceStatusChanged';
+
+    /** @return list<string> */
+    public static function eventTypes(): array
+    {
+        return [self::OBSERVATION_RECORDED, self::DEVICE_STATUS_CHANGED];
+    }
+}

--- a/app/Integrations/Healthcare/Rpm/SyntheticRpmCanonicalEventMapper.php
+++ b/app/Integrations/Healthcare/Rpm/SyntheticRpmCanonicalEventMapper.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Integrations\Healthcare\Rpm;
+
+use App\Integrations\Healthcare\Contracts\CanonicalEventMapper;
+use App\Integrations\Healthcare\DTO\CanonicalOperationalEvent;
+use App\Integrations\Healthcare\DTO\NormalizedPayload;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+/**
+ * Maps normalized RPM device messages onto canonical events. The wire payload
+ * is pseudonymous (patient_ref + LOINC + value); device identity travels as a
+ * serial number resolved to prod.rpm_devices at projection time.
+ */
+class SyntheticRpmCanonicalEventMapper implements CanonicalEventMapper
+{
+    public function map(NormalizedPayload $payload): array
+    {
+        $data = $payload->payload;
+        $eventType = $payload->eventType;
+        $occurredAt = CanonicalOperationalEvent::occurredAt($payload->occurredAt);
+        $eventId = (string) ($data['event_id'] ?? Str::uuid());
+
+        return match ($eventType) {
+            RpmEventVocabulary::OBSERVATION_RECORDED => [
+                new CanonicalOperationalEvent(
+                    eventId: $eventId,
+                    eventType: $eventType,
+                    entityType: 'rpm_observation',
+                    entityRef: $this->requiredString($data, 'patient_ref'),
+                    payload: [
+                        'patient_ref' => $this->requiredString($data, 'patient_ref'),
+                        'loinc_code' => $this->requiredString($data, 'loinc_code'),
+                        'display' => $data['display'] ?? null,
+                        'value' => $this->requiredNumeric($data, 'value'),
+                        'unit' => $data['unit'] ?? null,
+                        'observed_at' => $occurredAt->toIso8601String(),
+                        'transmission_id' => $data['transmission_id'] ?? $payload->externalId,
+                        'device_serial' => $data['device_serial'] ?? null,
+                        'quality_flag' => $data['quality_flag'] ?? 'ok',
+                    ],
+                    occurredAt: $occurredAt,
+                    idempotencyKey: "{$payload->idempotencyKey}:{$eventType}",
+                    correlationId: $data['correlation_id'] ?? null,
+                    sequenceKey: $data['sequence_key'] ?? null,
+                    metadata: ['source_message_type' => $payload->messageType],
+                ),
+            ],
+            RpmEventVocabulary::DEVICE_STATUS_CHANGED => [
+                new CanonicalOperationalEvent(
+                    eventId: $eventId,
+                    eventType: $eventType,
+                    entityType: 'rpm_device',
+                    entityRef: $this->requiredString($data, 'device_serial'),
+                    payload: [
+                        'device_serial' => $this->requiredString($data, 'device_serial'),
+                        'status' => $data['status'] ?? null,
+                        'battery_pct' => isset($data['battery_pct']) ? (int) $data['battery_pct'] : null,
+                        'occurred_at' => $occurredAt->toIso8601String(),
+                    ],
+                    occurredAt: $occurredAt,
+                    idempotencyKey: "{$payload->idempotencyKey}:{$eventType}",
+                    correlationId: $data['correlation_id'] ?? null,
+                    sequenceKey: $data['sequence_key'] ?? null,
+                    metadata: ['source_message_type' => $payload->messageType],
+                ),
+            ],
+            default => throw new InvalidArgumentException("Unsupported RPM event type [{$eventType}]."),
+        };
+    }
+
+    private function requiredString(array $data, string $key): string
+    {
+        $value = trim((string) ($data[$key] ?? ''));
+        if ($value === '') {
+            throw new InvalidArgumentException("RPM payload is missing required field [{$key}].");
+        }
+
+        return $value;
+    }
+
+    private function requiredNumeric(array $data, string $key): float
+    {
+        if (! isset($data[$key]) || ! is_numeric($data[$key])) {
+            throw new InvalidArgumentException("RPM payload is missing numeric field [{$key}].");
+        }
+
+        return (float) $data[$key];
+    }
+}

--- a/app/Integrations/Healthcare/Rpm/SyntheticRpmConnector.php
+++ b/app/Integrations/Healthcare/Rpm/SyntheticRpmConnector.php
@@ -1,0 +1,478 @@
+<?php
+
+namespace App\Integrations\Healthcare\Rpm;
+
+use App\Integrations\Healthcare\Contracts\HealthcareConnector;
+use App\Integrations\Healthcare\DTO\BackfillRequest;
+use App\Integrations\Healthcare\DTO\ConnectorCapabilities;
+use App\Integrations\Healthcare\DTO\ConnectorHealth;
+use App\Integrations\Healthcare\DTO\PollRequest;
+use App\Integrations\Healthcare\DTO\ReplayRequest;
+use App\Integrations\Healthcare\DTO\SourceMessage;
+use App\Integrations\Healthcare\DTO\WebhookEnvelope;
+use App\Integrations\Healthcare\Services\CanonicalEventWriter;
+use App\Integrations\Healthcare\Services\ProjectionDispatcher;
+use App\Integrations\Healthcare\Services\SourceRegistryService;
+use App\Models\Integration\CanonicalEventRecord;
+use App\Models\Integration\ConnectorWatermark;
+use App\Models\Integration\ProvenanceRecord;
+use App\Models\Raw\DeadLetter;
+use App\Models\Raw\InboundMessage;
+use App\Models\Raw\IngestRun;
+use App\Security\ClinicalPayloads\ClinicalPayloadException;
+use App\Security\ClinicalPayloads\ClinicalPayloadStore;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Throwable;
+
+/**
+ * Synthetic RPM device-feed connector (ACUM-PRD-HAH-001 §5.2) — the Phase 1
+ * MVP rides this until a real vendor is chosen (build brief §13 Q4). A copy of
+ * SyntheticHealthcareConnector's full lifecycle (webhook + poll + backfill +
+ * replay + dead-letter) with an RPM vocabulary: ObservationRecorded and
+ * DeviceStatusChanged, projected by RpmProjectionHandler into
+ * prod.rpm_observations and device state. Wire payloads are pseudonymous —
+ * patient_ref + LOINC + value + device serial, never MRN or address.
+ */
+class SyntheticRpmConnector implements HealthcareConnector
+{
+    private const CONNECTOR_KEY = 'synthetic.rpm';
+
+    public function __construct(
+        private readonly SourceRegistryService $sources,
+        private readonly SyntheticRpmMessageNormalizer $normalizer,
+        private readonly SyntheticRpmCanonicalEventMapper $mapper,
+        private readonly CanonicalEventWriter $writer,
+        private readonly ProjectionDispatcher $projector,
+        private readonly ClinicalPayloadStore $payloads,
+    ) {}
+
+    public function sourceKey(): string
+    {
+        return 'synthetic.rpm';
+    }
+
+    public function capabilities(): ConnectorCapabilities
+    {
+        return new ConnectorCapabilities(
+            connectorKey: self::CONNECTOR_KEY,
+            eventTypes: RpmEventVocabulary::eventTypes(),
+            metadata: ['purpose' => 'Home Hospital synthetic RPM device feed'],
+        );
+    }
+
+    public function healthCheck(): ConnectorHealth
+    {
+        return new ConnectorHealth(
+            status: 'healthy',
+            message: 'Synthetic RPM connector is available for deterministic Home Hospital tests.',
+            metrics: [
+                'supported_event_types' => count($this->capabilities()->eventTypes),
+            ],
+        );
+    }
+
+    public function backfill(BackfillRequest $request): IngestRun
+    {
+        return $this->ingestMessages($request->messages, 'backfill', $request->cursor);
+    }
+
+    public function poll(PollRequest $request): IngestRun
+    {
+        return $this->ingestMessages($request->messages, 'poll', $request->cursor);
+    }
+
+    public function handleWebhook(WebhookEnvelope $webhook): IngestRun
+    {
+        $messages = $webhook->payload['messages'] ?? [$webhook->payload];
+
+        return $this->ingestMessages($messages, 'webhook', null, [
+            'headers' => array_keys($webhook->headers),
+            'received_at' => $webhook->receivedAt,
+        ]);
+    }
+
+    public function replay(ReplayRequest $request): IngestRun
+    {
+        $source = $this->source();
+        $run = $this->startRun($source, 'replay', metadata: ['scope' => $request->scope]);
+        $query = CanonicalEventRecord::query()->where('source_id', $source->source_id);
+
+        if ($request->canonicalEventIds !== []) {
+            $query->whereIn('canonical_event_id', $request->canonicalEventIds);
+        }
+
+        $events = $query->orderBy('canonical_event_id')->get();
+        $succeeded = 0;
+        $failed = 0;
+
+        foreach ($events as $record) {
+            try {
+                $this->projectRecord($record, force: true);
+                $succeeded++;
+            } catch (Throwable $exception) {
+                $failed++;
+                $this->deadLetter(
+                    sourceId: $source->source_id,
+                    runId: $run->ingest_run_id,
+                    inboundMessageId: $record->inbound_message_id,
+                    failureStage: 'replay',
+                    reasonCode: 'projection_failed',
+                    message: 'The encrypted canonical RPM event could not be projected during replay.',
+                    exceptionClass: $exception::class,
+                    context: ['canonical_event_id' => $record->canonical_event_id],
+                );
+            }
+        }
+
+        $run->update([
+            'status' => $failed > 0 ? 'completed_with_errors' : 'completed',
+            'completed_at' => now(),
+            'messages_received' => $events->count(),
+            'messages_succeeded' => $succeeded,
+            'messages_failed' => $failed,
+        ]);
+
+        return $run->fresh();
+    }
+
+    private function ingestMessages(array $messages, string $runType, ?string $cursorBefore = null, array $metadata = []): IngestRun
+    {
+        $source = $this->source();
+        $run = $this->startRun($source, $runType, $cursorBefore, $metadata);
+        $received = 0;
+        $succeeded = 0;
+        $failed = 0;
+        $skipped = 0;
+
+        foreach ($messages as $index => $rawPayload) {
+            $received++;
+            $message = $this->recordRawMessage($source->source_id, $run->ingest_run_id, $rawPayload, $index);
+
+            if (! $message->wasRecentlyCreated && $message->parse_status === 'projected') {
+                $skipped++;
+
+                continue;
+            }
+
+            try {
+                $sourceMessage = new SourceMessage(
+                    messageType: (string) ($rawPayload['message_type'] ?? 'rpm.'.($rawPayload['event_type'] ?? 'unknown')),
+                    payload: $rawPayload,
+                    externalId: $rawPayload['external_id'] ?? ($rawPayload['transmission_id'] ?? null),
+                    receivedAt: $rawPayload['received_at'] ?? null,
+                    metadata: ['source_key' => $source->source_key],
+                );
+
+                if (! $this->normalizer->supports($sourceMessage)) {
+                    throw new \InvalidArgumentException("Unsupported RPM source message type [{$sourceMessage->messageType}].");
+                }
+
+                $normalized = $this->normalizer->normalize($sourceMessage);
+                if ($message->normalized_payload_object_id === null) {
+                    $stored = $this->payloads->storeJson(
+                        (int) $source->source_id,
+                        'normalized_message',
+                        $normalized->toArray(),
+                    );
+                    try {
+                        $message->update([
+                            'normalized_payload' => null,
+                            'normalized_payload_object_id' => $stored->payloadObjectId,
+                            'parse_status' => 'normalized',
+                        ]);
+                    } catch (Throwable $exception) {
+                        $this->discardPayload(
+                            $stored->payloadObjectId,
+                            (int) $source->source_id,
+                            'normalized_message_link_failed',
+                        );
+
+                        throw $exception;
+                    }
+                } else {
+                    $message->update(['parse_status' => 'normalized']);
+                }
+
+                $events = $this->mapper->map($normalized);
+
+                foreach ($events as $event) {
+                    $record = $this->writer->write($event, $source, $run, $message);
+                    $event = $event->withEventId($record->event_id);
+                    $this->projectRecord($record, event: $event);
+                    $this->writeProvenance($source->source_id, $message->inbound_message_id, $record);
+                }
+
+                $message->update(['parse_status' => 'projected']);
+                $succeeded++;
+            } catch (Throwable $exception) {
+                $message->update(['parse_status' => 'failed']);
+                $failed++;
+                $this->deadLetter(
+                    sourceId: $source->source_id,
+                    runId: $run->ingest_run_id,
+                    inboundMessageId: $message->inbound_message_id,
+                    failureStage: 'mapping',
+                    reasonCode: 'message_mapping_failed',
+                    message: 'The encrypted RPM source message could not be normalized and mapped.',
+                    exceptionClass: $exception::class,
+                    context: [
+                        'message_type' => $message->message_type,
+                    ],
+                );
+            }
+        }
+
+        $status = $failed > 0
+            ? ($succeeded > 0 || $skipped > 0 ? 'completed_with_errors' : 'failed')
+            : 'completed';
+
+        $run->update([
+            'status' => $status,
+            'completed_at' => now(),
+            'messages_received' => $received,
+            'messages_succeeded' => $succeeded,
+            'messages_failed' => $failed,
+            'messages_skipped' => $skipped,
+            'cursor_after' => $received > 0 ? (string) now()->getTimestamp() : $cursorBefore,
+        ]);
+
+        if ($status !== 'failed') {
+            ConnectorWatermark::updateOrCreate(
+                [
+                    'source_id' => $source->source_id,
+                    'connector_key' => self::CONNECTOR_KEY,
+                    'scope_type' => $runType,
+                    'scope_key' => 'default',
+                    'watermark_kind' => 'rpm_cursor',
+                ],
+                [
+                    'watermark_value' => $run->cursor_after,
+                    'last_success_at' => now(),
+                    'metadata' => ['run_uuid' => $run->run_uuid],
+                ],
+            );
+        }
+
+        return $run->fresh();
+    }
+
+    private function source(): \App\Models\Integration\Source
+    {
+        $scope = $this->enterpriseScope();
+
+        return $this->sources->ensureSource([
+            'source_key' => $this->sourceKey(),
+            'source_name' => 'Synthetic RPM Device Feed',
+            'vendor' => 'Zephyrus',
+            'system_class' => 'rpm',
+            'interface_type' => 'webhook',
+            'environment' => app()->environment('production') ? 'production' : 'sandbox',
+            'active_status' => $scope === [] ? 'testing' : 'active',
+            'metadata' => ['connector_key' => self::CONNECTOR_KEY],
+            ...$scope,
+        ]);
+    }
+
+    /** @return array<string, int|string> */
+    private function enterpriseScope(): array
+    {
+        $facilityKey = trim((string) config('integrations.synthetic.facility_key'));
+        if ($facilityKey === '') {
+            return [];
+        }
+
+        $facility = \App\Models\Org\Facility::query()
+            ->with('organization:organization_id,organization_key')
+            ->where('facility_key', $facilityKey)
+            ->where('is_active', true)
+            ->first();
+        if ($facility === null || $facility->organization === null) {
+            return [];
+        }
+
+        return [
+            'organization_id' => (int) $facility->organization_id,
+            'facility_id' => (int) $facility->facility_id,
+            'tenant_key' => (string) $facility->organization->organization_key,
+            'facility_key' => (string) $facility->facility_key,
+        ];
+    }
+
+    private function startRun(
+        \App\Models\Integration\Source $source,
+        string $runType,
+        ?string $cursorBefore = null,
+        array $metadata = [],
+    ): IngestRun {
+        return IngestRun::create([
+            'run_uuid' => (string) Str::uuid(),
+            'source_id' => $source->source_id,
+            'connector_key' => self::CONNECTOR_KEY,
+            'run_type' => $runType,
+            'status' => 'running',
+            'started_at' => now(),
+            'cursor_before' => $cursorBefore,
+            'metadata' => $metadata,
+        ]);
+    }
+
+    private function recordRawMessage(int $sourceId, int $runId, array $payload, int $index): InboundMessage
+    {
+        $messageType = (string) ($payload['message_type'] ?? 'rpm.'.($payload['event_type'] ?? 'unknown'));
+        $externalId = $payload['external_id'] ?? ($payload['transmission_id'] ?? null);
+        $idempotencyKey = (string) ($payload['idempotency_key'] ?? implode(':', array_filter([
+            $this->sourceKey(),
+            $messageType,
+            $externalId,
+            $externalId ? null : (string) $index,
+        ])));
+        $payloadHash = hash('sha256', json_encode($payload, JSON_THROW_ON_ERROR));
+
+        $existing = InboundMessage::query()
+            ->where('source_id', $sourceId)
+            ->where('idempotency_key', $idempotencyKey)
+            ->first();
+        if ($existing !== null) {
+            if (! hash_equals((string) $existing->payload_hash, $payloadHash)) {
+                throw new ClinicalPayloadException('raw_message_idempotency_conflict');
+            }
+            if ($existing->payload_object_id === null) {
+                $stored = $this->payloads->storeJson($sourceId, 'raw_message', $payload);
+                try {
+                    $existing->update([
+                        'payload' => null,
+                        'payload_object_id' => $stored->payloadObjectId,
+                    ]);
+                } catch (Throwable $exception) {
+                    $this->discardPayload($stored->payloadObjectId, $sourceId, 'raw_message_link_failed');
+
+                    throw $exception;
+                }
+            }
+
+            return $existing;
+        }
+
+        $stored = $this->payloads->storeJson($sourceId, 'raw_message', $payload);
+        try {
+            return InboundMessage::create([
+                'message_uuid' => (string) Str::uuid(),
+                'source_id' => $sourceId,
+                'ingest_run_id' => $runId,
+                'message_type' => $messageType,
+                'external_id' => $externalId,
+                'idempotency_key' => $idempotencyKey,
+                'payload_hash' => $payloadHash,
+                'payload' => null,
+                'payload_object_id' => $stored->payloadObjectId,
+                'received_at' => $payload['received_at'] ?? now(),
+                'parse_status' => 'received',
+                'metadata' => ['connector_key' => self::CONNECTOR_KEY],
+            ]);
+        } catch (QueryException $exception) {
+            $this->discardPayload($stored->payloadObjectId, $sourceId, 'raw_message_insert_race');
+            $existing = InboundMessage::query()
+                ->where('source_id', $sourceId)
+                ->where('idempotency_key', $idempotencyKey)
+                ->first();
+            if ($existing === null) {
+                throw $exception;
+            }
+            if (! hash_equals((string) $existing->payload_hash, $payloadHash)) {
+                throw new ClinicalPayloadException('raw_message_idempotency_conflict');
+            }
+
+            return $existing;
+        } catch (Throwable $exception) {
+            $this->discardPayload($stored->payloadObjectId, $sourceId, 'raw_message_insert_failed');
+
+            throw $exception;
+        }
+    }
+
+    private function projectRecord(
+        CanonicalEventRecord $record,
+        ?\App\Integrations\Healthcare\DTO\CanonicalOperationalEvent $event = null,
+        bool $force = false,
+    ): void {
+        if ($record->projection_status === 'projected' && ! $force) {
+            return;
+        }
+
+        $event ??= new \App\Integrations\Healthcare\DTO\CanonicalOperationalEvent(
+            eventId: $record->event_id,
+            eventType: $record->event_type,
+            entityType: $record->entity_type,
+            entityRef: $record->entity_ref,
+            payload: $record->payload ?? [],
+            occurredAt: $record->occurred_at,
+            idempotencyKey: $record->idempotency_key,
+            correlationId: $record->correlation_id,
+            causationId: $record->causation_id,
+            sequenceKey: $record->sequence_key,
+            metadata: $record->metadata ?? [],
+        );
+
+        DB::transaction(function () use ($record, $event): void {
+            $this->projector->project($event);
+            $record->update([
+                'projection_status' => 'projected',
+                'projected_at' => now(),
+            ]);
+        });
+    }
+
+    private function writeProvenance(int $sourceId, int $messageId, CanonicalEventRecord $record): void
+    {
+        ProvenanceRecord::create([
+            'source_id' => $sourceId,
+            'inbound_message_id' => $messageId,
+            'canonical_event_id' => $record->canonical_event_id,
+            'target_schema' => 'prod',
+            'target_table' => 'rpm_observations',
+            'target_pk' => $record->event_id,
+            'lineage' => [
+                'raw_message' => "raw.inbound_messages:{$messageId}",
+                'canonical_event' => "integration.canonical_events:{$record->canonical_event_id}",
+                'projection' => 'prod.rpm_observations',
+            ],
+        ]);
+    }
+
+    private function deadLetter(
+        ?int $sourceId,
+        ?int $runId,
+        ?int $inboundMessageId,
+        string $failureStage,
+        string $reasonCode,
+        string $message,
+        ?string $exceptionClass = null,
+        array $context = [],
+    ): DeadLetter {
+        return DeadLetter::create([
+            'dead_letter_uuid' => (string) Str::uuid(),
+            'source_id' => $sourceId,
+            'ingest_run_id' => $runId,
+            'inbound_message_id' => $inboundMessageId,
+            'failure_stage' => $failureStage,
+            'reason_code' => $reasonCode,
+            'message' => $message,
+            'exception_class' => $exceptionClass,
+            'context' => $context,
+            'status' => 'open',
+            'metadata' => ['connector_key' => self::CONNECTOR_KEY],
+        ]);
+    }
+
+    private function discardPayload(int $payloadObjectId, int $sourceId, string $reasonCode): void
+    {
+        $this->payloads->discard(
+            $payloadObjectId,
+            $sourceId,
+            $reasonCode,
+            'Encrypted clinical payload was discarded because the intended database link did not become authoritative.',
+        );
+    }
+}

--- a/app/Integrations/Healthcare/Rpm/SyntheticRpmMessageNormalizer.php
+++ b/app/Integrations/Healthcare/Rpm/SyntheticRpmMessageNormalizer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Integrations\Healthcare\Rpm;
+
+use App\Integrations\Healthcare\Contracts\SourceMessageNormalizer;
+use App\Integrations\Healthcare\DTO\NormalizedPayload;
+use App\Integrations\Healthcare\DTO\SourceMessage;
+
+class SyntheticRpmMessageNormalizer implements SourceMessageNormalizer
+{
+    public function supports(SourceMessage $message): bool
+    {
+        return str_starts_with($message->messageType, 'rpm.')
+            || in_array((string) ($message->payload['event_type'] ?? ''), RpmEventVocabulary::eventTypes(), true);
+    }
+
+    public function normalize(SourceMessage $message): NormalizedPayload
+    {
+        $eventType = (string) ($message->payload['event_type'] ?? str($message->messageType)->after('rpm.')->toString());
+        $externalId = $message->externalId ?? ($message->payload['external_id'] ?? $message->payload['transmission_id'] ?? null);
+        $idempotencyKey = (string) ($message->payload['idempotency_key']
+            ?? implode(':', array_filter([
+                'rpm',
+                $message->messageType,
+                $externalId,
+            ])));
+
+        return new NormalizedPayload(
+            messageType: $message->messageType,
+            eventType: $eventType,
+            payload: $message->payload,
+            idempotencyKey: $idempotencyKey,
+            externalId: $externalId,
+            occurredAt: $message->payload['observed_at'] ?? $message->payload['occurred_at'] ?? $message->receivedAt,
+            metadata: $message->metadata,
+        );
+    }
+}

--- a/app/Integrations/Healthcare/Services/RpmProjectionHandler.php
+++ b/app/Integrations/Healthcare/Services/RpmProjectionHandler.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Integrations\Healthcare\Services;
+
+use App\Integrations\Healthcare\Contracts\ProjectionHandler;
+use App\Integrations\Healthcare\DTO\CanonicalOperationalEvent;
+use App\Integrations\Healthcare\Rpm\RpmEventVocabulary;
+use App\Models\Home\RpmDevice;
+use App\Models\Home\RpmEnrollment;
+use App\Models\Home\RpmObservation;
+use InvalidArgumentException;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Projects canonical RPM events into the Home Hospital read models
+ * (ACUM-PRD-HAH-001 §5.2): ObservationRecorded → prod.rpm_observations
+ * (idempotent on observation_uuid, derived from the event idempotency key);
+ * DeviceStatusChanged → device status/battery + kit last-seen. An observation
+ * for a patient with no active enrollment is a mapping error — it dead-letters
+ * upstream rather than silently attaching to the wrong episode.
+ */
+class RpmProjectionHandler implements ProjectionHandler
+{
+    public function key(): string
+    {
+        return 'home.rpm';
+    }
+
+    public function eventTypes(): array
+    {
+        return RpmEventVocabulary::eventTypes();
+    }
+
+    public function supports(CanonicalOperationalEvent $event): bool
+    {
+        return in_array($event->eventType, $this->eventTypes(), true);
+    }
+
+    public function project(CanonicalOperationalEvent $event): void
+    {
+        match ($event->eventType) {
+            RpmEventVocabulary::OBSERVATION_RECORDED => $this->projectObservation($event),
+            RpmEventVocabulary::DEVICE_STATUS_CHANGED => $this->projectDeviceStatus($event),
+            default => throw new InvalidArgumentException("Unsupported RPM projection event [{$event->eventType}]."),
+        };
+    }
+
+    private function projectObservation(CanonicalOperationalEvent $event): void
+    {
+        $payload = $event->payload;
+        $patientRef = (string) ($payload['patient_ref'] ?? '');
+
+        $enrollment = RpmEnrollment::query()
+            ->where('patient_ref', $patientRef)
+            ->where('status', 'active')
+            ->where('is_deleted', false)
+            ->orderByDesc('rpm_enrollment_id')
+            ->first();
+
+        if ($enrollment === null) {
+            throw new InvalidArgumentException("No active RPM enrollment for patient_ref [{$patientRef}].");
+        }
+
+        $device = $this->deviceBySerial($payload['device_serial'] ?? null);
+
+        RpmObservation::updateOrCreate(
+            ['observation_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.rpm.observation.'.$event->idempotencyKey)->toString()],
+            [
+                'rpm_enrollment_id' => $enrollment->rpm_enrollment_id,
+                'rpm_device_id' => $device?->rpm_device_id,
+                'patient_ref' => $patientRef,
+                'loinc_code' => (string) $payload['loinc_code'],
+                'display' => $payload['display'] ?? null,
+                'value' => (float) $payload['value'],
+                'unit' => $payload['unit'] ?? null,
+                'observed_at' => $payload['observed_at'] ?? $event->occurredAt,
+                'received_at' => now(),
+                'source_key' => 'synthetic.rpm',
+                'transmission_id' => $payload['transmission_id'] ?? null,
+                'quality_flag' => (string) ($payload['quality_flag'] ?? 'ok'),
+                'metadata' => ['event_id' => $event->eventId],
+            ]
+        );
+
+        if ($device !== null) {
+            $device->update(['last_transmission_at' => $event->occurredAt]);
+            $device->kit?->update(['last_seen_at' => $event->occurredAt]);
+        }
+    }
+
+    private function projectDeviceStatus(CanonicalOperationalEvent $event): void
+    {
+        $payload = $event->payload;
+        $device = $this->deviceBySerial($payload['device_serial'] ?? null);
+
+        if ($device === null) {
+            throw new InvalidArgumentException('DeviceStatusChanged references an unknown device serial.');
+        }
+
+        $updates = ['last_transmission_at' => $event->occurredAt];
+        if (isset($payload['status']) && $payload['status'] !== null) {
+            $updates['status'] = (string) $payload['status'];
+        }
+        if (array_key_exists('battery_pct', $payload) && $payload['battery_pct'] !== null) {
+            $updates['battery_pct'] = (int) $payload['battery_pct'];
+        }
+
+        $device->update($updates);
+        $device->kit?->update(['last_seen_at' => $event->occurredAt]);
+    }
+
+    private function deviceBySerial(?string $serial): ?RpmDevice
+    {
+        if ($serial === null || trim($serial) === '') {
+            return null;
+        }
+
+        return RpmDevice::query()
+            ->where('serial_number', $serial)
+            ->where('is_deleted', false)
+            ->first();
+    }
+}

--- a/app/Integrations/Healthcare/Services/RpmProjectionHandler.php
+++ b/app/Integrations/Healthcare/Services/RpmProjectionHandler.php
@@ -23,6 +23,7 @@ class RpmProjectionHandler implements ProjectionHandler
 {
     public function __construct(
         private readonly \App\Services\Home\RpmAlertEvaluator $alerts,
+        private readonly \App\Services\Home\RpmFhirObservationRecorder $fhir,
     ) {}
 
     public function key(): string
@@ -91,10 +92,12 @@ class RpmProjectionHandler implements ProjectionHandler
             $device->kit?->update(['last_seen_at' => $event->occurredAt]);
         }
 
-        // Breach evaluation only on first projection — a replay of the same
-        // transmission must not inflate breach counts (idempotent pipeline).
+        // Breach evaluation + FHIR persistence only on first projection — a
+        // replay of the same transmission must not inflate breach counts or
+        // mint duplicate resource versions (idempotent pipeline).
         if ($observation->wasRecentlyCreated) {
             $this->alerts->evaluate($observation, $enrollment);
+            $this->fhir->recordForSourceKey($observation, (string) $observation->source_key);
         }
     }
 

--- a/app/Integrations/Healthcare/Services/RpmProjectionHandler.php
+++ b/app/Integrations/Healthcare/Services/RpmProjectionHandler.php
@@ -21,6 +21,10 @@ use Ramsey\Uuid\Uuid;
  */
 class RpmProjectionHandler implements ProjectionHandler
 {
+    public function __construct(
+        private readonly \App\Services\Home\RpmAlertEvaluator $alerts,
+    ) {}
+
     public function key(): string
     {
         return 'home.rpm';
@@ -63,7 +67,7 @@ class RpmProjectionHandler implements ProjectionHandler
 
         $device = $this->deviceBySerial($payload['device_serial'] ?? null);
 
-        RpmObservation::updateOrCreate(
+        $observation = RpmObservation::updateOrCreate(
             ['observation_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.rpm.observation.'.$event->idempotencyKey)->toString()],
             [
                 'rpm_enrollment_id' => $enrollment->rpm_enrollment_id,
@@ -85,6 +89,12 @@ class RpmProjectionHandler implements ProjectionHandler
         if ($device !== null) {
             $device->update(['last_transmission_at' => $event->occurredAt]);
             $device->kit?->update(['last_seen_at' => $event->occurredAt]);
+        }
+
+        // Breach evaluation only on first projection — a replay of the same
+        // transmission must not inflate breach counts (idempotent pipeline).
+        if ($observation->wasRecentlyCreated) {
+            $this->alerts->evaluate($observation, $enrollment);
         }
     }
 

--- a/app/Models/Home/HomeEpisode.php
+++ b/app/Models/Home/HomeEpisode.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use App\Models\Encounter;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class HomeEpisode extends Model
+{
+    protected $table = 'prod.home_episodes';
+
+    protected $primaryKey = 'home_episode_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'acuity_tier' => 'integer',
+        'target_los_days' => 'float',
+        'expected_discharge_date' => 'immutable_date',
+        'started_at' => 'immutable_datetime',
+        'ended_at' => 'immutable_datetime',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(HomeProgram::class, 'home_program_id', 'home_program_id');
+    }
+
+    public function referral(): BelongsTo
+    {
+        return $this->belongsTo(HomeReferral::class, 'home_referral_id', 'home_referral_id');
+    }
+
+    public function encounter(): BelongsTo
+    {
+        return $this->belongsTo(Encounter::class, 'encounter_id', 'encounter_id');
+    }
+
+    public function enrollments(): HasMany
+    {
+        return $this->hasMany(RpmEnrollment::class, 'home_episode_id', 'home_episode_id');
+    }
+
+    public function visits(): HasMany
+    {
+        return $this->hasMany(HomeVisit::class, 'home_episode_id', 'home_episode_id');
+    }
+
+    public function escalations(): HasMany
+    {
+        return $this->hasMany(HomeEscalation::class, 'home_episode_id', 'home_episode_id');
+    }
+
+    public function transitions(): HasMany
+    {
+        return $this->hasMany(HomeTransition::class, 'home_episode_id', 'home_episode_id');
+    }
+
+    public function alerts(): HasMany
+    {
+        return $this->hasMany(RpmAlert::class, 'home_episode_id', 'home_episode_id');
+    }
+
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('status', 'active')->where('is_deleted', false);
+    }
+}

--- a/app/Models/Home/HomeEscalation.php
+++ b/app/Models/Home/HomeEscalation.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class HomeEscalation extends Model
+{
+    protected $table = 'prod.home_escalations';
+
+    protected $primaryKey = 'home_escalation_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'initiated_at' => 'immutable_datetime',
+        'dispatched_at' => 'immutable_datetime',
+        'arrived_at' => 'immutable_datetime',
+        'resolved_at' => 'immutable_datetime',
+        'response_minutes' => 'integer',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function episode(): BelongsTo
+    {
+        return $this->belongsTo(HomeEpisode::class, 'home_episode_id', 'home_episode_id');
+    }
+
+    public function alert(): BelongsTo
+    {
+        return $this->belongsTo(RpmAlert::class, 'rpm_alert_id', 'rpm_alert_id');
+    }
+
+    public function scopeOpen(Builder $query): Builder
+    {
+        return $query->whereIn('status', ['open', 'responding'])->where('is_deleted', false);
+    }
+}

--- a/app/Models/Home/HomeProgram.php
+++ b/app/Models/Home/HomeProgram.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class HomeProgram extends Model
+{
+    protected $table = 'prod.home_programs';
+
+    protected $primaryKey = 'home_program_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'payer_rules' => JsonObject::class,
+        'conditions' => 'array',
+        'zone_slot_capacity' => JsonObject::class,
+        'slot_capacity' => 'integer',
+        'is_active' => 'boolean',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function referrals(): HasMany
+    {
+        return $this->hasMany(HomeReferral::class, 'home_program_id', 'home_program_id');
+    }
+
+    public function episodes(): HasMany
+    {
+        return $this->hasMany(HomeEpisode::class, 'home_program_id', 'home_program_id');
+    }
+}

--- a/app/Models/Home/HomeReferral.php
+++ b/app/Models/Home/HomeReferral.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use App\Models\Encounter;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class HomeReferral extends Model
+{
+    protected $table = 'prod.home_referrals';
+
+    protected $primaryKey = 'home_referral_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'screening' => JsonObject::class,
+        'referred_at' => 'immutable_datetime',
+        'status_changed_at' => 'immutable_datetime',
+        'activated_at' => 'immutable_datetime',
+        'declined_at' => 'immutable_datetime',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(HomeProgram::class, 'home_program_id', 'home_program_id');
+    }
+
+    public function encounter(): BelongsTo
+    {
+        return $this->belongsTo(Encounter::class, 'encounter_id', 'encounter_id');
+    }
+
+    public function episode(): HasOne
+    {
+        return $this->hasOne(HomeEpisode::class, 'home_referral_id', 'home_referral_id');
+    }
+}

--- a/app/Models/Home/HomeTransition.php
+++ b/app/Models/Home/HomeTransition.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use App\Models\Transport\TransportRequest;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class HomeTransition extends Model
+{
+    protected $table = 'prod.home_transitions';
+
+    protected $primaryKey = 'home_transition_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'checklist' => JsonObject::class,
+        'barriers' => 'array',
+        'started_at' => 'immutable_datetime',
+        'completed_at' => 'immutable_datetime',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function episode(): BelongsTo
+    {
+        return $this->belongsTo(HomeEpisode::class, 'home_episode_id', 'home_episode_id');
+    }
+
+    // regional.facilities has no Eloquent model (services query it raw);
+    // regional_facility_id stays a plain FK attribute.
+    public function transportRequest(): BelongsTo
+    {
+        return $this->belongsTo(TransportRequest::class, 'transport_request_id', 'transport_request_id');
+    }
+}

--- a/app/Models/Home/HomeVisit.php
+++ b/app/Models/Home/HomeVisit.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class HomeVisit extends Model
+{
+    protected $table = 'prod.home_visits';
+
+    protected $primaryKey = 'home_visit_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'is_waiver_required' => 'boolean',
+        'scheduled_start' => 'immutable_datetime',
+        'scheduled_end' => 'immutable_datetime',
+        'started_at' => 'immutable_datetime',
+        'completed_at' => 'immutable_datetime',
+        'on_time' => 'boolean',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function episode(): BelongsTo
+    {
+        return $this->belongsTo(HomeEpisode::class, 'home_episode_id', 'home_episode_id');
+    }
+}

--- a/app/Models/Home/RpmAlert.php
+++ b/app/Models/Home/RpmAlert.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RpmAlert extends Model
+{
+    protected $table = 'prod.rpm_alerts';
+
+    protected $primaryKey = 'rpm_alert_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'opened_at' => 'immutable_datetime',
+        'acknowledged_at' => 'immutable_datetime',
+        'resolved_at' => 'immutable_datetime',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function episode(): BelongsTo
+    {
+        return $this->belongsTo(HomeEpisode::class, 'home_episode_id', 'home_episode_id');
+    }
+
+    public function enrollment(): BelongsTo
+    {
+        return $this->belongsTo(RpmEnrollment::class, 'rpm_enrollment_id', 'rpm_enrollment_id');
+    }
+
+    public function observation(): BelongsTo
+    {
+        return $this->belongsTo(RpmObservation::class, 'rpm_observation_id', 'rpm_observation_id');
+    }
+
+    public function scopeOpen(Builder $query): Builder
+    {
+        return $query->where('status', 'open')->where('is_deleted', false);
+    }
+}

--- a/app/Models/Home/RpmDevice.php
+++ b/app/Models/Home/RpmDevice.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RpmDevice extends Model
+{
+    protected $table = 'prod.rpm_devices';
+
+    protected $primaryKey = 'rpm_device_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'battery_pct' => 'integer',
+        'last_transmission_at' => 'immutable_datetime',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function kit(): BelongsTo
+    {
+        return $this->belongsTo(RpmKit::class, 'rpm_kit_id', 'rpm_kit_id');
+    }
+}

--- a/app/Models/Home/RpmEnrollment.php
+++ b/app/Models/Home/RpmEnrollment.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class RpmEnrollment extends Model
+{
+    protected $table = 'prod.rpm_enrollments';
+
+    protected $primaryKey = 'rpm_enrollment_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'monitoring_plan' => JsonObject::class,
+        'baseline' => JsonObject::class,
+        'started_at' => 'immutable_datetime',
+        'ended_at' => 'immutable_datetime',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function episode(): BelongsTo
+    {
+        return $this->belongsTo(HomeEpisode::class, 'home_episode_id', 'home_episode_id');
+    }
+
+    public function kit(): BelongsTo
+    {
+        return $this->belongsTo(RpmKit::class, 'rpm_kit_id', 'rpm_kit_id');
+    }
+
+    public function observations(): HasMany
+    {
+        return $this->hasMany(RpmObservation::class, 'rpm_enrollment_id', 'rpm_enrollment_id');
+    }
+}

--- a/app/Models/Home/RpmKit.php
+++ b/app/Models/Home/RpmKit.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class RpmKit extends Model
+{
+    protected $table = 'prod.rpm_kits';
+
+    protected $primaryKey = 'rpm_kit_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'battery_pct' => 'integer',
+        'last_seen_at' => 'immutable_datetime',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function devices(): HasMany
+    {
+        return $this->hasMany(RpmDevice::class, 'rpm_kit_id', 'rpm_kit_id');
+    }
+
+    public function enrollments(): HasMany
+    {
+        return $this->hasMany(RpmEnrollment::class, 'rpm_kit_id', 'rpm_kit_id');
+    }
+}

--- a/app/Models/Home/RpmObservation.php
+++ b/app/Models/Home/RpmObservation.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models\Home;
+
+use App\Casts\JsonObject;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class RpmObservation extends Model
+{
+    protected $table = 'prod.rpm_observations';
+
+    protected $primaryKey = 'rpm_observation_id';
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'value' => 'float',
+        'observed_at' => 'immutable_datetime',
+        'received_at' => 'immutable_datetime',
+        'is_breach' => 'boolean',
+        'metadata' => JsonObject::class,
+        'is_deleted' => 'boolean',
+    ];
+
+    public function enrollment(): BelongsTo
+    {
+        return $this->belongsTo(RpmEnrollment::class, 'rpm_enrollment_id', 'rpm_enrollment_id');
+    }
+
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo(RpmDevice::class, 'rpm_device_id', 'rpm_device_id');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -98,6 +98,8 @@ class AppServiceProvider extends ServiceProvider
                 $app->make(\App\Integrations\Healthcare\Services\AncillaryProjectionHandler::class),
                 $app->make(\App\Integrations\Healthcare\Services\AdcStationEventProjectionHandler::class),
                 $app->make(\App\Integrations\Healthcare\Services\RxAdministrationRecordProjectionHandler::class),
+                // Home Hospital RPM feed (ObservationRecorded / DeviceStatusChanged).
+                $app->make(\App\Integrations\Healthcare\Services\RpmProjectionHandler::class),
             ]),
         );
         $this->app->alias(

--- a/app/Rtdc/Events/CanonicalEvent.php
+++ b/app/Rtdc/Events/CanonicalEvent.php
@@ -21,6 +21,24 @@ final readonly class CanonicalEvent
 
     public const ACUITY_CHANGED = 'AcuityChanged';
 
+    // Home Hospital vocabulary (ACUM-PRD-HAH-001 §5.1). Additive; consumed by
+    // the OCEL emission map (Phase 3) and the home workflow services.
+    public const HOME_REFERRAL_CREATED = 'HomeReferralCreated';
+
+    public const HOME_EPISODE_ACTIVATED = 'HomeEpisodeActivated';
+
+    public const RPM_OBSERVATION_BREACHED = 'RpmObservationBreached';
+
+    public const HOME_ESCALATION_OPENED = 'HomeEscalationOpened';
+
+    public const HOME_ESCALATION_RESOLVED = 'HomeEscalationResolved';
+
+    public const HOME_VISIT_COMPLETED = 'HomeVisitCompleted';
+
+    public const HOME_EPISODE_DISCHARGED = 'HomeEpisodeDischarged';
+
+    public const TRANSITION_HANDOFF_COMPLETED = 'TransitionHandoffCompleted';
+
     public function __construct(
         public string $eventId,
         public string $type,

--- a/app/Services/Cockpit/DrillBuilder.php
+++ b/app/Services/Cockpit/DrillBuilder.php
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Log;
  */
 class DrillBuilder
 {
-    public const DOMAINS = ['rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial', 'okr'];
+    public const DOMAINS = ['rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial', 'home', 'okr'];
 
     private const TITLES = [
         'rtdc' => 'Real-Time Demand & Capacity — Unit Capacity Board',
@@ -39,6 +39,7 @@ class DrillBuilder
         'quality' => 'Quality & Safety — HAI / Safety Ledger',
         'service' => 'Service Lines — Throughput',
         'financial' => 'Financial Stewardship',
+        'home' => 'Home Hospital — Virtual Ward',
         'okr' => 'Executive OKR Scorecard',
     ];
 
@@ -113,6 +114,7 @@ class DrillBuilder
                 'periop' => array_values(array_filter([$this->orRoomBoard(), $this->pacuBayBoard()])),
                 'staffing' => [$this->unitCoverage()],
                 'flow' => $this->flowTables($tiles),
+                'home' => $this->homeTables(),
                 'okr' => [$this->okrTable($tiles)],
                 default => [$this->measureLedger($domain, $tiles)],
             };
@@ -631,6 +633,102 @@ class DrillBuilder
             'h', 'hr', 'hrs', 'hour', 'hours' => DurationFormatter::minutes((float) $value * 60),
             default => null,
         };
+    }
+
+    /**
+     * Home Hospital drill (ACUM-PRD-HAH-001 §9): the ward board (episode,
+     * condition, day-of-stay, HEWS band, open alerts, next waiver visit) plus
+     * a referral-funnel snapshot. Pseudonymous refs only — never MRN/address.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function homeTables(): array
+    {
+        $episodes = \App\Models\Home\HomeEpisode::query()
+            ->with(['encounter.bed:bed_id,label'])
+            ->active()
+            ->orderBy('home_episode_id')
+            ->limit(16)
+            ->get();
+
+        $hews = app(\App\Services\Home\HewsService::class);
+        $rows = [];
+
+        foreach ($episodes as $episode) {
+            $score = $hews->computeForEpisode($episode);
+            $openAlerts = $episode->alerts()->whereIn('status', ['open', 'acknowledged'])->where('is_deleted', false)->get();
+            $critOpen = $openAlerts->contains(fn ($a) => $a->severity === 'critical' && $a->status === 'open');
+            $nextVisit = $episode->visits()
+                ->where('status', 'scheduled')
+                ->where('is_deleted', false)
+                ->orderBy('scheduled_start')
+                ->first();
+
+            $day = $episode->started_at !== null ? max(1, (int) $episode->started_at->diffInDays(now()) + 1) : null;
+
+            $rows[] = [
+                'slot' => ['v' => (string) ($episode->encounter?->bed?->label ?? '—'), 'strong' => true],
+                'patient' => ['v' => (string) $episode->patient_ref],
+                'condition' => ['v' => (string) ($episode->condition_label ?? $episode->condition_code), 'dim' => true],
+                'day' => ['v' => $day !== null ? "D{$day}".($episode->target_los_days !== null ? ' of '.rtrim(rtrim(number_format($episode->target_los_days, 1), '0'), '.') : '') : '—'],
+                'hews' => $score === null
+                    ? ['v' => '—', 'dim' => true]
+                    : ['tag' => [
+                        'text' => 'HEWS '.$score['score'],
+                        'status' => match ($score['band']) {
+                            'high' => 'critical',
+                            'medium' => 'warning',
+                            default => 'neutral',
+                        },
+                    ]],
+                'alerts' => $openAlerts->isEmpty()
+                    ? ['v' => '0', 'dim' => true]
+                    : ['tag' => [
+                        'text' => (string) $openAlerts->count(),
+                        // Earned urgency: coral only for an unacked critical.
+                        'status' => $critOpen ? 'critical' : 'warning',
+                    ]],
+                'next_visit' => ['v' => $nextVisit !== null
+                    ? $nextVisit->scheduled_start->diffForHumans(now(), ['short' => true, 'parts' => 1, 'syntax' => \Carbon\CarbonInterface::DIFF_RELATIVE_TO_NOW])
+                    : '—', 'dim' => $nextVisit === null],
+            ];
+        }
+
+        $funnel = \App\Models\Home\HomeReferral::query()
+            ->where('is_deleted', false)
+            ->selectRaw('status, count(*) AS n')
+            ->groupBy('status')
+            ->orderByRaw("array_position(ARRAY['referred','screened','eligible','consented','activated','declined','cancelled'], status)")
+            ->get();
+
+        $funnelRows = $funnel->map(fn ($row): array => [
+            'stage' => ['v' => ucfirst((string) $row->status), 'strong' => true],
+            'count' => (int) $row->n,
+        ])->all();
+
+        return array_values(array_filter([
+            $rows === [] ? null : [
+                'caption' => 'Virtual ward board',
+                'columns' => [
+                    ['key' => 'slot', 'header' => 'Slot', 'align' => 'left'],
+                    ['key' => 'patient', 'header' => 'Patient', 'align' => 'left'],
+                    ['key' => 'condition', 'header' => 'Condition', 'align' => 'left'],
+                    ['key' => 'day', 'header' => 'Day', 'align' => 'left'],
+                    ['key' => 'hews', 'header' => 'HEWS', 'align' => 'left'],
+                    ['key' => 'alerts', 'header' => 'Alerts', 'align' => 'right'],
+                    ['key' => 'next_visit', 'header' => 'Next visit', 'align' => 'right'],
+                ],
+                'rows' => $rows,
+            ],
+            $funnelRows === [] ? null : [
+                'caption' => 'Referral funnel',
+                'columns' => [
+                    ['key' => 'stage', 'header' => 'Stage', 'align' => 'left'],
+                    ['key' => 'count', 'header' => 'Referrals', 'align' => 'right'],
+                ],
+                'rows' => $funnelRows,
+            ],
+        ]));
     }
 
     /** @param list<array<string, mixed>> $tiles

--- a/app/Services/Cockpit/SnapshotBuilder.php
+++ b/app/Services/Cockpit/SnapshotBuilder.php
@@ -6,6 +6,7 @@ use App\Domain\Cockpit\Metrics\BaseMetrics;
 use App\Domain\Cockpit\Metrics\EdMetrics;
 use App\Domain\Cockpit\Metrics\FinancialMetrics;
 use App\Domain\Cockpit\Metrics\FlowMetrics;
+use App\Domain\Cockpit\Metrics\HomeMetrics;
 use App\Domain\Cockpit\Metrics\OkrMetrics;
 use App\Domain\Cockpit\Metrics\PeriopMetrics;
 use App\Domain\Cockpit\Metrics\QualityMetrics;
@@ -68,6 +69,7 @@ class SnapshotBuilder
         'rtdc' => 'rtdc.occupancy',
         'ed' => 'ed.nedocs',
         'periop' => 'periop.prime_util',
+        'home' => 'home.census_occupancy',
     ];
 
     public function __construct(
@@ -268,6 +270,9 @@ class SnapshotBuilder
             app(QualityMetrics::class),
             app(ServiceLineMetrics::class),
             app(FinancialMetrics::class),
+            // Home Hospital (ACUM-PRD-HAH-001): emits nothing while
+            // HOME_HOSPITAL_ENABLED is off — cockpit unchanged without it.
+            app(HomeMetrics::class),
             app(OkrMetrics::class),
         ];
     }

--- a/app/Services/Cockpit/SnapshotBuilder.php
+++ b/app/Services/Cockpit/SnapshotBuilder.php
@@ -206,6 +206,15 @@ class SnapshotBuilder
                 continue;
             }
 
+            // A flag-gated module that is OFF emits zero values and must be
+            // ABSENT from the snapshot (not an empty panel) — deployments
+            // without Home Hospital stay byte-identical. Distinct from a
+            // failing provider: safeMetrics logs those, and always-on domains
+            // always emit at least one tile.
+            if ($values === [] && $provider->domain() === 'home') {
+                continue;
+            }
+
             $domains[$provider->domain()] = $this->domainSection($provider->domain(), $values);
         }
 

--- a/app/Services/Demo/DemoRefreshCoordinator.php
+++ b/app/Services/Demo/DemoRefreshCoordinator.php
@@ -82,6 +82,13 @@ final class DemoRefreshCoordinator
                     '--refresh' => true,
                 ]));
             }
+            // Re-anchor the Home Hospital virtual ward (episodes, visits,
+            // referral funnel) onto the fresh census. Gated on the feature
+            // flag; absent entirely when Home Hospital is off. Idempotent —
+            // the seeder keys every row on natural keys.
+            if (config('home_hospital.enabled')) {
+                $domains[] = $this->step('home_hospital', fn () => Artisan::call('db:seed', ['--class' => 'HomeHospitalDemoSeeder', '--force' => true]));
+            }
             $domains[] = $this->step('ancillary', fn () => $this->ancillary->refresh($clock));
             $domains[] = $this->step('ancillary_ocel', fn () => Artisan::call('ocel:project-ancillary', [
                 '--since' => $clock->windowStart()->toIso8601String(),

--- a/app/Services/Eddy/EddyActionService.php
+++ b/app/Services/Eddy/EddyActionService.php
@@ -52,6 +52,16 @@ class EddyActionService
         // breach) pre-seeds a draft escalation-response proposal. Draft-only,
         // human-approved — escalation authority stays with the clinical team.
         'propose_escalation_response' => ['tier' => 'T3', 'risk' => 'high', 'label' => 'Propose a home-episode escalation response', 'recommendation_type' => 'eddy_home_escalation', 'alert_key' => 'home.'],
+        // Home Hospital Phase 3 (§6.3): the remaining six draft-only actions —
+        // the Post-Acute and Care Transition Agent's catalog. alert_key null on
+        // all six so actionForAlert() keeps routing crit home.* alerts to
+        // propose_escalation_response; these are composer/copilot-invoked.
+        'propose_hah_enrollment' => ['tier' => 'T2', 'risk' => 'medium', 'label' => 'Propose Hospital-at-Home enrollment for a home-eligible patient', 'recommendation_type' => 'eddy_hah_enrollment', 'alert_key' => null],
+        'propose_stepdown_cohort' => ['tier' => 'T2', 'risk' => 'medium', 'label' => 'Propose a step-down decant cohort', 'recommendation_type' => 'eddy_stepdown_cohort', 'alert_key' => null],
+        'propose_visit_reschedule' => ['tier' => 'T1', 'risk' => 'low', 'label' => 'Propose a home-visit reschedule', 'recommendation_type' => 'eddy_visit_reschedule', 'alert_key' => null],
+        'flag_rpm_gap' => ['tier' => 'T1', 'risk' => 'low', 'label' => 'Flag an RPM monitoring gap', 'recommendation_type' => 'eddy_rpm_gap', 'alert_key' => null],
+        'propose_home_discharge' => ['tier' => 'T2', 'risk' => 'medium', 'label' => 'Propose a home-episode discharge', 'recommendation_type' => 'eddy_home_discharge', 'alert_key' => null],
+        'flag_transition_barrier' => ['tier' => 'T1', 'risk' => 'low', 'label' => 'Flag a transition-of-care barrier', 'recommendation_type' => 'eddy_transition_barrier', 'alert_key' => null],
     ];
 
     /**

--- a/app/Services/Eddy/EddyActionService.php
+++ b/app/Services/Eddy/EddyActionService.php
@@ -47,6 +47,11 @@ class EddyActionService
         // invoked only) — X3's alert→action routing is unchanged, purely additive.
         'propose_pdsa_cycle' => ['tier' => 'T2', 'risk' => 'medium', 'label' => 'Draft a PDSA improvement cycle', 'recommendation_type' => 'eddy_pdsa_cycle', 'alert_key' => null],
         'propose_pathway_correction' => ['tier' => 'T2', 'risk' => 'medium', 'label' => 'Draft a care-pathway correction', 'recommendation_type' => 'eddy_pathway_correction', 'alert_key' => null],
+        // Home Hospital (ACUM-PRD-HAH-001 §6.3, Phase 1): a crit home.* cockpit
+        // alert (unacked critical vitals, blown response p90, waiver-visit
+        // breach) pre-seeds a draft escalation-response proposal. Draft-only,
+        // human-approved — escalation authority stays with the clinical team.
+        'propose_escalation_response' => ['tier' => 'T3', 'risk' => 'high', 'label' => 'Propose a home-episode escalation response', 'recommendation_type' => 'eddy_home_escalation', 'alert_key' => 'home.'],
     ];
 
     /**

--- a/app/Services/Flow/ForwardProjectionService.php
+++ b/app/Services/Flow/ForwardProjectionService.php
@@ -109,8 +109,50 @@ class ForwardProjectionService
             ->concat($this->evsDue($from, $to))
             ->concat($this->staffingShiftGaps($from, $to))
             ->concat($this->surgeProbability($from))
+            ->concat($this->homeFreeSlots($from, $to))
             ->values()
             ->all();
+    }
+
+    // -------------------------------------------------------------------
+    // home_slot_free — Home Hospital decant capacity (ACUM-PRD-HAH-001 §6.2).
+    // One item per expected home discharge inside the window: the virtual-
+    // ward slot that frees when the episode ends. probable (an EDD, not an
+    // order); absent entirely when the module flag is off.
+    // -------------------------------------------------------------------
+
+    /** @return Collection<int, array<string, mixed>> */
+    private function homeFreeSlots(CarbonImmutable $from, CarbonImmutable $to): Collection
+    {
+        if (! (bool) config('home_hospital.enabled')) {
+            return collect();
+        }
+
+        $rows = DB::select("
+            SELECT e.patient_ref, e.expected_discharge_date, enc.unit_id, enc.bed_id, b.label
+            FROM prod.home_episodes e
+            JOIN prod.home_programs p ON p.home_program_id = e.home_program_id
+            LEFT JOIN prod.encounters enc ON enc.encounter_id = e.encounter_id
+            LEFT JOIN prod.beds b ON b.bed_id = enc.bed_id
+            WHERE e.is_deleted = false AND e.status = 'active'
+              AND p.program_type = 'ahcah_acute'
+              AND e.expected_discharge_date IS NOT NULL
+              AND e.expected_discharge_date >= ?::date AND e.expected_discharge_date <= ?::date
+            ORDER BY e.expected_discharge_date
+        ", [$from->toDateString(), $to->toDateString()]);
+
+        return collect($rows)->map(fn (object $row, int $index): array => $this->item(
+            t: $this->dischargeBellTime((string) $row->expected_discharge_date, 'probable', $index),
+            kind: 'home_slot_free',
+            confidence: 'probable',
+            unitId: $row->unit_id !== null ? (int) $row->unit_id : null,
+            entity: ['type' => 'home_slot', 'label' => (string) ($row->label ?? 'HOME slot')],
+            patientRef: (string) $row->patient_ref,
+            bedId: $row->bed_id !== null ? (int) $row->bed_id : null,
+            label: 'Home slot frees — '.($row->label ?? 'virtual ward'),
+            service: 'home_hospital.expected_discharge',
+            reliability: null,
+        ));
     }
 
     // -------------------------------------------------------------------

--- a/app/Services/Home/HewsService.php
+++ b/app/Services/Home/HewsService.php
@@ -1,0 +1,254 @@
+<?php
+
+namespace App\Services\Home;
+
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\RpmEnrollment;
+use App\Models\Home\RpmObservation;
+use Illuminate\Support\Collection;
+
+/**
+ * Home Early Warning Score — deterministic modified NEWS2 (strategy §6.1).
+ *
+ * OPERATIONAL TRIAGE, NOT DIAGNOSIS. Transparent components, no ML:
+ *   1. NEWS2-style absolute banding per vital (RR, SpO2, SBP, HR, temp —
+ *      consciousness and supplemental-O2 are not RPM-observable and are
+ *      deliberately omitted; documented, not silently faked).
+ *   2. Baseline deviation vs the enrollment's first-24h calibration
+ *      (rpm_enrollments.baseline), so a chronically fast heart doesn't
+ *      page every hour — and a quiet drift off a personal baseline does.
+ *   3. Trend: a worsening slope over the trend window adds points.
+ *   4. Monitoring adherence: silence is a signal — missing expected
+ *      readings adds a point.
+ *
+ * Bands live in config('home_hospital.hews'); the score drives command-grid
+ * sort order and visit intensity. Escalation authority stays human.
+ */
+class HewsService
+{
+    private const LOINC_RR = '9279-1';
+
+    private const LOINC_SPO2 = '59408-5';
+
+    private const LOINC_SBP = '8480-6';
+
+    private const LOINC_HR = '8867-4';
+
+    private const LOINC_TEMP = '8310-5';
+
+    /**
+     * @return array{score:int,band:string,components:array<string,int>,vitals:array<string,float|null>,computed_at:string}|null
+     *         null when no scoreable observations exist in the lookback window.
+     */
+    public function computeForEpisode(HomeEpisode $episode): ?array
+    {
+        $enrollment = $episode->enrollments()
+            ->where('status', 'active')
+            ->orderByDesc('rpm_enrollment_id')
+            ->first();
+
+        if ($enrollment === null) {
+            return null;
+        }
+
+        $lookback = now()->subHours((int) config('home_hospital.hews.lookback_hours', 12));
+
+        $observations = RpmObservation::query()
+            ->where('rpm_enrollment_id', $enrollment->rpm_enrollment_id)
+            ->where('is_deleted', false)
+            ->where('quality_flag', 'ok')
+            ->where('observed_at', '>=', $lookback)
+            ->orderBy('observed_at')
+            ->get()
+            ->groupBy('loinc_code');
+
+        if ($observations->isEmpty()) {
+            return null;
+        }
+
+        $latest = fn (string $loinc): ?float => optional($observations->get($loinc)?->last())->value;
+
+        $vitals = [
+            self::LOINC_RR => $latest(self::LOINC_RR),
+            self::LOINC_SPO2 => $latest(self::LOINC_SPO2),
+            self::LOINC_SBP => $latest(self::LOINC_SBP),
+            self::LOINC_HR => $latest(self::LOINC_HR),
+            self::LOINC_TEMP => $latest(self::LOINC_TEMP),
+        ];
+
+        $components = [
+            'news2' => $this->news2Points($vitals),
+            'baseline_deviation' => $this->baselineDeviationPoints($enrollment, $vitals),
+            'trend' => $this->trendPoints($observations),
+            'adherence' => $this->adherencePoints($enrollment, $observations),
+        ];
+
+        $score = (int) array_sum($components);
+
+        return [
+            'score' => $score,
+            'band' => $this->band($score),
+            'components' => $components,
+            'vitals' => $vitals,
+            'computed_at' => now()->toIso8601String(),
+        ];
+    }
+
+    /** NEWS2 absolute banding (0–3 points per parameter, RPM-observable set). */
+    private function news2Points(array $vitals): int
+    {
+        $points = 0;
+
+        $rr = $vitals[self::LOINC_RR];
+        if ($rr !== null) {
+            $points += match (true) {
+                $rr <= 8 => 3,
+                $rr <= 11 => 1,
+                $rr <= 20 => 0,
+                $rr <= 24 => 2,
+                default => 3,
+            };
+        }
+
+        $spo2 = $vitals[self::LOINC_SPO2];
+        if ($spo2 !== null) {
+            $points += match (true) {
+                $spo2 <= 91 => 3,
+                $spo2 <= 93 => 2,
+                $spo2 <= 95 => 1,
+                default => 0,
+            };
+        }
+
+        $sbp = $vitals[self::LOINC_SBP];
+        if ($sbp !== null) {
+            $points += match (true) {
+                $sbp <= 90 => 3,
+                $sbp <= 100 => 2,
+                $sbp <= 110 => 1,
+                $sbp <= 219 => 0,
+                default => 3,
+            };
+        }
+
+        $hr = $vitals[self::LOINC_HR];
+        if ($hr !== null) {
+            $points += match (true) {
+                $hr <= 40 => 3,
+                $hr <= 50 => 1,
+                $hr <= 90 => 0,
+                $hr <= 110 => 1,
+                $hr <= 130 => 2,
+                default => 3,
+            };
+        }
+
+        $temp = $vitals[self::LOINC_TEMP];
+        if ($temp !== null) {
+            $points += match (true) {
+                $temp <= 35.0 => 3,
+                $temp <= 36.0 => 1,
+                $temp <= 38.0 => 0,
+                $temp <= 39.0 => 1,
+                default => 2,
+            };
+        }
+
+        return $points;
+    }
+
+    /**
+     * +1 per vital drifted >15% off the personal baseline mean, capped at +2.
+     * No baseline calibrated (first 24h still running) → contributes 0.
+     */
+    private function baselineDeviationPoints(RpmEnrollment $enrollment, array $vitals): int
+    {
+        $baseline = (array) ($enrollment->baseline['means'] ?? []);
+        if ($baseline === []) {
+            return 0;
+        }
+
+        $drifted = 0;
+        foreach ($vitals as $loinc => $value) {
+            $mean = $baseline[$loinc] ?? null;
+            if ($value === null || $mean === null || (float) $mean == 0.0) {
+                continue;
+            }
+            if (abs($value - (float) $mean) / (float) $mean > 0.15) {
+                $drifted++;
+            }
+        }
+
+        return min(2, $drifted);
+    }
+
+    /**
+     * Worsening short-window trend: SpO2 falling ≥3 points absolute or heart
+     * rate rising ≥15% across the trend window each add +1 (cap +2).
+     * First-vs-last inside the window — transparent, not a regression fit.
+     */
+    private function trendPoints(Collection $observations): int
+    {
+        $windowStart = now()->subHours((int) config('home_hospital.hews.trend_window_hours', 6));
+        $points = 0;
+
+        $spo2 = $observations->get(self::LOINC_SPO2)?->filter(
+            fn (RpmObservation $o): bool => $o->observed_at >= $windowStart
+        )->values();
+        if ($spo2 !== null && $spo2->count() >= 2 && ($spo2->first()->value - $spo2->last()->value) >= 3.0) {
+            $points++;
+        }
+
+        $hr = $observations->get(self::LOINC_HR)?->filter(
+            fn (RpmObservation $o): bool => $o->observed_at >= $windowStart
+        )->values();
+        if ($hr !== null && $hr->count() >= 2 && $hr->first()->value > 0
+            && (($hr->last()->value - $hr->first()->value) / $hr->first()->value) >= 0.15) {
+            $points++;
+        }
+
+        return $points;
+    }
+
+    /**
+     * +1 when fewer than half the expected readings arrived in the adherence
+     * window (per the enrollment's monitoring-plan cadence). Silence is a
+     * signal in a home ward — a dark kit is not a stable patient.
+     */
+    private function adherencePoints(RpmEnrollment $enrollment, Collection $observations): int
+    {
+        $cadence = (array) ($enrollment->monitoring_plan['cadence_minutes'] ?? []);
+        if ($cadence === []) {
+            return 0;
+        }
+
+        $windowHours = (int) config('home_hospital.hews.adherence_window_hours', 6);
+        $windowStart = now()->subHours($windowHours);
+
+        $expected = 0;
+        $received = 0;
+        foreach ($cadence as $loinc => $minutes) {
+            $minutes = (int) $minutes;
+            if ($minutes <= 0) {
+                continue;
+            }
+            $expected += (int) floor(($windowHours * 60) / $minutes);
+            $received += $observations->get((string) $loinc)?->filter(
+                fn (RpmObservation $o): bool => $o->observed_at >= $windowStart
+            )->count() ?? 0;
+        }
+
+        return ($expected > 0 && $received < $expected / 2) ? 1 : 0;
+    }
+
+    private function band(int $score): string
+    {
+        $bands = (array) config('home_hospital.hews.bands', ['low' => 0, 'medium' => 5, 'high' => 7]);
+
+        return match (true) {
+            $score >= (int) ($bands['high'] ?? 7) => 'high',
+            $score >= (int) ($bands['medium'] ?? 5) => 'medium',
+            default => 'low',
+        };
+    }
+}

--- a/app/Services/Home/HewsService.php
+++ b/app/Services/Home/HewsService.php
@@ -38,7 +38,7 @@ class HewsService
 
     /**
      * @return array{score:int,band:string,components:array<string,int>,vitals:array<string,float|null>,computed_at:string}|null
-     *         null when no scoreable observations exist in the lookback window.
+     *                                                                                                                           null when no scoreable observations exist in the lookback window.
      */
     public function computeForEpisode(HomeEpisode $episode): ?array
     {

--- a/app/Services/Home/HomeCapacityService.php
+++ b/app/Services/Home/HomeCapacityService.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Services\Home;
+
+use App\Models\Bed;
+use App\Models\Home\HomeEpisode;
+use App\Models\RtdcPrediction;
+use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * The decant valve, quantified (ACUM-PRD-HAH-001 §6.2): how many current ED
+ * and inpatient patients are home-eligible, how many home slots are free now
+ * and projected at 24/48h, and the avoided-bed-day ledger — the one-sentence
+ * story no HaH vendor can tell ("14 boarders, 9 home-eligible, 6 slots free
+ * tonight").
+ *
+ * writePredictions() lands the home slot forecast in prod.rtdc_predictions
+ * alongside physical capacity (same unit/service_date/horizon upsert as
+ * RtdcService), so the bed-meeting machinery sees the virtual ward without
+ * modification.
+ */
+class HomeCapacityService
+{
+    public function __construct(private readonly HomeReferralService $referrals) {}
+
+    /** @return array<string, mixed> */
+    public function decant(): array
+    {
+        $ward = Unit::query()->where('type', 'virtual_home')->where('is_deleted', false)->orderBy('unit_id')->first();
+
+        if ($ward === null) {
+            return [
+                'available' => false, 'freeSlotsNow' => 0, 'freeSlots24h' => 0, 'freeSlots48h' => 0,
+                'edEligibleNow' => 0, 'stepDownEligibleNow' => 0, 'activeEpisodes' => 0, 'avoidedBedDaysMtd' => 0.0,
+            ];
+        }
+
+        $freeNow = Bed::query()
+            ->where('unit_id', $ward->unit_id)
+            ->where('status', 'available')
+            ->where('is_deleted', false)
+            ->count();
+
+        $acute = HomeEpisode::query()
+            ->active()
+            ->whereHas('program', fn ($q) => $q->where('program_type', 'ahcah_acute'));
+
+        $discharging24h = (clone $acute)->where('expected_discharge_date', '<=', now()->addDay()->toDateString())->count();
+        $discharging48h = (clone $acute)->where('expected_discharge_date', '<=', now()->addDays(2)->toDateString())->count();
+
+        return [
+            'available' => true,
+            'freeSlotsNow' => $freeNow,
+            'freeSlots24h' => $freeNow + $discharging24h,
+            'freeSlots48h' => $freeNow + $discharging48h,
+            'edEligibleNow' => count($this->referrals->edCandidates()),
+            'stepDownEligibleNow' => count($this->referrals->stepDownCandidates()),
+            'activeEpisodes' => (clone $acute)->count(),
+            'avoidedBedDaysMtd' => $this->avoidedBedDaysMtd(),
+        ];
+    }
+
+    /** Upsert the home forecast alongside physical capacity (deterministic, idempotent). */
+    public function writePredictions(): void
+    {
+        $ward = Unit::query()->where('type', 'virtual_home')->where('is_deleted', false)->orderBy('unit_id')->first();
+        if ($ward === null) {
+            return;
+        }
+
+        $decant = $this->decant();
+        $today = now()->toDateString();
+
+        foreach (['by_2pm' => 'freeSlots24h', 'by_midnight' => 'freeSlots48h'] as $horizon => $key) {
+            RtdcPrediction::updateOrCreate(
+                ['unit_id' => $ward->unit_id, 'service_date' => $today, 'horizon' => $horizon],
+                [
+                    'discharges_probable' => max(0, $decant[$key] - $decant['freeSlotsNow']),
+                    'discharges_weighted' => max(0, $decant[$key] - $decant['freeSlotsNow']),
+                    'demand_ed' => $decant['edEligibleNow'],
+                    'demand_transfer' => $decant['stepDownEligibleNow'],
+                    'demand_expected' => $decant['edEligibleNow'] + $decant['stepDownEligibleNow'],
+                    'capacity_now' => $decant['freeSlotsNow'],
+                    // Negative bed_need = free decant capacity offered to the house.
+                    'bed_need' => ($decant['edEligibleNow'] + $decant['stepDownEligibleNow']) - $decant[$key],
+                ],
+            );
+        }
+    }
+
+    private function avoidedBedDaysMtd(): float
+    {
+        $row = DB::selectOne("
+            SELECT COALESCE(SUM(
+                EXTRACT(EPOCH FROM (LEAST(COALESCE(e.ended_at, now()), now()) - GREATEST(e.started_at, date_trunc('month', now())))) / 86400.0
+            ), 0) AS days
+            FROM prod.home_episodes e
+            JOIN prod.home_programs p ON p.home_program_id = e.home_program_id
+            WHERE e.is_deleted = false AND e.started_at IS NOT NULL AND e.started_at <= now()
+              AND COALESCE(e.ended_at, now()) >= date_trunc('month', now())
+              AND p.program_type = 'ahcah_acute'
+        ");
+
+        return round((float) ($row->days ?? 0), 1);
+    }
+}

--- a/app/Services/Home/HomeCensusService.php
+++ b/app/Services/Home/HomeCensusService.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Services\Home;
+
+use App\Models\Bed;
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeReferral;
+use App\Models\Unit;
+use Illuminate\Support\Collection;
+
+/**
+ * Builds the Virtual Bed Board (/home/census) payload — Phase 0 flagship
+ * (build brief §8.2). The virtual ward is a prod.units row, so occupancy
+ * comes off the same census spine as the house-wide boards.
+ *
+ * Slot-state vocabulary: prod.beds.status is CHECK-constrained to
+ * available|occupied|blocked|dirty; on the virtual ward "dirty" means
+ * pending kit setup, so it is translated to `pending_setup` at this
+ * boundary rather than widening the CHECK (build brief §6.1 ⚠).
+ *
+ * PHI posture: the payload carries pseudonymous patient_ref and service
+ * zones only — never MRNs or street addresses.
+ */
+class HomeCensusService
+{
+    /** @return array<string, mixed> */
+    public function build(): array
+    {
+        $unit = Unit::where('type', 'virtual_home')
+            ->where('is_deleted', false)
+            ->orderBy('unit_id')
+            ->first();
+
+        if ($unit === null) {
+            return [
+                'unit' => null,
+                'slots' => [],
+                'occupancy' => ['occupied' => 0, 'capacity' => 0, 'pct' => null],
+                'pipeline' => ['counts' => (object) [], 'declines' => (object) []],
+                'projectedDischarges' => ['next24h' => 0, 'next48h' => 0],
+            ];
+        }
+
+        $episodes = HomeEpisode::query()
+            ->with([
+                'program:home_program_id,code,name',
+                'encounter:encounter_id,bed_id',
+            ])
+            ->active()
+            ->get();
+
+        $episodesByBed = $episodes
+            ->filter(fn (HomeEpisode $e): bool => $e->encounter?->bed_id !== null)
+            ->keyBy(fn (HomeEpisode $e) => $e->encounter->bed_id);
+
+        $slots = Bed::where('unit_id', $unit->unit_id)
+            ->where('is_deleted', false)
+            ->orderBy('label')
+            ->get()
+            ->map(fn (Bed $bed): array => $this->slot($bed, $episodesByBed));
+
+        $occupied = $slots->where('status', 'occupied')->count();
+        $capacity = $slots->count();
+
+        return [
+            'unit' => [
+                'name' => $unit->name,
+                'abbreviation' => $unit->abbreviation,
+                'slotCount' => $capacity,
+            ],
+            'slots' => $slots->values()->all(),
+            'occupancy' => [
+                'occupied' => $occupied,
+                'capacity' => $capacity,
+                'pct' => $capacity > 0 ? round(100 * $occupied / $capacity, 1) : null,
+            ],
+            'pipeline' => $this->pipeline(),
+            'projectedDischarges' => $this->projectedDischarges($episodes),
+        ];
+    }
+
+    /**
+     * @param  Collection<int, HomeEpisode>  $episodesByBed
+     * @return array<string, mixed>
+     */
+    private function slot(Bed $bed, Collection $episodesByBed): array
+    {
+        $status = $bed->status === 'dirty' ? 'pending_setup' : $bed->status;
+        $episode = $episodesByBed->get($bed->bed_id);
+
+        $payload = null;
+        if ($status === 'occupied' && $episode !== null) {
+            $dayOfStay = $episode->started_at !== null
+                ? max(1, (int) $episode->started_at->diffInDays(now()) + 1)
+                : null;
+
+            $payload = [
+                'patientRef' => $episode->patient_ref,
+                'program' => $episode->program?->code,
+                'conditionLabel' => $episode->condition_label ?? $episode->condition_code,
+                'acuityTier' => $episode->acuity_tier,
+                'serviceZone' => $episode->service_zone,
+                'dayOfStay' => $dayOfStay,
+                'targetLosDays' => $episode->target_los_days,
+                'expectedDischargeDate' => $episode->expected_discharge_date?->toDateString(),
+                'provenance' => data_get($episode->metadata, 'provenance'),
+            ];
+        }
+
+        return [
+            'bedId' => $bed->bed_id,
+            'label' => $bed->label,
+            'status' => $status,
+            'episode' => $payload,
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function pipeline(): array
+    {
+        $counts = HomeReferral::where('is_deleted', false)
+            ->selectRaw('status, count(*) AS n')
+            ->groupBy('status')
+            ->pluck('n', 'status');
+
+        $declines = HomeReferral::where('is_deleted', false)
+            ->where('status', 'declined')
+            ->whereNotNull('decline_reason')
+            ->selectRaw('decline_reason, count(*) AS n')
+            ->groupBy('decline_reason')
+            ->pluck('n', 'decline_reason');
+
+        return [
+            'counts' => $counts->isEmpty() ? (object) [] : $counts,
+            'declines' => $declines->isEmpty() ? (object) [] : $declines,
+        ];
+    }
+
+    /**
+     * @param  Collection<int, HomeEpisode>  $episodes
+     * @return array{next24h: int, next48h: int}
+     */
+    private function projectedDischarges(Collection $episodes): array
+    {
+        $dates = $episodes->pluck('expected_discharge_date')->filter();
+
+        return [
+            'next24h' => $dates->filter(fn ($d) => $d->lte(now()->addDay()))->count(),
+            'next48h' => $dates->filter(fn ($d) => $d->lte(now()->addDays(2)))->count(),
+        ];
+    }
+}

--- a/app/Services/Home/HomeCommandService.php
+++ b/app/Services/Home/HomeCommandService.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Services\Home;
+
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\RpmAlert;
+use App\Models\Home\RpmObservation;
+use App\Models\Unit;
+use Illuminate\Support\Collection;
+
+/**
+ * Virtual Ward Command (/home/command) — the Phase 1 flagship surface
+ * (ACUM-PRD-HAH-001 §4.2). One payload per episode tile: pseudonymous
+ * identity, condition + program, day-of-stay vs expected LOS, vitals
+ * sparklines, HEWS chip, open alerts, next required visit, device status.
+ *
+ * Earned urgency: `breach` is true ONLY for an unacknowledged critical vital
+ * — the single condition that turns a tile coral in Phase 1. Sort order is
+ * the escalation-risk order (breach first, then HEWS, then acuity) so the
+ * sickest tile is always top-left.
+ */
+class HomeCommandService
+{
+    private const SPARKLINE_LOINCS = ['59408-5', '8867-4']; // SpO2, HR
+
+    private const SPARKLINE_POINTS = 12;
+
+    public function __construct(private readonly HewsService $hews) {}
+
+    /** @return array<string, mixed> */
+    public function build(): array
+    {
+        $ward = Unit::where('type', 'virtual_home')->where('is_deleted', false)->orderBy('unit_id')->first();
+
+        $episodes = HomeEpisode::query()
+            ->with([
+                'program:home_program_id,code,name',
+                'encounter.bed:bed_id,label',
+                'enrollments' => fn ($q) => $q->where('status', 'active')->with('kit:rpm_kit_id,kit_code,connectivity,battery_pct,last_seen_at'),
+            ])
+            ->active()
+            ->get();
+
+        $enrollmentIds = $episodes->flatMap(fn (HomeEpisode $e) => $e->enrollments->pluck('rpm_enrollment_id'))->all();
+
+        $seriesByEnrollment = $this->vitalSeries($enrollmentIds);
+
+        $alertsByEpisode = RpmAlert::query()
+            ->whereIn('home_episode_id', $episodes->pluck('home_episode_id'))
+            ->whereIn('status', ['open', 'acknowledged'])
+            ->where('is_deleted', false)
+            ->orderByRaw("CASE severity WHEN 'critical' THEN 0 WHEN 'warning' THEN 1 ELSE 2 END")
+            ->orderByDesc('opened_at')
+            ->get()
+            ->groupBy('home_episode_id');
+
+        $tiles = $episodes->map(fn (HomeEpisode $episode): array => $this->tile($episode, $seriesByEnrollment, $alertsByEpisode))
+            ->sortBy([
+                ['breach', 'desc'],
+                ['hewsScore', 'desc'],
+                ['acuityTier', 'asc'],
+            ])
+            ->values();
+
+        return [
+            'ward' => $ward === null ? null : ['name' => $ward->name, 'abbreviation' => $ward->abbreviation],
+            'episodes' => $tiles->map(fn (array $t): array => collect($t)->except('hewsScore')->all())->all(),
+            'summary' => [
+                'active' => $tiles->count(),
+                'breaches' => $tiles->where('breach', true)->count(),
+                'highRisk' => $tiles->where('hews.band', 'high')->count(),
+                'openAlerts' => $alertsByEpisode->flatten()->count(),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<int, array<string, array<string, mixed>>>  $seriesByEnrollment
+     * @param  Collection<int|string, Collection<int, RpmAlert>>  $alertsByEpisode
+     * @return array<string, mixed>
+     */
+    private function tile(HomeEpisode $episode, array $seriesByEnrollment, Collection $alertsByEpisode): array
+    {
+        $enrollment = $episode->enrollments->first();
+        $kit = $enrollment?->kit;
+        $hews = $this->hews->computeForEpisode($episode);
+        $alerts = $alertsByEpisode->get($episode->home_episode_id, collect());
+
+        $breach = $alerts->contains(
+            fn (RpmAlert $a): bool => $a->severity === 'critical' && $a->status === 'open'
+        );
+
+        $nextVisit = $episode->visits()
+            ->where('status', 'scheduled')
+            ->where('is_deleted', false)
+            ->orderBy('scheduled_start')
+            ->first();
+
+        $online = $kit?->last_seen_at !== null && $kit->last_seen_at->gt(now()->subMinutes(60));
+
+        return [
+            'episodeUuid' => $episode->episode_uuid,
+            'patientRef' => $episode->patient_ref,
+            'slotLabel' => $episode->encounter?->bed?->label,
+            'program' => $episode->program?->code,
+            'conditionLabel' => $episode->condition_label ?? $episode->condition_code,
+            'acuityTier' => $episode->acuity_tier,
+            'serviceZone' => $episode->service_zone,
+            'dayOfStay' => $episode->started_at !== null ? max(1, (int) $episode->started_at->diffInDays(now()) + 1) : null,
+            'targetLosDays' => $episode->target_los_days,
+            'expectedDischargeDate' => $episode->expected_discharge_date?->toDateString(),
+            'hews' => $hews === null ? null : [
+                'score' => $hews['score'],
+                'band' => $hews['band'],
+                'components' => $hews['components'],
+            ],
+            'hewsScore' => $hews['score'] ?? -1,
+            'vitals' => $enrollment === null ? [] : array_values($seriesByEnrollment[$enrollment->rpm_enrollment_id] ?? []),
+            'alerts' => [
+                'open' => $alerts->where('status', 'open')->count(),
+                'acknowledged' => $alerts->where('status', 'acknowledged')->count(),
+                'critical' => $alerts->where('severity', 'critical')->count(),
+                'items' => $alerts->take(3)->map(fn (RpmAlert $a): array => [
+                    'alertUuid' => $a->alert_uuid,
+                    'ruleKey' => $a->rule_key,
+                    'severity' => $a->severity,
+                    'status' => $a->status,
+                    'display' => $a->metadata['display'] ?? null,
+                    'value' => $a->metadata['last_value'] ?? $a->metadata['value'] ?? null,
+                    'unit' => $a->metadata['unit'] ?? null,
+                    'openedAt' => $a->opened_at?->toIso8601String(),
+                ])->values()->all(),
+            ],
+            'nextVisit' => $nextVisit === null ? null : [
+                'type' => $nextVisit->visit_type,
+                'scheduledStart' => $nextVisit->scheduled_start?->toIso8601String(),
+                'isWaiverRequired' => (bool) $nextVisit->is_waiver_required,
+            ],
+            'device' => $kit === null ? null : [
+                'kitCode' => $kit->kit_code,
+                'connectivity' => $kit->connectivity,
+                'batteryPct' => $kit->battery_pct,
+                'lastSeenAt' => $kit->last_seen_at?->toIso8601String(),
+                'online' => $online,
+            ],
+            'breach' => $breach,
+            'provenance' => data_get($episode->metadata, 'provenance'),
+        ];
+    }
+
+    /**
+     * Batched sparkline series: last N observations per (enrollment, vital)
+     * for the two headline vitals, chronological.
+     *
+     * @param  list<int>  $enrollmentIds
+     * @return array<int, array<string, array<string, mixed>>>
+     */
+    private function vitalSeries(array $enrollmentIds): array
+    {
+        if ($enrollmentIds === []) {
+            return [];
+        }
+
+        $rows = RpmObservation::query()
+            ->whereIn('rpm_enrollment_id', $enrollmentIds)
+            ->whereIn('loinc_code', self::SPARKLINE_LOINCS)
+            ->where('is_deleted', false)
+            ->where('observed_at', '>=', now()->subHours(24))
+            ->orderByDesc('observed_at')
+            ->limit(count($enrollmentIds) * count(self::SPARKLINE_LOINCS) * self::SPARKLINE_POINTS)
+            ->get(['rpm_enrollment_id', 'loinc_code', 'display', 'unit', 'value', 'observed_at']);
+
+        $series = [];
+        foreach ($rows->groupBy('rpm_enrollment_id') as $enrollmentId => $group) {
+            foreach ($group->groupBy('loinc_code') as $loinc => $observations) {
+                $window = $observations->take(self::SPARKLINE_POINTS)->reverse()->values();
+                $latest = $observations->first();
+                $series[$enrollmentId][$loinc] = [
+                    'loinc' => $loinc,
+                    'display' => $latest->display ?? $loinc,
+                    'unit' => $latest->unit,
+                    'latest' => (float) $latest->value,
+                    'series' => $window->pluck('value')->map(fn ($v): float => (float) $v)->all(),
+                ];
+            }
+        }
+
+        return $series;
+    }
+}

--- a/app/Services/Home/HomeEscalationService.php
+++ b/app/Services/Home/HomeEscalationService.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Services\Home;
+
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeEscalation;
+use App\Models\Home\RpmAlert;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Escalation lifecycle with the full response timing chain
+ * (initiated → dispatched → arrived → resolved) — the telemetry behind the
+ * 30-minute waiver floor (ACUM-PRD-HAH-001 §4.2, §8). response_minutes is
+ * stamped at arrival (initiated→arrived), the number the p90 tile reads.
+ *
+ * closeForEdReturn() is the ADT loop-closer (§5.2): when an escalated home
+ * patient is admitted/registered via the HL7 pipeline, the open escalation
+ * resolves with an ed_return outcome — no manual bookkeeping.
+ */
+class HomeEscalationService
+{
+    public function open(
+        HomeEpisode $episode,
+        string $triggerType,
+        ?RpmAlert $alert = null,
+        ?string $responseMode = null,
+    ): HomeEscalation {
+        // One open escalation per episode: a second trigger while responding
+        // joins the existing chain rather than forking a parallel clock.
+        $existing = HomeEscalation::query()
+            ->where('home_episode_id', $episode->home_episode_id)
+            ->whereIn('status', ['open', 'responding'])
+            ->where('is_deleted', false)
+            ->first();
+
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        return HomeEscalation::create([
+            'escalation_uuid' => Uuid::uuid4()->toString(),
+            'home_episode_id' => $episode->home_episode_id,
+            'rpm_alert_id' => $alert?->rpm_alert_id,
+            'patient_ref' => $episode->patient_ref,
+            'trigger_type' => $triggerType,
+            'response_mode' => $responseMode,
+            'status' => 'open',
+            'initiated_at' => now(),
+            'metadata' => $alert === null ? [] : ['rule_key' => $alert->rule_key, 'severity' => $alert->severity],
+        ]);
+    }
+
+    public function markDispatched(HomeEscalation $escalation, string $responseMode): HomeEscalation
+    {
+        $escalation->update([
+            'status' => 'responding',
+            'response_mode' => $responseMode,
+            'dispatched_at' => $escalation->dispatched_at ?? now(),
+        ]);
+
+        return $escalation->fresh();
+    }
+
+    public function markArrived(HomeEscalation $escalation): HomeEscalation
+    {
+        $arrivedAt = $escalation->arrived_at ?? now();
+
+        $escalation->update([
+            'status' => 'responding',
+            'arrived_at' => $arrivedAt,
+            'response_minutes' => $escalation->response_minutes
+                ?? max(0, (int) round($escalation->initiated_at->diffInMinutes($arrivedAt))),
+        ]);
+
+        return $escalation->fresh();
+    }
+
+    public function resolve(HomeEscalation $escalation, string $outcome): HomeEscalation
+    {
+        $escalation->update([
+            'status' => 'resolved',
+            'resolved_at' => $escalation->resolved_at ?? now(),
+            'outcome' => $outcome,
+        ]);
+
+        return $escalation->fresh();
+    }
+
+    /**
+     * ADT close loop: resolve the open escalation for a patient who just
+     * arrived at the hospital. Returns the resolved escalation, or null when
+     * the patient has no open escalation (the overwhelmingly common case).
+     */
+    public function closeForEdReturn(string $patientRef): ?HomeEscalation
+    {
+        $open = HomeEscalation::query()
+            ->where('patient_ref', $patientRef)
+            ->whereIn('status', ['open', 'responding'])
+            ->where('is_deleted', false)
+            ->orderByDesc('initiated_at')
+            ->first();
+
+        if ($open === null) {
+            return null;
+        }
+
+        $open->update([
+            'status' => 'resolved',
+            'response_mode' => $open->response_mode ?? 'ed_return',
+            'resolved_at' => now(),
+            'outcome' => 'ed_return',
+            'metadata' => array_merge((array) $open->metadata, ['closed_by' => 'adt_ed_registration']),
+        ]);
+
+        return $open->fresh();
+    }
+}

--- a/app/Services/Home/HomeLogisticsService.php
+++ b/app/Services/Home/HomeLogisticsService.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Services\Home;
+
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeVisit;
+use App\Models\Home\RpmKit;
+
+/**
+ * Field Operations & Logistics (/home/logistics) — ACUM-PRD-HAH-001 §4.2.
+ *
+ * ⚠ THE ONE ADDRESS CONTEXT. This service is the only code path allowed to
+ * read episode metadata.logistics_address; every other Home payload carries
+ * pseudonymous refs and service zones only (build brief §8.4). A test greps
+ * the other surfaces to keep this contract honest.
+ */
+class HomeLogisticsService
+{
+    /** @return array<string, mixed> */
+    public function build(): array
+    {
+        $episodes = HomeEpisode::query()
+            ->with('program:home_program_id,code')
+            ->active()
+            ->whereHas('program', fn ($q) => $q->where('program_type', 'ahcah_acute'))
+            ->get()
+            ->keyBy('home_episode_id');
+
+        $today = HomeVisit::query()
+            ->with('episode:home_episode_id,service_zone,metadata')
+            ->whereIn('home_episode_id', $episodes->keys())
+            ->where('is_deleted', false)
+            ->whereBetween('scheduled_start', [now()->startOfDay(), now()->endOfDay()])
+            ->orderBy('scheduled_start')
+            ->get();
+
+        $rail = $episodes->map(function (HomeEpisode $episode) use ($today): array {
+            $visits = $today->where('home_episode_id', $episode->home_episode_id);
+            $waiver = $visits->where('is_waiver_required', true);
+
+            return [
+                'patientRef' => $episode->patient_ref,
+                'serviceZone' => $episode->service_zone,
+                // Restricted context: the street address surfaces HERE ONLY.
+                'address' => data_get($episode->metadata, 'logistics_address'),
+                'waiverRequired' => (int) config('home_hospital.waiver.required_visits_per_day', 2),
+                'waiverCompleted' => $waiver->where('status', 'completed')->count(),
+                'waiverScheduled' => $waiver->where('status', 'scheduled')->count(),
+                'compliant' => $waiver->where('status', 'completed')->count()
+                    + $waiver->where('status', 'scheduled')->count()
+                    >= (int) config('home_hospital.waiver.required_visits_per_day', 2),
+                'visits' => $visits->map(fn (HomeVisit $v): array => [
+                    'visitUuid' => $v->visit_uuid,
+                    'type' => $v->visit_type,
+                    'status' => $v->status,
+                    'scheduledStart' => $v->scheduled_start?->toIso8601String(),
+                    'assignedTo' => $v->assigned_to,
+                    'isWaiverRequired' => (bool) $v->is_waiver_required,
+                    'onTime' => $v->on_time,
+                ])->values()->all(),
+            ];
+        })->values();
+
+        $assignments = $today
+            ->whereIn('status', ['scheduled', 'en_route', 'in_progress'])
+            ->groupBy(fn (HomeVisit $v): string => $v->assigned_to ?? 'Unassigned')
+            ->map(fn ($visits, string $assignee): array => [
+                'assignee' => $assignee,
+                'stops' => $visits->map(fn (HomeVisit $v): array => [
+                    'patientRef' => $v->patient_ref,
+                    'type' => $v->visit_type,
+                    'scheduledStart' => $v->scheduled_start?->toIso8601String(),
+                    'serviceZone' => optional($v->episode)->service_zone,
+                    'address' => data_get(optional($v->episode)->metadata, 'logistics_address'),
+                ])->values()->all(),
+            ])
+            ->values();
+
+        return [
+            'complianceRail' => $rail->all(),
+            'assignments' => $assignments->all(),
+            'kits' => [
+                'byStatus' => RpmKit::query()->where('is_deleted', false)
+                    ->selectRaw('status, count(*) AS n')->groupBy('status')->pluck('n', 'status'),
+                'lowBattery' => RpmKit::query()->where('is_deleted', false)
+                    ->where('battery_pct', '<', 30)->count(),
+            ],
+            'deliveries' => HomeVisit::query()
+                ->whereIn('visit_type', ['delivery', 'lab_draw'])
+                ->where('is_deleted', false)
+                ->where('scheduled_start', '>=', now()->subDay())
+                ->orderBy('scheduled_start')
+                ->limit(20)
+                ->get()
+                ->map(fn (HomeVisit $v): array => [
+                    'visitUuid' => $v->visit_uuid,
+                    'patientRef' => $v->patient_ref,
+                    'type' => $v->visit_type,
+                    'status' => $v->status,
+                    'scheduledStart' => $v->scheduled_start?->toIso8601String(),
+                ])->values()->all(),
+        ];
+    }
+}

--- a/app/Services/Home/HomeReferralService.php
+++ b/app/Services/Home/HomeReferralService.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace App\Services\Home;
+
+use App\Models\Bed;
+use App\Models\Encounter;
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeProgram;
+use App\Models\Home\HomeReferral;
+use App\Models\Home\RpmEnrollment;
+use App\Models\Home\RpmKit;
+use App\Models\Unit;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Referral funnel + eligibility worklists (ACUM-PRD-HAH-001 §4.2, §7).
+ *
+ * The worklists are the capacity-unification thesis made operational: ED
+ * candidates come off the LIVE ED census (stable-ESI boarders first — every
+ * activation is a boarding hour avoided) and step-down candidates off
+ * inpatient encounters at/near expected LOS. Funnel transitions are strictly
+ * ordered (referred → screened → eligible → consented → activated) with
+ * coded decline reasons at every stage — decline analytics are the §11
+ * selection-bias guardrail, not an afterthought.
+ *
+ * activate() is the census-spine moment: it claims a free slot (bed) on the
+ * virtual ward, opens the encounter + episode, assigns an available kit with
+ * an active enrollment, and opens the inbound activation checklist.
+ */
+class HomeReferralService
+{
+    private const FUNNEL_ORDER = ['referred', 'screened', 'eligible', 'consented', 'activated'];
+
+    public function __construct(private readonly HomeTransitionService $transitions) {}
+
+    /** @return array<string, mixed> */
+    public function build(): array
+    {
+        $referrals = HomeReferral::query()
+            ->with('program:home_program_id,code,name')
+            ->where('is_deleted', false)
+            ->orderByDesc('referred_at')
+            ->limit(60)
+            ->get()
+            ->map(fn (HomeReferral $r): array => $this->present($r));
+
+        return [
+            'funnel' => $referrals->groupBy('status')->map->values(),
+            'counts' => $referrals->countBy('status'),
+            'edCandidates' => $this->edCandidates(),
+            'stepDownCandidates' => $this->stepDownCandidates(),
+            'freeSlots' => $this->freeSlotCount(),
+        ];
+    }
+
+    /**
+     * Home-eligible ED candidates off the live ED census: still-in-ED or
+     * boarding (admit decided, no bed), clinically stable (ESI 3–5).
+     * Boarders sort first — they are the decant opportunity.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function edCandidates(): array
+    {
+        $known = $this->refsAlreadyInFunnel();
+
+        return DB::table('prod.ed_visits')
+            ->whereNull('departed_at')
+            ->where('is_deleted', false)
+            ->where(fn ($q) => $q->whereNull('disposition')->orWhere('disposition', 'admitted'))
+            ->where('esi_level', '>=', 3)
+            ->orderByRaw('(admit_decision_at IS NOT NULL AND bed_assigned_at IS NULL) DESC')
+            ->orderBy('arrived_at')
+            ->limit(20)
+            ->get()
+            ->reject(fn (object $v): bool => in_array($v->patient_ref, $known, true))
+            ->map(fn (object $v): array => [
+                'patientRef' => $v->patient_ref,
+                'esiLevel' => (int) $v->esi_level,
+                'arrivedAt' => $v->arrived_at,
+                'isBoarding' => $v->admit_decision_at !== null && $v->bed_assigned_at === null,
+                'losMinutes' => max(0, (int) round(now()->diffInMinutes($v->arrived_at, true))),
+                'source' => 'ed_diversion',
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Inpatient step-down candidates: active encounters on physical wards,
+     * stable acuity, at/near expected discharge — decanting them frees a
+     * physical bed early.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function stepDownCandidates(): array
+    {
+        $known = $this->refsAlreadyInFunnel();
+
+        return Encounter::query()
+            ->with('unit:unit_id,abbreviation,type')
+            ->active()
+            ->whereHas('unit', fn ($q) => $q->whereIn('type', ['med_surg', 'step_down'])->where('is_deleted', false))
+            ->where('acuity_tier', '>=', 3)
+            ->whereNotNull('expected_discharge_date')
+            ->where('expected_discharge_date', '<=', now()->addDays(2)->toDateString())
+            ->orderBy('expected_discharge_date')
+            ->limit(20)
+            ->get()
+            ->reject(fn (Encounter $e): bool => in_array($e->patient_ref, $known, true))
+            ->map(fn (Encounter $e): array => [
+                'patientRef' => $e->patient_ref,
+                'unit' => $e->unit?->abbreviation,
+                'acuityTier' => $e->acuity_tier,
+                'admittedAt' => $e->admitted_at?->toIso8601String(),
+                'expectedDischargeDate' => $e->expected_discharge_date?->toDateString(),
+                'encounterId' => $e->encounter_id,
+                'source' => 'inpatient_stepdown',
+            ])
+            ->values()
+            ->all();
+    }
+
+    /** @param array<string, mixed> $attributes */
+    public function create(array $attributes): HomeReferral
+    {
+        $program = HomeProgram::query()
+            ->where('code', $attributes['program_code'] ?? 'ahcah_acute')
+            ->where('is_active', true)
+            ->firstOrFail();
+
+        return HomeReferral::create([
+            'referral_uuid' => Uuid::uuid4()->toString(),
+            'home_program_id' => $program->home_program_id,
+            'patient_ref' => (string) $attributes['patient_ref'],
+            'encounter_id' => $attributes['encounter_id'] ?? null,
+            'source' => (string) $attributes['source'],
+            'status' => 'referred',
+            'screening' => (array) ($attributes['screening'] ?? []),
+            'payer_class' => $attributes['payer_class'] ?? null,
+            'service_zone' => $attributes['service_zone'] ?? null,
+            'referred_by' => $attributes['referred_by'] ?? null,
+            'referred_at' => now(),
+            'status_changed_at' => now(),
+        ]);
+    }
+
+    /** Advance one strictly-ordered funnel step; activation claims a slot. */
+    public function advance(HomeReferral $referral): HomeReferral
+    {
+        $index = array_search($referral->status, self::FUNNEL_ORDER, true);
+
+        if ($index === false || $referral->status === 'activated') {
+            throw ValidationException::withMessages([
+                'status' => "Referral in status [{$referral->status}] cannot advance.",
+            ]);
+        }
+
+        $next = self::FUNNEL_ORDER[$index + 1];
+
+        if ($next === 'activated') {
+            return $this->activate($referral);
+        }
+
+        $referral->update(['status' => $next, 'status_changed_at' => now()]);
+
+        return $referral->fresh();
+    }
+
+    public function decline(HomeReferral $referral, string $reason, ?string $note = null): HomeReferral
+    {
+        if (in_array($referral->status, ['activated', 'declined', 'cancelled'], true)) {
+            throw ValidationException::withMessages([
+                'status' => "Referral in status [{$referral->status}] cannot be declined.",
+            ]);
+        }
+
+        $referral->update([
+            'status' => 'declined',
+            'decline_reason' => $reason,
+            'decline_note' => $note,
+            'declined_at' => now(),
+            'status_changed_at' => now(),
+        ]);
+
+        return $referral->fresh();
+    }
+
+    /**
+     * Consented → activated: claim a free virtual-ward slot, open the
+     * census-spine encounter + episode, assign a kit, open the inbound
+     * activation checklist. Fails loudly when the ward is full — a referral
+     * must never activate into thin air.
+     */
+    public function activate(HomeReferral $referral): HomeReferral
+    {
+        if ($referral->status !== 'consented') {
+            throw ValidationException::withMessages([
+                'status' => 'Only a consented referral can be activated.',
+            ]);
+        }
+
+        return DB::transaction(function () use ($referral): HomeReferral {
+            $ward = Unit::query()
+                ->where('type', 'virtual_home')
+                ->where('is_deleted', false)
+                ->orderBy('unit_id')
+                ->firstOrFail();
+
+            $slot = Bed::query()
+                ->where('unit_id', $ward->unit_id)
+                ->where('status', 'available')
+                ->where('is_deleted', false)
+                ->orderBy('bed_id')
+                ->lockForUpdate()
+                ->first();
+
+            if ($slot === null) {
+                throw ValidationException::withMessages([
+                    'slot' => 'No free virtual-ward slot — activation would exceed program capacity.',
+                ]);
+            }
+
+            $screening = (array) $referral->screening;
+            $conditionCode = (string) ($screening['condition_code'] ?? 'unspecified');
+
+            $encounter = Encounter::create([
+                'patient_ref' => $referral->patient_ref,
+                'unit_id' => $ward->unit_id,
+                'bed_id' => $slot->bed_id,
+                'admitted_at' => now(),
+                'expected_discharge_date' => now()->addDays(6)->toDateString(),
+                'acuity_tier' => (int) ($screening['acuity_tier'] ?? 3),
+                'status' => 'active',
+                'created_by' => 'home-hospital',
+            ]);
+            $slot->update(['status' => 'occupied', 'modified_by' => 'home-hospital']);
+
+            $episode = HomeEpisode::create([
+                'episode_uuid' => Uuid::uuid4()->toString(),
+                'home_program_id' => $referral->home_program_id,
+                'home_referral_id' => $referral->home_referral_id,
+                'encounter_id' => $encounter->encounter_id,
+                'patient_ref' => $referral->patient_ref,
+                'condition_code' => $conditionCode,
+                'condition_label' => $screening['condition_label'] ?? null,
+                'admission_source' => $referral->source,
+                'acuity_tier' => (int) ($screening['acuity_tier'] ?? 3),
+                'status' => 'active',
+                'service_zone' => $referral->service_zone,
+                'target_los_days' => 6.0,
+                'expected_discharge_date' => now()->addDays(6)->toDateString(),
+                'started_at' => now(),
+            ]);
+
+            $kit = RpmKit::query()
+                ->where('status', 'available')
+                ->where('is_deleted', false)
+                ->orderBy('rpm_kit_id')
+                ->lockForUpdate()
+                ->first();
+
+            if ($kit !== null) {
+                RpmEnrollment::create([
+                    'enrollment_uuid' => Uuid::uuid4()->toString(),
+                    'home_episode_id' => $episode->home_episode_id,
+                    'rpm_kit_id' => $kit->rpm_kit_id,
+                    'patient_ref' => $referral->patient_ref,
+                    'status' => 'active',
+                    'monitoring_plan' => ['cadence_minutes' => ['8867-4' => 60, '59408-5' => 60, '8480-6' => 240, '8462-4' => 240]],
+                    'started_at' => now(),
+                ]);
+                $kit->update(['status' => 'assigned']);
+            }
+
+            $this->transitions->ensureInbound($episode);
+
+            $referral->update([
+                'status' => 'activated',
+                'activated_at' => now(),
+                'status_changed_at' => now(),
+            ]);
+
+            return $referral->fresh();
+        });
+    }
+
+    /** @return array<string, mixed> */
+    private function present(HomeReferral $r): array
+    {
+        return [
+            'referralUuid' => $r->referral_uuid,
+            'patientRef' => $r->patient_ref,
+            'program' => $r->program?->code,
+            'source' => $r->source,
+            'status' => $r->status,
+            'payerClass' => $r->payer_class,
+            'serviceZone' => $r->service_zone,
+            'declineReason' => $r->decline_reason,
+            'referredAt' => $r->referred_at?->toIso8601String(),
+            'statusChangedAt' => $r->status_changed_at?->toIso8601String(),
+            'screening' => collect((array) $r->screening)->except('street_address')->all(),
+        ];
+    }
+
+    /** @return list<string> */
+    private function refsAlreadyInFunnel(): array
+    {
+        return HomeReferral::query()
+            ->where('is_deleted', false)
+            ->whereNotIn('status', ['declined', 'cancelled'])
+            ->pluck('patient_ref')
+            ->merge(HomeEpisode::query()->active()->pluck('patient_ref'))
+            ->unique()
+            ->values()
+            ->all();
+    }
+
+    private function freeSlotCount(): int
+    {
+        return Bed::query()
+            ->join('prod.units', 'prod.units.unit_id', '=', 'prod.beds.unit_id')
+            ->where('prod.units.type', 'virtual_home')
+            ->where('prod.beds.status', 'available')
+            ->where('prod.beds.is_deleted', false)
+            ->count();
+    }
+}

--- a/app/Services/Home/HomeTransitionService.php
+++ b/app/Services/Home/HomeTransitionService.php
@@ -1,0 +1,314 @@
+<?php
+
+namespace App\Services\Home;
+
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeTransition;
+use App\Models\Home\RpmEnrollment;
+use App\Models\Transport\TransportRequest;
+use App\Services\Transport\RegionalTransferService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Inbound activation checklists and outbound governed handoffs
+ * (ACUM-PRD-HAH-001 §7). Nothing here is rebuilt: outbound handoffs write
+ * prod.transport_requests (request_type = care_transition) and, for facility
+ * destinations, ride RegionalTransferService's candidate scoring +
+ * opportunity-cost ledger (regional.transfer_decisions) — the same machinery
+ * an acute transfer uses.
+ *
+ * discharge() closes the census-spine loop (encounter discharged, slot freed,
+ * kit returned) and — for routine discharges — enrolls the patient into the
+ * 30-day post-discharge monitoring cohort at a step-down cadence (billable
+ * under the 2026 RPM codes).
+ */
+class HomeTransitionService
+{
+    public const INBOUND_CHECKLIST = ['consent', 'home_safety_check', 'kit_delivery', 'first_visit'];
+
+    public const OUTBOUND_CHECKLIST = ['discharge_readiness', 'med_reconciliation', 'handoff_report', 'equipment_return'];
+
+    public function __construct(private readonly RegionalTransferService $regional) {}
+
+    /** @return array<string, mixed> */
+    public function build(): array
+    {
+        $transitions = HomeTransition::query()
+            ->with('episode:home_episode_id,patient_ref,condition_label,status')
+            ->where('is_deleted', false)
+            ->whereIn('status', ['pending', 'in_progress', 'blocked'])
+            ->orderBy('direction')
+            ->orderBy('home_transition_id')
+            ->get()
+            ->map(fn (HomeTransition $t): array => $this->present($t));
+
+        return [
+            'inbound' => $transitions->where('direction', 'inbound')->values(),
+            'outbound' => $transitions->where('direction', 'outbound')->values(),
+            'postDischargeCohort' => $this->postDischargeCohort(),
+            // Acute episodes eligible for an outbound handoff / discharge.
+            'activeEpisodes' => HomeEpisode::query()
+                ->active()
+                ->whereHas('program', fn ($q) => $q->where('program_type', 'ahcah_acute'))
+                ->orderBy('patient_ref')
+                ->get(['home_episode_id', 'episode_uuid', 'patient_ref', 'condition_label'])
+                ->map(fn (HomeEpisode $e): array => [
+                    'episodeUuid' => $e->episode_uuid,
+                    'patientRef' => $e->patient_ref,
+                    'conditionLabel' => $e->condition_label,
+                ])->values()->all(),
+        ];
+    }
+
+    public function ensureInbound(HomeEpisode $episode): HomeTransition
+    {
+        $existing = HomeTransition::query()
+            ->where('home_episode_id', $episode->home_episode_id)
+            ->where('direction', 'inbound')
+            ->where('is_deleted', false)
+            ->first();
+
+        if ($existing !== null) {
+            return $existing;
+        }
+
+        return HomeTransition::create([
+            'transition_uuid' => Uuid::uuid4()->toString(),
+            'home_episode_id' => $episode->home_episode_id,
+            'patient_ref' => $episode->patient_ref,
+            'direction' => 'inbound',
+            'status' => 'in_progress',
+            'checklist' => array_fill_keys(self::INBOUND_CHECKLIST, 'pending'),
+            'started_at' => now(),
+        ]);
+    }
+
+    public function completeChecklistItem(HomeTransition $transition, string $item): HomeTransition
+    {
+        $checklist = (array) $transition->checklist;
+
+        if (! array_key_exists($item, $checklist)) {
+            throw ValidationException::withMessages(['item' => "Unknown checklist item [{$item}]."]);
+        }
+
+        $checklist[$item] = 'complete';
+        $allComplete = collect($checklist)->every(fn ($state): bool => $state === 'complete');
+
+        $transition->update([
+            'checklist' => $checklist,
+            'status' => $allComplete ? 'completed' : 'in_progress',
+            'completed_at' => $allComplete ? now() : null,
+        ]);
+
+        return $transition->fresh();
+    }
+
+    /**
+     * Open the outbound handoff: transition row + care_transition transport
+     * request; facility destinations (SNF) also get a regional transfer
+     * decision with candidate scoring + opportunity cost.
+     *
+     * @return array{transition: HomeTransition, transportRequestId: int, decisionId: int|null}
+     */
+    public function startOutbound(
+        HomeEpisode $episode,
+        string $receivingEntityType,
+        ?string $handoffOwner = null,
+        ?int $userId = null,
+    ): array {
+        $existing = HomeTransition::query()
+            ->where('home_episode_id', $episode->home_episode_id)
+            ->where('direction', 'outbound')
+            ->whereIn('status', ['pending', 'in_progress', 'blocked'])
+            ->where('is_deleted', false)
+            ->first();
+
+        if ($existing !== null) {
+            throw ValidationException::withMessages([
+                'transition' => 'An outbound handoff is already open for this episode.',
+            ]);
+        }
+
+        return DB::transaction(function () use ($episode, $receivingEntityType, $handoffOwner, $userId): array {
+            $request = TransportRequest::create([
+                'request_uuid' => (string) \Illuminate\Support\Str::uuid(),
+                'request_type' => 'care_transition',
+                'priority' => 'routine',
+                'status' => 'requested',
+                'patient_ref' => $episode->patient_ref,
+                'encounter_ref' => $episode->encounter_id !== null ? (string) $episode->encounter_id : null,
+                'origin' => 'HOME virtual ward',
+                'destination' => match ($receivingEntityType) {
+                    'pcp' => 'Primary care follow-up',
+                    'home_health' => 'Home health agency',
+                    'snf' => 'Skilled nursing facility',
+                    default => 'Community follow-up',
+                },
+                // CHECK-constrained vocabulary; a PCP/home-health handoff has
+                // no clinical transport → 'ambulatory' (patient self-conveys).
+                'transport_mode' => $receivingEntityType === 'snf' ? 'stretcher' : 'ambulatory',
+                'clinical_service' => 'home_hospital',
+                'requested_by' => $handoffOwner,
+                'requested_at' => now(),
+                'metadata' => ['home_episode_uuid' => $episode->episode_uuid],
+                'created_by_user_id' => $userId,
+            ]);
+
+            $decisionId = null;
+            $facilityId = null;
+
+            if ($receivingEntityType === 'snf') {
+                $decision = $this->regional->decide($request, ['decision_status' => 'draft'], $userId);
+                $decisionId = (int) $decision['decisionId'];
+                $facilityId = DB::table('regional.transfer_decisions')
+                    ->where('transfer_decision_id', $decisionId)
+                    ->value('selected_facility_id');
+            }
+
+            $transition = HomeTransition::create([
+                'transition_uuid' => Uuid::uuid4()->toString(),
+                'home_episode_id' => $episode->home_episode_id,
+                'patient_ref' => $episode->patient_ref,
+                'direction' => 'outbound',
+                'status' => 'in_progress',
+                'checklist' => array_fill_keys(self::OUTBOUND_CHECKLIST, 'pending'),
+                'handoff_owner' => $handoffOwner,
+                'receiving_entity_type' => $receivingEntityType,
+                'regional_facility_id' => $facilityId,
+                'transport_request_id' => $request->transport_request_id,
+                'started_at' => now(),
+            ]);
+
+            return [
+                'transition' => $transition,
+                'transportRequestId' => (int) $request->transport_request_id,
+                'decisionId' => $decisionId,
+            ];
+        });
+    }
+
+    /**
+     * Close the episode on the census spine and (routine discharges) enroll
+     * the 30-day post-discharge monitoring cohort at step-down cadence.
+     */
+    public function discharge(HomeEpisode $episode, string $disposition): HomeEpisode
+    {
+        if ($episode->status !== 'active') {
+            throw ValidationException::withMessages([
+                'episode' => 'Only an active episode can be discharged.',
+            ]);
+        }
+
+        return DB::transaction(function () use ($episode, $disposition): HomeEpisode {
+            $encounter = $episode->encounter;
+            if ($encounter !== null) {
+                $encounter->update(['status' => 'discharged', 'discharged_at' => now(), 'modified_by' => 'home-hospital']);
+                $encounter->bed?->update(['status' => 'available', 'modified_by' => 'home-hospital']);
+            }
+
+            foreach ($episode->enrollments()->where('status', 'active')->get() as $enrollment) {
+                $enrollment->update(['status' => 'ended', 'ended_at' => now()]);
+                $enrollment->kit?->update(['status' => 'available']);
+            }
+
+            $episode->update([
+                'status' => 'completed',
+                'disposition' => $disposition,
+                'ended_at' => now(),
+            ]);
+
+            if ($disposition === 'routine_discharge') {
+                $this->enrollPostDischargeCohort($episode);
+            }
+
+            return $episode->fresh();
+        });
+    }
+
+    /**
+     * The 30-day post-discharge cohort: a lower-acuity episode on the
+     * post_discharge_rpm program line — NO slot/encounter (it is not an
+     * avoided bed-day), step-down monitoring cadence (BP/SpO2 twice daily,
+     * weight daily), 30-day window.
+     */
+    private function enrollPostDischargeCohort(HomeEpisode $acute): void
+    {
+        $program = \App\Models\Home\HomeProgram::query()
+            ->where('program_type', 'post_discharge_rpm')
+            ->where('is_active', true)
+            ->first();
+
+        if ($program === null) {
+            return;
+        }
+
+        $cohortEpisode = HomeEpisode::create([
+            'episode_uuid' => Uuid::uuid4()->toString(),
+            'home_program_id' => $program->home_program_id,
+            'home_referral_id' => $acute->home_referral_id,
+            'patient_ref' => $acute->patient_ref,
+            'condition_code' => $acute->condition_code,
+            'condition_label' => $acute->condition_label,
+            'admission_source' => $acute->admission_source,
+            'acuity_tier' => 5,
+            'status' => 'active',
+            'service_zone' => $acute->service_zone,
+            'target_los_days' => 30.0,
+            'expected_discharge_date' => now()->addDays(30)->toDateString(),
+            'started_at' => now(),
+            'metadata' => ['cohort' => 'post_discharge', 'acute_episode_uuid' => $acute->episode_uuid],
+        ]);
+
+        RpmEnrollment::create([
+            'enrollment_uuid' => Uuid::uuid4()->toString(),
+            'home_episode_id' => $cohortEpisode->home_episode_id,
+            'rpm_kit_id' => $acute->enrollments()->latest('rpm_enrollment_id')->value('rpm_kit_id')
+                ?? \App\Models\Home\RpmKit::query()->where('is_deleted', false)->orderBy('rpm_kit_id')->value('rpm_kit_id'),
+            'patient_ref' => $acute->patient_ref,
+            'status' => 'active',
+            // Step-down cadence: BP + SpO2 q12h, weight daily.
+            'monitoring_plan' => ['cadence_minutes' => ['8480-6' => 720, '8462-4' => 720, '59408-5' => 720, '29463-7' => 1440]],
+            'started_at' => now(),
+            'metadata' => ['cohort' => 'post_discharge'],
+        ]);
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function postDischargeCohort(): array
+    {
+        return HomeEpisode::query()
+            ->with('program:home_program_id,code')
+            ->active()
+            ->whereHas('program', fn ($q) => $q->where('program_type', 'post_discharge_rpm'))
+            ->orderBy('started_at')
+            ->get()
+            ->map(fn (HomeEpisode $e): array => [
+                'episodeUuid' => $e->episode_uuid,
+                'patientRef' => $e->patient_ref,
+                'conditionLabel' => $e->condition_label ?? $e->condition_code,
+                'dayOfCohort' => $e->started_at !== null ? max(1, (int) $e->started_at->diffInDays(now()) + 1) : null,
+                'windowDays' => 30,
+                'endsOn' => $e->expected_discharge_date?->toDateString(),
+            ])
+            ->all();
+    }
+
+    /** @return array<string, mixed> */
+    private function present(HomeTransition $t): array
+    {
+        return [
+            'transitionUuid' => $t->transition_uuid,
+            'patientRef' => $t->patient_ref,
+            'conditionLabel' => $t->episode?->condition_label,
+            'direction' => $t->direction,
+            'status' => $t->status,
+            'checklist' => (array) $t->checklist,
+            'handoffOwner' => $t->handoff_owner,
+            'receivingEntityType' => $t->receiving_entity_type,
+            'barriers' => (array) $t->barriers,
+            'startedAt' => $t->started_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Services/Home/RpmAlertEvaluator.php
+++ b/app/Services/Home/RpmAlertEvaluator.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Services\Home;
+
+use App\Models\Home\RpmAlert;
+use App\Models\Home\RpmEnrollment;
+use App\Models\Home\RpmObservation;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Evaluates a projected observation against the patient's personalized
+ * thresholds (rpm_enrollments.monitoring_plan.thresholds, falling back to
+ * config('home_hospital.vital_thresholds')) and opens/refreshes a patient
+ * alert (ACUM-PRD-HAH-001 §6.1, alarm governance §8).
+ *
+ * Alarm-fatigue guardrails: one OPEN alert per (episode, rule) — repeated
+ * breaches refresh the open alert's metadata instead of stacking rows; the
+ * severity may escalate warning→critical in place but never silently
+ * downgrades. Alert burden per patient-day is itself a tracked KPI.
+ */
+class RpmAlertEvaluator
+{
+    /** Returns the open/updated alert when the observation breaches, else null. */
+    public function evaluate(RpmObservation $observation, RpmEnrollment $enrollment): ?RpmAlert
+    {
+        $breach = $this->classify($observation, $enrollment);
+
+        if ($breach === null) {
+            return null;
+        }
+
+        [$severity, $bound] = $breach;
+
+        if (! $observation->is_breach) {
+            $observation->update(['is_breach' => true]);
+        }
+
+        $ruleKey = "{$observation->loinc_code}.{$bound}";
+
+        $open = RpmAlert::query()
+            ->where('home_episode_id', $enrollment->home_episode_id)
+            ->where('rule_key', $ruleKey)
+            ->where('status', 'open')
+            ->where('is_deleted', false)
+            ->first();
+
+        if ($open !== null) {
+            $open->update([
+                // Escalate in place, never downgrade an open alert.
+                'severity' => $severity === 'critical' ? 'critical' : $open->severity,
+                'rpm_observation_id' => $observation->rpm_observation_id,
+                'metadata' => array_merge((array) $open->metadata, [
+                    'last_value' => $observation->value,
+                    'last_observed_at' => $observation->observed_at?->toIso8601String(),
+                    'breach_count' => (int) ($open->metadata['breach_count'] ?? 1) + 1,
+                ]),
+            ]);
+
+            return $open->fresh();
+        }
+
+        return RpmAlert::create([
+            'alert_uuid' => Uuid::uuid4()->toString(),
+            'home_episode_id' => $enrollment->home_episode_id,
+            'rpm_enrollment_id' => $enrollment->rpm_enrollment_id,
+            'rpm_observation_id' => $observation->rpm_observation_id,
+            'patient_ref' => $observation->patient_ref,
+            'rule_key' => $ruleKey,
+            'severity' => $severity,
+            'status' => 'open',
+            'opened_at' => now(),
+            'metadata' => [
+                'loinc_code' => $observation->loinc_code,
+                'display' => $observation->display,
+                'value' => $observation->value,
+                'unit' => $observation->unit,
+                'threshold_source' => $this->hasPersonalThresholds($enrollment, $observation->loinc_code)
+                    ? 'personalized'
+                    : 'default',
+                'breach_count' => 1,
+            ],
+        ]);
+    }
+
+    /** @return array{0:'warning'|'critical',1:string}|null [severity, low|high] */
+    private function classify(RpmObservation $observation, RpmEnrollment $enrollment): ?array
+    {
+        $thresholds = $this->thresholdsFor($enrollment, $observation->loinc_code);
+        if ($thresholds === []) {
+            return null;
+        }
+
+        $value = (float) $observation->value;
+
+        if (isset($thresholds['critical_low']) && $value <= (float) $thresholds['critical_low']) {
+            return ['critical', 'low'];
+        }
+        if (isset($thresholds['critical_high']) && $value >= (float) $thresholds['critical_high']) {
+            return ['critical', 'high'];
+        }
+        if (isset($thresholds['warning_low']) && $value <= (float) $thresholds['warning_low']) {
+            return ['warning', 'low'];
+        }
+        if (isset($thresholds['warning_high']) && $value >= (float) $thresholds['warning_high']) {
+            return ['warning', 'high'];
+        }
+
+        return null;
+    }
+
+    /** @return array<string, float|int> */
+    private function thresholdsFor(RpmEnrollment $enrollment, string $loinc): array
+    {
+        $personal = (array) ($enrollment->monitoring_plan['thresholds'][$loinc] ?? []);
+        $defaults = (array) config("home_hospital.vital_thresholds.{$loinc}", []);
+
+        return array_merge($defaults, $personal);
+    }
+
+    private function hasPersonalThresholds(RpmEnrollment $enrollment, string $loinc): bool
+    {
+        return (array) ($enrollment->monitoring_plan['thresholds'][$loinc] ?? []) !== [];
+    }
+}

--- a/app/Services/Home/RpmFhirObservationRecorder.php
+++ b/app/Services/Home/RpmFhirObservationRecorder.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Services\Home;
+
+use App\Models\Home\RpmObservation;
+use App\Security\ClinicalPayloads\ClinicalPayloadStore;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Persists each projected RPM observation as a FHIR R4 Observation
+ * (US Core vital-signs shape) in fhir.resource_versions with a
+ * fhir.resource_links row back to prod.rpm_observations
+ * (ACUM-PRD-HAH-001 §5.2 / build brief §6.6).
+ *
+ * Append-only and idempotent: fhir_id = observation_uuid, version_id = '1'
+ * (device readings never amend; a corrected reading is a NEW transmission).
+ * Resource JSON is encrypted out-of-row via the ClinicalPayloadStore, exactly
+ * like the SMART poll path; when the store is disabled (dev without payload
+ * encryption) recording is skipped with a log line — never a hard failure of
+ * the projection.
+ */
+class RpmFhirObservationRecorder
+{
+    public function __construct(private readonly ClinicalPayloadStore $payloads) {}
+
+    /** Resolve the integration source once per request; the feed key is stable. */
+    public function recordForSourceKey(RpmObservation $observation, string $sourceKey): void
+    {
+        $sourceId = DB::table('integration.sources')->where('source_key', $sourceKey)->value('source_id');
+
+        if ($sourceId === null) {
+            return;
+        }
+
+        $this->record($observation, (int) $sourceId);
+    }
+
+    public function record(RpmObservation $observation, int $sourceId): void
+    {
+        $resource = $this->observationResource($observation);
+        $resourceJson = json_encode($resource, JSON_THROW_ON_ERROR);
+        $hash = hash('sha256', $resourceJson);
+
+        try {
+            $stored = $this->payloads->storeJson($sourceId, 'fhir_resource', $resource);
+        } catch (\Throwable $exception) {
+            Log::info('home_hospital.fhir_observation_skipped', [
+                'reason' => $exception->getMessage(),
+                'observation_uuid' => $observation->observation_uuid,
+            ]);
+
+            return;
+        }
+
+        try {
+            DB::transaction(function () use ($observation, $sourceId, $hash, $stored): void {
+                $exists = DB::table('fhir.resource_versions')
+                    ->where('source_id', $sourceId)
+                    ->where('resource_type', 'Observation')
+                    ->where('fhir_id', $observation->observation_uuid)
+                    ->where('version_id', '1')
+                    ->exists();
+
+                if ($exists) {
+                    return;
+                }
+
+                $resourceVersionId = DB::table('fhir.resource_versions')->insertGetId([
+                    'source_id' => $sourceId,
+                    'resource_type' => 'Observation',
+                    'fhir_id' => $observation->observation_uuid,
+                    'version_id' => '1',
+                    'last_updated' => $observation->observed_at,
+                    'resource_hash' => $hash,
+                    'resource_data' => json_encode((object) [], JSON_THROW_ON_ERROR),
+                    'payload_object_id' => $stored->payloadObjectId,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ], 'resource_version_id');
+
+                DB::table('fhir.resource_links')->insertOrIgnore([
+                    'source_id' => $sourceId,
+                    'resource_type' => 'Observation',
+                    'fhir_id' => $observation->observation_uuid,
+                    'internal_schema' => 'prod',
+                    'internal_table' => 'rpm_observations',
+                    'internal_pk' => (string) $observation->rpm_observation_id,
+                    'metadata' => json_encode(['resource_version_id' => $resourceVersionId], JSON_THROW_ON_ERROR),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            });
+        } catch (\Throwable $exception) {
+            $this->payloads->discard(
+                $stored->payloadObjectId,
+                $sourceId,
+                'fhir_observation_link_failed',
+                'Encrypted FHIR Observation payload discarded because the version row did not become authoritative.',
+            );
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * Minimal US Core vital-signs Observation. subject carries the
+     * pseudonymous patient_ref (never an MRN); device identity stays a
+     * serial-keyed reference resolved via prod.rpm_devices.
+     *
+     * @return array<string, mixed>
+     */
+    private function observationResource(RpmObservation $observation): array
+    {
+        return [
+            'resourceType' => 'Observation',
+            'id' => $observation->observation_uuid,
+            'meta' => [
+                'profile' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs'],
+            ],
+            'status' => 'final',
+            'category' => [[
+                'coding' => [[
+                    'system' => 'http://terminology.hl7.org/CodeSystem/observation-category',
+                    'code' => 'vital-signs',
+                    'display' => 'Vital Signs',
+                ]],
+            ]],
+            'code' => [
+                'coding' => [[
+                    'system' => 'http://loinc.org',
+                    'code' => $observation->loinc_code,
+                    'display' => $observation->display,
+                ]],
+            ],
+            'subject' => ['reference' => 'Patient/'.$observation->patient_ref],
+            'effectiveDateTime' => $observation->observed_at?->toIso8601String(),
+            'issued' => $observation->received_at?->toIso8601String(),
+            'valueQuantity' => [
+                'value' => (float) $observation->value,
+                'unit' => $observation->unit,
+                'system' => 'http://unitsofmeasure.org',
+                'code' => $observation->unit,
+            ],
+        ];
+    }
+}

--- a/app/Services/PatientFlow/PatientFlowHl7IngestPipeline.php
+++ b/app/Services/PatientFlow/PatientFlowHl7IngestPipeline.php
@@ -16,6 +16,7 @@ use App\Security\ClinicalPayloads\ClinicalPayloadStore;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -286,6 +287,22 @@ class PatientFlowHl7IngestPipeline
             });
 
             $this->completeRun($run);
+
+            // Home Hospital escalation close-loop (ACUM-PRD-HAH-001 §5.2): an
+            // escalated home patient arriving via ADT admit/register resolves
+            // their open escalation with an ed_return outcome. Non-critical:
+            // guarded so a home-module fault can never fail an ADT ingest.
+            if ((bool) config('home_hospital.enabled')
+                && in_array((string) ($normalized['event_type'] ?? ''), ['admit', 'register'], true)) {
+                try {
+                    app(\App\Services\Home\HomeEscalationService::class)
+                        ->closeForEdReturn((string) $normalized['patient_id']);
+                } catch (Throwable $exception) {
+                    Log::warning('home_hospital.escalation_close_failed', [
+                        'error' => $exception->getMessage(),
+                    ]);
+                }
+            }
 
             return [
                 'receipt' => $this->receipt($run, $message, $record, ! $messageCreated),

--- a/app/Services/Transport/RegionalTransferService.php
+++ b/app/Services/Transport/RegionalTransferService.php
@@ -58,8 +58,12 @@ class RegionalTransferService
     /** @param array<string,mixed> $payload */
     public function decide(TransportRequest $request, array $payload, ?int $userId): array
     {
-        if ($request->request_type !== 'transfer') {
-            abort(422, 'Regional transfer decisions only apply to transfer requests.');
+        // care_transition joined the decision surface with Home Hospital
+        // Phase 2 (ACUM-PRD-HAH-001 §7): an outbound SNF/home-health handoff
+        // reuses the same regional candidate scoring + opportunity-cost
+        // ledger as an acute transfer. Additive — transfer behavior unchanged.
+        if (! in_array($request->request_type, ['transfer', 'care_transition'], true)) {
+            abort(422, 'Regional transfer decisions only apply to transfer or care-transition requests.');
         }
 
         $this->seedNetwork();

--- a/arena/app/pathways.py
+++ b/arena/app/pathways.py
@@ -19,6 +19,14 @@ import pandas as pd
 # sepsis recognition (SSC bundle).
 SEPSIS_ABX_TARGET_MIN = 180
 
+# Home Hospital (ACUM-PRD-HAH-001 §6.3) — the designed pathway's operating
+# numbers: referral→activation within 24h, the CMS AHCAH waiver floor of two
+# in-person visits per full ward day, and the 30-minute emergency-response
+# requirement (MedPAC 2024).
+HOME_ACTIVATION_SLA_MIN = 24 * 60
+HOME_WAIVER_VISITS_PER_DAY = 2
+HOME_RESPONSE_FLOOR_MIN = 30
+
 
 def _minutes_between(a: Any, b: Any) -> float | None:
     if a is None or b is None or pd.isna(a) or pd.isna(b):
@@ -71,6 +79,51 @@ def evaluate_surgical_safety(timeline: dict[str, Any], counts: dict[str, int], g
     return deviations
 
 
+def evaluate_home_hospital(timeline: dict[str, Any], counts: dict[str, int], group: pd.DataFrame) -> list[str]:
+    """Home Hospital virtual-ward pathway: referral→activation SLA, the
+    two-visits-per-full-day waiver cadence, and the escalation protocol
+    (every open resolved; response inside the 30-minute floor)."""
+    deviations: list[str] = []
+
+    referral = timeline.get("home-refer")
+    activation = timeline.get("home-activate")
+    if referral is not None and activation is not None:
+        minutes = _minutes_between(referral, activation)
+        if minutes is not None and minutes > HOME_ACTIVATION_SLA_MIN:
+            deviations.append("activation_beyond_sla")
+
+    # Waiver cadence over FULL elapsed ward days (partial admission/discharge
+    # days are not judged). Waiver visits preferred when the attr is present;
+    # otherwise every completed visit counts toward the floor.
+    end = timeline.get("home-discharge") or group["ocel:timestamp"].max()
+    full_days = 0
+    if activation is not None:
+        minutes = _minutes_between(activation, end)
+        full_days = int(minutes // (24 * 60)) if minutes is not None else 0
+    if full_days >= 1:
+        visits = group[group["ocel:activity"] == "home-visit-complete"]
+        if "waiver_required" in group.columns:
+            flagged = visits["waiver_required"].astype(str).str.lower().isin({"true", "1", "yes"})
+            waiver_visits = int(flagged.sum()) if flagged.any() else len(visits)
+        else:
+            waiver_visits = len(visits)
+        if waiver_visits < HOME_WAIVER_VISITS_PER_DAY * full_days:
+            deviations.append("visit_cadence_below_floor")
+
+    if counts.get("home-escalation-open", 0) > counts.get("home-escalation-resolve", 0):
+        deviations.append("escalation_unresolved")
+
+    if "response_minutes" in group.columns:
+        response = pd.to_numeric(
+            group[group["ocel:activity"] == "home-escalation-resolve"]["response_minutes"],
+            errors="coerce",
+        ).dropna()
+        if len(response) > 0 and float(response.max()) > HOME_RESPONSE_FLOOR_MIN:
+            deviations.append("escalation_response_late")
+
+    return deviations
+
+
 # The versioned pathway registry. `case_type` is the OCEL object the pathway is
 # grouped by; `trigger` is the activity whose presence marks a case as being on
 # the pathway; `activities` bounds the sub-log the engine extracts.
@@ -113,6 +166,28 @@ PATHWAYS: dict[str, dict[str, Any]] = {
         "deviation_labels": {
             "safety_step_missing": "A checklist step (Sign-In / Time-Out / Sign-Out) is missing",
             "safety_check_flagged": "A checklist step was flagged incomplete",
+        },
+    },
+    "home_hospital": {
+        "label": "Home Hospital virtual-ward pathway (AHCAH)",
+        "version": 1,
+        "owner": "clinical:home-hospital",
+        "case_type": "Home Episode",
+        "trigger": "home-activate",
+        "activities": [
+            "home-refer",
+            "home-activate",
+            "home-visit-complete",
+            "home-escalation-open",
+            "home-escalation-resolve",
+            "home-discharge",
+        ],
+        "evaluate": evaluate_home_hospital,
+        "deviation_labels": {
+            "activation_beyond_sla": "Referral-to-activation beyond the 24-hour SLA",
+            "visit_cadence_below_floor": "In-person visits below the 2-per-day waiver floor",
+            "escalation_unresolved": "An escalation was opened but never resolved",
+            "escalation_response_late": "Escalation response beyond the 30-minute floor",
         },
     },
 }

--- a/arena/tests/test_home_hospital_conformance.py
+++ b/arena/tests/test_home_hospital_conformance.py
@@ -1,0 +1,87 @@
+"""Home Hospital pathway conformance (ACUM-PRD-HAH-001 §6.3) against a
+hand-built OCEL 2.0 fixture: a conformant episode (activation inside the 24h
+SLA, waiver cadence held, escalation resolved in 22 min) and a deviant one
+(late activation, cadence below the floor, escalation left open).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app import conformance
+
+
+def _ev(eid: str, activity: str, time: str, oid: str, extra: dict | None = None) -> dict:
+    attributes = [{"name": key, "value": value} for key, value in (extra or {}).items()]
+    return {
+        "id": eid,
+        "type": activity,
+        "time": time,
+        "attributes": attributes,
+        "relationships": [{"objectId": oid, "qualifier": "subject"}],
+    }
+
+
+FIXTURE = {
+    "objectTypes": [
+        {"name": "Home Episode", "attributes": []},
+    ],
+    "eventTypes": [
+        {"name": a, "attributes": []}
+        for a in [
+            "home-refer", "home-activate", "home-visit-complete",
+            "home-escalation-open", "home-escalation-resolve", "home-discharge",
+        ]
+    ],
+    "objects": [
+        {"id": "home-ep-1", "type": "Home Episode", "attributes": [], "relationships": []},
+        {"id": "home-ep-2", "type": "Home Episode", "attributes": [], "relationships": []},
+    ],
+    "events": [
+        # home-ep-1 — conformant: activation 4h after referral; two full ward
+        # days each holding the 2-visit waiver floor; escalation resolved 22 min.
+        _ev("h1", "home-refer", "2026-06-01T08:00:00Z", "home-ep-1"),
+        _ev("h2", "home-activate", "2026-06-01T12:00:00Z", "home-ep-1"),
+        _ev("h3", "home-visit-complete", "2026-06-01T15:00:00Z", "home-ep-1", {"waiver_required": "true"}),
+        _ev("h4", "home-visit-complete", "2026-06-01T20:00:00Z", "home-ep-1", {"waiver_required": "true"}),
+        _ev("h5", "home-visit-complete", "2026-06-02T09:00:00Z", "home-ep-1", {"waiver_required": "true"}),
+        _ev("h6", "home-visit-complete", "2026-06-02T18:00:00Z", "home-ep-1", {"waiver_required": "true"}),
+        _ev("h7", "home-escalation-open", "2026-06-02T21:00:00Z", "home-ep-1"),
+        _ev("h8", "home-escalation-resolve", "2026-06-02T22:00:00Z", "home-ep-1", {"response_minutes": 22}),
+        _ev("h9", "home-visit-complete", "2026-06-03T09:00:00Z", "home-ep-1", {"waiver_required": "true"}),
+        _ev("h10", "home-visit-complete", "2026-06-03T11:00:00Z", "home-ep-1", {"waiver_required": "true"}),
+        _ev("h11", "home-discharge", "2026-06-03T16:00:00Z", "home-ep-1"),
+        # home-ep-2 — deviant: activation 30h after referral; one full ward day
+        # with only one waiver visit; escalation opened, never resolved.
+        _ev("h12", "home-refer", "2026-06-05T08:00:00Z", "home-ep-2"),
+        _ev("h13", "home-activate", "2026-06-06T14:00:00Z", "home-ep-2"),
+        _ev("h14", "home-visit-complete", "2026-06-06T18:00:00Z", "home-ep-2", {"waiver_required": "true"}),
+        _ev("h15", "home-escalation-open", "2026-06-07T10:00:00Z", "home-ep-2"),
+        _ev("h16", "home-discharge", "2026-06-07T20:00:00Z", "home-ep-2"),
+    ],
+}
+
+
+@pytest.fixture
+def ocel_path(tmp_path) -> str:
+    p = tmp_path / "home-conformance-fixture.json"
+    p.write_text(json.dumps(FIXTURE), encoding="utf-8")
+    return str(p)
+
+
+def test_home_hospital_conformance(ocel_path: str) -> None:
+    results = conformance.check(ocel_path, pathway_key="home_hospital")
+    assert len(results) == 1
+    home = results[0]
+
+    assert home["pathway"] == "home_hospital"
+    assert home["cases"] == 2
+    assert home["conformant"] == 1
+    assert home["deviant"] == 1
+
+    codes = {d["code"]: d["count"] for d in home["deviations"]}
+    assert codes.get("activation_beyond_sla") == 1
+    assert codes.get("visit_cadence_below_floor") == 1
+    assert codes.get("escalation_unresolved") == 1

--- a/config/home_hospital.php
+++ b/config/home_hospital.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Home Hospital (HOME) module configuration.
+ *
+ * Strategy: docs/home-hospital/Zephyrus_Hospital_at_Home_Strategy_and_Design.md
+ * Build brief: docs/home-hospital/HOME-HOSPITAL-BUILD-PROMPT.md (ACUM-PRD-HAH-001)
+ *
+ * Feature flags gate routes, nav, seeds, and demo refresh. Disabling a flag
+ * stops new work without deleting audit records — the middleware answers 404
+ * so the module is invisible when off (same doctrine as Virtual Rounds).
+ */
+
+return [
+    'enabled' => filter_var(env('HOME_HOSPITAL_ENABLED', false), FILTER_VALIDATE_BOOL),
+
+    // Sub-flags for later phases; all inert until their phase ships.
+    'rpm_ingest_enabled' => filter_var(env('HOME_HOSPITAL_RPM_INGEST_ENABLED', false), FILTER_VALIDATE_BOOL),
+    'eddy_enabled' => filter_var(env('HOME_HOSPITAL_EDDY_ENABLED', false), FILTER_VALIDATE_BOOL),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Virtual ward identity
+    |--------------------------------------------------------------------------
+    | The virtual ward is one more prod.units row (type = virtual_home) whose
+    | beds are program slots — census, occupancy, huddles, and the cockpit
+    | machinery work unmodified. It is deliberately NOT in the HospitalManifest
+    | roster: manifest-derived denominators (licensed beds, staffed-bed totals,
+    | occupancy tuning) must not absorb virtual slots. RtdcSeeder exempts
+    | virtual_home units from its manifest soft-trim.
+    */
+    'unit_abbreviation' => env('HOME_HOSPITAL_UNIT_ABBR', 'HOME'),
+    'unit_name' => env('HOME_HOSPITAL_UNIT_NAME', 'Summit Home Hospital — Virtual Ward'),
+    'slot_count' => (int) env('HOME_HOSPITAL_SLOT_COUNT', 12),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Initial condition set (§13 Q1 recommended default)
+    |--------------------------------------------------------------------------
+    | Evidence-anchored starting conditions (Levine 2024 cohort). Surfaced to
+    | product/clinical leadership as an open question; adjust per deployment.
+    */
+    'conditions' => [
+        'heart_failure' => 'Heart Failure',
+        'copd' => 'COPD Exacerbation',
+        'pneumonia' => 'Pneumonia / Respiratory Infection',
+        'cellulitis' => 'Cellulitis / Skin & Soft Tissue Infection',
+        'uti' => 'Kidney / Urinary Tract Infection',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Waiver operating floor (CMS AHCAH / MedPAC 2024)
+    |--------------------------------------------------------------------------
+    | Compliance telemetry constants, not soft goals: ≥2 in-person clinician
+    | visits per day + daily MD evaluation; emergency in-person response
+    | within 30 minutes.
+    */
+    'waiver' => [
+        'required_visits_per_day' => 2,
+        'emergency_response_minutes' => 30,
+    ],
+];

--- a/config/home_hospital.php
+++ b/config/home_hospital.php
@@ -60,4 +60,46 @@ return [
         'required_visits_per_day' => 2,
         'emergency_response_minutes' => 30,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | HEWS — Home Early Warning Score (strategy §6.1)
+    |--------------------------------------------------------------------------
+    | OPERATIONAL TRIAGE, NOT DIAGNOSIS. Deterministic modified-NEWS2:
+    | absolute NEWS2-style banding per vital, plus a baseline-deviation
+    | component (vs the enrollment's first-24h calibration), a short-window
+    | trend component, and a monitoring-adherence signal. Escalation authority
+    | always rests with the clinical team (FDA CDS posture, brief §4.2).
+    | Bands are config here (metric-definition style); an ML sidecar is a
+    | later upgrade path, never a silent swap.
+    */
+    'hews' => [
+        'lookback_hours' => 12,        // observations older than this don't score
+        'trend_window_hours' => 6,     // slope window for the trend component
+        'baseline_window_hours' => 24, // enrollment calibration window
+        'adherence_window_hours' => 6, // expected-vs-received cadence window
+        'bands' => [
+            'low' => 0,     // 0–4
+            'medium' => 5,  // 5–6
+            'high' => 7,    // ≥7 — drives command-grid sort + visit intensity
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default vital thresholds (LOINC-keyed)
+    |--------------------------------------------------------------------------
+    | Global defaults for breach alerting; per-patient overrides live in
+    | rpm_enrollments.monitoring_plan.thresholds[<loinc>]. Personalized
+    | thresholds are the alarm-fatigue guardrail (§8): alerts fire on the
+    | patient's numbers, not the population's.
+    */
+    'vital_thresholds' => [
+        '8867-4' => ['critical_low' => 40, 'warning_low' => 50, 'warning_high' => 110, 'critical_high' => 130],  // heart rate
+        '59408-5' => ['critical_low' => 88, 'warning_low' => 92],                                                // SpO2
+        '8480-6' => ['critical_low' => 85, 'warning_low' => 95, 'warning_high' => 180, 'critical_high' => 200],  // systolic BP
+        '8462-4' => ['warning_high' => 110, 'critical_high' => 120],                                             // diastolic BP
+        '9279-1' => ['critical_low' => 8, 'warning_low' => 10, 'warning_high' => 22, 'critical_high' => 27],     // respiratory rate
+        '8310-5' => ['critical_low' => 34.5, 'warning_low' => 35.5, 'warning_high' => 38.5, 'critical_high' => 39.5], // temperature °C
+    ],
 ];

--- a/database/migrations/2026_07_17_000010_create_home_hospital_program_tables.php
+++ b/database/migrations/2026_07_17_000010_create_home_hospital_program_tables.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Traits\SafeMigration;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Home Hospital Phase 0 — program lines, referral funnel, and episode spine
+ * (ACUM-PRD-HAH-001 §7; docs/home-hospital/HOME-HOSPITAL-BUILD-PROMPT.md).
+ *
+ * The episode spine links to an encounter on the virtual_home unit so census,
+ * occupancy, huddles, and the cockpit machinery work unmodified. Home tables
+ * live ALONGSIDE the census spine (like prod.discharge_facts), never inside
+ * prod.encounters. Operational paths carry pseudonymous patient_ref and
+ * service zones only — never MRNs or street addresses.
+ */
+return new class extends Migration
+{
+    use SafeMigration;
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('prod.home_programs')) {
+            Schema::create('prod.home_programs', function (Blueprint $table): void {
+                $table->id('home_program_id');
+                $table->uuid('program_uuid')->unique();
+                $table->string('code', 60)->unique();
+                $table->string('name', 160);
+                $table->string('program_type', 40);
+                // Payer-aware from day one (§2): coverage rules per payer class.
+                $table->jsonb('payer_rules')->default(DB::raw("'{}'::jsonb"));
+                // Qualifying condition codes for eligibility screening.
+                $table->jsonb('conditions')->default(DB::raw("'[]'::jsonb"));
+                // Slot capacity by service zone, e.g. {"north": 6, "central": 6}.
+                $table->jsonb('zone_slot_capacity')->default(DB::raw("'{}'::jsonb"));
+                $table->integer('slot_capacity')->default(0);
+                $table->boolean('is_active')->default(true);
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['program_type', 'is_active'], 'home_programs_type_active_idx');
+            });
+        }
+
+        if (! Schema::hasTable('prod.home_referrals')) {
+            Schema::create('prod.home_referrals', function (Blueprint $table): void {
+                $table->id('home_referral_id');
+                $table->uuid('referral_uuid')->unique();
+                $table->foreignId('home_program_id')
+                    ->constrained('prod.home_programs', 'home_program_id')
+                    ->restrictOnDelete();
+                $table->string('patient_ref', 190);
+                // Source encounter (ED boarder / inpatient) the referral screens.
+                $table->foreignId('encounter_id')->nullable()
+                    ->constrained('prod.encounters', 'encounter_id')
+                    ->nullOnDelete();
+                $table->string('source', 40);
+                $table->string('status', 40)->default('referred');
+                // Coded decline reason feeds selection-bias analytics (§11).
+                $table->string('decline_reason', 60)->nullable();
+                $table->text('decline_note')->nullable();
+                // Screening payload: zone, payer, home-safety, connectivity.
+                $table->jsonb('screening')->default(DB::raw("'{}'::jsonb"));
+                $table->string('payer_class', 40)->nullable();
+                $table->string('service_zone', 60)->nullable();
+                $table->string('referred_by', 190)->nullable();
+                $table->timestampTz('referred_at');
+                $table->timestampTz('status_changed_at')->nullable();
+                $table->timestampTz('activated_at')->nullable();
+                $table->timestampTz('declined_at')->nullable();
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['home_program_id', 'status'], 'home_referrals_program_status_idx');
+                $table->index(['status', 'referred_at'], 'home_referrals_status_referred_idx');
+                $table->index('patient_ref', 'home_referrals_patient_ref_idx');
+            });
+        }
+
+        if (! Schema::hasTable('prod.home_episodes')) {
+            Schema::create('prod.home_episodes', function (Blueprint $table): void {
+                $table->id('home_episode_id');
+                $table->uuid('episode_uuid')->unique();
+                $table->foreignId('home_program_id')
+                    ->constrained('prod.home_programs', 'home_program_id')
+                    ->restrictOnDelete();
+                $table->foreignId('home_referral_id')->nullable()
+                    ->constrained('prod.home_referrals', 'home_referral_id')
+                    ->nullOnDelete();
+                // The encounter on the virtual_home unit — the census-spine link.
+                $table->foreignId('encounter_id')->nullable()
+                    ->constrained('prod.encounters', 'encounter_id')
+                    ->nullOnDelete();
+                $table->string('patient_ref', 190);
+                $table->string('condition_code', 60);
+                $table->string('condition_label', 160)->nullable();
+                $table->string('drg_code', 20)->nullable();
+                $table->string('admission_source', 40);
+                $table->smallInteger('acuity_tier')->default(3); // 1 = sickest
+                $table->string('status', 40)->default('pending_activation');
+                $table->string('disposition', 40)->nullable();
+                $table->string('service_zone', 60)->nullable();
+                $table->decimal('target_los_days', 4, 1)->nullable();
+                $table->date('expected_discharge_date')->nullable();
+                $table->timestampTz('started_at')->nullable();
+                $table->timestampTz('ended_at')->nullable();
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['home_program_id', 'status'], 'home_episodes_program_status_idx');
+                $table->index(['status', 'started_at'], 'home_episodes_status_started_idx');
+                $table->index('patient_ref', 'home_episodes_patient_ref_idx');
+            });
+        }
+
+        $this->addCheckConstraint('prod.home_programs', 'home_programs_program_type_check',
+            "program_type IN ('ahcah_acute','observation_at_home','post_discharge_rpm','chronic_rpm','snf_at_home')");
+        $this->addCheckConstraint('prod.home_programs', 'home_programs_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+        $this->addCheckConstraint('prod.home_referrals', 'home_referrals_source_check',
+            "source IN ('ed_diversion','inpatient_stepdown','direct','ambulatory')");
+        $this->addCheckConstraint('prod.home_referrals', 'home_referrals_status_check',
+            "status IN ('referred','screened','eligible','consented','activated','declined','cancelled')");
+        $this->addCheckConstraint('prod.home_referrals', 'home_referrals_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+        $this->addCheckConstraint('prod.home_episodes', 'home_episodes_admission_source_check',
+            "admission_source IN ('ed_diversion','inpatient_stepdown','direct','ambulatory')");
+        $this->addCheckConstraint('prod.home_episodes', 'home_episodes_status_check',
+            "status IN ('pending_activation','active','completed','cancelled')");
+        $this->addCheckConstraint('prod.home_episodes', 'home_episodes_disposition_check',
+            "disposition IS NULL OR disposition IN ('routine_discharge','ed_return','readmitted','transferred','deceased','other')");
+        $this->addCheckConstraint('prod.home_episodes', 'home_episodes_acuity_tier_check',
+            'acuity_tier BETWEEN 1 AND 5');
+        $this->addCheckConstraint('prod.home_episodes', 'home_episodes_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+    }
+
+    public function down(): void
+    {
+        $this->safeDropIfExists('prod.home_episodes');
+        $this->safeDropIfExists('prod.home_referrals');
+        $this->safeDropIfExists('prod.home_programs');
+    }
+
+    private function addCheckConstraint(string $table, string $name, string $expression): void
+    {
+        [$schema, $relation] = explode('.', $table, 2);
+        $exists = DB::table('pg_constraint as constraint')
+            ->join('pg_class as relation', 'relation.oid', '=', 'constraint.conrelid')
+            ->join('pg_namespace as namespace', 'namespace.oid', '=', 'relation.relnamespace')
+            ->where('namespace.nspname', $schema)
+            ->where('relation.relname', $relation)
+            ->where('constraint.conname', $name)
+            ->exists();
+
+        if (! $exists) {
+            DB::statement("ALTER TABLE {$table} ADD CONSTRAINT {$name} CHECK ({$expression})");
+        }
+    }
+};

--- a/database/migrations/2026_07_17_000020_create_home_hospital_rpm_tables.php
+++ b/database/migrations/2026_07_17_000020_create_home_hospital_rpm_tables.php
@@ -1,0 +1,215 @@
+<?php
+
+use App\Traits\SafeMigration;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Home Hospital Phase 0 — RPM kit/device inventory, enrollments, the
+ * high-volume observation ledger, and patient-level clinical alerts
+ * (ACUM-PRD-HAH-001 §5.1–5.2).
+ *
+ * prod.rpm_observations ships UNPARTITIONED (build brief §13 Q5 default):
+ * no declarative table-partitioning convention exists in this repo, and one
+ * must not be introduced silently. Retention policy: observations older than
+ * 18 months are eligible for rollup into daily aggregates (metadata carries
+ * the rollup marker); monthly range-partitioning is a proposed, reviewed
+ * follow-up once volume warrants it. observation_uuid is the idempotency key
+ * (vendor transmission id), mirroring raw.inbound_messages dedupe.
+ */
+return new class extends Migration
+{
+    use SafeMigration;
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('prod.rpm_kits')) {
+            Schema::create('prod.rpm_kits', function (Blueprint $table): void {
+                $table->id('rpm_kit_id');
+                $table->uuid('kit_uuid')->unique();
+                $table->string('kit_code', 60)->unique();
+                $table->string('vendor', 80)->nullable();
+                $table->string('model', 80)->nullable();
+                $table->string('status', 40)->default('available');
+                // Prefer cellular backhaul — broadband equity guardrail (§8).
+                $table->string('connectivity', 40)->nullable();
+                $table->smallInteger('battery_pct')->nullable();
+                $table->timestampTz('last_seen_at')->nullable();
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['status', 'is_deleted'], 'rpm_kits_status_idx');
+            });
+        }
+
+        if (! Schema::hasTable('prod.rpm_devices')) {
+            Schema::create('prod.rpm_devices', function (Blueprint $table): void {
+                $table->id('rpm_device_id');
+                $table->uuid('device_uuid')->unique();
+                $table->foreignId('rpm_kit_id')
+                    ->constrained('prod.rpm_kits', 'rpm_kit_id')
+                    ->restrictOnDelete();
+                $table->string('device_type', 40);
+                $table->string('serial_number', 120)->nullable();
+                // FHIR Device id once projected (fhir.resource_links owns the map).
+                $table->string('fhir_device_id', 190)->nullable();
+                $table->string('status', 40)->default('active');
+                $table->smallInteger('battery_pct')->nullable();
+                $table->timestampTz('last_transmission_at')->nullable();
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['rpm_kit_id', 'status'], 'rpm_devices_kit_status_idx');
+            });
+        }
+
+        if (! Schema::hasTable('prod.rpm_enrollments')) {
+            Schema::create('prod.rpm_enrollments', function (Blueprint $table): void {
+                $table->id('rpm_enrollment_id');
+                $table->uuid('enrollment_uuid')->unique();
+                $table->foreignId('home_episode_id')
+                    ->constrained('prod.home_episodes', 'home_episode_id')
+                    ->restrictOnDelete();
+                $table->foreignId('rpm_kit_id')
+                    ->constrained('prod.rpm_kits', 'rpm_kit_id')
+                    ->restrictOnDelete();
+                $table->string('patient_ref', 190);
+                $table->string('status', 40)->default('pending');
+                // Per-vital cadence + personalized thresholds + baseline window.
+                $table->jsonb('monitoring_plan')->default(DB::raw("'{}'::jsonb"));
+                // Patient-specific baselines calibrated over the first 24h (HEWS input).
+                $table->jsonb('baseline')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampTz('started_at')->nullable();
+                $table->timestampTz('ended_at')->nullable();
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['home_episode_id', 'status'], 'rpm_enrollments_episode_status_idx');
+                $table->index(['rpm_kit_id', 'status'], 'rpm_enrollments_kit_status_idx');
+            });
+        }
+
+        if (! Schema::hasTable('prod.rpm_observations')) {
+            Schema::create('prod.rpm_observations', function (Blueprint $table): void {
+                $table->id('rpm_observation_id');
+                // Idempotency key = vendor transmission id (deduped at ingest).
+                $table->uuid('observation_uuid')->unique();
+                $table->foreignId('rpm_enrollment_id')
+                    ->constrained('prod.rpm_enrollments', 'rpm_enrollment_id')
+                    ->restrictOnDelete();
+                $table->foreignId('rpm_device_id')->nullable()
+                    ->constrained('prod.rpm_devices', 'rpm_device_id')
+                    ->nullOnDelete();
+                $table->string('patient_ref', 190);
+                // LOINC vital-sign codes: HR 8867-4, SpO2 59408-5, SBP 8480-6,
+                // DBP 8462-4, RR 9279-1, temp 8310-5, weight 29463-7.
+                $table->string('loinc_code', 20);
+                $table->string('display', 80)->nullable();
+                $table->decimal('value', 10, 2);
+                $table->string('unit', 20)->nullable();
+                $table->timestampTz('observed_at');
+                $table->timestampTz('received_at');
+                // Transmission provenance (source + vendor transmission id).
+                $table->string('source_key', 60)->nullable();
+                $table->string('transmission_id', 190)->nullable();
+                $table->string('quality_flag', 20)->default('ok');
+                $table->boolean('is_breach')->default(false);
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['rpm_enrollment_id', 'observed_at'], 'rpm_observations_enrollment_observed_idx');
+                $table->index(['patient_ref', 'loinc_code', 'observed_at'], 'rpm_observations_patient_vital_idx');
+                $table->index(['is_breach', 'observed_at'], 'rpm_observations_breach_idx');
+            });
+        }
+
+        if (! Schema::hasTable('prod.rpm_alerts')) {
+            Schema::create('prod.rpm_alerts', function (Blueprint $table): void {
+                $table->id('rpm_alert_id');
+                $table->uuid('alert_uuid')->unique();
+                $table->foreignId('home_episode_id')
+                    ->constrained('prod.home_episodes', 'home_episode_id')
+                    ->restrictOnDelete();
+                $table->foreignId('rpm_enrollment_id')->nullable()
+                    ->constrained('prod.rpm_enrollments', 'rpm_enrollment_id')
+                    ->nullOnDelete();
+                $table->foreignId('rpm_observation_id')->nullable()
+                    ->constrained('prod.rpm_observations', 'rpm_observation_id')
+                    ->nullOnDelete();
+                $table->string('patient_ref', 190);
+                $table->string('rule_key', 80);
+                $table->string('severity', 20);
+                $table->string('status', 40)->default('open');
+                $table->timestampTz('opened_at');
+                $table->timestampTz('acknowledged_at')->nullable();
+                $table->string('acknowledged_by', 190)->nullable();
+                $table->timestampTz('resolved_at')->nullable();
+                $table->string('resolved_by', 190)->nullable();
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['home_episode_id', 'status'], 'rpm_alerts_episode_status_idx');
+                $table->index(['status', 'severity', 'opened_at'], 'rpm_alerts_status_severity_idx');
+            });
+        }
+
+        $this->addCheckConstraint('prod.rpm_kits', 'rpm_kits_status_check',
+            "status IN ('available','assigned','in_transit','maintenance','retired','lost')");
+        $this->addCheckConstraint('prod.rpm_kits', 'rpm_kits_connectivity_check',
+            "connectivity IS NULL OR connectivity IN ('cellular','wifi','hybrid')");
+        $this->addCheckConstraint('prod.rpm_kits', 'rpm_kits_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+        $this->addCheckConstraint('prod.rpm_devices', 'rpm_devices_device_type_check',
+            "device_type IN ('bp_monitor','pulse_oximeter','thermometer','scale','ecg_patch','glucometer','stethoscope','tablet','other')");
+        $this->addCheckConstraint('prod.rpm_devices', 'rpm_devices_status_check',
+            "status IN ('active','inactive','fault','retired')");
+        $this->addCheckConstraint('prod.rpm_devices', 'rpm_devices_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+        $this->addCheckConstraint('prod.rpm_enrollments', 'rpm_enrollments_status_check',
+            "status IN ('pending','active','paused','ended')");
+        $this->addCheckConstraint('prod.rpm_enrollments', 'rpm_enrollments_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+        $this->addCheckConstraint('prod.rpm_observations', 'rpm_observations_quality_flag_check',
+            "quality_flag IN ('ok','suspect','artifact','stale')");
+        $this->addCheckConstraint('prod.rpm_observations', 'rpm_observations_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+        $this->addCheckConstraint('prod.rpm_alerts', 'rpm_alerts_severity_check',
+            "severity IN ('watch','warning','critical')");
+        $this->addCheckConstraint('prod.rpm_alerts', 'rpm_alerts_status_check',
+            "status IN ('open','acknowledged','resolved','expired')");
+        $this->addCheckConstraint('prod.rpm_alerts', 'rpm_alerts_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+    }
+
+    public function down(): void
+    {
+        $this->safeDropIfExists('prod.rpm_alerts');
+        $this->safeDropIfExists('prod.rpm_observations');
+        $this->safeDropIfExists('prod.rpm_enrollments');
+        $this->safeDropIfExists('prod.rpm_devices');
+        $this->safeDropIfExists('prod.rpm_kits');
+    }
+
+    private function addCheckConstraint(string $table, string $name, string $expression): void
+    {
+        [$schema, $relation] = explode('.', $table, 2);
+        $exists = DB::table('pg_constraint as constraint')
+            ->join('pg_class as relation', 'relation.oid', '=', 'constraint.conrelid')
+            ->join('pg_namespace as namespace', 'namespace.oid', '=', 'relation.relnamespace')
+            ->where('namespace.nspname', $schema)
+            ->where('relation.relname', $relation)
+            ->where('constraint.conname', $name)
+            ->exists();
+
+        if (! $exists) {
+            DB::statement("ALTER TABLE {$table} ADD CONSTRAINT {$name} CHECK ({$expression})");
+        }
+    }
+};

--- a/database/migrations/2026_07_17_000030_create_home_hospital_operations_tables.php
+++ b/database/migrations/2026_07_17_000030_create_home_hospital_operations_tables.php
@@ -1,0 +1,168 @@
+<?php
+
+use App\Traits\SafeMigration;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Home Hospital Phase 0 — field visits, escalations, and transitions
+ * (ACUM-PRD-HAH-001 §4.2, §7).
+ *
+ * home_visits carries the CMS AHCAH waiver operating floor as first-class
+ * telemetry: is_waiver_required marks the ≥2-in-person-visits-per-day + daily
+ * MD evaluation floor, and on-time state is derived from scheduled vs actual.
+ * home_escalations stores the full response timing chain (initiated →
+ * dispatched → arrived → resolved) against the 30-minute emergency-response
+ * requirement. home_transitions reuses the regional graph
+ * (regional.facilities) and prod.transport_requests rather than rebuilding
+ * destination selection.
+ */
+return new class extends Migration
+{
+    use SafeMigration;
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('prod.home_visits')) {
+            Schema::create('prod.home_visits', function (Blueprint $table): void {
+                $table->id('home_visit_id');
+                $table->uuid('visit_uuid')->unique();
+                $table->foreignId('home_episode_id')
+                    ->constrained('prod.home_episodes', 'home_episode_id')
+                    ->restrictOnDelete();
+                $table->string('patient_ref', 190);
+                $table->string('visit_type', 40);
+                $table->boolean('is_waiver_required')->default(false);
+                $table->string('status', 40)->default('scheduled');
+                $table->timestampTz('scheduled_start');
+                $table->timestampTz('scheduled_end')->nullable();
+                $table->timestampTz('started_at')->nullable();
+                $table->timestampTz('completed_at')->nullable();
+                // Staffing-model-agnostic assignee ref (employed RN or contracted
+                // community paramedic — open question §13 Q2).
+                $table->string('assigned_to', 190)->nullable();
+                $table->boolean('on_time')->nullable();
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['home_episode_id', 'scheduled_start'], 'home_visits_episode_scheduled_idx');
+                $table->index(['status', 'scheduled_start'], 'home_visits_status_scheduled_idx');
+                $table->index(['is_waiver_required', 'scheduled_start'], 'home_visits_waiver_idx');
+            });
+        }
+
+        if (! Schema::hasTable('prod.home_escalations')) {
+            Schema::create('prod.home_escalations', function (Blueprint $table): void {
+                $table->id('home_escalation_id');
+                $table->uuid('escalation_uuid')->unique();
+                $table->foreignId('home_episode_id')
+                    ->constrained('prod.home_episodes', 'home_episode_id')
+                    ->restrictOnDelete();
+                $table->foreignId('rpm_alert_id')->nullable()
+                    ->constrained('prod.rpm_alerts', 'rpm_alert_id')
+                    ->nullOnDelete();
+                $table->string('patient_ref', 190);
+                $table->string('trigger_type', 40);
+                $table->string('response_mode', 40)->nullable();
+                $table->string('status', 40)->default('open');
+                // Full timing chain — response-time telemetry vs the 30-min floor.
+                $table->timestampTz('initiated_at');
+                $table->timestampTz('dispatched_at')->nullable();
+                $table->timestampTz('arrived_at')->nullable();
+                $table->timestampTz('resolved_at')->nullable();
+                $table->integer('response_minutes')->nullable();
+                $table->string('outcome', 40)->nullable();
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['home_episode_id', 'initiated_at'], 'home_escalations_episode_initiated_idx');
+                $table->index(['status', 'initiated_at'], 'home_escalations_status_idx');
+            });
+        }
+
+        if (! Schema::hasTable('prod.home_transitions')) {
+            Schema::create('prod.home_transitions', function (Blueprint $table): void {
+                $table->id('home_transition_id');
+                $table->uuid('transition_uuid')->unique();
+                $table->foreignId('home_episode_id')
+                    ->constrained('prod.home_episodes', 'home_episode_id')
+                    ->restrictOnDelete();
+                $table->string('patient_ref', 190);
+                $table->string('direction', 20); // inbound activation | outbound handoff
+                $table->string('status', 40)->default('pending');
+                // Inbound: consent, home-safety check, kit delivery, first visit.
+                // Outbound: discharge readiness items. Checklist item => state.
+                $table->jsonb('checklist')->default(DB::raw("'{}'::jsonb"));
+                $table->string('handoff_owner', 190)->nullable();
+                $table->string('receiving_entity_type', 40)->nullable();
+                $table->foreignId('regional_facility_id')->nullable()
+                    ->constrained('regional.facilities', 'regional_facility_id')
+                    ->nullOnDelete();
+                $table->foreignId('transport_request_id')->nullable()
+                    ->constrained('prod.transport_requests', 'transport_request_id')
+                    ->nullOnDelete();
+                $table->jsonb('barriers')->default(DB::raw("'[]'::jsonb"));
+                $table->timestampTz('started_at')->nullable();
+                $table->timestampTz('completed_at')->nullable();
+                $table->jsonb('metadata')->default(DB::raw("'{}'::jsonb"));
+                $table->timestampsTz();
+                $table->boolean('is_deleted')->default(false);
+
+                $table->index(['home_episode_id', 'direction'], 'home_transitions_episode_direction_idx');
+                $table->index(['status', 'direction'], 'home_transitions_status_idx');
+            });
+        }
+
+        $this->addCheckConstraint('prod.home_visits', 'home_visits_visit_type_check',
+            "visit_type IN ('rn','community_paramedic','md_np_tele','md_np_in_person','lab_draw','delivery','other')");
+        $this->addCheckConstraint('prod.home_visits', 'home_visits_status_check',
+            "status IN ('scheduled','en_route','in_progress','completed','missed','cancelled')");
+        $this->addCheckConstraint('prod.home_visits', 'home_visits_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+        $this->addCheckConstraint('prod.home_escalations', 'home_escalations_trigger_type_check',
+            "trigger_type IN ('critical_vital','clinical_deterioration','patient_request','caregiver_request','device_failure','other')");
+        $this->addCheckConstraint('prod.home_escalations', 'home_escalations_response_mode_check',
+            "response_mode IS NULL OR response_mode IN ('tele_assessment','field_dispatch','ems','ed_return')");
+        $this->addCheckConstraint('prod.home_escalations', 'home_escalations_status_check',
+            "status IN ('open','responding','resolved')");
+        $this->addCheckConstraint('prod.home_escalations', 'home_escalations_outcome_check',
+            "outcome IS NULL OR outcome IN ('managed_at_home','ed_return','readmitted','deceased','other')");
+        $this->addCheckConstraint('prod.home_escalations', 'home_escalations_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+        $this->addCheckConstraint('prod.home_transitions', 'home_transitions_direction_check',
+            "direction IN ('inbound','outbound')");
+        $this->addCheckConstraint('prod.home_transitions', 'home_transitions_status_check',
+            "status IN ('pending','in_progress','completed','blocked')");
+        $this->addCheckConstraint('prod.home_transitions', 'home_transitions_receiving_entity_check',
+            "receiving_entity_type IS NULL OR receiving_entity_type IN ('pcp','home_health','snf','other')");
+        $this->addCheckConstraint('prod.home_transitions', 'home_transitions_metadata_object_check',
+            "jsonb_typeof(metadata) = 'object'");
+    }
+
+    public function down(): void
+    {
+        $this->safeDropIfExists('prod.home_transitions');
+        $this->safeDropIfExists('prod.home_escalations');
+        $this->safeDropIfExists('prod.home_visits');
+    }
+
+    private function addCheckConstraint(string $table, string $name, string $expression): void
+    {
+        [$schema, $relation] = explode('.', $table, 2);
+        $exists = DB::table('pg_constraint as constraint')
+            ->join('pg_class as relation', 'relation.oid', '=', 'constraint.conrelid')
+            ->join('pg_namespace as namespace', 'namespace.oid', '=', 'relation.relnamespace')
+            ->where('namespace.nspname', $schema)
+            ->where('relation.relname', $relation)
+            ->where('constraint.conname', $name)
+            ->exists();
+
+        if (! $exists) {
+            DB::statement("ALTER TABLE {$table} ADD CONSTRAINT {$name} CHECK ({$expression})");
+        }
+    }
+};

--- a/database/seeders/CockpitKpiDefinitionSeeder.php
+++ b/database/seeders/CockpitKpiDefinitionSeeder.php
@@ -210,7 +210,7 @@ class CockpitKpiDefinitionSeeder extends Seeder
             'home.escalation_response_p90' => $this->kpi('Escalation response p90', 'p90 escalation response time vs the 30-minute waiver floor (trailing 7d).', 'min', 'down', 30, 25, 31, 120,
                 'Home escalation response p90 {display} — 30-min waiver floor at risk'),
             'home.visit_compliance_today' => $this->kpi('Waiver visit compliance', 'Percent of due waiver-required visits completed today (≥2/day floor).', '%', 'up', 100, 95, 80, 120,
-                'Waiver visit compliance {display} — below the AHCAH floor'),
+                'Waiver visit compliance {display} — below the AHCAH floor', null, 98),
             'home.device_offline_pct' => $this->kpi('Kits offline', 'Assigned RPM kits with a transmission gap over 60 minutes.', '%', 'down', 0, 10, null, 120,
                 'Home RPM kits offline — {display} of assigned kits dark'),
             'home.rpm_adherence' => $this->kpi('Monitoring adherence', 'Received vs expected readings across active enrollments (6h window).', '%', 'up', 80, 70, null, 120),

--- a/database/seeders/CockpitKpiDefinitionSeeder.php
+++ b/database/seeders/CockpitKpiDefinitionSeeder.php
@@ -199,6 +199,24 @@ class CockpitKpiDefinitionSeeder extends Seeder
             'financial.cost_per_case' => $this->kpi('Cost / OR case', 'Cost per OR case vs budget.', '$k', 'down', null, null, null, 3600),
             'financial.contract_labor' => $this->kpi('Contract labor', 'Contract labor dollars today.', '$k', 'down', null, null, null, 3600),
             'financial.overtime' => $this->kpi('Overtime', 'Overtime hours as a percent of worked hours.', '%', 'down', 4, 4, 6, 3600),
+
+            // ---------------- Home Hospital (ACUM-PRD-HAH-001 §9) — 120s ----
+            // Earned-Red ration: alert_template ONLY on the four alerting rows
+            // (unacked criticals, response p90, visit compliance, kits offline).
+            // Benchmarks are the national numbers (Levine 2024 / CMS waiver).
+            'home.census_occupancy' => $this->kpi('Virtual ward occupancy', 'Occupied program slots as a percent of the virtual ward.', '%', 'up', null, null, null, 120),
+            'home.unacked_critical_vitals' => $this->kpi('Unacked critical vitals', 'Open critical patient vitals awaiting clinician acknowledgement.', '', 'down', 0, null, 1, 120,
+                'HOME critical vitals unacknowledged — {display} open'),
+            'home.escalation_response_p90' => $this->kpi('Escalation response p90', 'p90 escalation response time vs the 30-minute waiver floor (trailing 7d).', 'min', 'down', 30, 25, 31, 120,
+                'Home escalation response p90 {display} — 30-min waiver floor at risk'),
+            'home.visit_compliance_today' => $this->kpi('Waiver visit compliance', 'Percent of due waiver-required visits completed today (≥2/day floor).', '%', 'up', 100, 95, 80, 120,
+                'Waiver visit compliance {display} — below the AHCAH floor'),
+            'home.device_offline_pct' => $this->kpi('Kits offline', 'Assigned RPM kits with a transmission gap over 60 minutes.', '%', 'down', 0, 10, null, 120,
+                'Home RPM kits offline — {display} of assigned kits dark'),
+            'home.rpm_adherence' => $this->kpi('Monitoring adherence', 'Received vs expected readings across active enrollments (6h window).', '%', 'up', 80, 70, null, 120),
+            'home.escalation_rate_7d' => $this->kpi('Escalations / 100 episode-days', 'Escalations per 100 home episode-days, trailing 7d (national ≈6.2%).', '', 'down', 6.2, 8, null, 120, null, ['benchmark' => 6.2, 'benchmark_source' => 'Levine 2024']),
+            'home.referral_conversion_7d' => $this->kpi('Referral conversion', 'Referrals activated as a percent of referrals received, trailing 7d (real programs ≈22%).', '%', 'up', 22, null, null, 120, null, ['benchmark' => 22, 'benchmark_source' => 'HaH Users Group']),
+            'home.avoided_bed_days_mtd' => $this->kpi('Avoided bed-days MTD', 'Active home episode-days this month — occupied bed-days the house did not spend.', 'days', 'up', null, null, null, 120),
         ];
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -57,6 +57,11 @@ class DatabaseSeeder extends Seeder
             // Virtual Rounds pilot templates (rounds.templates). Idempotent by
             // (name, version); template UUIDs are minted once and preserved.
             RoundTemplateSeeder::class,
+            // Home Hospital virtual ward + demo cohort. Gated on
+            // HOME_HOSPITAL_ENABLED (no-op otherwise); runs BEFORE
+            // DemoTuningSeeder so tuning sees final unit/bed state. The
+            // virtual_home unit is exempt from RtdcSeeder's manifest soft-trim.
+            HomeHospitalDemoSeeder::class,
             // DemoTuningSeeder runs LAST: it tunes whatever the base seeders produced into the
             // compelling live demo state (85% occupancy, today's staffing gaps, near-now SLAs,
             // clean ED bed inventory, varied OR surgeons). Idempotent; Postgres-only.

--- a/database/seeders/HomeHospitalDemoSeeder.php
+++ b/database/seeders/HomeHospitalDemoSeeder.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Bed;
+use App\Models\Encounter;
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeProgram;
+use App\Models\Home\HomeReferral;
+use App\Models\Home\HomeVisit;
+use App\Models\Home\RpmDevice;
+use App\Models\Home\RpmEnrollment;
+use App\Models\Home\RpmKit;
+use App\Models\Unit;
+use Illuminate\Database\Seeder;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Home Hospital Phase 0 demo cohort (ACUM-PRD-HAH-001; build brief §6.16).
+ *
+ * Seeds the virtual ward as one more prod.units row (type = virtual_home,
+ * exempt from RtdcSeeder's manifest soft-trim) with prod.beds rows as program
+ * slots, so census/occupancy/huddles/cockpit machinery work unmodified. Slot
+ * states map onto the existing prod.beds CHECK (available|occupied|blocked|
+ * dirty); "dirty" carries the pending-kit-setup meaning on this unit.
+ *
+ * Gated on HOME_HOSPITAL_ENABLED — a bare `db:seed` on a deployment without
+ * the module leaves no trace. Idempotent: every row keys on a natural key
+ * (program code, kit code, patient_ref) via updateOrCreate/firstOrCreate.
+ * Ownership: encounters carry created_by = OWNER; home rows carry
+ * metadata.provenance = 'demo' (drives the frontend ProvenanceBadge).
+ */
+class HomeHospitalDemoSeeder extends Seeder
+{
+    public const OWNER = 'home-hospital-demo';
+
+    /**
+     * Demo cohort: deterministic patient_refs; slot index = position on the
+     * board. Conditions come from the §13 Q1 default set. day = day-of-stay.
+     */
+    private const EPISODES = [
+        ['ref' => 'HOME-DEMO-001', 'condition' => 'heart_failure', 'label' => 'Heart Failure', 'day' => 4, 'los' => 6.0, 'tier' => 2, 'zone' => 'north'],
+        ['ref' => 'HOME-DEMO-002', 'condition' => 'copd', 'label' => 'COPD Exacerbation', 'day' => 2, 'los' => 5.0, 'tier' => 3, 'zone' => 'north'],
+        ['ref' => 'HOME-DEMO-003', 'condition' => 'pneumonia', 'label' => 'Pneumonia / Respiratory Infection', 'day' => 5, 'los' => 6.0, 'tier' => 3, 'zone' => 'central'],
+        ['ref' => 'HOME-DEMO-004', 'condition' => 'cellulitis', 'label' => 'Cellulitis / SSTI', 'day' => 1, 'los' => 4.0, 'tier' => 4, 'zone' => 'central'],
+        ['ref' => 'HOME-DEMO-005', 'condition' => 'uti', 'label' => 'Kidney / UTI', 'day' => 3, 'los' => 5.0, 'tier' => 3, 'zone' => 'south'],
+        ['ref' => 'HOME-DEMO-006', 'condition' => 'heart_failure', 'label' => 'Heart Failure', 'day' => 6, 'los' => 6.0, 'tier' => 2, 'zone' => 'south'],
+        ['ref' => 'HOME-DEMO-007', 'condition' => 'copd', 'label' => 'COPD Exacerbation', 'day' => 2, 'los' => 6.0, 'tier' => 3, 'zone' => 'north'],
+        ['ref' => 'HOME-DEMO-008', 'condition' => 'pneumonia', 'label' => 'Pneumonia / Respiratory Infection', 'day' => 1, 'los' => 5.0, 'tier' => 3, 'zone' => 'central'],
+    ];
+
+    /** Referral funnel snapshot — includes declines with coded reasons (§11 selection-bias analytics). */
+    private const REFERRALS = [
+        ['ref' => 'HOME-REF-101', 'source' => 'ed_diversion', 'status' => 'screened', 'zone' => 'north', 'payer' => 'medicare_ffs'],
+        ['ref' => 'HOME-REF-102', 'source' => 'ed_diversion', 'status' => 'eligible', 'zone' => 'central', 'payer' => 'medicare_advantage'],
+        ['ref' => 'HOME-REF-103', 'source' => 'inpatient_stepdown', 'status' => 'consented', 'zone' => 'south', 'payer' => 'medicare_ffs'],
+        ['ref' => 'HOME-REF-104', 'source' => 'inpatient_stepdown', 'status' => 'referred', 'zone' => 'north', 'payer' => 'commercial'],
+        ['ref' => 'HOME-REF-105', 'source' => 'ed_diversion', 'status' => 'declined', 'zone' => 'central', 'payer' => 'medicaid', 'decline' => 'patient_preference'],
+        ['ref' => 'HOME-REF-106', 'source' => 'ed_diversion', 'status' => 'declined', 'zone' => 'out_of_zone', 'payer' => 'medicare_ffs', 'decline' => 'out_of_service_zone'],
+    ];
+
+    public function run(): void
+    {
+        if (! (bool) config('home_hospital.enabled')) {
+            return;
+        }
+
+        $unit = $this->seedVirtualUnit();
+        $programs = $this->seedPrograms();
+        $this->seedKits();
+        $this->seedEpisodes($unit, $programs['ahcah_acute']);
+        $this->seedReferrals($programs['ahcah_acute']);
+    }
+
+    private function seedVirtualUnit(): Unit
+    {
+        $slotCount = (int) config('home_hospital.slot_count', 12);
+
+        $unit = Unit::updateOrCreate(
+            ['abbreviation' => (string) config('home_hospital.unit_abbreviation', 'HOME')],
+            [
+                'name' => (string) config('home_hospital.unit_name', 'Summit Home Hospital — Virtual Ward'),
+                'type' => 'virtual_home',
+                'staffed_bed_count' => $slotCount,
+                'ratio_floor' => 4,
+                'created_by' => self::OWNER,
+                'is_deleted' => false,
+            ]
+        );
+
+        for ($i = 1; $i <= $slotCount; $i++) {
+            Bed::firstOrCreate(
+                ['unit_id' => $unit->unit_id, 'label' => sprintf('%s-%02d', $unit->abbreviation, $i)],
+                ['status' => 'available', 'bed_type' => 'home_slot', 'created_by' => self::OWNER]
+            );
+        }
+
+        return $unit;
+    }
+
+    /** @return array<string, HomeProgram> */
+    private function seedPrograms(): array
+    {
+        $conditions = array_keys((array) config('home_hospital.conditions', []));
+
+        $acute = HomeProgram::updateOrCreate(
+            ['code' => 'ahcah_acute'],
+            [
+                'program_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.program.ahcah_acute')->toString(),
+                'name' => 'Acute Hospital at Home (AHCAH waiver)',
+                'program_type' => 'ahcah_acute',
+                'conditions' => $conditions,
+                'slot_capacity' => (int) config('home_hospital.slot_count', 12),
+                'zone_slot_capacity' => ['north' => 4, 'central' => 4, 'south' => 4],
+                'payer_rules' => ['medicare_ffs' => 'covered_waiver', 'medicare_advantage' => 'plan_dependent', 'commercial' => 'contract_dependent', 'medicaid' => 'state_dependent'],
+                'is_active' => true,
+                'metadata' => ['provenance' => 'demo'],
+            ]
+        );
+
+        $postDischarge = HomeProgram::updateOrCreate(
+            ['code' => 'post_discharge_rpm'],
+            [
+                'program_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.post_discharge_rpm')->toString(),
+                'name' => '30-Day Post-Discharge Monitoring',
+                'program_type' => 'post_discharge_rpm',
+                'conditions' => $conditions,
+                'slot_capacity' => 0,
+                'is_active' => true,
+                'metadata' => ['provenance' => 'demo'],
+            ]
+        );
+
+        return ['ahcah_acute' => $acute, 'post_discharge_rpm' => $postDischarge];
+    }
+
+    private function seedKits(): void
+    {
+        for ($i = 1; $i <= 10; $i++) {
+            $kit = RpmKit::updateOrCreate(
+                ['kit_code' => sprintf('KIT-%03d', $i)],
+                [
+                    'kit_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.kit.'.$i)->toString(),
+                    'vendor' => 'Synthetic Health',
+                    'model' => 'SH-100',
+                    'status' => 'available',
+                    'connectivity' => 'cellular',
+                    'battery_pct' => 100,
+                    'metadata' => ['provenance' => 'demo'],
+                ]
+            );
+
+            foreach (['bp_monitor', 'pulse_oximeter', 'thermometer', 'scale'] as $type) {
+                RpmDevice::updateOrCreate(
+                    ['rpm_kit_id' => $kit->rpm_kit_id, 'device_type' => $type],
+                    [
+                        'device_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.device.'.$i.'.'.$type)->toString(),
+                        'serial_number' => sprintf('SH100-%03d-%s', $i, strtoupper(substr($type, 0, 2))),
+                        'status' => 'active',
+                        'battery_pct' => 90,
+                        'metadata' => ['provenance' => 'demo'],
+                    ]
+                );
+            }
+        }
+    }
+
+    private function seedEpisodes(Unit $unit, HomeProgram $program): void
+    {
+        $slots = Bed::where('unit_id', $unit->unit_id)->where('is_deleted', false)->orderBy('bed_id')->get()->values();
+        $kits = RpmKit::where('is_deleted', false)->orderBy('rpm_kit_id')->get()->values();
+
+        foreach (self::EPISODES as $i => $spec) {
+            $bed = $slots[$i] ?? null;
+            if ($bed === null) {
+                continue;
+            }
+
+            $admittedAt = now()->subDays($spec['day'])->subHours(3);
+            $expected = now()->addDays(max(0, (int) ceil($spec['los'] - $spec['day'])))->toDateString();
+
+            $encounter = Encounter::updateOrCreate(
+                ['patient_ref' => $spec['ref'], 'unit_id' => $unit->unit_id, 'status' => 'active'],
+                [
+                    'bed_id' => $bed->bed_id,
+                    'admitted_at' => $admittedAt,
+                    'expected_discharge_date' => $expected,
+                    'acuity_tier' => $spec['tier'],
+                    'created_by' => self::OWNER,
+                    'is_deleted' => false,
+                ]
+            );
+
+            if ($bed->status !== 'occupied') {
+                $bed->update(['status' => 'occupied', 'modified_by' => self::OWNER]);
+            }
+
+            $episode = HomeEpisode::updateOrCreate(
+                ['patient_ref' => $spec['ref'], 'home_program_id' => $program->home_program_id],
+                [
+                    'episode_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.episode.'.$spec['ref'])->toString(),
+                    'encounter_id' => $encounter->encounter_id,
+                    'condition_code' => $spec['condition'],
+                    'condition_label' => $spec['label'],
+                    'admission_source' => $i % 2 === 0 ? 'ed_diversion' : 'inpatient_stepdown',
+                    'acuity_tier' => $spec['tier'],
+                    'status' => 'active',
+                    'service_zone' => $spec['zone'],
+                    'target_los_days' => $spec['los'],
+                    'expected_discharge_date' => $expected,
+                    'started_at' => $admittedAt,
+                    'metadata' => ['provenance' => 'demo'],
+                ]
+            );
+
+            $kit = $kits[$i] ?? null;
+            if ($kit !== null) {
+                RpmEnrollment::updateOrCreate(
+                    ['home_episode_id' => $episode->home_episode_id, 'rpm_kit_id' => $kit->rpm_kit_id],
+                    [
+                        'enrollment_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.enrollment.'.$spec['ref'])->toString(),
+                        'patient_ref' => $spec['ref'],
+                        'status' => 'active',
+                        'monitoring_plan' => ['cadence_minutes' => ['8867-4' => 60, '59408-5' => 60, '8480-6' => 240, '8462-4' => 240]],
+                        'started_at' => $admittedAt,
+                        'metadata' => ['provenance' => 'demo'],
+                    ]
+                );
+                if ($kit->status !== 'assigned') {
+                    $kit->update(['status' => 'assigned']);
+                }
+            }
+
+            $this->seedVisits($episode, $spec['ref']);
+        }
+
+        // Two slots beyond the cohort model non-available states: one blocked
+        // (home-safety hold), one dirty (= pending kit setup on this unit).
+        $blocked = $slots[count(self::EPISODES)] ?? null;
+        if ($blocked !== null && $blocked->status === 'available') {
+            $blocked->update(['status' => 'blocked', 'modified_by' => self::OWNER]);
+        }
+        $pending = $slots[count(self::EPISODES) + 1] ?? null;
+        if ($pending !== null && $pending->status === 'available') {
+            $pending->update(['status' => 'dirty', 'modified_by' => self::OWNER]);
+        }
+    }
+
+    private function seedVisits(HomeEpisode $episode, string $ref): void
+    {
+        // Waiver operating floor: two in-person visits today (§3). One completed
+        // this morning, one upcoming — feeds the compliance rail and the
+        // next-visit countdown without hand-tuned clock states.
+        $visits = [
+            ['type' => 'rn', 'start' => now()->startOfDay()->addHours(9), 'status' => 'completed', 'waiver' => true],
+            ['type' => 'community_paramedic', 'start' => now()->startOfDay()->addHours(18), 'status' => 'scheduled', 'waiver' => true],
+            ['type' => 'md_np_tele', 'start' => now()->startOfDay()->addHours(11), 'status' => 'completed', 'waiver' => false],
+        ];
+
+        foreach ($visits as $j => $v) {
+            $completed = $v['status'] === 'completed';
+            HomeVisit::updateOrCreate(
+                [
+                    'home_episode_id' => $episode->home_episode_id,
+                    'visit_type' => $v['type'],
+                    'scheduled_start' => $v['start'],
+                ],
+                [
+                    'visit_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.visit.'.$ref.'.'.$j.'.'.$v['start']->toDateString()),
+                    'patient_ref' => $ref,
+                    'is_waiver_required' => $v['waiver'],
+                    'status' => $v['status'],
+                    'started_at' => $completed ? $v['start'] : null,
+                    'completed_at' => $completed ? $v['start']->copy()->addMinutes(40) : null,
+                    'on_time' => $completed ? true : null,
+                    'metadata' => ['provenance' => 'demo'],
+                ]
+            );
+        }
+    }
+
+    private function seedReferrals(HomeProgram $program): void
+    {
+        foreach (self::REFERRALS as $spec) {
+            $declined = $spec['status'] === 'declined';
+            HomeReferral::updateOrCreate(
+                ['patient_ref' => $spec['ref'], 'home_program_id' => $program->home_program_id],
+                [
+                    'referral_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.referral.'.$spec['ref'])->toString(),
+                    'source' => $spec['source'],
+                    'status' => $spec['status'],
+                    'decline_reason' => $spec['decline'] ?? null,
+                    'declined_at' => $declined ? now()->subHours(5) : null,
+                    'screening' => [
+                        'service_zone' => $spec['zone'],
+                        'payer_class' => $spec['payer'],
+                        'connectivity' => 'cellular_ok',
+                        'home_safety' => $declined ? 'not_assessed' : 'passed',
+                    ],
+                    'payer_class' => $spec['payer'],
+                    'service_zone' => $spec['zone'],
+                    'referred_by' => self::OWNER,
+                    'referred_at' => now()->subHours(8),
+                    'status_changed_at' => now()->subHours(2),
+                    'metadata' => ['provenance' => 'demo'],
+                ]
+            );
+        }
+    }
+}

--- a/database/seeders/HomeHospitalDemoSeeder.php
+++ b/database/seeders/HomeHospitalDemoSeeder.php
@@ -373,6 +373,30 @@ class HomeHospitalDemoSeeder extends Seeder
                 ]
             );
 
+            // The first two episodes carry a linked ACTIVATED referral
+            // (referred 5h before admission): the OCEL home-refer anchor for
+            // the sidecar's time-to-activation SLA check, and a non-zero
+            // referral-conversion tile. Idempotent on (patient_ref, program).
+            if ($i < 2 && $episode->home_referral_id === null) {
+                $referral = HomeReferral::updateOrCreate(
+                    ['patient_ref' => $spec['ref'], 'home_program_id' => $program->home_program_id],
+                    [
+                        'referral_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.referral.activated.'.$spec['ref'])->toString(),
+                        'source' => $i % 2 === 0 ? 'ed_diversion' : 'inpatient_stepdown',
+                        'status' => 'activated',
+                        'screening' => ['condition_code' => $spec['condition'], 'home_safety' => 'passed', 'connectivity' => 'cellular_ok'],
+                        'payer_class' => 'medicare_ffs',
+                        'service_zone' => $spec['zone'],
+                        'referred_by' => self::OWNER,
+                        'referred_at' => $admittedAt->copy()->subHours(5),
+                        'activated_at' => $admittedAt,
+                        'status_changed_at' => $admittedAt,
+                        'metadata' => ['provenance' => 'demo'],
+                    ]
+                );
+                $episode->update(['home_referral_id' => $referral->home_referral_id]);
+            }
+
             $kit = $kits[$i] ?? null;
             if ($kit !== null) {
                 RpmEnrollment::updateOrCreate(
@@ -431,7 +455,7 @@ class HomeHospitalDemoSeeder extends Seeder
             'md_np_tele' => 'NP D. Ramirez',
         ];
 
-        foreach ($visits as $j => $v) {
+        foreach ($visits as $v) {
             $completed = $v['start']->lt(now()->subMinutes(45));
             HomeVisit::updateOrCreate(
                 [
@@ -440,7 +464,12 @@ class HomeHospitalDemoSeeder extends Seeder
                     'scheduled_start' => $v['start'],
                 ],
                 [
-                    'visit_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.visit.'.$ref.'.'.$j.'.'.$v['start']->toDateString()),
+                    // Derived from the NATURAL KEY, never a positional index:
+                    // slot positions shift as the rolling window advances, and
+                    // an index-based uuid collides across UTC-midnight re-runs
+                    // (wedged the dev seeder once — same failure family as the
+                    // legacy 'demo-today' staffing marker).
+                    'visit_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.visit.'.$ref.'.'.$v['type'].'.'.$v['start']->toIso8601String()),
                     'patient_ref' => $ref,
                     'is_waiver_required' => $v['waiver'],
                     'status' => $completed ? 'completed' : 'scheduled',

--- a/database/seeders/HomeHospitalDemoSeeder.php
+++ b/database/seeders/HomeHospitalDemoSeeder.php
@@ -358,7 +358,18 @@ class HomeHospitalDemoSeeder extends Seeder
                     'target_los_days' => $spec['los'],
                     'expected_discharge_date' => $expected,
                     'started_at' => $admittedAt,
-                    'metadata' => ['provenance' => 'demo'],
+                    'metadata' => [
+                        'provenance' => 'demo',
+                        // Physical address is CONFINED to the logistics
+                        // context (build brief §8.4) — HomeLogisticsService is
+                        // the only reader; a test greps other payloads.
+                        'logistics_address' => sprintf(
+                            '%d %s Street, %s zone',
+                            120 + $i * 7,
+                            ['Maple', 'Cedar', 'Oak', 'Birch', 'Elm', 'Spruce', 'Willow', 'Aspen'][$i % 8],
+                            ucfirst($spec['zone'])
+                        ),
+                    ],
                 ]
             );
 
@@ -409,6 +420,12 @@ class HomeHospitalDemoSeeder extends Seeder
             ['type' => 'rn', 'start' => now()->startOfDay()->addDay()->addHours(9), 'waiver' => true],
         ];
 
+        $assignees = [
+            'rn' => crc32($ref) % 2 === 0 ? 'RN K. Alvarez' : 'RN T. Osei',
+            'community_paramedic' => 'Paramedic J. Kowalski',
+            'md_np_tele' => 'NP D. Ramirez',
+        ];
+
         foreach ($visits as $j => $v) {
             $completed = $v['start']->lt(now()->subMinutes(45));
             HomeVisit::updateOrCreate(
@@ -422,6 +439,7 @@ class HomeHospitalDemoSeeder extends Seeder
                     'patient_ref' => $ref,
                     'is_waiver_required' => $v['waiver'],
                     'status' => $completed ? 'completed' : 'scheduled',
+                    'assigned_to' => $assignees[$v['type']] ?? null,
                     'started_at' => $completed ? $v['start'] : null,
                     'completed_at' => $completed ? $v['start']->copy()->addMinutes(40) : null,
                     'on_time' => $completed ? true : null,

--- a/database/seeders/HomeHospitalDemoSeeder.php
+++ b/database/seeders/HomeHospitalDemoSeeder.php
@@ -411,9 +411,14 @@ class HomeHospitalDemoSeeder extends Seeder
         // Waiver operating floor: two in-person visits per day (§3) + a daily
         // MD tele-eval. Completion is time-aware — a visit whose slot is >45
         // minutes past reads completed, so the compliance rail stays honest at
-        // any refresh hour. Tomorrow's RN visit keeps a live countdown on the
-        // command grid even late in the day.
+        // any refresh hour. Yesterday's pair guarantees completed-visit history
+        // at ANY clock hour (the UTC-day-boundary trap: just past midnight UTC,
+        // all of "today's" slots are still in the future) — OCEL visit events
+        // and CMS compliance never read empty. Tomorrow's RN visit keeps a live
+        // countdown on the command grid even late in the day.
         $visits = [
+            ['type' => 'rn', 'start' => now()->startOfDay()->subDay()->addHours(9), 'waiver' => true],
+            ['type' => 'community_paramedic', 'start' => now()->startOfDay()->subDay()->addHours(18), 'waiver' => true],
             ['type' => 'rn', 'start' => now()->startOfDay()->addHours(9), 'waiver' => true],
             ['type' => 'community_paramedic', 'start' => now()->startOfDay()->addHours(18), 'waiver' => true],
             ['type' => 'md_np_tele', 'start' => now()->startOfDay()->addHours(11), 'waiver' => false],

--- a/database/seeders/HomeHospitalDemoSeeder.php
+++ b/database/seeders/HomeHospitalDemoSeeder.php
@@ -70,6 +70,155 @@ class HomeHospitalDemoSeeder extends Seeder
         $this->seedKits();
         $this->seedEpisodes($unit, $programs['ahcah_acute']);
         $this->seedReferrals($programs['ahcah_acute']);
+        $this->seedObservations();
+        $this->seedEscalationHistory();
+    }
+
+    /**
+     * Trailing-12h vitals per active enrollment so HEWS, sparklines, and
+     * adherence read real rows: SpO2/HR/RR hourly, BP + temp q4h. Values are
+     * deterministic per patient (no Math.random demo drift); HOME-DEMO-001
+     * deliberately declines to a critical SpO2 (87%) so exactly one open
+     * critical patient alert exists — the Phase 1 DoD breach path. Rolling
+     * refresh prunes demo observations older than 48h (seeder-owned rows
+     * only, marked source_key = demo-seed).
+     */
+    private function seedObservations(): void
+    {
+        \App\Models\Home\RpmObservation::query()
+            ->where('source_key', 'demo-seed')
+            ->where('observed_at', '<', now()->subHours(48))
+            ->delete();
+
+        $enrollments = RpmEnrollment::query()
+            ->with('kit')
+            ->where('status', 'active')
+            ->where('is_deleted', false)
+            ->orderBy('rpm_enrollment_id')
+            ->get();
+
+        $evaluator = app(\App\Services\Home\RpmAlertEvaluator::class);
+
+        foreach ($enrollments->values() as $index => $enrollment) {
+            $ref = $enrollment->patient_ref;
+            $declining = $ref === 'HOME-DEMO-001';
+
+            // Per-patient baselines: stable, patient-shaped numbers.
+            $base = [
+                '59408-5' => 96.0 - ($index % 3),          // SpO2 94–96
+                '8867-4' => 72.0 + (($index * 7) % 20),    // HR 72–92
+                '9279-1' => 16.0 + ($index % 4),           // RR 16–19
+                '8480-6' => 118.0 + (($index * 5) % 18),   // SBP
+                '8462-4' => 74.0 + (($index * 3) % 10),    // DBP
+                '8310-5' => 36.8,                          // Temp °C
+            ];
+
+            $enrollment->update(['baseline' => ['means' => $base, 'window_hours' => 24]]);
+
+            $displays = [
+                '59408-5' => ['Oxygen saturation', '%'],
+                '8867-4' => ['Heart rate', 'bpm'],
+                '9279-1' => ['Respiratory rate', '/min'],
+                '8480-6' => ['Systolic blood pressure', 'mmHg'],
+                '8462-4' => ['Diastolic blood pressure', 'mmHg'],
+                '8310-5' => ['Body temperature', 'Cel'],
+            ];
+
+            $latestByVital = [];
+
+            for ($hoursAgo = 11; $hoursAgo >= 0; $hoursAgo--) {
+                $observedAt = now()->subHours($hoursAgo)->startOfHour()->addMinutes(($index * 7) % 50);
+
+                foreach ($base as $loinc => $mean) {
+                    $hourly = in_array($loinc, ['59408-5', '8867-4', '9279-1'], true);
+                    if (! $hourly && $hoursAgo % 4 !== 0) {
+                        continue;
+                    }
+
+                    // Deterministic wiggle; the declining patient walks SpO2
+                    // down from baseline to 87% (critical) and HR up.
+                    $wiggle = (($hoursAgo * 3 + $index * 5) % 7 - 3) * 0.4;
+                    $value = $mean + $wiggle;
+                    if ($declining && $loinc === '59408-5') {
+                        $value = max(87.0, $mean - (11 - $hoursAgo) * 0.8);
+                    }
+                    if ($declining && $loinc === '8867-4') {
+                        $value = $mean + (11 - $hoursAgo) * 1.6;
+                    }
+
+                    $observation = \App\Models\Home\RpmObservation::updateOrCreate(
+                        ['observation_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS,
+                            "zephyrus.home.obs.{$ref}.{$loinc}.".$observedAt->format('YmdH'))->toString()],
+                        [
+                            'rpm_enrollment_id' => $enrollment->rpm_enrollment_id,
+                            'rpm_device_id' => null,
+                            'patient_ref' => $ref,
+                            'loinc_code' => $loinc,
+                            'display' => $displays[$loinc][0],
+                            'value' => round($value, 1),
+                            'unit' => $displays[$loinc][1],
+                            'observed_at' => $observedAt,
+                            'received_at' => $observedAt->copy()->addMinutes(1),
+                            'source_key' => 'demo-seed',
+                            'quality_flag' => 'ok',
+                            'metadata' => ['provenance' => 'demo'],
+                        ]
+                    );
+                    $latestByVital[$loinc] = $observation;
+                }
+            }
+
+            // Alert state from the latest readings via the REAL evaluator (the
+            // same path live ingestion takes; dedupes to one open alert/rule).
+            foreach ($latestByVital as $observation) {
+                $evaluator->evaluate($observation, $enrollment);
+            }
+
+            $enrollment->kit?->update([
+                'last_seen_at' => now()->subMinutes(($index * 3) % 12),
+                'battery_pct' => 68 + (($index * 9) % 30),
+            ]);
+        }
+    }
+
+    /**
+     * Response-time history for the escalation p90 tile: two resolved
+     * escalations inside the trailing 7d, both under the 30-minute waiver
+     * floor, outcome managed-at-home.
+     */
+    private function seedEscalationHistory(): void
+    {
+        $specs = [
+            ['ref' => 'HOME-DEMO-002', 'daysAgo' => 1, 'response' => 22],
+            ['ref' => 'HOME-DEMO-005', 'daysAgo' => 3, 'response' => 28],
+        ];
+
+        foreach ($specs as $spec) {
+            $episode = HomeEpisode::query()->where('patient_ref', $spec['ref'])->where('is_deleted', false)->first();
+            if ($episode === null) {
+                continue;
+            }
+
+            $initiated = now()->subDays($spec['daysAgo'])->setTime(14, 10);
+
+            \App\Models\Home\HomeEscalation::updateOrCreate(
+                ['escalation_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.escalation.'.$spec['ref'].'.'.$spec['daysAgo'])->toString()],
+                [
+                    'home_episode_id' => $episode->home_episode_id,
+                    'patient_ref' => $spec['ref'],
+                    'trigger_type' => 'clinical_deterioration',
+                    'response_mode' => 'field_dispatch',
+                    'status' => 'resolved',
+                    'initiated_at' => $initiated,
+                    'dispatched_at' => $initiated->copy()->addMinutes(6),
+                    'arrived_at' => $initiated->copy()->addMinutes($spec['response']),
+                    'resolved_at' => $initiated->copy()->addMinutes($spec['response'] + 35),
+                    'response_minutes' => $spec['response'],
+                    'outcome' => 'managed_at_home',
+                    'metadata' => ['provenance' => 'demo'],
+                ]
+            );
+        }
     }
 
     private function seedVirtualUnit(): Unit
@@ -248,17 +397,20 @@ class HomeHospitalDemoSeeder extends Seeder
 
     private function seedVisits(HomeEpisode $episode, string $ref): void
     {
-        // Waiver operating floor: two in-person visits today (§3). One completed
-        // this morning, one upcoming — feeds the compliance rail and the
-        // next-visit countdown without hand-tuned clock states.
+        // Waiver operating floor: two in-person visits per day (§3) + a daily
+        // MD tele-eval. Completion is time-aware — a visit whose slot is >45
+        // minutes past reads completed, so the compliance rail stays honest at
+        // any refresh hour. Tomorrow's RN visit keeps a live countdown on the
+        // command grid even late in the day.
         $visits = [
-            ['type' => 'rn', 'start' => now()->startOfDay()->addHours(9), 'status' => 'completed', 'waiver' => true],
-            ['type' => 'community_paramedic', 'start' => now()->startOfDay()->addHours(18), 'status' => 'scheduled', 'waiver' => true],
-            ['type' => 'md_np_tele', 'start' => now()->startOfDay()->addHours(11), 'status' => 'completed', 'waiver' => false],
+            ['type' => 'rn', 'start' => now()->startOfDay()->addHours(9), 'waiver' => true],
+            ['type' => 'community_paramedic', 'start' => now()->startOfDay()->addHours(18), 'waiver' => true],
+            ['type' => 'md_np_tele', 'start' => now()->startOfDay()->addHours(11), 'waiver' => false],
+            ['type' => 'rn', 'start' => now()->startOfDay()->addDay()->addHours(9), 'waiver' => true],
         ];
 
         foreach ($visits as $j => $v) {
-            $completed = $v['status'] === 'completed';
+            $completed = $v['start']->lt(now()->subMinutes(45));
             HomeVisit::updateOrCreate(
                 [
                     'home_episode_id' => $episode->home_episode_id,
@@ -269,7 +421,7 @@ class HomeHospitalDemoSeeder extends Seeder
                     'visit_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.visit.'.$ref.'.'.$j.'.'.$v['start']->toDateString()),
                     'patient_ref' => $ref,
                     'is_waiver_required' => $v['waiver'],
-                    'status' => $v['status'],
+                    'status' => $completed ? 'completed' : 'scheduled',
                     'started_at' => $completed ? $v['start'] : null,
                     'completed_at' => $completed ? $v['start']->copy()->addMinutes(40) : null,
                     'on_time' => $completed ? true : null,

--- a/database/seeders/RtdcSeeder.php
+++ b/database/seeders/RtdcSeeder.php
@@ -68,8 +68,13 @@ class RtdcSeeder extends Seeder
         // Soft-delete any pre-existing units that are NOT in the manifest roster
         // (legacy 'SD', the old single 'ICU', etc.) so the live app shows only the
         // Summit 25. Additive/non-destructive: flips is_deleted, never DROPs rows.
+        // virtual_home units are exempt: the Home Hospital virtual ward is
+        // deliberately NOT in the manifest (its slots must never inflate
+        // manifest-derived physical denominators) and is owned by
+        // HomeHospitalDemoSeeder — see docs/home-hospital/HOME-HOSPITAL-BUILD-PROMPT.md.
         $manifestAbbrs = $manifest->unitAbbrs();
         Unit::whereNotIn('abbreviation', $manifestAbbrs)
+            ->where('type', '!=', 'virtual_home')
             ->where('is_deleted', false)
             ->update(['is_deleted' => true]);
 

--- a/docs/DEVLOG-home-hospital-2026-07-17.md
+++ b/docs/DEVLOG-home-hospital-2026-07-17.md
@@ -1,7 +1,91 @@
-# DEVLOG — Home Hospital Module · Phase 0 Foundation (2026-07-17)
+# DEVLOG — Home Hospital Module · Phases 0–1 (2026-07-17)
 
 **Branch:** `feature/home-hospital-phase-0`
 **Source of truth:** [ACUM-PRD-HAH-001](./home-hospital/Zephyrus_Hospital_at_Home_Strategy_and_Design.md) · [Build brief](./home-hospital/HOME-HOSPITAL-BUILD-PROMPT.md)
+
+---
+
+## Phase 1 · Observability MVP (same day, evening)
+
+User decisions taken before Phase 1: continue on ONE branch (single PR when
+demo-ready); HEWS as specified in the brief; §13 defaults confirmed as-is;
+prod demo enablement AFTER Phase 1 ships.
+
+### What shipped (Phase 1)
+
+- **HEWS** (`HewsService`): deterministic modified NEWS2 — absolute banding
+  over the RPM-observable set (RR, SpO2, SBP, HR, temp; consciousness and
+  supplemental-O2 deliberately omitted, documented), + baseline-deviation vs
+  the enrollment's first-24h calibration (>15% drift, cap +2), + short-window
+  trend (SpO2 falling ≥3 abs / HR rising ≥15%, cap +2), + adherence (+1 when
+  <half the expected cadence arrived). Bands in `config/home_hospital.php`.
+  Labeled operational triage, not diagnosis, everywhere it surfaces.
+- **Patient alerting** (`RpmAlertEvaluator` → `prod.rpm_alerts`): personalized
+  thresholds (`monitoring_plan.thresholds` over `vital_thresholds` defaults);
+  ONE open alert per (episode, rule) — repeat breaches refresh metadata and
+  may escalate warning→critical in place, never downgrade; evaluation runs
+  only on first projection (replays never inflate). Ack/resolve API records
+  the acting human.
+- **Escalation workflow** (`HomeEscalationService` + API): open → dispatch →
+  arrive → resolve timing chain; `response_minutes` stamped at arrival (the
+  p90 tile input); one open escalation per episode. **ADT close-loop** hooked
+  into `PatientFlowHl7IngestPipeline`: an admit/register for a patient with an
+  open escalation resolves it `ed_return` (flag-gated, guarded — can never
+  fail an ADT ingest).
+- **Cockpit**: `HomeMetrics` provider (9 `home.*` keys seeded; Earned-Red
+  ration = alert_template only on unacked-criticals / response-p90 /
+  visit-compliance / kits-offline). The home domain is ABSENT from the
+  snapshot when the flag is off (SnapshotBuilder skips the empty flag-gated
+  provider — deployments without the module stay byte-identical).
+  `?drill=home` (ward board + referral funnel tables); crit `home.*` alerts
+  route to the new draft-only Eddy `propose_escalation_response`.
+- **Virtual Ward Command** (`/home/command`): episode tiles sorted by
+  escalation risk (breach → HEWS → acuity); HEWS chip, SpO2/HR sparklines,
+  next-visit countdown, device status; coral ONLY for an unacked critical.
+- **FHIR**: each first-projection observation persists as a US Core
+  vital-signs Observation in `fhir.resource_versions` (fhir_id =
+  observation_uuid, version 1, encrypted out-of-row) + `resource_links` to
+  `prod.rpm_observations`. Skips gracefully where the payload store is off.
+- **Canonical vocabulary**: the 8 home event constants added to
+  `App\Rtdc\Events\CanonicalEvent` (consumed by Phase 3 OCEL).
+- **Demo seed**: trailing-12h deterministic vitals + baselines per enrollment;
+  HOME-DEMO-001 deliberately declines to SpO2 87% → exactly one open critical
+  alert (the DoD path); resolved escalation history (22/28 min); time-aware
+  waiver visits (past slots complete, tomorrow's RN visit keeps a countdown).
+
+### Phase 1 verification
+
+- 21 Home Feature tests green (134 assertions) incl.: one-critical-alert
+  invariant, HEWS determinism/transparency, breach dedupe via the real
+  connector, human-recorded ack/resolve, escalation chain + response_minutes,
+  ADT ed_return close (+ stranger no-op), snapshot home domain crit tile +
+  `actionForAlert('home.unacked_critical_vitals','crit') =
+  propose_escalation_response`, flag-off domain absence, drill tables,
+  command-page breach-first ordering, FHIR version+link rows.
+- Nav vitest 31 green; Pint / `tsc --noEmit` / `vite build` /
+  `check-ui-canon.sh` (ratchet unchanged) all clean.
+- Cockpit tiles verified live on `zephyrus_dev`: 9 tiles, honest values
+  (occupancy 66.7%, 1 crit unacked vital, p90 27min warn, compliance 100%,
+  kits online, adherence 100%).
+
+### Session/environment notes
+
+- **Concurrent-session clobber (evening):** another agent session switched the
+  main checkout to `feature/ux-hfe-remediation` mid-build; it checkpointed the
+  uncommitted Phase-1 work as `a514138 wip:` on this branch first (nothing
+  lost). Work continues in the dedicated worktree
+  `~/Github/Zephyrus-home-hospital` (hardlinked vendor/node_modules; isolated
+  test DB `zephyrus_test_home` — the tests/bootstrap guard requires the
+  `zephyrus_test*` name prefix).
+- **`php artisan serve` quirk:** the ServeCommand child intermittently boots
+  without APP_KEY on this host; raw `php -S 127.0.0.1:<port> -t public` from
+  the worktree serves correctly (root 200). AGENTS.md's "auto-auth on /" note
+  is stale — the login gate is real; browser walkthrough needs a login.
+- **Remaining manual step:** browser walkthrough of `/home/command`,
+  `/home/census`, and `?drill=home` (kernel-level rendering + payloads are
+  test-verified; the visual pass needs an authenticated browser session).
+
+---
 
 Phase 0 of the Home Hospital (HOME) workspace: schema, models, feature gating,
 virtual-ward seeding, the Virtual Bed Board, and a synthetic RPM ingestion

--- a/docs/DEVLOG-home-hospital-2026-07-17.md
+++ b/docs/DEVLOG-home-hospital-2026-07-17.md
@@ -1,7 +1,60 @@
-# DEVLOG — Home Hospital Module · Phases 0–1 (2026-07-17)
+# DEVLOG — Home Hospital Module · Phases 0–2 (2026-07-17)
 
 **Branch:** `feature/home-hospital-phase-0`
 **Source of truth:** [ACUM-PRD-HAH-001](./home-hospital/Zephyrus_Hospital_at_Home_Strategy_and_Design.md) · [Build brief](./home-hospital/HOME-HOSPITAL-BUILD-PROMPT.md)
+
+---
+
+## Phase 2 · Transitions (same day, night)
+
+### What shipped (Phase 2)
+
+- **Referral funnel + eligibility worklists** (`HomeReferralService`,
+  `/home/referrals`): ED candidates off the LIVE ED census (stable ESI 3–5,
+  boarders first — the decant valve reading real boarding), step-down
+  candidates off encounters at/near expected LOS on physical wards; strictly
+  ordered funnel (referred → screened → eligible → consented → activated)
+  with coded declines at every stage. **activate()** claims a free slot
+  (locked), opens the census-spine encounter + episode, assigns an available
+  kit + enrollment, and opens the inbound checklist — fails loudly (422) when
+  the ward is full.
+- **Transitions board** (`HomeTransitionService`, `/home/transitions`):
+  inbound activation checklists (consent / home-safety / kit delivery / first
+  visit); outbound governed handoffs writing `prod.transport_requests`
+  (`request_type = care_transition`) — SNF destinations ride
+  `RegionalTransferService::decide()` verbatim (guard widened additively to
+  accept care_transition) producing a `regional.transfer_decisions` row with
+  candidate scoring + opportunity-cost payload; one open handoff per episode.
+  **discharge()** closes the loop: encounter discharged, slot freed, kit
+  returned, and routine discharges auto-enroll the **30-day post-discharge
+  cohort** (no slot — not an avoided bed-day; step-down cadence BP/SpO2 q12h
+  + daily weight, billable under the 2026 RPM codes).
+- **Field Ops & Logistics** (`HomeLogisticsService`, `/home/logistics`): the
+  2-visits/day waiver compliance rail, per-clinician route assignments, kit
+  inventory + low-battery count, deliveries. **The ONE address surface** —
+  street addresses live in episode `metadata.logistics_address` and are read
+  ONLY here; a test greps every other Home endpoint for leakage.
+- Three new pages on the token canon + nav leaves; API endpoints for the
+  full referral/transition/logistics workflows.
+
+### Phase 2 verification
+
+- 28 Home Feature tests green (196 assertions). Phase 2 DoD proven: referral
+  traverses referred → activated creating the episode on the virtual unit
+  (encounter + occupied slot + kit + inbound checklist); SNF handoff produces
+  a care_transition transport request + scored transfer decision with
+  non-empty opportunity-cost payload; routine discharge frees slot/kit and
+  enrolls the 30-day cohort at step-down cadence; **address confinement
+  grep-verified across all six non-logistics endpoints**; worklists surface
+  live-census candidates (ESI-2 excluded, boarders flagged).
+- Cockpit + Eddy regression: 165/166 in the background run; the single
+  failure was a worktree env artifact (missing `.env.testing` → flag-on
+  domain roster) — green after copying the testing env; the pinned 8-domain
+  test remains the flag-off contract.
+- `tsc` / `vite build` / `check-ui-canon.sh` / Pint / nav vitest (31) clean.
+- Dev smoke: 8-row compliance rail with confined addresses, 4 field
+  assignments, live worklists (20 ED + 20 step-down candidates off the real
+  dev census), 2 free slots.
 
 ---
 

--- a/docs/DEVLOG-home-hospital-2026-07-17.md
+++ b/docs/DEVLOG-home-hospital-2026-07-17.md
@@ -1,7 +1,70 @@
-# DEVLOG — Home Hospital Module · Phases 0–2 (2026-07-17)
+# DEVLOG — Home Hospital Module · Phases 0–3 (2026-07-17)
 
 **Branch:** `feature/home-hospital-phase-0`
 **Source of truth:** [ACUM-PRD-HAH-001](./home-hospital/Zephyrus_Hospital_at_Home_Strategy_and_Design.md) · [Build brief](./home-hospital/HOME-HOSPITAL-BUILD-PROMPT.md)
+
+---
+
+## Phase 3 · Intelligence & compliance (same day, late night)
+
+### What shipped (Phase 3)
+
+- **The decant line, made literal** (`HomeCapacityService` + `/api/home/decant`
+  + the RTDC Global Huddle "Home decant" section): home-eligible counts (ED +
+  step-down off the live census) and the free-slot forecast (now / 24h / 48h)
+  rendered next to boarding metrics — mounted only when the flag is on, the
+  huddle is byte-identical without it. `writePredictions()` upserts the home
+  forecast into `prod.rtdc_predictions` (by_2pm / by_midnight) alongside
+  physical capacity, same upsert contract as RtdcService.
+- **Forward projection**: new `home_slot_free` stream in
+  `ForwardProjectionService` (one probable item per expected home discharge,
+  provenance `home_hospital.expected_discharge`; absent when the flag is off).
+- **Avoided bed-days to the executive brief**: no new code — the brief
+  composes from the shared cockpit snapshot (`capacity.snapshot` /
+  `executive_brief.compose` tools), so the home domain incl.
+  `home.avoided_bed_days_mtd` flows in automatically. Also on the huddle
+  decant line + cockpit tile + `?drill=home`.
+- **OCEL / Arena**: `EmissionMap::forHomeEpisode/forHomeVisit/forHomeEscalation`
+  + `OcelProjector::collectHomeEpisodes()` (flag-gated) + catalog object types
+  (Home Episode, RPM Kit, Home Visit, Escalation) and `home` activity verbs —
+  the corpus for time-to-activation / visit-cadence / escalation-protocol
+  conformance; the 48-Hour Flow Review folds home in via ocel.* as designed.
+  Dev smoke: 36 home events projected (activations, visits, escalation chains).
+- **Eddy catalog complete**: the remaining six draft-only actions
+  (propose_hah_enrollment, propose_stepdown_cohort, propose_visit_reschedule,
+  flag_rpm_gap, propose_home_discharge, flag_transition_barrier) — alert_key
+  null on all six so crit `home.*` alerts keep routing to
+  propose_escalation_response; every one requires human approval.
+- **CMS AHCAH waiver / 2028-study export** (`php artisan home:cms-export`):
+  episode volume + mean LOS + in-episode mortality + return-to-hospital,
+  escalation p90 + 30-minute-floor compliance, waiver-visit compliance,
+  monitoring/alert stats, and the equity block the study explicitly demands
+  (decline reasons, payer distribution, activation rate BY payer, zone
+  distribution) — all from prod.home_* tables, pseudonymous, with national
+  benchmarks attached. Refuses politely when the module is off.
+
+### Phase 3 verification
+
+- 34 Home Feature tests green (260 assertions): decant payload + predictions
+  rows, home_slot_free stream on/off, all seven Eddy actions draft-only +
+  routing invariant, OCEL home pathway on/off (events + object types), CMS
+  export variables + pseudonymity + disabled-refusal.
+- Fixed in passing: the demo seeder now seeds yesterday's completed waiver
+  visits too — the UTC-day-boundary trap (just past midnight UTC, "today's"
+  visits are all future) had zeroed OCEL visit events and CMS compliance.
+- Full vitest 531 green; Pint / tsc / vite build / check-ui-canon clean.
+- Dev smoke: decant 2 free slots / 20 ED + 20 step-down eligible; CMS export
+  8 episodes, p90 27.4 min, 100% within-floor, 100% visit compliance.
+
+### Remaining (deliberately out of Phase 3)
+
+- Home reference pathway rows in ClinicalPathwaySeeder + Arena sidecar
+  conformance checks (needs the pm4py sidecar running; the OCEL corpus they
+  read is now live) — small follow-up.
+- Browser walkthrough of all six surfaces + the huddle decant line (kernel-
+  level rendering and payloads are test-verified).
+- "Later" ring per the brief: chronic RPM lines, SNF-at-home, multi-facility,
+  payer-facing reporting.
 
 ---
 

--- a/docs/DEVLOG-home-hospital-2026-07-17.md
+++ b/docs/DEVLOG-home-hospital-2026-07-17.md
@@ -1,0 +1,108 @@
+# DEVLOG — Home Hospital Module · Phase 0 Foundation (2026-07-17)
+
+**Branch:** `feature/home-hospital-phase-0`
+**Source of truth:** [ACUM-PRD-HAH-001](./home-hospital/Zephyrus_Hospital_at_Home_Strategy_and_Design.md) · [Build brief](./home-hospital/HOME-HOSPITAL-BUILD-PROMPT.md)
+
+Phase 0 of the Home Hospital (HOME) workspace: schema, models, feature gating,
+virtual-ward seeding, the Virtual Bed Board, and a synthetic RPM ingestion
+pipeline — all against the Summit Regional demo hospital.
+
+## What shipped
+
+- **Schema (11 tables, `prod`):** `home_programs`, `home_referrals`,
+  `home_episodes`, `rpm_kits`, `rpm_devices`, `rpm_enrollments`,
+  `rpm_observations`, `rpm_alerts`, `home_visits`, `home_escalations`,
+  `home_transitions`. All follow the `{table}_id` PK + `_uuid` + `patient_ref`
+  + `metadata` jsonb + `is_deleted` + CHECK-via-`DB::statement` conventions
+  (35 CHECK constraints). Three migrations, validated on `zephyrus_dev`
+  (`--path`) and on fresh `zephyrus_test` (RefreshDatabase suite).
+- **Feature gating:** `config/home_hospital.php` (`HOME_HOSPITAL_ENABLED`,
+  default off) + `EnsureHomeHospitalEnabled` (404 when off) applied inline by
+  FQCN on the `home.` web group and `/api/home` group; Inertia
+  `features.home_hospital` prop; the HOME nav domain (workspaces section) is
+  hidden via a new `NavDomain.requiredFeature` field honored in
+  `isDomainVisible` — nav and route gate can never disagree.
+- **Virtual ward:** seeded by `HomeHospitalDemoSeeder` (flag-gated, idempotent
+  on natural keys): one `prod.units` row `type = virtual_home` (`HOME`, 12
+  slots), 8 active episodes on census-spine encounters, referral funnel with
+  coded declines, 10 kits / 40 devices / 8 enrollments, waiver-floor visits
+  (2/day + tele). Wired into `DatabaseSeeder` (before `DemoTuningSeeder`) and
+  `DemoRefreshCoordinator` (flag-gated step).
+- **Virtual Bed Board (`/home/census`):** `HomeCensusService` →
+  `HomeDashboardController` (Inertia `Home/Census`) + `/api/home/census`.
+  Slot grid + program-capacity metric wall + enrollment pipeline, on the
+  design-system barrel (`Section`/`MetricGrid`/`metric`), demo rows carry the
+  `ProvenanceBadge`. Earned urgency respected: slot states are grey/teal/amber
+  informational; no coral anywhere in Phase 0.
+- **Synthetic RPM pipeline:** `SyntheticRpmConnector` (full lifecycle copy of
+  `SyntheticHealthcareConnector`: webhook/poll/backfill/replay, dead-letter,
+  watermarks, encrypted payload store) + `RpmEventVocabulary`
+  (`ObservationRecorded`, `DeviceStatusChanged`) + normalizer/mapper +
+  `RpmProjectionHandler` (registered in `AppServiceProvider`) projecting into
+  `prod.rpm_observations` and device state. Proven by Feature tests:
+  breach-free ingest, idempotent replay, unknown-patient dead-letter.
+
+## Decisions (with rationale)
+
+1. **`rpm_observations` ships UNPARTITIONED** (build brief §13 Q5 default).
+   No declarative partitioning convention exists in this repo and one must not
+   arrive silently. Retention: >18-month observations are rollup-eligible;
+   monthly range-partitioning is a proposed, separately-reviewed follow-up.
+2. **The virtual ward is NOT in the HospitalManifest.** Manifest-derived
+   physical denominators (licensed beds, staffed-bed totals, occupancy tuning
+   — which whitelists `icu|step_down|med_surg`) must not absorb virtual slots.
+   Instead `RtdcSeeder`'s manifest soft-trim now exempts `type = virtual_home`,
+   and `HomeHospitalDemoSeeder` owns the ward. **Watch item:** house-wide
+   rollups that enumerate all units will include the ward once the flag is on;
+   physical-only surfaces should filter `type != 'virtual_home'` if that reads
+   wrong in review.
+3. **Slot states map onto the existing `prod.beds` CHECK** (`available |
+   occupied | blocked | dirty`); on this unit `dirty` carries the
+   "pending kit setup" meaning and is translated to `pending_setup` at the
+   service boundary — no CHECK widening in Phase 0.
+4. **`NavDomain.requiredFeature` added** (nav SSOT) — the leaf-level
+   `requiredFeature` already existed; domain-level gating is additive and
+   admin does NOT bypass it (tested).
+5. **RpmProjectionHandler pulled forward from Phase 1** — without a projection
+   owner, every connector message would dead-letter; a connector that cannot
+   land an observation is not demonstrable. HEWS/alerting/FHIR storage remain
+   Phase 1.
+6. **Dev-DB debt cleared in passing:** `zephyrus_dev` was blocked on
+   `2026_07_13_000400` (enterprise scope binding) because `hosp_org` was
+   empty and the one active source pointed at `ZEPHYRUS-500` instead of a
+   canonical facility key. Ran `SummitDeploymentSeeder`, remapped
+   `synthetic-flow-ehr` → `SUMMIT_REGIONAL`/`SUMMIT_HEALTH`, migrated clean.
+
+## Open questions (§13 — decided by default, awaiting product/clinical review)
+
+| # | Question | Default taken |
+|---|---|---|
+| 1 | First condition set | HF, COPD, pneumonia/resp. infection, cellulitis, UTI (`config/home_hospital.php`) |
+| 2 | Field staffing model | Board is staffing-model-agnostic (`home_visits.assigned_to` is an opaque ref) |
+| 3 | Pilot census / radius | 12 slots, 3 zones (north/central/south) in the demo seed |
+| 4 | First RPM vendor | `SyntheticRpmConnector` until chosen; `HealthcareConnector` keeps it vendor-agnostic |
+| 5 | Observation partitioning | Unpartitioned + documented retention (see Decision 1) |
+| 6 | Payer matrix | Demo `payer_rules` placeholder on the program row; harden before real referral screening |
+
+## Verification
+
+- `php artisan test tests/Feature/Home/` — 9 passed (53 assertions): gating
+  404s, flag-off seeder no-op, Inertia census render, API payload,
+  pseudonymity scan (no `mrn`/`address` in wire payload), seeder idempotency,
+  RPM ingest end-to-end / idempotent replay / dead-letter.
+- Full `vitest` suite 531 passed (nav roster tests updated: 9 workspace
+  domains; new feature-gate visibility test).
+- `npx tsc --noEmit` clean; `npx vite build` clean; `scripts/check-ui-canon.sh`
+  passed (raw-palette ratchet unchanged at ≤76).
+- Pint clean on all touched PHP.
+- Demo seeder run twice on `zephyrus_dev`: counts stable
+  (1 unit / 12 slots / 8 episodes / 6 referrals / 10 kits / 40 devices).
+  `RtdcSeeder` re-run does not soft-delete the ward.
+
+## Next (Phase 1 · Observability MVP)
+
+HEWS + patient alerts with acknowledgement workflow, `/home/command` episode
+tiles, `HomeMetrics` cockpit provider + seeded `home.*` definitions (Earned-Red
+ration per §9), `?drill=home`, Eddy `home.` catalog route
+(`propose_escalation_response`), ADT escalation-close loop, FHIR Observation
+storage in `fhir.resource_versions`.

--- a/docs/home-hospital/HOME-HOSPITAL-BUILD-PROMPT.md
+++ b/docs/home-hospital/HOME-HOSPITAL-BUILD-PROMPT.md
@@ -1,0 +1,674 @@
+# Claude Code Build Prompt — Zephyrus **Home Hospital** Module
+
+> **Source of truth:** `ACUM-PRD-HAH-001` — *"Extending Zephyrus to Hospital at Home:
+> Acute Care at Home, Remote Patient Monitoring & Transitions of Care — Strategy and
+> Module Design"* (Sanjay M. Udoshi, MD; 2026-07-17), available in-repo as
+> [`Zephyrus_Hospital_at_Home_Strategy_and_Design.md`](./Zephyrus_Hospital_at_Home_Strategy_and_Design.md).
+> This file operationalizes that strategy into an executable engineering brief. Where this
+> file and the strategy doc disagree, this file wins — it has been reconciled against the
+> actual codebase (see [§14 Reconciliation notes](#14-reconciliation-notes--deltas-from-the-strategy-doc)).
+
+---
+
+## 0. How to use this prompt
+
+You are a Claude Code agent building the **Home Hospital (HOME)** module inside the
+Zephyrus repository (`/Users/sudoshi/Github/Zephyrus`). This is a large, multi-phase
+build. Do **not** attempt it in one pass.
+
+**Before writing any code, read, in order:**
+1. `PRODUCT.md` — who the users are, the "rigorous / composed / defensible" personality, the anti-references.
+2. `DESIGN.md` (+ `.impeccable/design.json`) — the visual system, the North Star "Operations Bridge."
+3. `CLAUDE.md` — the **Token Canon** (design non-negotiables) and the Two-System Rule.
+4. `AGENTS.md` — build/test/deploy commands, backend/frontend architecture, key patterns.
+5. `.claude/rules/auth-system.md` — the protected auth system you must **not** touch.
+6. This file, in full, plus the referenced roadmap section for the phase you are on.
+
+**Working rules:**
+- Work **one phase at a time** (§9). Each phase is independently demonstrable. Do not
+  start Phase N+1 until Phase N passes its Definition of Done.
+- Build against the **synthetic Summit Regional demo hospital** — never against a
+  production or canonical DB. Use a local disposable database (e.g. `zephyrus_test`)
+  for schema work; never run `migrate:fresh` against a shared DB.
+- **Reuse before you build.** Almost every capability this module needs already exists
+  (§6). A new provider, a new connector, a new set of tables, and a new nav domain —
+  the machinery around them is inherited. If you find yourself writing a new snapshot
+  engine, a new alert lifecycle, or a new realtime channel auth layer, stop: you have
+  drifted off the intended path.
+- Keep the **impeccable design hook** on. Run `scripts/check-ui-canon.sh` before
+  considering any frontend work done.
+- When you hit one of the **open product/clinical questions** (§13), do not silently
+  pick — surface the decision, state your recommended default, and proceed on the
+  default only if unblocked.
+
+---
+
+## 1. Mission & the one-instrument thesis
+
+Build a **Home Hospital** workspace that runs an acute **Hospital-at-Home (HaH)** virtual
+ward as *one more altitude of the same instrument* — sharing Zephyrus's census spine,
+cockpit, alerting, governance (Eddy), and process mining (Arena).
+
+**The differentiator is not a monitoring app.** Every competitor (Medically
+Home/DispatchHealth, Biofourmis, Inbound Health, Contessa) orchestrates home care.
+None of them unify it with the hospital's **live house-wide demand and capacity.**
+Zephyrus already holds the live ED boarding count, floor census vs. staffed capacity,
+and expected discharges. The winning feature is the sentence no HaH vendor can say:
+
+> *"We have 14 ED boarders, 9 of them home-eligible, 6 home slots free tonight — enroll
+> these and boarding hours fall."*
+
+Every design and data decision serves that **capacity-unification (decant-valve)**
+thesis. Every active home episode-day is an **avoided occupied bed-day**, attributable
+against the very boarding pressure the cockpit already displays. If a feature does not
+eventually feed that story, it is lower priority than one that does.
+
+---
+
+## 2. Strategic context (the "why", condensed)
+
+Enough context to make correct product judgments. Full citations live in the strategy doc §12.
+
+- **The waiver is durable now.** The CMS Acute Hospital Care at Home (AHCAH) waiver was
+  extended through **September 30, 2030** (Consolidated Appropriations Act, 2026;
+  42 U.S.C. §1395cc-7). HaH is a fundable, permanent service line, not a pilot. Design
+  for a five-year horizon.
+- **A federal study is coming.** HHS must report by **2028-09-30** comparing home vs.
+  brick-and-mortar inpatient on readmissions, mortality, infections, staffing,
+  escalations/transfers, patient experience, conditions/DRGs, cost, and equity
+  (addressing selection bias). **Capture these as first-class operational data** — it
+  turns a compliance burden into a reporting asset.
+- **RPM billing widened in 2026.** The CY2026 PFS final rule added shorter-duration RPM
+  codes (99445 for 2–15 days of device data; 99470 for 10–19 min management) and RTM
+  parallels. Lower-acuity, shorter post-discharge/chronic monitoring is now billable —
+  so the module's enrollment/eligibility logic must be **payer-aware from day one**
+  (only ~half of state Medicaid programs reimburse RPM; commercial coverage is uneven).
+- **The population is comorbid and escalation-prone.** Most common HaH diagnoses: heart
+  failure, respiratory infection (incl. COVID-19), sepsis, kidney/UTI, cellulitis; mean
+  HCC ≈ 3.15, CMI ≈ 1.31, ~42.5% HF, ~43.3% COPD. Build for this cohort, not the worried well.
+- **The evidence supports a CMO defending the program** (comparable/lower mortality,
+  fewer ICU escalations, lower total cost). But a 2026 meta-analysis warns heterogeneity
+  is high — **a program that instruments its own escalation and readmission rates in
+  real time is more defensible than one leaning on literature.** That is Zephyrus's job.
+
+**Commercial positioning:** à-la-carte module in the **$85–95K/yr** band, between ED
+($65K) and Perioperative ($85K); included in **Enterprise Plus**. This pulls the
+BUSINESS_PLAN's Year-3 "telehealth operations" line into the current window.
+
+---
+
+## 3. National benchmark KPIs — the numbers the dashboard tracks against
+
+Wire these as the **targets/comparators** in `ops.metric_definitions` and Program Analytics.
+The program measures itself against national benchmarks, not aspiration.
+
+| KPI | National benchmark | Source |
+|---|---|---|
+| Escalation (return-to-hospital) rate | ≈ **6.2%** | Levine et al. 2024 |
+| In-episode mortality | ≈ **0.5%** | Levine et al. 2024 |
+| 30-day readmission | ≈ **15.6%** | Levine et al. 2024 |
+| Mean length of stay | ≈ **6.3 days** | Levine et al. 2024 |
+| Emergency in-person response | within **30 minutes** | CMS waiver / MedPAC 2024 |
+| In-person visit cadence | **≥ 2 per day + daily MD** eval | CMS waiver / MedPAC 2024 |
+
+These last two are **waiver operating-floor requirements** — treat them as compliance
+telemetry (§8), not soft goals.
+
+---
+
+## 4. Non-negotiable guardrails
+
+Violating any of these is a defect, regardless of feature completeness.
+
+### 4.1 Design canon (from `CLAUDE.md` + `DESIGN.md`)
+- **Two-System Rule.** Blue/slate `healthcare-*` palette governs all operational surfaces
+  and interaction. Crimson `#9B1B30` + gold `#C9A227` is the Acumenus brand/heritage +
+  focus layer **only**. Never promote crimson to a HOME dashboard primary.
+- **Earned urgency / Earned-Red.** Grey is the resting baseline. Coral-red appears **only**
+  for a genuine breach — an unacknowledged critical vital, a blown response SLA, or a
+  missed waiver-required visit. This is *clinical* monitoring: alarm fatigue here is a
+  patient-safety failure, not just a UX one. A metric enters the cockpit alert ticker
+  **only** if its seeded definition carries an `alert_template` — ration them (§7).
+- **Status never by color alone.** Every teal/amber/coral/sky state travels with an arrow
+  (▲ ▼ ▬), an icon, or a worded label.
+- **Typography:** Figtree via `font-sans` only; weights 400/500/600 (`font-normal` /
+  `font-medium` / `font-semibold`) — **no `font-bold`/`font-extrabold`**. Tailwind size
+  scale only — **no `text-[Npx]`** (the `text-[11px]` cockpit micro-caption exception
+  applies **only** inside `Components/cockpit/`; HOME pages hold the `text-xs` floor).
+  Metrics/IDs use `tabular-nums`, never `font-mono`.
+- **Surfaces:** exactly one primitive — `Components/ui/Surface.tsx` via `<Card>`/`<Panel>`.
+  Never `bg-white`/`bg-gray-*` surfaces, never glassmorphism (`backdrop-blur`). Resting
+  panels = `shadow-sm`; only modals/dropdowns/tooltips get `shadow-lg`.
+- **Color:** `healthcare-*` tokens with a `dark:` pair, always. No raw Tailwind palette
+  (`bg-gray/red/blue/green/amber/...`) in `resources/js`. Status = `healthcare-critical/
+  warning/success/info`. Interactive blue = `healthcare-primary`.
+- **Spacing:** 4px grid. `PageContentLayout` owns the gutter (`p-4`); don't double-gutter.
+- **Do not reintroduce the KPI "left status stripe."** It was deliberately removed and
+  replaced by a status **dot** (`KpiTile.tsx` renders it). Use the existing `KpiTile` /
+  `metric()` factory as-is; do not hand-build tiles.
+- Run `/impeccable <command>` for design work; run `scripts/check-ui-canon.sh` before
+  declaring frontend done (it hard-fails on faux-bold, `text-[Npx]`, `oklch(`, new
+  `backdrop-blur`; the raw-palette count is a ratchet that may only go **down**).
+
+### 4.2 PHI, privacy, and safety
+- **PHI-free-wire rule.** Only aggregate pings travel on public Reverb channels
+  (`home.census`, cockpit ping). Patient-level vitals are fetched over authenticated APIs
+  with TanStack cache invalidation on ping — exactly like the cockpit stream
+  (`routes/channels.php` documents this doctrine). If per-patient **push** is ever
+  required, it must move to a `PrivateChannel` with a real auth callback — a deliberate,
+  documented contract change, never incidental.
+- **Pseudonymity preserved.** Operational and analytic paths use `patient_ref` and
+  service **zones**, never MRNs or street addresses. Physical address is confined to a
+  restricted logistics context only. Never put PHI in URL params, query strings, or
+  public channel payloads.
+- **HEWS is operational triage, not a medical device.** The Home Early Warning Score is
+  decision support for operations, **not diagnosis.** Ship clear labeling; stay inside
+  FDA clinical-decision-support boundaries; escalation authority always rests with the
+  clinical team — exactly as Eddy actions always rest with a human approver.
+- **Eddy governance is inviolable.** Every new Home action is **draft-only**; a human
+  approves. The agent proposes, a human disposes. No direct domain mutation from an
+  agent token.
+
+### 4.3 Protected systems — do NOT modify
+- The **authentication system** enumerated in `.claude/rules/auth-system.md` (temp-password
+  + Resend flow, ChangePasswordModal, etc.). Additions only, never architectural change.
+- The **nine existing cockpit metric providers**, `SnapshotBuilder`, `StatusEngine`,
+  `AlertEngine`, the integration control plane, and the census `CensusProjector` — you
+  **extend** these by adding to their registration points, you do not rewrite them.
+- Deployment: production is **manual-only** (`./deploy.sh`). Never add a GitHub Actions
+  deploy job or push to prod.
+
+---
+
+## 5. Concept & placement
+
+- **New nav domain:** working name **Home Hospital (HOME)**, added as a new **Workspace**
+  in the Altitude model (Cockpit → Workspaces → Study), gated behind a feature flag and
+  route middleware (§6.11). It sits in the `workspaces` section of `navigationConfig.ts`
+  next to RTDC, EMERGENCY, PERIOPERATIVE, etc.
+- **The virtual ward is modeled as a unit.** Seed one or more `prod.units` rows with a
+  `virtual_home` type and `prod.beds` rows as program **slots**. Because the program is a
+  unit, census, occupancy, huddles, and the entire cockpit machinery work **unmodified**.
+- **Three capability rings ship progressively** (map to phases):
+  1. **Acute HaH at waiver grade** — virtual-ward census & command, RPM observability,
+     twice-daily visit logistics, escalation with response-time telemetry, CMS reporting.
+  2. **Extended observability** — post-discharge 30-day monitoring cohorts,
+     ED-diversion / observation-at-home, chronic RPM lines (HF, COPD) on the same pipes
+     at lower acuity.
+  3. **Transitions of care** — admission pathways in, governed handoffs out.
+
+---
+
+## 6. Architecture — what you inherit (verified file map)
+
+This is the load-bearing section. Every path below was verified against the current
+codebase. **Reuse these; extend at the named registration points.**
+
+### 6.1 Census spine (event-sourced occupancy)
+- Tables: `prod.units`, `prod.beds` (`database/migrations/2026_06_20_000010_create_rtdc_units_beds_tables.php`);
+  `prod.encounters`, `prod.census_snapshots` (`..._000020_...`); `prod.operational_events` (`..._000030_...`).
+- Models: `app/Models/Unit.php`, `Bed.php`, `Encounter.php`, `CensusSnapshot.php`, `OperationalEvent.php`.
+- Projector: `app/Rtdc/CensusProjector.php` — `apply(CanonicalEvent $event)` dispatches via
+  `match($event->type)` onto idempotent `updateOrCreate` read-model updates; `snapshot(int $unitId)`
+  recomputes occupancy and writes a `census_snapshots` row.
+- **`prod.units.type` is a free-form string with no CHECK constraint** — adding `virtual_home`
+  needs **no constraint migration on `prod.units`.** ⚠️ But `prod.beds.status` has a CHECK
+  (`available|occupied|blocked|dirty`) — model slot states within it (map "pending-setup"/"blocked"
+  onto existing states or extend the CHECK deliberately). ⚠️ `prod.gmlos_references.unit_type` has a
+  CHECK (`med_surg|icu|step_down|ed`) — extend it only if a home unit needs a GMLOS reference row.
+
+### 6.2 Cockpit snapshot & metric providers
+- Assembler: `app/Services/Cockpit/SnapshotBuilder.php`. **Registration point:** the
+  `providers()` method returns the nine providers in order (`OkrMetrics` last). **Add
+  `HomeMetrics` here.** `DOMAIN_GAUGES` const maps a domain → its headline gauge key
+  (add `'home' => 'home.<gauge>'`).
+- Base class: `app/Domain/Cockpit/Metrics/BaseMetrics.php` (abstract) — inject `StatusEngine`;
+  implement `domain(): string` and `metrics(SnapshotContext $ctx): array` (returns `MetricValue[]`).
+  Helpers: `fromKey($ctx,$key,$value,$overrides)`, `fromLegacy(...)`, `compact()`.
+- Closest analog to copy: `app/Domain/Cockpit/Metrics/RtdcMetrics.php` (census-based).
+- DTO: `app/Support/Cockpit/MetricValue.php`; context: `app/Domain/Cockpit/SnapshotContext.php`;
+  refresh job: `app/Jobs/RefreshCockpitSnapshot.php`.
+
+### 6.3 StatusEngine + metric definitions (admin-editable bands)
+- Engine: `app/Services/Cockpit/StatusEngine.php` — `resolveStatus(float $value, MetricDefinition $def)`
+  reads `direction` (`up`/`down`), `ok`/`warn`/`crit` edges, `watch_band_pct`; resolves crit→warn→ok→watch→normal.
+- Enum: `app/Enums/CockpitStatus.php` — `NORMAL/OK/WATCH/WARN/CRIT`; `canon()` → `neutral/success/info/warning/critical`.
+  **Backend emits logical names only;** the teal/amber/coral/sky tokens are client-side
+  (`resources/js/Components/cockpit/statusStyle.ts`).
+- Table/model: `ops.metric_definitions` / `app/Models/Ops/MetricDefinition.php`.
+- **Seed new `home.*` keys here:** `database/seeders/CockpitKpiDefinitionSeeder.php` — add rows
+  via the `kpi(label, def, unit, direction, target, warn, crit, refreshSecs, alertTemplate=null, ...)`
+  helper; `run()` upserts by `metric_key` (idempotent), auto-derives `domain` from the key prefix.
+  Admin editing UI: `resources/js/Pages/Admin/CockpitThresholds.tsx` + `app/Http/Controllers/Admin/CockpitPolicyController.php`.
+
+### 6.4 Alerting → Eddy Action Inbox
+- Engine: `app/Services/Cockpit/AlertEngine.php` — `reconcile($facilityKey, $candidates)` runs the
+  flap-damping lifecycle (`pending → open → cleared`, `hold_count`) against `prod.cockpit_alerts`;
+  thresholds in `config/cockpit.php`.
+- **Candidates are derived in `SnapshotBuilder::deriveAlerts()` from every visible warn/crit
+  `MetricValue` whose definition has a non-empty `alert_template`.** This is the Earned-Red ration.
+- Fan-out: `app/Services/Cockpit/AlertFanout.php` + `Channels/{PushAlertChannel,TeamsAlertChannel}.php`;
+  model `app/Models/Cockpit/CockpitAlert.php`.
+- Alert → Eddy: `app/Services/Eddy/EddyActionService.php` — `CATALOG` maps action types →
+  `{tier, risk, label, recommendation_type, alert_key}`; `actionForAlert($alertKey, $status)` routes
+  an opened alert onto a catalog action by `alert_key` **prefix**. **Add a `'home.'`-prefixed entry**
+  so home alerts auto-route.
+
+### 6.5 Integration control plane (device & FHIR ingestion)
+Message flow: `source → raw.inbound_messages → integration.canonical_events → ProjectionHandler → prod.*`.
+- Foundation migration (creates `integration.sources`, `raw.inbound_messages`, `integration.canonical_events`,
+  `raw.dead_letters`, `integration.connector_watermarks`, `fhir.*`, `integration.provenance_records`):
+  `database/migrations/2026_06_25_000030_create_healthcare_integration_foundation_tables.php`.
+- Connector contract: `app/Integrations/Healthcare/Contracts/HealthcareConnector.php`
+  (`sourceKey`, `capabilities`, `healthCheck`, `backfill`, `poll` [FHIR-poll], `handleWebhook` [webhook], `replay`).
+- **Reference connector to copy (full lifecycle, webhook + poll):**
+  `app/Integrations/Healthcare/Synthetic/SyntheticHealthcareConnector.php`.
+- Projection contract: `app/Integrations/Healthcare/Contracts/ProjectionHandler.php`
+  (`key()`, `eventTypes()`, `supports()`, `project()`); router `Services/ProjectionDispatcher.php`
+  (one owner per eventType). Canonical writer: `Services/CanonicalEventWriter.php`.
+- **Registration seam:** `app/Providers/AppServiceProvider.php` (~L95–126) — `ProjectionDispatcher`
+  is constructed with an explicit array of handlers; **add your `RpmProjectionHandler` here.**
+- Working HL7v2 exemplar (production ADT): `app/Services/PatientFlow/PatientFlowHl7IngestPipeline.php`.
+  ⚠️ Wire the **escalation-close loop** through this: when an escalated home patient is registered in
+  the ED via ADT, resolve the open `prod.home_escalations` row with an `ed_return` outcome.
+- Dead-letter/replay: `raw.dead_letters` + `app/Jobs/ReplayPendingIntegrationEvents.php`.
+- Per-feed freshness SLAs: `config/integrations.php` (defaults) + `Services/SourceSloDefinitionService.php`
+  / `SourceObservabilityService.php` (per-source SLOs).
+
+### 6.6 FHIR R4
+- Poll client (SMART backend-services, `_history`, watermarking, tombstones):
+  `app/Integrations/Healthcare/Services/SmartBackendFhirClient.php` (Epic variant: `EpicSmartFhirClient.php`).
+- Storage/versioning: every resource persists as **both** a `raw.inbound_messages` row and a
+  `fhir.resource_versions` row (append-only, uniquely keyed `source_id, resource_type, fhir_id, version_id`).
+  `fhir.resource_links` maps FHIR ids → internal projected rows. Models: `app/Models/Fhir/ResourceVersion.php`,
+  `ResourceLink.php`. Resource JSON is encrypted out-of-row.
+- Store RPM as FHIR **Observation / Device / ServiceRequest** (US Core profiles; IEEE 11073 PHD via
+  vendor gateways). **LOINC vital codes:** heart rate `8867-4`, SpO₂ `59408-5`, systolic `8480-6`,
+  diastolic `8462-4`, respiratory rate `9279-1`, body temperature `8310-5`, weight `29463-7`.
+
+### 6.7 Canonical event vocabulary + OCEL projection
+- RTDC operational vocabulary (PascalCase constants): `app/Rtdc/Events/CanonicalEvent.php`. **Add**
+  `HomeReferralCreated`, `HomeEpisodeActivated`, `RpmObservationBreached`, `HomeEscalationOpened`,
+  `HomeEscalationResolved`, `HomeVisitCompleted`, `HomeEpisodeDischarged`, `TransitionHandoffCompleted`.
+- OCEL emission map (pure, DB-free transformers): `app/Domain/Ocel/EmissionMap.php` — add `forHomeEpisode()`
+  etc.; PHI hashed via `hashRef()`. Projector: `app/Domain/Ocel/OcelProjector.php` — add a `collectHomeEpisodes()`
+  method + call it in `project()`. Catalog: `app/Domain/Ocel/OcelCatalog.php` — add object types
+  (`Home Episode`, `RPM Kit`, `Home Visit`, `Escalation`) and activity verbs (additive; uncatalogued verbs still project).
+
+### 6.8 Eddy (governed action agent)
+- Catalog: `app/Services/Eddy/EddyActionService.php::CATALOG` — **adding a new action is a pure
+  additive row** (`tier`, `risk`, `label`, `recommendation_type`, `alert_key`). Everything else
+  (FormRequest validation via `Rule::in(array_keys(CATALOG))`, controller, tiering, role-gating)
+  reads from the catalog. Add: `propose_hah_enrollment`, `propose_stepdown_cohort`,
+  `propose_escalation_response`, `propose_visit_reschedule`, `flag_rpm_gap`, `propose_home_discharge`,
+  `flag_transition_barrier`.
+- Governance write path: `propose()` creates `Recommendation(draft) → OperationalAction(draft) →
+  Approval(pending)` via `app/Services/Ops/OperationalActionLifecycleService.php`. Human-only approve
+  (`app/Http/Controllers/Api/Eddy/EddyActionController.php`, gated on `actsAsHuman()`). Config: `config/eddy.php`.
+- Inbox surfaces: web `/ops/agent-inbox` (`routes/web.php`); frontend `resources/js/Components/cockpit/ActionInboxModal.tsx`.
+
+### 6.9 Arena (process mining, OCEL 2.0) & the 48-Hour Flow Review
+- `app/Domain/Arena/FlowReviewService.php` (`WINDOW_HOURS = 48`) — folds the home program in once
+  home events project into `ocel.*`. Conformance: `ArenaService::conformance()` / `ArenaSidecarClient::conformance()`
+  against reference pathways seeded in `database/seeders/ClinicalPathwaySeeder.php` (add home pathways:
+  time-to-activation SLA, visit cadence, escalation-protocol adherence).
+
+### 6.10 Predictions layer (deterministic) & avoided bed-days
+- Store: `prod.rtdc_predictions` (`database/migrations/2026_06_20_000040_...`), upsert on unique
+  `(unit_id, service_date, horizon)`; model `app/Models/RtdcPrediction.php`. Deterministic write pattern:
+  `app/Services/RtdcService.php::prediction()`. The +24h composition substrate is
+  `app/Services/Flow/ForwardProjectionService.php` (every projected item tagged confidence
+  ∈ {definite, probable, possible} + provenance) — **add a home free-slot stream here.**
+- Economics ledger: `prod.discharge_facts` (`database/migrations/2026_07_04_100040_...`) feeds
+  materialized views (`ops.mv_*`). Roll **avoided bed-days** up here / alongside; surface in the RTDC
+  huddle and executive brief.
+
+### 6.11 Feature-flag + route gating (copy Virtual Rounds)
+- Config precedent: `config/rounds.php` returns `['enabled' => filter_var(env('VIRTUAL_ROUNDS_ENABLED', false), FILTER_VALIDATE_BOOL), ...]`.
+  **Create `config/home_hospital.php`** (mirroring it) with `enabled` ← `HOME_HOSPITAL_ENABLED` plus sub-flags.
+- Middleware precedent: `app/Http/Middleware/EnsureRoundsEnabled.php` → `abort_unless((bool) config('rounds.enabled'), 404)`.
+  **Create `app/Http/Middleware/EnsureHomeHospitalEnabled.php`** reading `config('home_hospital.enabled')`.
+- ⚠️ Laravel 11 style: **no `$routeMiddleware` alias array** — apply the middleware **inline by FQCN**
+  in `routes/web.php` and `routes/api.php` (exactly as Virtual Rounds does at `routes/web.php:158-159`
+  and `routes/api.php:218-219`).
+
+### 6.12 Ambient telemetry hooks (wearable/RPM substrate)
+- `flow_realtime.ambient_signal_adapters` + `flow_realtime.ambient_signal_events`
+  (`database/migrations/2026_06_26_000070_...`). Register a wearable/RPM feed as an adapter row; RPM
+  readings can land as `ambient_signal_events` (idempotent on `(adapter_id, external_event_id)`,
+  `subject_ref_hash` PHI-safe). Service: `app/Services/PatientFlow/AmbientSignalService.php`.
+  Decide (§13) whether RPM rides the ambient-signal path or a dedicated `rpm_observations` ledger — the
+  strategy doc favors the dedicated ledger for volume; ambient signals remain the lower-fidelity hook.
+
+### 6.13 Realtime (Reverb)
+- Doctrine: `routes/channels.php` (public `Channel`, PHI-free aggregate pings; no auth callbacks).
+- Cockpit ping event: `app/Events/Cockpit/CockpitSnapshotUpdated.php` (public `hospital.cockpit`,
+  `broadcastAs('.cockpit.updated')`). Bed ping: `app/Events/Rtdc/BedsChanged.php`.
+- Frontend invalidation-on-ping: `resources/js/features/cockpit/live.ts` (`useLiveCockpit()` →
+  `echo.channel('hospital.cockpit').listen('.cockpit.updated', () => qc.invalidateQueries(...))`);
+  SSE fallback `useCockpitStream.ts`; RTDC analog `resources/js/features/rtdc/hooks.ts::useLiveCensus`.
+  **Pattern: the ping carries no data; it only triggers `invalidateQueries`, and the authenticated refetch does the work.**
+
+### 6.14 Frontend design-system primitives & page pattern
+- Surface: `resources/js/Components/ui/Surface.tsx`; `Panel` = `resources/js/Components/CommandCenter/Panel.tsx`
+  (re-exports Surface) and the titled wrapper `resources/js/Components/ui/Panel.jsx`.
+- KPI tile: `resources/js/Components/CommandCenter/KpiTile.tsx` (status **dot**, arrow, gauge/number,
+  sparkline when `detailed`, source-trust badge). Gauge: `Components/CommandCenter/Gauge.tsx`. Sparkline:
+  `Components/cockpit/Sparkline.tsx`.
+- **Build HOME pages on the design-system barrel** `resources/js/Components/system/index.ts` —
+  `Section`, `MetricGrid`, and the `metric(input)` factory (`Components/system/metric.ts`); the metric
+  contract is `resources/js/types/commandCenter.ts` (`KpiMetric`, incl. `sourceTrust`, `trajectory`,
+  `status: critical|warning|success|info|neutral`).
+- **Template to copy:** `resources/js/Pages/RTDC/BedTracking.tsx` (page) + `resources/js/Components/RTDC/RTDCPageLayout.tsx`
+  (workspace layout shell wrapping `DashboardLayout` + `PageContentLayout` + `<Head>`). Create a
+  `HomePageLayout.tsx` copy and `resources/js/Pages/Home/*` pages.
+
+### 6.15 Navigation registration
+- SSOT: `resources/js/config/navigationConfig.ts`. Define a `HOME: NavDomain` (mirror the `RTDC` const)
+  with `key:'home'`, `label:'Home Hospital'`, a Lucide icon (e.g. `HeartPulse`/`House`),
+  `dashboardHref:'/home/command'`, `matchPrefixes:['/home']`, and `groups` for the six surfaces.
+  Register it in `NAV_SECTIONS` → `workspaces` section `domains` array. That single registration feeds
+  desktop nav, mobile drawer, command palette, and route-ownership. Ownership must be exactly 1 —
+  `matchPrefixes:['/home']` is collision-free. (If `/home/analytics` is later re-homed to Study,
+  add it to `ANALYTICS.matchPrefixes` and `HOME.excludePrefixes`, the pattern RTDC already uses.)
+
+### 6.16 Dev/live mode & demo seed
+- Data service: `resources/js/services/data-service.js` (`dev` → mock, `live` → `/api/...`);
+  `resources/js/Contexts/ModeContext.tsx` (defaults `'dev'`). Mock files: `resources/js/mock-data/*`.
+  Add `resources/js/mock-data/home.js` + getters, or fetch `/api/home/*` with a demo-provenance backend.
+- Demo hospital: `database/seeders/SummitDeploymentSeeder.php` (Summit Regional, code `ZEPHYRUS-500`).
+  Commands: `zephyrus:demo-seed` (`app/Console/Commands/DemoSeedCommand.php`), `zephyrus:demo-refresh`
+  (`DemoRefreshCommand.php` → `App\Services\Demo\DemoRefreshCoordinator`, guarded by `config('demo.enabled')`,
+  scheduled every 15 min). Deterministic generators: `app/Services/Demo/DistributionSampler.php`,
+  `OperationalDemoDataService.php` (writes tagged with an `OWNER` marker so live deployments are never
+  overwritten). Registration order: `database/seeders/DatabaseSeeder.php` (`DemoTuningSeeder` last).
+  **Pattern:** create `app/Services/Demo/HomeHospitalDemoGenerator.php` (mirror `Ancillary/PharmacyDemoGenerator.php`),
+  wrap in `HomeHospitalDemoSeeder`, register before `DemoTuningSeeder`, hook into `DemoRefreshCoordinator`.
+  Synthetic tiles show a `ProvenanceBadge` when `metadata.provenance === 'demo'`.
+
+---
+
+## 7. Data model — new tables (prod schema)
+
+Follow the established conventions **exactly** (verified in `database/migrations/`):
+
+- **PK:** `$table->id('{table}_id')` (bigint identity, named `{table}_id`).
+- **Public/idempotency key:** a **separate** `$table->uuid('{thing}_uuid')->unique()` column (the `_id`
+  and `_uuid` are two different columns — the `_id` is the numeric PK, the `_uuid`/`idempotency_key`
+  are dedupe/public keys).
+- **`patient_ref`** (pseudonymous, `string(190)`, never an MRN) + `encounter_ref` where relevant.
+- **`metadata`** `jsonb` default `'{}'::jsonb` (CHECK `jsonb_typeof(metadata) = 'object'`).
+- **`is_deleted`** boolean default false (soft delete). `timestampsTz()`.
+- **CHECK constraints via raw `DB::statement(...)`** after an existence probe (see the private
+  `addCheckConstraint()` helper pattern in `2026_06_25_000030_...`). Use the `SafeMigration` trait
+  (`app/Traits/SafeMigration.php`).
+- Keep the **RPM observation ledger separate** from `prod.encounters` — mirror how `prod.discharge_facts`
+  stays a distinct ledger.
+
+| Table | Purpose |
+|---|---|
+| `prod.home_programs` | Program lines (AHCAH acute, observation-at-home, post-discharge RPM, chronic RPM, SNF-at-home) with slot capacity by service zone |
+| `prod.home_referrals` | Funnel spine: source, status, decline reason, screening JSON (zone, payer, home-safety, connectivity) |
+| `prod.home_episodes` | Episode spine, linked to an `encounter` on the virtual unit: program, admission source, condition + DRG, acuity tier, target vs. actual LOS, disposition |
+| `prod.rpm_kits` / `prod.rpm_devices` | Kit and device inventory, lifecycle, battery & connectivity telemetry |
+| `prod.rpm_enrollments` | Kit-to-episode assignment + per-patient monitoring plan (per-vital cadence, personalized thresholds, baseline window) |
+| `prod.rpm_observations` | High-volume vitals ledger, LOINC-coded, with device & transmission provenance and a quality flag |
+| `prod.rpm_alerts` | Patient-level clinical alerts (rule, severity, opened/acked/resolved, escalation link) |
+| `prod.home_visits` | Scheduled/completed visits (RN, paramedic, MD/NP tele, labs, delivery), waiver-required flag, on-time telemetry |
+| `prod.home_escalations` | Trigger, response mode, full timing chain (initiated → dispatched → arrived → resolved), outcome (managed at home / ED return / readmit) |
+| `prod.home_transitions` | Inbound activation & outbound handoff milestones, receiving-entity FK to `regional.facilities`, readiness checklist |
+
+**Virtual-unit seeding:** seed `prod.units` rows with `type = 'virtual_home'` and `prod.beds` rows as
+slots, so census/occupancy/huddles/cockpit work unmodified.
+
+> ⚠️ **`prod.rpm_observations` is high-volume.** The strategy doc calls for **monthly
+> range-partitioning**, but **no declarative table-partitioning exists anywhere in the repo today** —
+> this would be a *new* convention. Do it via raw `DB::statement` in the migration `up()` (consistent
+> with how schemas and CHECK constraints are already created), and **flag it explicitly** in the PR
+> description and DEVLOG as a new pattern for review. Alternatively, ship Phase 0/1 unpartitioned with
+> a documented retention/rollup policy and add partitioning as a follow-up. Do not silently introduce it.
+
+**Transitions substrate to reuse (do not rebuild):** `prod.transport_requests.request_type` already
+includes `care_transition` and `discharge` (CHECK-constrained); `regional.facilities` +
+`regional.facility_capabilities` + `regional.transfer_decisions.opportunity_cost_payload` model
+external facilities and destination selection with opportunity-cost scoring.
+
+---
+
+## 8. The six surfaces (`resources/js/Pages/Home/*`)
+
+Each reuses an existing Zephyrus component pattern; each route is under the `home.` group and gated by
+`EnsureHomeHospitalEnabled`. Build on `Section`/`MetricGrid`/`metric` and `HomePageLayout`.
+
+1. **Virtual Ward Command · `/home/command`** *(flagship)* — a grid of **episode tiles**: pseudonymous
+   identity, condition + program, day-of-stay vs. expected LOS, live vitals sparklines, a **Home Early
+   Warning Score (HEWS)** chip, open alerts, the **next required visit with a countdown**, and
+   device/connectivity status. Grey resting baseline; coral only for a true breach (unacknowledged
+   critical vital, blown response SLA, missed waiver-required visit). Tiles **drill in place** to the
+   patient lens.
+2. **Virtual Bed Board · `/home/census`** — RTDC-pattern board of program slots
+   (occupied / available / pending-setup / blocked), an enrollment-pipeline column, projected discharges
+   at 24 h and 48 h. Shares one census engine with the house-wide huddle (because the program is a unit).
+3. **Eligibility & Referral Funnel · `/home/referrals`** — two live worklists: **ED candidates**
+   (screened over the live ED census: qualifying conditions, service-zone address, payer class, clinical
+   stability) and **inpatient step-down candidates** (at/near expected LOS with home-eligible profiles).
+   Funnel states: referred → screened → eligible → consented → activated / declined, **with decline
+   reasons** (real programs convert only a minority — design for ~22% conversion).
+4. **Field Operations & Logistics · `/home/logistics`** — visit scheduling with a **two-visits-per-day
+   compliance rail**, a route/assignment view for field nurses & community paramedics (reuse **Transport
+   dispatch** patterns), kit inventory & lifecycle, and delivery tracking (meds, meals, DME, labs).
+   ⚠️ This is the **only** context where physical address is permitted; keep it out of everything else.
+5. **Transitions of Care Board · `/home/transitions`** — inbound activation checklists (consent,
+   home-safety check, kit delivery, first visit) and outbound handoffs (discharge readiness, handoff
+   owner, receiving entity via `regional.facilities`, barrier tracking) plus a **30-day post-discharge
+   monitoring cohort** with a step-down cadence (billable under the 2026 RPM codes).
+6. **Program Analytics · `/home/analytics`** *(Study)* — outcomes vs. matched inpatient comparators (LOS,
+   escalation, mortality, 30-day readmission — see §3), program economics & **avoided bed-days**, funnel
+   conversion, alert burden per patient-day, visit on-time compliance, RPM adherence.
+
+**Wiring per page** (mirror RTDC): React page in `Pages/Home/`, `Inertia::render('Home/<Page>', $service->build())`
+method on a new `HomeDashboardController`, `Route::prefix('home')->name('home.')->group(...)` in
+`routes/web.php` with `EnsureHomeHospitalEnabled` on the group, live data via `app/Http/Controllers/Api/Home/*`
+under a `->prefix('home')` group in `routes/api.php`.
+
+---
+
+## 9. Cockpit integration
+
+- **New provider:** `app/Domain/Cockpit/Metrics/HomeMetrics.php` (`domain(): 'home'`), registered in
+  `SnapshotBuilder::providers()`. Seed thresholds into `ops.metric_definitions` via
+  `CockpitKpiDefinitionSeeder` so they stay admin-editable and audited.
+- **Metric keys** (attach an `alert_template` **only** to the alerting rows — this is the Earned-Red ration):
+
+  | Metric key | Cockpit tile | Alerting |
+  |---|---|---|
+  | `home.census_occupancy` | Virtual ward occupancy vs. slots | — |
+  | `home.unacked_critical_vitals` | Unacked critical vitals (count · max age) | **Critical → Eddy** |
+  | `home.escalation_response_p90` | Escalation response p90 (minutes) | Warn / Crit |
+  | `home.visit_compliance_today` | Waiver visit compliance % | **Critical** |
+  | `home.device_offline_pct` | Kits offline / transmission gaps | Warn |
+  | `home.rpm_adherence` | Patient monitoring adherence % | Watch |
+  | `home.escalation_rate_7d` | Escalations per 100 episode-days | Watch |
+  | `home.referral_conversion_7d` | Referral → enrollment conversion % | — |
+  | `home.avoided_bed_days_mtd` | Avoided bed-days MTD (executive) | — |
+
+- **Drill:** add `'home'` to `DrillBuilder::DOMAINS` + `TITLES` (`app/Services/Cockpit/DrillBuilder.php`)
+  and mirror it in `cockpitDrillDomains` (`resources/js/types/cockpit.ts`); wire the detail source in
+  `DrillBuilder::build()`. A `?drill=home` modal exposes the census strip, alert list, funnel snapshot,
+  and response-time trend; **wall-display mode inherits automatically.**
+- **The decant line (the whole thesis, made literal):** the RTDC global huddle gains a **"home decant"
+  line** — home-eligible counts and free slots surfaced next to boarding metrics.
+
+---
+
+## 10. Intelligence layer
+
+### 10.1 Home Early Warning Score (HEWS) & escalation risk
+- Compute **deterministically first** (transparent SQL/PHP over opaque ML, matching the Predictions
+  philosophy). Blend a modified **NEWS2** with patient-specific baselines calibrated over the first 24 h,
+  vital-sign trend slopes, and a monitoring-adherence signal. Bands live in metric-definition-style
+  config; leave an ML upgrade path via a sidecar later.
+- A daily per-episode **escalation-risk tier** (condition, day-of-stay, HEWS trajectory, adherence, visit
+  findings) drives visit intensity and the command-grid **sort order**.
+- **Label it clearly as operational triage, not diagnosis** (§4.2).
+
+### 10.2 Capacity forecasting & avoided bed-days
+- Enrollment-pipeline forecast (home-eligible ED census + step-down candidates near expected LOS) +
+  per-episode discharge projection → **free-slot forecast at 24 h / 48 h / 7 d**, surfaced in the RTDC
+  global huddle and written alongside physical capacity via `prod.rtdc_predictions` /
+  `ForwardProjectionService`.
+- Every active home episode-day rolls up as an **avoided occupied bed-day** into the ops materialized
+  views and the executive brief — the ROI accounting that makes the program legible to a COO.
+
+### 10.3 Eddy actions & Arena
+- Add the seven draft-only Home actions to `EddyActionService::CATALOG` (§6.8). This is where the
+  June-2025 plan's **Post-Acute and Care Transition Agent** lands.
+- Arena gains object types (`HomeEpisode`, `RpmKit`, `HomeVisit`, `Escalation`) + conformance checks
+  (time-to-activation SLA, visit cadence, escalation-protocol adherence); the **48-Hour Flow Review**
+  folds in the home program (§6.7, §6.9).
+
+---
+
+## 11. Compliance, safety & privacy (build these in, not on)
+- **Waiver conditions as first-class telemetry.** Visit compliance, response times, and CMS-required
+  reporting are **generated from the `prod.home_*` tables**; extend the append-only user-audit ledger to
+  home-episode access. Capturing the 2028 study variables (readmission, mortality, escalations, equity)
+  as operational data makes the federal report a byproduct.
+- **Clinical alarm governance.** Alert burden per patient-day is itself a tracked KPI; thresholds are
+  personalized to each patient's baseline; clinical alerts are flap-damped exactly as `AlertEngine`
+  damps operational tiles.
+- **Equity & selection-bias guardrails.** Connectivity screening (prefer cellular-backhauled kits),
+  language/caregiver requirements, and **decline-reason analytics** surface selection bias before it
+  becomes a finding in the federal study.
+
+---
+
+## 12. Phased roadmap — build order, deliverables & Definition of Done
+
+Each phase is independently demonstrable against the Summit Regional demo hospital. **Do not proceed to
+the next phase until the current DoD passes.** Estimates are from the strategy doc.
+
+### Phase 0 · Foundation *(4–6 wks)*
+**Scope:** schemas & migrations (§7); virtual-unit seeding; feature flag (`config/home_hospital.php`) +
+`EnsureHomeHospitalEnabled` + HOME nav domain; a **synthetic RPM connector** + demo cohort in the demo
+seed; census board via RTDC reuse.
+**Deliverables:** all `prod.home_*` / `prod.rpm_*` migrations (with the partitioning decision documented);
+`virtual_home` unit + slots seeded; `HomeHospitalDemoGenerator` + `HomeHospitalDemoSeeder` wired into
+`zephyrus:demo-refresh`; `SyntheticRpmConnector` (copy of `SyntheticHealthcareConnector`); `/home/census`
+rendering real seeded slots; nav domain visible only when the flag is on.
+**DoD:** `php artisan migrate` clean on a fresh `zephyrus_test`; `php artisan test` green; `./vendor/bin/pint`
+clean; flag **off** → `/home/*` returns 404 and the nav domain is hidden; flag **on** → `/home/census`
+shows the seeded virtual ward; `zephyrus:demo-refresh --validate` passes (0 critical, idempotent).
+
+### Phase 1 · Observability MVP *(6–8 wks)*
+**Scope:** vitals ingestion pipeline (connector → `raw.inbound_messages` → canonical events →
+`RpmProjectionHandler` → `prod.rpm_observations` + FHIR `Observation`); HEWS + patient alerts with an
+**acknowledgement workflow**; **Virtual Ward Command** page (`/home/command`); cockpit home tiles +
+`?drill=home`; escalation workflow with **response timers**.
+**Deliverables:** `RpmProjectionHandler` registered in `AppServiceProvider`; new canonical event
+constants; `HomeMetrics` provider + seeded `home.*` definitions (alert rows only where §9 says);
+`'home'` in `DrillBuilder::DOMAINS` + `cockpitDrillDomains`; `home.` Eddy `CATALOG` entry so
+`home.unacked_critical_vitals` routes to `propose_escalation_response`; the ADT escalation-close loop.
+**DoD:** a synthetic breached vital flows end-to-end to an acked `prod.rpm_alerts` row and a cockpit
+tile; a critical vital raises exactly one flap-damped alert that seeds a **draft** Eddy action requiring
+human approval (never auto-executes); `?drill=home` + `?display=wall` render; `scripts/check-ui-canon.sh`
+passes; the `verify` skill drives the command page and observes a live escalation timer.
+
+### Phase 2 · Transitions *(6–8 wks)*
+**Scope:** referral funnel + eligibility worklists (ED + step-down); transitions board; care-transition &
+regional-facility handoffs (reuse `transport_requests` + `regional.facilities`); 30-day post-discharge
+cohort; logistics/visit board.
+**Deliverables:** `/home/referrals`, `/home/transitions`, `/home/logistics`; ED-diversion worklist wired
+to the live ED census; step-down worklist wired to encounters at/near expected LOS; decline-reason capture
++ analytics; two-visits-per-day compliance rail; handoffs writing `transport_requests` with
+`request_type = care_transition`.
+**DoD:** a referral traverses referred → activated and creates a `home_episodes` row on the virtual unit;
+an outbound handoff produces a `transport_request` + a `regional.transfer_decisions` row with
+opportunity-cost scoring; the post-discharge cohort tracks a step-down cadence; physical address appears
+**only** in the logistics context (grep-verify it is absent from other props/payloads/URLs).
+
+### Phase 3 · Intelligence & compliance *(8+ wks)*
+**Scope:** capacity/discharge forecasting into the RTDC huddle; Eddy catalog actions (all seven); OCEL
+projection + conformance; executive ROI tiles; CMS waiver reporting exports.
+**Deliverables:** home free-slot forecast in `ForwardProjectionService` + `prod.rtdc_predictions`; the
+huddle **"home decant" line**; avoided-bed-days rollup into `ops.mv_*` + the executive brief; OCEL
+`EmissionMap::forHomeEpisode()` + `OcelProjector::collectHomeEpisodes()` + catalog rows; home reference
+pathways in `ClinicalPathwaySeeder` + conformance checks; CMS/2028-study export capturing the mandated
+variables.
+**DoD:** the huddle shows home-eligible counts + free slots next to boarding metrics; the 48-Hour Flow
+Review includes home objects; a CMS reporting export produces the waiver + 2028-study variables from the
+`prod.home_*` tables; all Eddy home actions are draft-only and human-approved.
+
+### Later *(not scheduled)*
+Chronic RPM lines (HF, COPD), SNF-at-home, multi-facility program operations, payer-facing reporting.
+
+---
+
+## 13. Open questions — surface, don't silently decide
+
+Raise each with product/clinical leadership; state your recommended default and proceed on it only if unblocked:
+1. **Which conditions first?** Evidence points to **heart failure, COPD, pneumonia/respiratory infection,
+   cellulitis, UTI**. *(Default: seed exactly these as the initial `home_programs` condition set.)*
+2. **Field staffing model:** employed nurses vs. contracted community paramedics. *(Affects the logistics
+   board's assignment model — build it staffing-model-agnostic.)*
+3. **Target daily census & service radius** for the pilot. *(Affects slot capacity per service zone and
+   the demo cohort size; Kaiser matured ~7→13 ADC, Mount Sinai ~30/mo → 50–60.)*
+4. **Which single RPM vendor** to integrate first for the Phase 1 MVP. *(Until decided, Phase 1 rides the
+   `SyntheticRpmConnector`; the `HealthcareConnector` abstraction keeps you vendor-agnostic.)*
+5. **`rpm_observations` partitioning** (§7) — introduce a new range-partitioning convention now, or ship
+   unpartitioned with a retention/rollup policy and add it later? *(Default: ship unpartitioned in
+   Phase 0/1 with a documented rollup; propose partitioning as a reviewed follow-up.)*
+6. **Payer-aware eligibility** rules per program line — confirm the payer matrix (RPM Medicaid/commercial
+   coverage varies) before hardening the referral screen.
+
+---
+
+## 14. Reconciliation notes — deltas from the strategy doc
+
+Discovered while grounding this prompt against the live codebase. These **correct or sharpen** the
+strategy doc; follow the code truth.
+
+1. **No KPI "left status stripe."** The doc/DESIGN describe a 3px left status stripe on KPI tiles; the
+   actual `KpiTile.tsx` **removed it** in favor of a status **dot** (with a "replaces the banned
+   side-stripe" comment). Use the existing tile as-is; do not add a stripe.
+2. **No table-partitioning exists in the repo.** The doc's "monthly range-partitioned `rpm_observations`"
+   would be a *new* convention. Treat it as §13 Q5 — decide explicitly; don't silently introduce it.
+3. **`{table}_id` PK and `_uuid` are separate columns**, not one. The `_id` is the bigint PK; the
+   `_uuid`/`idempotency_key` are dedupe/public keys.
+4. **Feature-gating middleware is applied inline by FQCN** (Laravel 11 `bootstrap/app.php` style) — there
+   is no `$routeMiddleware` alias array to edit. Copy the Virtual Rounds wiring exactly.
+5. **`prod.units.type` needs no constraint migration** for `virtual_home` (free-form string), but
+   `prod.beds.status` and `prod.gmlos_references.unit_type` **are** CHECK-constrained — extend those
+   deliberately if home slot states or GMLOS references require it.
+6. **`ProjectionHandler`s are hand-registered** in `app/Providers/AppServiceProvider.php` (~L95) — a new
+   `RpmProjectionHandler` must be added there; there is no auto-tagging.
+7. **Adding an Eddy action / OCEL object type is purely additive** — a `CATALOG` row (Eddy) or an
+   `OcelCatalog` entry + one `EmissionMap::forX()` transformer + one `OcelProjector::collectX()` call.
+   Don't over-engineer these.
+
+---
+
+## 15. Testing, verification & done
+
+- **Backend:** `php artisan test` (add Feature tests for the ingestion pipeline, HEWS computation,
+  escalation timers, the decant forecast, and gating-off 404s; Unit tests for `HomeMetrics` and the
+  deterministic HEWS/forecast math). `./vendor/bin/pint` clean.
+- **Frontend:** `scripts/check-ui-canon.sh` passes (raw-palette ratchet may only go down); `npm run build`
+  clean. Verify dark **and** light themes, `prefers-reduced-motion`, and wall-display (`?display=wall`).
+- **Demo integrity:** `zephyrus:demo-refresh --validate` stays at 0 critical / 0 warnings and remains
+  idempotent; synthetic tiles carry the demo `ProvenanceBadge`.
+- **End-to-end:** use the `verify` skill to drive each new surface in the running app (`./start-dev.sh`,
+  Laravel :8001 / Vite :5176) and observe real behavior — not just green tests. Confirm the one-instrument
+  story renders: from the cockpit/huddle you can see home-eligible boarders and free home slots together.
+- **Per-PR:** small, reviewable PRs per phase-slice; DEVLOG entry under `docs/` (e.g.
+  `docs/DEVLOG-home-hospital-YYYY-MM-DD.md`) following the existing DEVLOG convention; note any new
+  convention (esp. partitioning) for review. Never deploy to production — that is manual-only.
+
+---
+
+## 16. The one-sentence definition of success
+
+> Zephyrus becomes the **only command center that connects home capacity to ED boarding, floor occupancy,
+> and discharge planning in a single, defensible view** — running the virtual ward as a lever on the whole
+> hospital's throughput, with clinical-grade monitoring that never cries wolf and governance that keeps a
+> human in every consequential loop.

--- a/docs/home-hospital/Zephyrus_Hospital_at_Home_Strategy_and_Design.md
+++ b/docs/home-hospital/Zephyrus_Hospital_at_Home_Strategy_and_Design.md
@@ -1,0 +1,290 @@
+# Extending Zephyrus to Hospital at Home
+
+**Acute Care at Home, Remote Patient Monitoring & Transitions of Care — Strategy and Module Design**
+
+`ACUM-PRD-HAH-001` · Sanjay M. Udoshi, MD — Founder & Chief Medical Information Officer, Acumenus, Inc. · July 17, 2026
+<br>**CONFIDENTIAL** · © 2026 Acumenus, Inc. All rights reserved.
+
+> _Faithful Markdown conversion of `Zephyrus_Hospital_at_Home_Strategy_and_Design.docx`. This is the strategy source-of-truth behind the engineering brief in [`HOME-HOSPITAL-BUILD-PROMPT.md`](./HOME-HOSPITAL-BUILD-PROMPT.md). Tables and callout boxes were reconstructed from the DOCX; wording is unchanged._
+
+---
+
+## Contents
+
+1. Executive Summary
+2. The Strategic Opportunity: Hospital at Home in 2026
+3. Why Zephyrus Is Uniquely Positioned
+4. Module Design: The Home Hospital Workspace
+5. Data and Integration Architecture
+6. Intelligence Layer
+7. Transitions of Care
+8. Compliance, Safety, and Privacy
+9. Implementation Roadmap
+10. Business Case and Positioning
+11. Risks and Open Questions
+12. References
+
+# 1. Executive Summary
+
+Hospital at Home (HaH) — delivering acute, hospital-level care in a patient’s residence — has crossed the line from pilot to durable service line. In February 2026 Congress extended the CMS Acute Hospital Care at Home (AHCAH) waiver for roughly five years, through September 30, 2030, giving health systems the payment certainty they need to invest in permanent home-hospital operations (AMA 2026; 42 U.S.C. §1395cc-7). At the same time, CMS relaxed the billing floors on remote monitoring for calendar year 2026, making shorter, lower-acuity monitoring reimbursable for the first time (CY2026 PFS Final Rule). The clinical evidence is now strong enough to defend the model in a Monday review: randomized and national claims-based studies show comparable or lower mortality, fewer ICU escalations, and lower total cost of care versus traditional inpatient admission (Levine et al. 2020; Levine et al. 2024; Vakkalanka et al. 2026).
+
+This document proposes a **Home Hospital** module for Zephyrus. The thesis is simple and specific to our platform: every competitor orchestrates the home care itself, but none unify it with live house-wide demand and capacity. Zephyrus already computes one server-side operations snapshot across the Emergency Department, Real-Time Demand & Capacity (RTDC), Perioperative, and Process Improvement. A virtual ward is, structurally, one more unit whose beds are program slots — so census, huddles, cockpit tiles, alerting, and the governed Eddy action loop apply to home patients with minimal new machinery. The differentiated product is not a monitoring app; it is the only command center that can say, in one glance, “we have 14 ED boarders, 9 of them home-eligible, 6 home slots free tonight — enroll these and boarding hours fall.”
+
+> **The opportunity in one line**
+>
+> A five-year waiver extension turns Hospital at Home into a fundable service line; Zephyrus is uniquely positioned to run it as a **capacity-decompression instrument**, not just another care-at-home tool.
+
+The recommendation is a four-phase build that reuses Zephyrus’s integration control plane for device and FHIR ingestion, adds a compact set of home-specific data tables alongside (not inside) the existing census spine, and surfaces a virtual-ward command surface, an eligibility-and-referral funnel, a field-logistics board, and a transitions-of-care board. It pulls the BUSINESS_PLAN’s Year-3 “telehealth operations” item forward into the current window while the waiver tailwind is strongest, and positions a new à-la-carte module in the $85–95K range between the ED and Perioperative tiers.
+
+# 2. The Strategic Opportunity: Hospital at Home in 2026
+
+## 2.1 What Hospital at Home is
+
+Hospital at Home substitutes home-based care for a traditional inpatient admission for a defined set of acute conditions. Under the CMS AHCAH waiver the patient is formally an inpatient — admitted from an Emergency Department or an inpatient bed — but receives their care at home. The waiver sets a firm operating floor: a **daily physician evaluation** (which may be virtual), a **minimum of two in-person clinician visits per day** by a registered nurse or community paramedic, and the ability to deliver **in-person emergency clinical services at the home within 30 minutes** (MedPAC 2024). Around that floor, programs wrap remote patient monitoring (RPM), tele-visits, and home delivery of medications, labs, imaging, durable medical equipment, and often meals.
+
+The condition mix is well characterized. In the first national claims analysis of the waiver, the most common diagnoses were heart failure, respiratory infection (including COVID-19), sepsis, kidney/urinary-tract infection, and cellulitis; the population is medically complex (mean HCC score 3.15, case-mix index 1.31; 42.5% with heart failure, 43.3% with COPD) (Levine et al. 2024). A HaH module must be built for exactly this comorbid, escalation-prone population — not the worried well.
+
+## 2.2 Regulatory and payment status
+
+### 2.2.1 The AHCAH waiver — extended through 2030
+
+The AHCAH waiver flexibilities, first created in November 2020, were extended by the **Consolidated Appropriations Act, 2026** (Public Law 119-75), signed in early February 2026, which amended Section 1866G of the Social Security Act (42 U.S.C. §1395cc-7) to move the expiration from January 30, 2026 to **September 30, 2030** (AMA 2026; U.S. Code). The standalone vehicle — H.R. 4313, the Hospital Inpatient Services Modernization Act, which passed the House on December 1, 2025 — carried the same date and its study requirements were folded into the enacted package (Congress.gov 2025).
+
+> **New program requirement to design for**
+>
+> The extension directs HHS to deliver a study and report by **September 30, 2028** comparing home versus brick-and-mortar inpatient care on readmissions, mortality, infections, staffing, escalations/transfers, patient experience, conditions/DRGs, cost, and equity — explicitly addressing selection bias (Congress.gov 2025). A Zephyrus module that captures these variables as first-class operational data turns a compliance burden into a reporting asset.
+
+CMS is also opening the data: a second public AHCAH data release began March 17, 2026 (covering April 2023–September 2025), giving the field nearly five years of program data to benchmark against (CMS 2026).
+
+### 2.2.2 Remote monitoring reimbursement — the 2026 changes
+
+The CY2026 Medicare Physician Fee Schedule final rule (published in the Federal Register on November 5, 2025, effective January 1, 2026) materially widened remote-monitoring payment. It retained the legacy RPM codes (99453, 99454, 99457, 99458, 99091) and RTM codes (98975–98981), and **added shorter-duration codes**: new RPM **99445** for device supply covering just 2–15 days of data in a 30-day period (paid at parity with 99454), and **99470** for 10–19 minutes of monitoring management per month; parallel new RTM codes (98979, 98984, 98985) mirror the change (Nixon Law Group 2026; Federal Register 2025). The prior 16-day and 20-minute billing floors no longer gate all reimbursement, so lower-acuity and shorter home-monitoring episodes — exactly the post-discharge and chronic cohorts described later in this document — become billable.
+
+> **Payment caveat — Medicaid and commercial vary**
+>
+> Only about half of state Medicaid programs reimburse RPM, most with restrictions (CCHP 2026), and commercial coverage is uneven. The module’s enrollment and eligibility logic must be **payer-aware** from day one, not bolted on later.
+
+## 2.3 The clinical evidence base
+
+The evidence is what lets a CMO defend the program. Three anchors matter:
+
+- **The founding RCT.** In the first U.S. randomized trial of substitutive hospital-level care at home (Brigham and Women’s / Faulkner), the adjusted acute-episode cost was **38% lower** than inpatient care, with a **30-day readmission rate of 7% versus 23%**, and markedly lower utilization of labs, imaging, and consults (Levine et al. 2020).
+- **National claims outcomes (the KPI benchmarks).** Across 5,132 Medicare fee-for-service patients in the waiver’s first year, mean length of stay was **6.3 days**, escalation back to the hospital was **6.2%**, in-episode mortality **0.5%**, and 30-day readmission **15.6%** (Levine et al. 2024). These are the numbers a virtual-ward dashboard should track against.
+- **Large propensity-matched safety data.** In a 15,871-patient matched study, HaH was associated with lower in-hospital mortality (**0.4% vs 3.6%**), fewer ICU escalations (**3.5% vs 7.9%**), and modestly lower total 30-day cost, with 30-day readmissions statistically unchanged (Vakkalanka et al. 2026).
+
+A 2026 meta-analysis of 11 randomized trials in older adults reinforces the direction of travel — shorter stays, lower readmission risk, no mortality penalty, and lower cost — while cautioning that heterogeneity is high, so programs should trust their own instrumented outcomes over pooled averages (He et al. 2026). That caution is itself an argument for Zephyrus: a program that measures its own escalation and readmission rates in real time is defensible in a way that one relying on literature is not.
+
+## 2.4 Operating models and the competitive landscape
+
+Leading programs share a common shape: a 24/7 virtual command center with physician and nurse coverage, in-home visits by nurses or mobile-integrated-health paramedics at least twice daily, a nurse practitioner every other day in some models, and a technology kit for continuous or intermittent vitals. Kaiser Permanente’s Advanced Care at Home (built with Medically Home) grew its average daily census from roughly 7 to 13 patients as it matured; Mount Sinai at Home — one of the earliest programs, seeded by a 2014 CMS Innovation grant — runs about 30 admissions per month and has planned to scale toward 50–60, coordinated from a 24/7 virtual command center with a telemedicine kit that includes a remote stethoscope (Kaiser/AJMC; Mount Sinai 2023).
+
+The vendor market, by contrast, is consolidating and unsettled — which is the opening. DispatchHealth and Medically Home merged in mid-2025 into a single national platform; Best Buy divested Current Health barely four years after paying nearly $400M for it; and CoPilotIQ and Biofourmis combined in late 2024 (DispatchHealth 2025; Healthcare Dive 2025; HCI 2024). Every one of these players orchestrates the home care itself. **None of them unifies home-hospital operations with the hospital’s live inpatient demand and capacity, its OR and ED pressure, its staffing, or its process-mining and governance layer.** That whitespace is precisely where an operations-intelligence platform wins.
+
+# 3. Why Zephyrus Is Uniquely Positioned
+
+## 3.1 The assets the module inherits
+
+Zephyrus 2.0 was built around exactly the primitives a home-hospital program needs. The module reuses them rather than rebuilding:
+
+- **A census spine.** prod.encounters, prod.units, prod.beds, and prod.census_snapshots drive house-wide RTDC, with event-sourced occupancy (prod.operational_events projected by CensusProjector). A virtual ward is one more unit whose beds are program slots.
+- **One server-computed snapshot.** SnapshotBuilder composes nine domain metric providers; each emits values resolved by a single StatusEngine against admin-editable band edges in ops.metric_definitions. Alerts derive from templates, are flap-damped by AlertEngine, and feed Eddy’s approval-gated Action Inbox. A new domain provider inherits all of this.
+- **An integration control plane.** integration.sources → raw.inbound_messages → integration.canonical_events → ProjectionHandler → prod.*, with per-feed freshness SLAs, dead-letter/replay, FHIR R4 client scaffolding, and a working HL7v2 ingest exemplar. Device and FHIR observation feeds ride these same rails.
+- **A transitions substrate.** prod.transport_requests.request_type already includes care_transition and discharge; the regional schema models external facilities, capabilities, and transfer decisions with opportunity-cost scoring; prod.discharge_facts is a separate outcomes/billing ledger.
+- **Ambient telemetry hooks and governed intelligence.** flow_realtime.ambient_signal_* anticipates sensor/wearable feeds; Eddy provides a draft-only, human-approved action catalog; Arena projects operations into an OCEL 2.0 log for conformance checking; and a deterministic Predictions layer already forecasts census and demand.
+- **A disciplined design system.** The ISA-101 “earned urgency” canon — status never by color alone, coral reserved for real breaches — is exactly the discipline clinical-grade home monitoring needs to avoid alarm fatigue.
+
+> **Gap analysis**
+>
+> There is **no existing HaH, RPM, or telehealth surface** in Zephyrus today. The BUSINESS_PLAN parks “telehealth operations” in Year 3 (2028); the June-2025 market-leapfrog plan already specifies a “Post-Acute and Care Transition Agent” and names wearable and post-acute data as territory to own. This module makes that intent concrete and pulls it forward.
+
+## 3.2 The differentiated thesis: capacity unification
+
+The home program should be presented not as a parallel service but as a **decompression valve on house-wide capacity**. Because Zephyrus already holds the live ED boarding count, floor census against staffed capacity, and expected discharges, it can do what no HaH vendor can: quantify, in real time, how many current ED and inpatient patients are home-eligible, how many home slots are free tonight and projected tomorrow, and what enrolling them would do to boarding hours and occupancy. Every active home episode is an avoided occupied bed-day, attributable against the very boarding pressure the cockpit already displays. That is the defensible, one-instrument story.
+
+# 4. Module Design: The Home Hospital Workspace
+
+## 4.1 Concept and placement
+
+The module adds a nav domain — working name **Home Hospital** (HOME) — as a new Workspace in the Altitude model (Cockpit → Workspaces → Study), behind a feature flag (features.home_hospital) and an EnsureHomeHospitalEnabled route middleware, mirroring the virtual-rounds gating pattern already in the codebase. It treats home-based acute care as one more altitude of the same instrument: the virtual ward appears in the cockpit next to ED and RTDC, its patients are monitored with the same earned-urgency discipline, and its processes are mined by Arena and coached by Eddy.
+
+Three capability rings ship progressively: (1) **acute Hospital-at-Home** at waiver grade — virtual-ward census and command, RPM observability, twice-daily visit logistics, escalation with response-time telemetry, and CMS reporting; (2) **extended observability** — post-discharge 30-day monitoring cohorts, ED-diversion/observation-at-home, and chronic RPM lines (heart failure, COPD) on the same pipes at lower acuity; and (3) **transitions of care** — admission pathways in and governed handoffs out.
+
+## 4.2 Screens and surfaces
+
+Six surfaces make up the workspace; each reuses an existing Zephyrus component pattern.
+
+#### Virtual Ward Command · /home/command
+
+The flagship surface: a grid of episode tiles, each showing pseudonymous identity, condition and program, day-of-stay versus expected length of stay, live vitals sparklines, a Home Early Warning Score chip, open alerts, the next required visit with a countdown, and device/connectivity status. Grey is the resting baseline; coral is reserved for true breaches — an unacknowledged critical vital, a blown response SLA, or a missed waiver-required visit. Tiles drill in place to the patient lens.
+
+#### Virtual Bed Board · /home/census
+
+An RTDC-pattern board of program slots (occupied / available / pending-setup / blocked), an enrollment pipeline column, and projected discharges at 24 and 48 hours. Because the program is modeled as a unit, this board and the house-wide huddle share one census engine.
+
+#### Eligibility & Referral Funnel · /home/referrals
+
+Two live worklists: ED candidates screened over the live ED census (qualifying conditions, service-zone address, payer class, clinical stability) and inpatient step-down candidates at or near expected LOS with home-eligible profiles. The funnel tracks referred → screened → eligible → consented → activated / declined, with decline reasons — important because real programs convert only a minority of consults (one program enrolled roughly 22% of consults, with a similar share declining out of preference for the hospital) (HaH Users Group).
+
+#### Field Operations & Logistics · /home/logistics
+
+Visit scheduling with a two-visits-per-day compliance rail, a route/assignment view for field nurses and community paramedics (reusing Transport dispatch patterns), kit inventory and lifecycle, and delivery tracking for medications, meals, DME, and labs.
+
+#### Transitions of Care Board · /home/transitions
+
+Inbound activation checklists (consent, home-safety check, kit delivery, first visit) and outbound handoffs — discharge readiness, handoff owner, receiving entity (PCP, home health, or SNF via regional.facilities), barrier tracking, and a 30-day post-discharge monitoring cohort with a step-down cadence.
+
+#### Program Analytics · /home/analytics (Study)
+
+Outcomes against matched inpatient comparators (LOS, escalation, mortality, 30-day readmission), program economics and avoided bed-days, funnel conversion, alert burden per patient-day, visit on-time compliance, and RPM adherence.
+
+## 4.3 Cockpit integration
+
+A new HomeMetrics provider (extending BaseMetrics) contributes a home domain to the single snapshot, with thresholds seeded into ops.metric_definitions so they remain admin-editable and audited. Alert templates are the “earned red” ration — only the metrics below carry them, so the cockpit never fires per-vital noise.
+
+| **Metric key** | **Cockpit tile** | **Alerting** |
+| --- | --- | --- |
+| home.census_occupancy | Virtual ward occupancy vs. slots | — |
+| home.unacked_critical_vitals | Unacked critical vitals (count · max age) | Critical → Eddy |
+| home.escalation_response_p90 | Escalation response p90 (minutes) | Warn / Crit |
+| home.visit_compliance_today | Waiver visit compliance % | Critical |
+| home.device_offline_pct | Kits offline / transmission gaps | Warn |
+| home.rpm_adherence | Patient monitoring adherence % | Watch |
+| home.escalation_rate_7d | Escalations per 100 episode-days | Watch |
+| home.referral_conversion_7d | Referral → enrollment conversion % | — |
+| home.avoided_bed_days_mtd | Avoided bed-days MTD (executive) | — |
+
+A ?drill=home modal exposes the census strip, alert list, funnel snapshot, and response-time trend; wall-display mode inherits automatically. Crucially, the RTDC global huddle gains a “home decant” line — home-eligible counts and free slots surfaced next to boarding metrics — operationalizing the capacity-unification thesis.
+
+# 5. Data and Integration Architecture
+
+## 5.1 Schema
+
+New tables live in the prod schema and follow the established conventions exactly: a {table}_id primary key, a _uuid public/idempotency key, pseudonymous patient_ref (never an MRN), a jsonb metadata column, an is_deleted soft-delete flag, CHECK constraints via raw statements, and the SafeMigration trait. The RPM observation ledger is kept **separate** from prod.encounters, mirroring how prod.discharge_facts stays a distinct ledger.
+
+| **Table** | **Purpose** |
+| --- | --- |
+| prod.home_programs | Program lines (AHCAH acute, observation-at-home, post-discharge RPM, chronic RPM, SNF-at-home) with slot capacity by service zone |
+| prod.home_referrals | Funnel spine: source, status, decline reason, screening JSON (zone, payer, home-safety, connectivity) |
+| prod.home_episodes | Episode spine linked to an encounter on the virtual unit: program, admission source, condition + DRG, acuity tier, target vs. actual LOS, disposition |
+| prod.rpm_kits / rpm_devices | Kit and device inventory, lifecycle, battery and connectivity telemetry |
+| prod.rpm_enrollments | Kit-to-episode assignment + per-patient monitoring plan (per-vital cadence, personalized thresholds, baseline window) |
+| prod.rpm_observations | High-volume vitals ledger, monthly range-partitioned, LOINC-coded, with device and transmission provenance and a quality flag |
+| prod.rpm_alerts | Patient-level clinical alerts (rule, severity, opened/acked/resolved, escalation link) |
+| prod.home_visits | Scheduled/completed visits (RN, paramedic, MD/NP tele, labs, delivery), waiver-required flag, on-time telemetry |
+| prod.home_escalations | Trigger, response mode, full timing chain (initiated → dispatched → arrived → resolved), outcome (managed at home / ED return / readmit) |
+| prod.home_transitions | Inbound activation and outbound handoff milestones, receiving entity FK to regional.facilities, readiness checklist |
+
+The virtual ward itself is modeled by seeding one or more prod.units rows with a virtual_home type and prod.beds rows as slots — so census, occupancy, huddles, and the entire cockpit machinery work unmodified. New operational event types (HomeReferralCreated, HomeEpisodeActivated, RpmObservationBreached, HomeEscalationOpened/Resolved, HomeVisitCompleted, HomeEpisodeDischarged, TransitionHandoffCompleted) extend the canonical event vocabulary and project into ocel.* via a new emission-map branch so Arena sees the home pathway.
+
+## 5.2 Device and FHIR ingestion
+
+RPM vendor feeds are new HealthcareConnector implementations (webhook and FHIR-poll styles) that land in raw.inbound_messages (idempotency key = transmission id), normalize to integration.canonical_events (ObservationRecorded, DeviceStatusChanged), and project via a new RpmProjectionHandler into prod.rpm_observations and device state. Observations are stored as HL7 **FHIR R4** Observation/Device/ServiceRequest resources in fhir.resource_versions with resource_links to internal rows, using **US Core** profiles, **IEEE 11073 PHD** semantics via vendor gateways, and **LOINC** vital-sign codes (heart rate 8867-4, SpO₂ 59408-5, systolic 8480-6 / diastolic 8462-4, respiratory rate 9279-1, body temperature 8310-5, weight 29463-7). The existing HL7v2 ADT ingest closes the escalation loop automatically: when an escalated home patient is registered in the ED, the open escalation resolves with an ed_return outcome. Per-feed freshness SLAs live at the source level; per-patient transmission-gap detection is layered on top.
+
+> **Interoperability posture**
+>
+> Because ingestion rides the existing control plane, the module is **EHR-agnostic** — a hedge against Epic’s and Oracle Health’s embedded care-at-home offerings and against RPM-vendor lock-in. The connector abstraction is the strategic moat, not any single device kit.
+
+## 5.3 Realtime and PHI handling
+
+Consistent with Zephyrus’s PHI-free-wire rule, only aggregate pings travel on public Reverb channels (home.census, cockpit ping); patient-level vitals are fetched over authenticated APIs with TanStack cache invalidation on ping, exactly like the cockpit stream. If per-patient push is ever required, it must move to a PrivateChannel with an auth callback — a deliberate, documented contract change, not an incidental one.
+
+# 6. Intelligence Layer
+
+## 6.1 Home Early Warning Score and escalation risk
+
+A Home Early Warning Score (HEWS) is computed deterministically first — matching the existing Predictions philosophy of transparent SQL/PHP over opaque ML. It blends a modified NEWS2 with patient-specific baselines calibrated over the first 24 hours, vital-sign trend slopes, and a monitoring-adherence signal; bands live in metric-definition-style config with an ML upgrade path via a sidecar later. A daily per-episode escalation-risk tier (condition, day-of-stay, HEWS trajectory, adherence, visit findings) drives visit intensity and the command-grid sort order.
+
+> **Safety positioning — this is operational triage, not a medical device**
+>
+> HEWS is decision **support** for operations, not diagnosis. The module must ship with clear labeling and stay inside FDA clinical-decision-support boundaries; escalation authority always rests with the clinical team, exactly as Eddy actions always rest with a human approver.
+
+## 6.2 Capacity forecasting and avoided bed-days
+
+An enrollment-pipeline forecast (home-eligible ED census plus step-down candidates near expected LOS) and a per-episode discharge projection produce a free-slot forecast at 24/48 hours and 7 days, surfaced in the RTDC global huddle and written alongside physical capacity in prod.rtdc_predictions. Every active home episode-day rolls up as an avoided occupied bed-day into the ops materialized views and the executive brief — the ROI accounting that makes the program legible to a COO.
+
+## 6.3 Eddy actions and Arena process mining
+
+New draft-only entries join the Eddy action catalog — propose_hah_enrollment, propose_stepdown_cohort, propose_escalation_response, propose_visit_reschedule, flag_rpm_gap, propose_home_discharge, flag_transition_barrier — riding the existing Recommendation → Action → Approval governance so that the agent proposes and a human disposes. This is where the June-2025 plan’s Post-Acute and Care Transition Agent finally lands. Arena gains new object types (HomeEpisode, RpmKit, HomeVisit, Escalation) and conformance checks against the designed pathway (time-to-activation SLA, visit cadence, escalation-protocol adherence), and the 48-Hour Flow Review folds in the home program.
+
+# 7. Transitions of Care
+
+Transitions are where a home-hospital program creates — or destroys — value, and where Zephyrus’s existing substrate gives it an edge. Three admission pathways feed the ward: **ED diversion** (screen and enroll before an avoidable admission), **inpatient early-discharge / step-down** (decant an occupied bed once a patient is stable), and **direct or ambulatory admission**. The eligibility funnel in §4.2 instruments all three; the ED-diversion path is wired to the live ED census and the step-down path to encounters at or near expected LOS.
+
+On the way out, the transitions board manages structured handoffs to the PCP, home health, or a skilled nursing facility, reusing prod.transport_requests with request_type = care_transition and the regional.facilities graph for destination selection with its opportunity-cost scoring. A 30-day post-discharge monitoring cohort — now billable under the relaxed 2026 RPM codes — extends observation past the acute episode with a step-down cadence, directly targeting the readmission measures on which both the program and the hospital are judged.
+
+The KPIs that run a virtual ward are drawn straight from the evidence base, so the program measures itself against national benchmarks rather than aspiration:
+
+| **KPI** | **National benchmark** | **Source** |
+| --- | --- | --- |
+| Escalation (return-to-hospital) rate | ≈ 6.2% | Levine et al. 2024 |
+| In-episode mortality | ≈ 0.5% | Levine et al. 2024 |
+| 30-day readmission | ≈ 15.6% | Levine et al. 2024 |
+| Mean length of stay | ≈ 6.3 days | Levine et al. 2024 |
+| Emergency in-person response | within 30 minutes | CMS waiver / MedPAC 2024 |
+| In-person visit cadence | ≥ 2 per day + daily MD | CMS waiver / MedPAC 2024 |
+
+*Benchmark KPIs a Zephyrus virtual-ward dashboard should track against, with primary sources.*
+
+# 8. Compliance, Safety, and Privacy
+
+- **Waiver conditions as first-class telemetry.** Visit compliance, response times, and the CMS-required reporting are generated from the prod.home_* tables; the append-only user-audit ledger extends to home-episode access. Capturing the 2028 study variables (readmission, mortality, escalations, equity) as operational data turns the reporting mandate into a byproduct.
+- **Pseudonymity preserved.** Operational and analytic paths use patient_ref and service zones, never street addresses; physical address is confined to a restricted logistics context. This matches the platform-wide convention and keeps PHI off public channels.
+- **Clinical alarm governance.** Alert burden per patient-day is itself a tracked KPI; thresholds are personalized to each patient’s baseline; and clinical alerts are flap-damped exactly as AlertEngine damps operational tiles — the earned-urgency canon applied to patient safety.
+- **Equity and selection-bias guardrails.** Connectivity screening (cellular-backhauled kits mitigate broadband gaps), language and caregiver requirements, and decline-reason analytics surface selection bias before it becomes a finding in the federal study.
+
+# 9. Implementation Roadmap
+
+The build is phased so that each phase is independently demonstrable and the highest-learning surfaces ship first. All phases reuse existing Zephyrus infrastructure; the estimates assume the module is developed against the synthetic Summit Regional demo hospital before any production integration.
+
+| **Phase** | **Scope** | **Est.** |
+| --- | --- | --- |
+| **Phase 0** · Foundation | Schemas and migrations, virtual-unit seeding, feature flag and nav domain, a synthetic RPM connector and demo cohort in the demo seed, census board via RTDC reuse | 4–6 wks |
+| **Phase 1** · Observability MVP | Vitals ingestion pipeline, HEWS and patient alerts with an acknowledgement workflow, Virtual Ward Command page, cockpit home tiles and ?drill=home, escalation workflow with response timers | 6–8 wks |
+| **Phase 2** · Transitions | Referral funnel and eligibility worklists (ED + step-down), transitions board, care-transition and regional-facility handoffs, 30-day post-discharge cohort, logistics/visit board | 6–8 wks |
+| **Phase 3** · Intelligence & compliance | Capacity/discharge forecasting into the RTDC huddle, Eddy catalog actions, OCEL projection and conformance, executive ROI tiles, CMS waiver reporting exports | 8+ wks |
+| **Later** | Chronic RPM lines, SNF-at-home, multi-facility program operations, payer-facing reporting | — |
+
+# 10. Business Case and Positioning
+
+The market timing is the argument. The five-year waiver extension converts Hospital at Home from a reimbursement gamble into a fundable, durable service line, and hospitals are actively investing in the operational tooling to run it (AMA 2026; MedPAC 2024, which counted roughly 328 approved hospitals and about 23,000 discharges by April 2024). Zephyrus should meet that demand while the tailwind is strongest.
+
+Commercially, the Home Hospital module fits cleanly into the existing à-la-carte structure — positioned in the **$85–95K per year** band between the ED ($65K) and Perioperative ($85K) modules, and included in the Enterprise Plus tier. This pulls the BUSINESS_PLAN’s Year-3 “telehealth operations” line into the current window. The differentiation against pure HaH vendors (Medically Home/DispatchHealth, Biofourmis, Inbound Health, Contessa) is not feature parity on home-care orchestration — it is the things only Zephyrus has: house-wide capacity unification (the decant valve), process mining and conformance (Arena), governed operations agents (Eddy), an EHR-agnostic control plane, and an anti-alarm-fatigue design system.
+
+> **The one-instrument pitch**
+>
+> Sell Home Hospital as the module that makes the virtual ward a lever on the whole hospital’s throughput — the only command center that connects home capacity to ED boarding, floor occupancy, and discharge planning in a single, defensible view.
+
+# 11. Risks and Open Questions
+
+| **Risk** | **Mitigation** |
+| --- | --- |
+| Clinical-safety scope creep — positioning Zephyrus as a medical device | Frame HEWS as operational triage support, not diagnosis; ship clear labeling; keep escalation authority with clinicians (mirrors Eddy governance) |
+| Policy risk beyond the 2030 window; commercial-payer dependence | Payer-aware eligibility from day one; design for the extended-observability and chronic-RPM rings that stand on RPM billing independent of the waiver |
+| RPM vendor lock-in | The HealthcareConnector abstraction; support multiple kit vendors behind one projection handler |
+| PHI expansion (continuous home vitals) | Monthly partitioning and retention/rollup policy on rpm_observations; audit-ledger extension; PHI kept off public channels |
+| Integration burden vs. EHR-embedded competitors (Epic Care at Home) | Lean on the existing coexistence-adapter strategy in the control plane; compete on capacity intelligence, not EHR proximity |
+
+Open questions for product and clinical leadership: which conditions to support first (the evidence points to heart failure, COPD, pneumonia/respiratory infection, cellulitis, and UTI); whether to staff field visits with employed nurses or contracted community paramedics; the target daily census and service radius for the pilot; and which single RPM vendor to integrate first for the Phase 1 MVP.
+
+# 12. References
+
+*Primary and named secondary sources. Regulatory and payment facts were re-verified against source after research; the AHCAH extension vehicle was confirmed as the Consolidated Appropriations Act, 2026 (H.R. 4313 being the standalone House vehicle).*
+
+1. American Medical Association. “Lawmakers extend CMS hospital-at-home waiver for five years.” 2026. ama-assn.org/public-health/population-health/lawmakers-extend-cms-hospital-home-waiver-five-years
+2. 42 U.S.C. §1395cc-7 — Extension of Acute Hospital Care at Home waiver flexibilities. U.S. Code (current text). uscode.house.gov
+3. H.R. 4313, Hospital Inpatient Services Modernization Act, 119th Congress (2025). congress.gov/bill/119th-congress/house-bill/4313/text
+4. CMS. “Acute Hospital Care at Home Data Release Fact Sheet.” 2026. cms.gov/newsroom/fact-sheets/acute-hospital-care-home-data-release-fact-sheet-0
+5. CMS. CY2026 Medicare Physician Fee Schedule Final Rule (CMS-1832-F). Federal Register, Nov 5, 2025. federalregister.gov/documents/2025/11/05/2025-19787
+6. Nixon Law Group. “CMS Finalizes 2026 Remote Monitoring Reimbursement Updates — What Changed for RPM and RTM.” 2026. nixonlawgroup.com
+7. Center for Connected Health Policy (CCHP). “Remote Patient Monitoring.” 2026. cchpca.org/topic/remote-patient-monitoring/
+8. Levine DM, et al. “Hospital-Level Care at Home for Acutely Ill Adults: A Randomized Controlled Trial.” Annals of Internal Medicine, 2020. doi:10.7326/M19-0600
+9. Levine DM, et al. National outcomes of the CMS Acute Hospital Care at Home waiver (Medicare FFS claims). Annals of Internal Medicine, 2024. doi:10.7326/M23-2264
+10. Vakkalanka JP, et al. Hospital at Home vs. traditional inpatient care, propensity-matched Medicare study. JAMA Network Open, 2026;9(5):e2610810. jamanetwork.com/journals/jamanetworkopen/fullarticle/2848612
+11. He, et al. “Efficacy and Safety of Hospital-at-Home versus Traditional Inpatient Care” (systematic review/meta-analysis, 11 RCTs). Gerontology, 2026. doi:10.1159/000551394
+12. MedPAC. June 2024 Report to Congress, Ch. 6: Medicare’s Acute Hospital Care at Home Program. medpac.gov
+13. Kaiser Permanente Advanced Care at Home at scale. American Journal of Managed Care. ajmc.com/view/advanced-care-at-home-at-scale-in-an-integrated-health-care-system
+14. Mount Sinai at Home. Department of Medicine 2023 specialty report. reports.mountsinai.org
+15. Hospital at Home Users Group. Technical Assistance Center — Patient Eligibility, Referral and Intake. hahusersgroup.org
+16. DispatchHealth. “DispatchHealth and Medically Home Merger Closes.” 2025. dispatchhealth.com/press-room
+17. Healthcare Dive / Fierce Healthcare. “Best Buy sells Current Health.” 2025. healthcaredive.com; fiercehealthcare.com
+18. Healthcare Innovation. “CoPilotIQ and Biofourmis merge.” 2024. hcinnovationgroup.com

--- a/resources/js/Components/Home/HomePageLayout.tsx
+++ b/resources/js/Components/Home/HomePageLayout.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import DashboardLayout from '@/Components/Dashboard/DashboardLayout';
+import PageContentLayout from '@/Components/Common/PageContentLayout';
+import { Head } from '@inertiajs/react';
+
+interface HomePageLayoutProps {
+    title: string;
+    subtitle?: string;
+    headerContent?: ReactNode;
+    children: ReactNode;
+}
+
+const HomePageLayout = ({ title, subtitle, headerContent = null, children }: HomePageLayoutProps) => {
+    return (
+        <DashboardLayout>
+            <Head title={`${title} - Home Hospital`} />
+            <PageContentLayout title={title} subtitle={subtitle} headerContent={headerContent}>
+                <div className="space-y-4">
+                    {children}
+                </div>
+            </PageContentLayout>
+        </DashboardLayout>
+    );
+};
+
+export default HomePageLayout;

--- a/resources/js/Pages/Home/Census.tsx
+++ b/resources/js/Pages/Home/Census.tsx
@@ -1,0 +1,270 @@
+import HomePageLayout from '@/Components/Home/HomePageLayout';
+import { Section, MetricGrid, metric } from '@/Components/system';
+import { ProvenanceBadge } from '@/Components/cockpit/ProvenanceBadge';
+
+// Virtual Bed Board — Phase 0 flagship of the Home Hospital workspace
+// (ACUM-PRD-HAH-001 §4.2). The virtual ward is one more census-spine unit, so
+// this board reads the same engine as the house-wide huddle. Earned urgency:
+// slot states are informational (grey/teal/amber baseline); coral is reserved
+// for later-phase true breaches (unacked critical vitals, blown response SLAs).
+
+interface SlotEpisode {
+  patientRef: string;
+  program: string | null;
+  conditionLabel: string | null;
+  acuityTier: number | null;
+  serviceZone: string | null;
+  dayOfStay: number | null;
+  targetLosDays: number | null;
+  expectedDischargeDate: string | null;
+  provenance: string | null;
+}
+
+interface Slot {
+  bedId: number;
+  label: string;
+  status: 'available' | 'occupied' | 'pending_setup' | 'blocked';
+  episode: SlotEpisode | null;
+}
+
+interface CensusProps {
+  unit: { name: string; abbreviation: string; slotCount: number } | null;
+  slots: Slot[];
+  occupancy: { occupied: number; capacity: number; pct: number | null };
+  pipeline: {
+    counts: Record<string, number>;
+    declines: Record<string, number>;
+  };
+  projectedDischarges: { next24h: number; next48h: number };
+}
+
+const SLOT_STATUS: Record<
+  Slot['status'],
+  { label: string; dotClass: string }
+> = {
+  available: {
+    label: 'Available',
+    dotClass: 'bg-healthcare-success dark:bg-healthcare-success-dark',
+  },
+  occupied: {
+    label: 'Occupied',
+    dotClass: 'bg-healthcare-info dark:bg-healthcare-info-dark',
+  },
+  pending_setup: {
+    label: 'Pending setup',
+    dotClass: 'bg-healthcare-warning dark:bg-healthcare-warning-dark',
+  },
+  blocked: {
+    label: 'Blocked',
+    dotClass: 'bg-healthcare-border dark:bg-healthcare-border-dark',
+  },
+};
+
+const FUNNEL_ORDER = ['referred', 'screened', 'eligible', 'consented', 'activated', 'declined'] as const;
+
+const FUNNEL_LABELS: Record<(typeof FUNNEL_ORDER)[number], string> = {
+  referred: 'Referred',
+  screened: 'Screened',
+  eligible: 'Eligible',
+  consented: 'Consented',
+  activated: 'Activated',
+  declined: 'Declined',
+};
+
+function declineLabel(reason: string): string {
+  return reason.replaceAll('_', ' ').replace(/^./, (c) => c.toUpperCase());
+}
+
+function SlotCard({ slot }: { slot: Slot }) {
+  const status = SLOT_STATUS[slot.status];
+  const episode = slot.episode;
+
+  return (
+    <div
+      className="rounded-lg border border-healthcare-border dark:border-healthcare-border-dark
+                 bg-healthcare-surface dark:bg-healthcare-surface-dark shadow-sm p-3
+                 flex flex-col gap-2"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+          {slot.label}
+        </span>
+        <span className="flex items-center gap-1.5 text-xs font-medium text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+          <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${status.dotClass}`} />
+          {status.label}
+        </span>
+      </div>
+
+      {episode ? (
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm font-medium tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+              {episode.patientRef}
+            </span>
+            {episode.provenance === 'demo' && <ProvenanceBadge />}
+          </div>
+          <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+            {episode.conditionLabel ?? '—'}
+          </span>
+          <div className="flex items-center justify-between gap-2 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+            <span className="tabular-nums">
+              Day {episode.dayOfStay ?? '—'}
+              {episode.targetLosDays != null && ` of ${episode.targetLosDays}`}
+            </span>
+            {episode.serviceZone && <span>{episode.serviceZone}</span>}
+          </div>
+        </div>
+      ) : (
+        <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+          {slot.status === 'pending_setup'
+            ? 'Kit delivery & setup in progress'
+            : slot.status === 'blocked'
+              ? 'Held — not accepting enrollment'
+              : 'Open for enrollment'}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default function Census({ unit, slots, occupancy, pipeline, projectedDischarges }: CensusProps) {
+  const available = slots.filter((s) => s.status === 'available').length;
+  const pendingSetup = slots.filter((s) => s.status === 'pending_setup').length;
+  const blocked = slots.filter((s) => s.status === 'blocked').length;
+
+  const capacityMetrics = [
+    metric({
+      key: 'home-occupancy',
+      label: 'Ward occupancy',
+      value: occupancy.pct ?? 0,
+      unit: '%',
+      status: 'neutral',
+      definition: 'Occupied program slots ÷ total slots on the virtual ward.',
+    }),
+    metric({
+      key: 'home-occupied',
+      label: 'Occupied slots',
+      value: occupancy.occupied,
+      status: 'neutral',
+      definition: 'Active home episodes holding a program slot right now.',
+    }),
+    metric({
+      key: 'home-available',
+      label: 'Free slots tonight',
+      value: available,
+      status: available === 0 ? 'warning' : 'success',
+      definition: 'Slots open for enrollment — the decant capacity next to ED boarding.',
+    }),
+    metric({
+      key: 'home-pending',
+      label: 'Pending setup',
+      value: pendingSetup,
+      status: 'neutral',
+      definition: 'Slots awaiting kit delivery, connectivity check, or home-safety sign-off.',
+    }),
+    metric({
+      key: 'home-blocked',
+      label: 'Blocked',
+      value: blocked,
+      status: 'neutral',
+      definition: 'Slots held back from enrollment (staffing, zone coverage, or safety hold).',
+    }),
+    metric({
+      key: 'home-discharge-24',
+      label: 'Projected discharges · 24h',
+      value: projectedDischarges.next24h,
+      status: 'info',
+      definition: 'Episodes at expected discharge within 24 hours — slots freeing up.',
+    }),
+    metric({
+      key: 'home-discharge-48',
+      label: 'Projected discharges · 48h',
+      value: projectedDischarges.next48h,
+      status: 'info',
+      definition: 'Episodes at expected discharge within 48 hours.',
+    }),
+  ];
+
+  const funnelTotal = FUNNEL_ORDER.reduce((n, k) => n + (pipeline.counts[k] ?? 0), 0);
+
+  return (
+    <HomePageLayout
+      title="Virtual Bed Board"
+      subtitle={unit ? `${unit.name} · ${occupancy.occupied}/${occupancy.capacity} slots occupied` : 'Virtual ward not provisioned'}
+    >
+      <div className="flex flex-col gap-5">
+        <Section
+          title="Program capacity"
+          icon="heroicons:home-modern"
+          summary={
+            unit
+              ? `${available} free · ${pendingSetup} pending setup · ${blocked} blocked`
+              : 'Seed the virtual ward to activate this board'
+          }
+        >
+          <MetricGrid metrics={capacityMetrics} />
+        </Section>
+
+        <Section
+          title="Ward slots"
+          icon="heroicons:squares-2x2"
+          summary={unit ? `${occupancy.capacity} program slots on ${unit.abbreviation}` : 'No virtual_home unit found'}
+        >
+          {slots.length > 0 ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+              {slots.map((slot) => (
+                <SlotCard key={slot.bedId} slot={slot} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+              No program slots yet — run the Home Hospital demo seed or provision the ward.
+            </p>
+          )}
+        </Section>
+
+        <Section
+          title="Enrollment pipeline"
+          icon="heroicons:funnel"
+          summary={`${funnelTotal} referrals in the funnel`}
+        >
+          <div
+            className="rounded-lg border border-healthcare-border dark:border-healthcare-border-dark
+                       bg-healthcare-surface dark:bg-healthcare-surface-dark shadow-sm
+                       divide-y divide-healthcare-border dark:divide-healthcare-border-dark"
+          >
+            {FUNNEL_ORDER.map((stage) => (
+              <div key={stage} className="flex items-center justify-between px-4 py-2">
+                <span className="text-sm text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                  {FUNNEL_LABELS[stage]}
+                </span>
+                <span className="text-sm font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                  {pipeline.counts[stage] ?? 0}
+                </span>
+              </div>
+            ))}
+            {Object.keys(pipeline.declines).length > 0 && (
+              <div className="px-4 py-2">
+                <p className="text-xs font-medium uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                  Decline reasons
+                </p>
+                <div className="mt-1 flex flex-col gap-1">
+                  {Object.entries(pipeline.declines).map(([reason, count]) => (
+                    <div key={reason} className="flex items-center justify-between">
+                      <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        {declineLabel(reason)}
+                      </span>
+                      <span className="text-xs font-medium tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        {count}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </Section>
+      </div>
+    </HomePageLayout>
+  );
+}

--- a/resources/js/Pages/Home/Command.tsx
+++ b/resources/js/Pages/Home/Command.tsx
@@ -1,0 +1,223 @@
+import HomePageLayout from '@/Components/Home/HomePageLayout';
+import { Section } from '@/Components/system';
+import { Sparkline } from '@/Components/cockpit/Sparkline';
+import { ProvenanceBadge } from '@/Components/cockpit/ProvenanceBadge';
+
+// Virtual Ward Command — the Home Hospital flagship (ACUM-PRD-HAH-001 §4.2).
+// A grid of episode tiles sorted by escalation risk (breach → HEWS → acuity).
+// Earned urgency: the resting tile is grey; ONLY an unacknowledged critical
+// vital (breach=true) earns the coral treatment. HEWS is operational triage,
+// not diagnosis — the chip carries the band label, never a diagnosis claim.
+
+interface VitalSeries {
+  loinc: string;
+  display: string;
+  unit: string | null;
+  latest: number;
+  series: number[];
+}
+
+interface EpisodeAlertItem {
+  alertUuid: string;
+  ruleKey: string;
+  severity: 'watch' | 'warning' | 'critical';
+  status: string;
+  display: string | null;
+  value: number | null;
+  unit: string | null;
+  openedAt: string | null;
+}
+
+interface EpisodeTile {
+  episodeUuid: string;
+  patientRef: string;
+  slotLabel: string | null;
+  program: string | null;
+  conditionLabel: string | null;
+  acuityTier: number | null;
+  serviceZone: string | null;
+  dayOfStay: number | null;
+  targetLosDays: number | null;
+  expectedDischargeDate: string | null;
+  hews: { score: number; band: 'low' | 'medium' | 'high'; components: Record<string, number> } | null;
+  vitals: VitalSeries[];
+  alerts: { open: number; acknowledged: number; critical: number; items: EpisodeAlertItem[] };
+  nextVisit: { type: string; scheduledStart: string | null; isWaiverRequired: boolean } | null;
+  device: { kitCode: string; connectivity: string | null; batteryPct: number | null; lastSeenAt: string | null; online: boolean } | null;
+  breach: boolean;
+  provenance: string | null;
+}
+
+interface CommandProps {
+  ward: { name: string; abbreviation: string } | null;
+  episodes: EpisodeTile[];
+  summary: { active: number; breaches: number; highRisk: number; openAlerts: number };
+}
+
+const HEWS_STYLE: Record<'low' | 'medium' | 'high', { label: string; dotClass: string }> = {
+  low: { label: 'Low', dotClass: 'bg-healthcare-success dark:bg-healthcare-success-dark' },
+  medium: { label: 'Medium', dotClass: 'bg-healthcare-warning dark:bg-healthcare-warning-dark' },
+  high: { label: 'High', dotClass: 'bg-healthcare-critical dark:bg-healthcare-critical-dark' },
+};
+
+const VISIT_LABELS: Record<string, string> = {
+  rn: 'RN visit',
+  community_paramedic: 'Paramedic visit',
+  md_np_tele: 'MD/NP tele',
+  md_np_in_person: 'MD/NP in person',
+  lab_draw: 'Lab draw',
+  delivery: 'Delivery',
+  other: 'Visit',
+};
+
+function visitCountdown(iso: string | null): { text: string; overdue: boolean } {
+  if (!iso) return { text: '—', overdue: false };
+  const deltaMin = Math.round((new Date(iso).getTime() - Date.now()) / 60000);
+  if (deltaMin >= 0) {
+    const h = Math.floor(deltaMin / 60);
+    return { text: h > 0 ? `in ${h}h ${deltaMin % 60}m` : `in ${deltaMin}m`, overdue: false };
+  }
+  const late = Math.abs(deltaMin);
+  const h = Math.floor(late / 60);
+  return { text: h > 0 ? `overdue ${h}h ${late % 60}m` : `overdue ${late}m`, overdue: true };
+}
+
+function EpisodeCard({ tile }: { tile: EpisodeTile }) {
+  const hews = tile.hews ? HEWS_STYLE[tile.hews.band] : null;
+  const countdown = visitCountdown(tile.nextVisit?.scheduledStart ?? null);
+
+  return (
+    <div
+      className={`rounded-lg border bg-healthcare-surface dark:bg-healthcare-surface-dark shadow-sm p-3 flex flex-col gap-2.5 ${
+        tile.breach
+          ? 'border-healthcare-critical dark:border-healthcare-critical-dark'
+          : 'border-healthcare-border dark:border-healthcare-border-dark'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-col">
+          <span className="flex items-center gap-2">
+            <span className="text-sm font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+              {tile.patientRef}
+            </span>
+            {tile.provenance === 'demo' && <ProvenanceBadge />}
+          </span>
+          <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+            {tile.conditionLabel ?? '—'}
+            {tile.slotLabel && <span className="tabular-nums"> · {tile.slotLabel}</span>}
+          </span>
+        </div>
+        {hews && tile.hews && (
+          <span className="flex shrink-0 items-center gap-1.5 rounded border border-healthcare-border dark:border-healthcare-border-dark px-1.5 py-0.5 text-xs font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+            <span aria-hidden className={`h-1.5 w-1.5 rounded-full ${hews.dotClass}`} />
+            HEWS {tile.hews.score} · {hews.label}
+          </span>
+        )}
+      </div>
+
+      {tile.breach && (
+        <p className="text-xs font-medium text-healthcare-critical dark:text-healthcare-critical-dark">
+          ◆ Unacknowledged critical vital
+        </p>
+      )}
+
+      <div className="flex items-center justify-between gap-2 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+        <span className="tabular-nums">
+          Day {tile.dayOfStay ?? '—'}
+          {tile.targetLosDays != null && ` of ${tile.targetLosDays}`}
+        </span>
+        {tile.serviceZone && <span>{tile.serviceZone}</span>}
+        <span className="tabular-nums">
+          {tile.alerts.open + tile.alerts.acknowledged} alert{tile.alerts.open + tile.alerts.acknowledged === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      {tile.vitals.length > 0 && (
+        <div className="grid grid-cols-2 gap-2">
+          {tile.vitals.map((vital) => (
+            <div key={vital.loinc} className="flex flex-col gap-0.5">
+              <div className="flex items-baseline justify-between gap-1">
+                <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark truncate">
+                  {vital.display}
+                </span>
+                <span className="text-sm font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                  {vital.latest}
+                  {vital.unit && <span className="text-xs font-normal"> {vital.unit}</span>}
+                </span>
+              </div>
+              <Sparkline
+                data={vital.series}
+                status="neutral"
+                id={`${tile.episodeUuid}-${vital.loinc}`}
+                className="h-8 w-full"
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-auto flex items-center justify-between gap-2 border-t border-healthcare-border dark:border-healthcare-border-dark pt-2 text-xs">
+        <span
+          className={
+            countdown.overdue
+              ? 'font-medium text-healthcare-warning dark:text-healthcare-warning-dark'
+              : 'text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark'
+          }
+        >
+          {tile.nextVisit
+            ? `${VISIT_LABELS[tile.nextVisit.type] ?? 'Visit'} ${countdown.text}${tile.nextVisit.isWaiverRequired ? ' · waiver' : ''}`
+            : 'No visit scheduled'}
+        </span>
+        {tile.device && (
+          <span className="flex shrink-0 items-center gap-1.5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+            <span
+              aria-hidden
+              className={`h-1.5 w-1.5 rounded-full ${
+                tile.device.online
+                  ? 'bg-healthcare-success dark:bg-healthcare-success-dark'
+                  : 'bg-healthcare-warning dark:bg-healthcare-warning-dark'
+              }`}
+            />
+            <span className="tabular-nums">
+              {tile.device.kitCode} · {tile.device.online ? 'online' : 'offline'}
+            </span>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function Command({ ward, episodes, summary }: CommandProps) {
+  return (
+    <HomePageLayout
+      title="Virtual Ward Command"
+      subtitle={
+        ward
+          ? `${ward.name} · ${summary.active} active episodes · ${summary.openAlerts} open alerts`
+          : 'Virtual ward not provisioned'
+      }
+    >
+      <Section
+        title="Active episodes"
+        icon="heroicons:heart"
+        summary={`${summary.breaches} breach${summary.breaches === 1 ? '' : 'es'} · ${summary.highRisk} high-risk · sorted by escalation risk`}
+      >
+        {episodes.length > 0 ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3">
+            {episodes.map((tile) => (
+              <EpisodeCard key={tile.episodeUuid} tile={tile} />
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+            No active home episodes. Activate a referral from the funnel, or run the demo seed.
+          </p>
+        )}
+      </Section>
+      <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+        HEWS is operational triage support, not a diagnostic device. Escalation decisions rest with the clinical team.
+      </p>
+    </HomePageLayout>
+  );
+}

--- a/resources/js/Pages/Home/Logistics.tsx
+++ b/resources/js/Pages/Home/Logistics.tsx
@@ -1,0 +1,222 @@
+import HomePageLayout from '@/Components/Home/HomePageLayout';
+import { Section } from '@/Components/system';
+
+// Field Operations & Logistics (ACUM-PRD-HAH-001 §4.2). ⚠ THE ONE ADDRESS
+// SURFACE: patient street addresses render here and nowhere else in the
+// module — every other Home payload carries pseudonymous refs + zones only.
+
+interface RailVisit {
+  visitUuid: string;
+  type: string;
+  status: string;
+  scheduledStart: string | null;
+  assignedTo: string | null;
+  isWaiverRequired: boolean;
+  onTime: boolean | null;
+}
+
+interface RailRow {
+  patientRef: string;
+  serviceZone: string | null;
+  address: string | null;
+  waiverRequired: number;
+  waiverCompleted: number;
+  waiverScheduled: number;
+  compliant: boolean;
+  visits: RailVisit[];
+}
+
+interface AssignmentStop {
+  patientRef: string;
+  type: string;
+  scheduledStart: string | null;
+  serviceZone: string | null;
+  address: string | null;
+}
+
+interface Assignment {
+  assignee: string;
+  stops: AssignmentStop[];
+}
+
+interface Delivery {
+  visitUuid: string;
+  patientRef: string;
+  type: string;
+  status: string;
+  scheduledStart: string | null;
+}
+
+interface LogisticsProps {
+  complianceRail: RailRow[];
+  assignments: Assignment[];
+  kits: { byStatus: Record<string, number>; lowBattery: number };
+  deliveries: Delivery[];
+}
+
+const VISIT_LABELS: Record<string, string> = {
+  rn: 'RN',
+  community_paramedic: 'Paramedic',
+  md_np_tele: 'MD/NP tele',
+  md_np_in_person: 'MD/NP',
+  lab_draw: 'Lab draw',
+  delivery: 'Delivery',
+  other: 'Visit',
+};
+
+const surface =
+  'rounded-lg border border-healthcare-border dark:border-healthcare-border-dark bg-healthcare-surface dark:bg-healthcare-surface-dark shadow-sm';
+
+function timeOf(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+export default function Logistics({ complianceRail, assignments, kits, deliveries }: LogisticsProps) {
+  const compliant = complianceRail.filter((r) => r.compliant).length;
+
+  return (
+    <HomePageLayout
+      title="Field Ops & Logistics"
+      subtitle={`${compliant}/${complianceRail.length} episodes on the 2-visit waiver rail · ${kits.lowBattery} kits low battery`}
+    >
+      <div className="flex flex-col gap-5">
+        <Section
+          title="Waiver compliance rail"
+          icon="heroicons:clipboard-document-check"
+          summary="≥2 in-person visits per day, per episode — the AHCAH operating floor"
+        >
+          <div className={`${surface} overflow-x-auto`}>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-healthcare-border dark:border-healthcare-border-dark text-left text-xs uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                  <th className="px-4 py-2 font-medium">Patient</th>
+                  <th className="px-4 py-2 font-medium">Zone</th>
+                  <th className="px-4 py-2 font-medium">Address</th>
+                  <th className="px-4 py-2 font-medium text-right">Waiver visits</th>
+                  <th className="px-4 py-2 font-medium text-right">Rail</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-healthcare-border dark:divide-healthcare-border-dark">
+                {complianceRail.map((row) => (
+                  <tr key={row.patientRef}>
+                    <td className="px-4 py-2 tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                      {row.patientRef}
+                    </td>
+                    <td className="px-4 py-2 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                      {row.serviceZone ?? '—'}
+                    </td>
+                    <td className="px-4 py-2 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                      {row.address ?? '—'}
+                    </td>
+                    <td className="px-4 py-2 text-right tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                      {row.waiverCompleted} done · {row.waiverScheduled} scheduled / {row.waiverRequired}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <span
+                        className={`text-xs font-medium ${
+                          row.compliant
+                            ? 'text-healthcare-success dark:text-healthcare-success-dark'
+                            : 'text-healthcare-warning dark:text-healthcare-warning-dark'
+                        }`}
+                      >
+                        {row.compliant ? '● on rail' : '▲ at risk'}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Section>
+
+        <Section
+          title="Field assignments"
+          icon="heroicons:map"
+          summary="Today's routes by clinician — staffing-model-agnostic"
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3">
+            {assignments.length === 0 && (
+              <p className="text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                No field visits remaining today.
+              </p>
+            )}
+            {assignments.map((a) => (
+              <div key={a.assignee} className={`${surface} p-3 flex flex-col gap-1.5`}>
+                <span className="text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                  {a.assignee}
+                </span>
+                {a.stops.map((stop, i) => (
+                  <div key={`${stop.patientRef}-${i}`} className="flex flex-col">
+                    <span className="text-xs tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                      {timeOf(stop.scheduledStart)} · {stop.patientRef} · {VISIT_LABELS[stop.type] ?? stop.type}
+                    </span>
+                    <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                      {stop.address ?? stop.serviceZone ?? '—'}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <Section
+          title="Kits & deliveries"
+          icon="heroicons:cube"
+          summary="RPM kit lifecycle and last-24h deliveries"
+        >
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+            <div className={`${surface} p-3`}>
+              <h3 className="text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                Kit inventory
+              </h3>
+              <div className="mt-2 flex flex-col gap-1">
+                {Object.entries(kits.byStatus).map(([status, count]) => (
+                  <div key={status} className="flex items-center justify-between">
+                    <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                      {status.replaceAll('_', ' ')}
+                    </span>
+                    <span className="text-xs font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                      {count}
+                    </span>
+                  </div>
+                ))}
+                <div className="flex items-center justify-between border-t border-healthcare-border dark:border-healthcare-border-dark pt-1">
+                  <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    low battery (&lt;30%)
+                  </span>
+                  <span className="text-xs font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                    {kits.lowBattery}
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div className={`${surface} p-3`}>
+              <h3 className="text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                Deliveries & draws
+              </h3>
+              <div className="mt-2 flex flex-col gap-1">
+                {deliveries.length === 0 && (
+                  <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    Nothing scheduled in the last 24 hours.
+                  </p>
+                )}
+                {deliveries.map((d) => (
+                  <div key={d.visitUuid} className="flex items-center justify-between gap-2">
+                    <span className="text-xs tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                      {d.patientRef}
+                    </span>
+                    <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                      {VISIT_LABELS[d.type] ?? d.type} · {d.status} · {timeOf(d.scheduledStart)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </Section>
+      </div>
+    </HomePageLayout>
+  );
+}

--- a/resources/js/Pages/Home/Referrals.tsx
+++ b/resources/js/Pages/Home/Referrals.tsx
@@ -1,0 +1,294 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { router } from '@inertiajs/react';
+import HomePageLayout from '@/Components/Home/HomePageLayout';
+import { Section } from '@/Components/system';
+
+// Eligibility & Referral Funnel (ACUM-PRD-HAH-001 §4.2). The worklists are
+// the decant valve made operational: home-eligible ED patients (boarders
+// first) and step-down inpatients, each one click from the funnel. Declines
+// always carry a coded reason — the §11 selection-bias guardrail.
+
+interface FunnelReferral {
+  referralUuid: string;
+  patientRef: string;
+  program: string | null;
+  source: string;
+  status: string;
+  payerClass: string | null;
+  serviceZone: string | null;
+  declineReason: string | null;
+  referredAt: string | null;
+}
+
+interface EdCandidate {
+  patientRef: string;
+  esiLevel: number;
+  isBoarding: boolean;
+  losMinutes: number;
+  source: string;
+}
+
+interface StepDownCandidate {
+  patientRef: string;
+  unit: string | null;
+  acuityTier: number | null;
+  expectedDischargeDate: string | null;
+  encounterId: number;
+  source: string;
+}
+
+interface ReferralsProps {
+  funnel: Record<string, FunnelReferral[]>;
+  counts: Record<string, number>;
+  edCandidates: EdCandidate[];
+  stepDownCandidates: StepDownCandidate[];
+  freeSlots: number;
+}
+
+const STAGES = ['referred', 'screened', 'eligible', 'consented', 'activated', 'declined'] as const;
+
+const STAGE_LABELS: Record<(typeof STAGES)[number], string> = {
+  referred: 'Referred',
+  screened: 'Screened',
+  eligible: 'Eligible',
+  consented: 'Consented',
+  activated: 'Activated',
+  declined: 'Declined',
+};
+
+const DECLINE_REASONS = [
+  'patient_preference',
+  'out_of_service_zone',
+  'clinical_ineligibility',
+  'payer_not_covered',
+  'home_safety_failed',
+  'connectivity_failed',
+] as const;
+
+const surface =
+  'rounded-lg border border-healthcare-border dark:border-healthcare-border-dark bg-healthcare-surface dark:bg-healthcare-surface-dark shadow-sm';
+
+function reload() {
+  router.reload();
+}
+
+function ReferralCard({ referral }: { referral: FunnelReferral }) {
+  const [declining, setDeclining] = useState(false);
+  const [reason, setReason] = useState<string>(DECLINE_REASONS[0]);
+  const [busy, setBusy] = useState(false);
+  const terminal = referral.status === 'activated' || referral.status === 'declined';
+
+  const advance = async () => {
+    setBusy(true);
+    try {
+      await axios.post(`/api/home/referrals/${referral.referralUuid}/advance`);
+      reload();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const decline = async () => {
+    setBusy(true);
+    try {
+      await axios.post(`/api/home/referrals/${referral.referralUuid}/decline`, { reason });
+      reload();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={`${surface} p-2.5 flex flex-col gap-1.5`}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+          {referral.patientRef}
+        </span>
+        <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+          {referral.source === 'ed_diversion' ? 'ED' : referral.source === 'inpatient_stepdown' ? 'Step-down' : referral.source}
+        </span>
+      </div>
+      <div className="flex items-center justify-between gap-2 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+        <span>{referral.payerClass ?? '—'}</span>
+        <span>{referral.serviceZone ?? '—'}</span>
+      </div>
+      {referral.declineReason && (
+        <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+          Declined: {referral.declineReason.replaceAll('_', ' ')}
+        </p>
+      )}
+      {!terminal && !declining && (
+        <div className="flex items-center gap-2 pt-0.5">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={advance}
+            className="rounded bg-healthcare-primary px-2 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-60"
+          >
+            {referral.status === 'consented' ? 'Activate' : 'Advance'}
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => setDeclining(true)}
+            className="rounded border border-healthcare-border dark:border-healthcare-border-dark px-2 py-1 text-xs font-medium text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark hover:opacity-80"
+          >
+            Decline
+          </button>
+        </div>
+      )}
+      {!terminal && declining && (
+        <div className="flex items-center gap-2 pt-0.5">
+          <select
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            className="rounded border border-healthcare-border dark:border-healthcare-border-dark bg-healthcare-surface dark:bg-healthcare-surface-dark px-1.5 py-1 text-xs text-healthcare-text-primary dark:text-healthcare-text-primary-dark"
+          >
+            {DECLINE_REASONS.map((r) => (
+              <option key={r} value={r}>
+                {r.replaceAll('_', ' ')}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={decline}
+            className="rounded bg-healthcare-primary px-2 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-60"
+          >
+            Confirm
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Referrals({ funnel, counts, edCandidates, stepDownCandidates, freeSlots }: ReferralsProps) {
+  const [busyRef, setBusyRef] = useState<string | null>(null);
+
+  const refer = async (candidate: { patientRef: string; source: string; encounterId?: number }) => {
+    setBusyRef(candidate.patientRef);
+    try {
+      await axios.post('/api/home/referrals', {
+        patient_ref: candidate.patientRef,
+        source: candidate.source,
+        encounter_id: candidate.encounterId ?? null,
+      });
+      reload();
+    } finally {
+      setBusyRef(null);
+    }
+  };
+
+  return (
+    <HomePageLayout
+      title="Referrals & Eligibility"
+      subtitle={`${freeSlots} free home slot${freeSlots === 1 ? '' : 's'} tonight · ${counts['activated'] ?? 0} activated`}
+    >
+      <div className="flex flex-col gap-5">
+        <Section
+          title="Eligibility worklists"
+          icon="heroicons:magnifying-glass"
+          summary={`${edCandidates.length} ED candidates · ${stepDownCandidates.length} step-down candidates — screened over the live census`}
+        >
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+            <div className={`${surface} p-3`}>
+              <h3 className="text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                ED candidates
+              </h3>
+              <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                Stable (ESI 3–5), boarders first — each activation is boarding relieved.
+              </p>
+              <div className="mt-2 flex flex-col divide-y divide-healthcare-border dark:divide-healthcare-border-dark">
+                {edCandidates.length === 0 && (
+                  <p className="py-2 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    No home-eligible ED patients right now.
+                  </p>
+                )}
+                {edCandidates.map((c) => (
+                  <div key={c.patientRef} className="flex items-center justify-between gap-2 py-1.5">
+                    <span className="text-sm tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                      {c.patientRef}
+                    </span>
+                    <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                      ESI {c.esiLevel}
+                      {c.isBoarding && ' · ▲ boarding'}
+                      {` · ${Math.floor(c.losMinutes / 60)}h in ED`}
+                    </span>
+                    <button
+                      type="button"
+                      disabled={busyRef === c.patientRef}
+                      onClick={() => refer(c)}
+                      className="rounded bg-healthcare-primary px-2 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-60"
+                    >
+                      Refer
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div className={`${surface} p-3`}>
+              <h3 className="text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                Inpatient step-down candidates
+              </h3>
+              <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                At or near expected LOS — decanting frees a physical bed early.
+              </p>
+              <div className="mt-2 flex flex-col divide-y divide-healthcare-border dark:divide-healthcare-border-dark">
+                {stepDownCandidates.length === 0 && (
+                  <p className="py-2 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    No step-down candidates inside the 48-hour window.
+                  </p>
+                )}
+                {stepDownCandidates.map((c) => (
+                  <div key={c.patientRef} className="flex items-center justify-between gap-2 py-1.5">
+                    <span className="text-sm tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                      {c.patientRef}
+                    </span>
+                    <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                      {c.unit ?? '—'} · EDD {c.expectedDischargeDate ?? '—'}
+                    </span>
+                    <button
+                      type="button"
+                      disabled={busyRef === c.patientRef}
+                      onClick={() => refer(c)}
+                      className="rounded bg-healthcare-primary px-2 py-1 text-xs font-medium text-white hover:opacity-90 disabled:opacity-60"
+                    >
+                      Refer
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        <Section
+          title="Referral funnel"
+          icon="heroicons:funnel"
+          summary="referred → screened → eligible → consented → activated, declines always coded"
+        >
+          <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3">
+            {STAGES.map((stage) => (
+              <div key={stage} className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    {STAGE_LABELS[stage]}
+                  </span>
+                  <span className="text-xs font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                    {counts[stage] ?? 0}
+                  </span>
+                </div>
+                {(funnel[stage] ?? []).map((referral) => (
+                  <ReferralCard key={referral.referralUuid} referral={referral} />
+                ))}
+              </div>
+            ))}
+          </div>
+        </Section>
+      </div>
+    </HomePageLayout>
+  );
+}

--- a/resources/js/Pages/Home/Transitions.tsx
+++ b/resources/js/Pages/Home/Transitions.tsx
@@ -1,0 +1,245 @@
+import { useState } from 'react';
+import axios from 'axios';
+import { router } from '@inertiajs/react';
+import HomePageLayout from '@/Components/Home/HomePageLayout';
+import { Section } from '@/Components/system';
+
+// Transitions of Care Board (ACUM-PRD-HAH-001 §4.2/§7): inbound activation
+// checklists, outbound governed handoffs (care_transition transport request +
+// regional decision with opportunity-cost scoring for SNF), and the 30-day
+// post-discharge monitoring cohort (billable under the 2026 RPM codes).
+
+interface Transition {
+  transitionUuid: string;
+  patientRef: string;
+  conditionLabel: string | null;
+  direction: 'inbound' | 'outbound';
+  status: string;
+  checklist: Record<string, string>;
+  handoffOwner: string | null;
+  receivingEntityType: string | null;
+  barriers: string[];
+}
+
+interface CohortMember {
+  episodeUuid: string;
+  patientRef: string;
+  conditionLabel: string | null;
+  dayOfCohort: number | null;
+  windowDays: number;
+  endsOn: string | null;
+}
+
+interface ActiveEpisode {
+  episodeUuid: string;
+  patientRef: string;
+  conditionLabel: string | null;
+}
+
+interface TransitionsProps {
+  inbound: Transition[];
+  outbound: Transition[];
+  postDischargeCohort: CohortMember[];
+  activeEpisodes: ActiveEpisode[];
+}
+
+const CHECKLIST_LABELS: Record<string, string> = {
+  consent: 'Consent',
+  home_safety_check: 'Home safety check',
+  kit_delivery: 'Kit delivery',
+  first_visit: 'First visit',
+  discharge_readiness: 'Discharge readiness',
+  med_reconciliation: 'Med reconciliation',
+  handoff_report: 'Handoff report',
+  equipment_return: 'Equipment return',
+};
+
+const RECEIVING_LABELS: Record<string, string> = {
+  pcp: 'Primary care',
+  home_health: 'Home health',
+  snf: 'Skilled nursing facility',
+  other: 'Other',
+};
+
+const surface =
+  'rounded-lg border border-healthcare-border dark:border-healthcare-border-dark bg-healthcare-surface dark:bg-healthcare-surface-dark shadow-sm';
+
+function TransitionCard({ transition }: { transition: Transition }) {
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const complete = async (item: string) => {
+    setBusy(item);
+    try {
+      await axios.post(`/api/home/transitions/${transition.transitionUuid}/checklist`, { item });
+      router.reload();
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  return (
+    <div className={`${surface} p-3 flex flex-col gap-2`}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-sm font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+          {transition.patientRef}
+        </span>
+        <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+          {transition.direction === 'outbound'
+            ? (RECEIVING_LABELS[transition.receivingEntityType ?? 'other'] ?? 'Handoff')
+            : (transition.conditionLabel ?? 'Activation')}
+        </span>
+      </div>
+      <div className="flex flex-col gap-1">
+        {Object.entries(transition.checklist).map(([item, state]) => (
+          <div key={item} className="flex items-center justify-between gap-2">
+            <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+              {state === 'complete' ? '● ' : '○ '}
+              {CHECKLIST_LABELS[item] ?? item}
+            </span>
+            {state !== 'complete' && (
+              <button
+                type="button"
+                disabled={busy === item}
+                onClick={() => complete(item)}
+                className="rounded border border-healthcare-border dark:border-healthcare-border-dark px-1.5 py-0.5 text-xs font-medium text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark hover:opacity-80 disabled:opacity-60"
+              >
+                Done
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+      {transition.handoffOwner && (
+        <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+          Owner: {transition.handoffOwner}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function Transitions({ inbound, outbound, postDischargeCohort, activeEpisodes }: TransitionsProps) {
+  const [episodeUuid, setEpisodeUuid] = useState('');
+  const [receiving, setReceiving] = useState<'pcp' | 'home_health' | 'snf' | 'other'>('home_health');
+  const [busy, setBusy] = useState(false);
+
+  const startHandoff = async () => {
+    if (!episodeUuid) return;
+    setBusy(true);
+    try {
+      await axios.post(`/api/home/episodes/${episodeUuid}/handoff`, { receiving_entity_type: receiving });
+      router.reload();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <HomePageLayout
+      title="Transitions of Care"
+      subtitle={`${inbound.length} activating · ${outbound.length} handing off · ${postDischargeCohort.length} in the 30-day cohort`}
+    >
+      <div className="flex flex-col gap-5">
+        <Section
+          title="Inbound activations"
+          icon="heroicons:arrow-down-tray"
+          summary="Consent, home-safety, kit delivery, first visit — the activation floor"
+        >
+          {inbound.length > 0 ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
+              {inbound.map((t) => (
+                <TransitionCard key={t.transitionUuid} transition={t} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+              No activations in progress — new activations open here automatically.
+            </p>
+          )}
+        </Section>
+
+        <Section
+          title="Outbound handoffs"
+          icon="heroicons:arrow-up-tray"
+          summary="Governed handoffs — SNF destinations score candidates with opportunity cost"
+        >
+          <div className="flex flex-col gap-3">
+            <div className={`${surface} p-3 flex flex-wrap items-center gap-2`}>
+              <span className="text-sm text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                Start handoff:
+              </span>
+              <select
+                value={episodeUuid}
+                onChange={(e) => setEpisodeUuid(e.target.value)}
+                className="rounded border border-healthcare-border dark:border-healthcare-border-dark bg-healthcare-surface dark:bg-healthcare-surface-dark px-2 py-1 text-sm text-healthcare-text-primary dark:text-healthcare-text-primary-dark"
+              >
+                <option value="">Select episode…</option>
+                {activeEpisodes.map((e) => (
+                  <option key={e.episodeUuid} value={e.episodeUuid}>
+                    {e.patientRef} — {e.conditionLabel ?? '—'}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={receiving}
+                onChange={(e) => setReceiving(e.target.value as typeof receiving)}
+                className="rounded border border-healthcare-border dark:border-healthcare-border-dark bg-healthcare-surface dark:bg-healthcare-surface-dark px-2 py-1 text-sm text-healthcare-text-primary dark:text-healthcare-text-primary-dark"
+              >
+                {Object.entries(RECEIVING_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                disabled={busy || !episodeUuid}
+                onClick={startHandoff}
+                className="rounded bg-healthcare-primary px-2.5 py-1 text-sm font-medium text-white hover:opacity-90 disabled:opacity-60"
+              >
+                Open handoff
+              </button>
+            </div>
+            {outbound.length > 0 && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
+                {outbound.map((t) => (
+                  <TransitionCard key={t.transitionUuid} transition={t} />
+                ))}
+              </div>
+            )}
+          </div>
+        </Section>
+
+        <Section
+          title="30-day post-discharge cohort"
+          icon="heroicons:calendar-days"
+          summary="Step-down monitoring cadence after routine discharge — readmission watch"
+        >
+          {postDischargeCohort.length > 0 ? (
+            <div
+              className={`${surface} divide-y divide-healthcare-border dark:divide-healthcare-border-dark`}
+            >
+              {postDischargeCohort.map((m) => (
+                <div key={m.episodeUuid} className="flex items-center justify-between gap-2 px-4 py-2">
+                  <span className="text-sm tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                    {m.patientRef}
+                  </span>
+                  <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    {m.conditionLabel ?? '—'}
+                  </span>
+                  <span className="text-xs tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    Day {m.dayOfCohort ?? '—'} of {m.windowDays} · ends {m.endsOn ?? '—'}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+              Cohort is empty — routine discharges enroll here automatically.
+            </p>
+          )}
+        </Section>
+      </div>
+    </HomePageLayout>
+  );
+}

--- a/resources/js/Pages/RTDC/GlobalHuddle.tsx
+++ b/resources/js/Pages/RTDC/GlobalHuddle.tsx
@@ -1,12 +1,39 @@
 import RTDCPageLayout from '@/Components/RTDC/RTDCPageLayout';
 import { useBedMeeting, useLiveCensus } from '@/features/rtdc/hooks';
 import { Section, MetricGrid, Panel, EmptyState, metric, STATUS_VAR } from '@/Components/system';
+import { usePage } from '@inertiajs/react';
+import { useQuery } from '@tanstack/react-query';
+import axios from 'axios';
 
 const TODAY = new Date().toISOString().slice(0, 10);
+
+interface DecantPayload {
+  available: boolean;
+  freeSlotsNow: number;
+  freeSlots24h: number;
+  freeSlots48h: number;
+  edEligibleNow: number;
+  stepDownEligibleNow: number;
+  activeEpisodes: number;
+  avoidedBedDaysMtd: number;
+}
+
+/** The home decant line (ACUM-PRD-HAH-001 §6.2) — mounted only when the
+ *  Home Hospital flag is on; the huddle is byte-identical without it. */
+function useHomeDecant(enabled: boolean) {
+  return useQuery<DecantPayload>({
+    queryKey: ['home', 'decant'],
+    queryFn: async () => (await axios.get('/api/home/decant')).data,
+    enabled,
+    refetchInterval: 60_000,
+  });
+}
 
 export default function GlobalHuddle() {
   useLiveCensus();
   const { data: rollup, isLoading } = useBedMeeting(TODAY, 'by_2pm');
+  const features = (usePage().props as { features?: { home_hospital?: boolean } }).features;
+  const { data: decant } = useHomeDecant(features?.home_hospital === true);
 
   const netBedNeed = rollup?.net_bed_need ?? 0;
   const totalDeficit = rollup?.total_positive_bed_need ?? 0;
@@ -34,12 +61,56 @@ export default function GlobalHuddle() {
     }),
   ];
 
+  const decantMetrics = decant?.available
+    ? [
+        metric({
+          key: 'home-eligible',
+          label: 'Home-eligible now',
+          value: decant.edEligibleNow + decant.stepDownEligibleNow,
+          display: `${decant.edEligibleNow + decant.stepDownEligibleNow}`,
+          status: 'info',
+          caption: `${decant.edEligibleNow} in the ED · ${decant.stepDownEligibleNow} step-down`,
+          definition: 'Patients on the live census screening home-eligible — each enrollment relieves a physical bed.',
+          drillHref: '/home/referrals',
+        }),
+        metric({
+          key: 'home-free-slots',
+          label: 'Free home slots tonight',
+          value: decant.freeSlotsNow,
+          status: decant.freeSlotsNow === 0 ? 'warning' : 'success',
+          caption: `${decant.freeSlots24h} by tomorrow · ${decant.freeSlots48h} by 48h`,
+          definition: 'Open virtual-ward slots — the decant valve on house capacity.',
+          drillHref: '/home/census',
+        }),
+        metric({
+          key: 'home-avoided',
+          label: 'Avoided bed-days MTD',
+          value: decant.avoidedBedDaysMtd,
+          status: 'neutral',
+          caption: `${decant.activeEpisodes} active home episodes`,
+          definition: 'Active home episode-days this month — occupied bed-days the house did not spend.',
+        }),
+      ]
+    : [];
+
   return (
     <RTDCPageLayout title="Hospital Bed Meeting" subtitle="Real-Time Demand Capacity — system roll-up">
       <div className="flex flex-col gap-5">
         <Section title="System roll-up" icon="heroicons:building-office-2" summary="Net bed need and total deficit by 2pm">
           <MetricGrid metrics={kpiMetrics} />
         </Section>
+
+        {decantMetrics.length > 0 && (
+          <Section
+            title="Home decant"
+            icon="heroicons:home-modern"
+            summary="Home-eligible census vs free virtual-ward slots — enroll these and boarding hours fall"
+            drillHref="/home/referrals"
+            drillLabel="Referrals"
+          >
+            <MetricGrid metrics={decantMetrics} />
+          </Section>
+        )}
 
         <Section title="Unit bed need" icon="heroicons:table-cells" summary="Capacity vs expected demand per unit">
           <Panel className="p-4">

--- a/resources/js/config/navigationConfig.ts
+++ b/resources/js/config/navigationConfig.ts
@@ -556,6 +556,9 @@ const HOME: NavDomain = {
       items: [
         { label: 'Virtual Ward Command', href: '/home/command', icon: HeartPulse },
         { label: 'Virtual Bed Board', href: '/home/census', icon: BedDouble },
+        { label: 'Referrals & Eligibility', href: '/home/referrals', icon: ClipboardList },
+        { label: 'Transitions of Care', href: '/home/transitions', icon: ArrowRightCircle },
+        { label: 'Field Ops & Logistics', href: '/home/logistics', icon: Truck },
       ],
     },
   ],

--- a/resources/js/config/navigationConfig.ts
+++ b/resources/js/config/navigationConfig.ts
@@ -546,14 +546,15 @@ const HOME: NavDomain = {
   key: 'home',
   label: 'Home Hospital',
   icon: HeartPulse,
-  dashboardHref: '/home/census',
-  dashboardLabel: 'Virtual Bed Board',
+  dashboardHref: '/home/command',
+  dashboardLabel: 'Virtual Ward Command',
   matchPrefixes: ['/home'],
   requiredFeature: 'home_hospital',
   groups: [
     {
       title: 'Operations',
       items: [
+        { label: 'Virtual Ward Command', href: '/home/command', icon: HeartPulse },
         { label: 'Virtual Bed Board', href: '/home/census', icon: BedDouble },
       ],
     },

--- a/resources/js/config/navigationConfig.ts
+++ b/resources/js/config/navigationConfig.ts
@@ -77,6 +77,7 @@ export interface NavigationCapabilities {
  *  disabled feature is hidden — never rendered as a dead link that 404s. */
 export interface NavigationFeatures {
   readonly virtual_rounds?: boolean;
+  readonly home_hospital?: boolean;
 }
 
 export interface NavigationAccess {
@@ -117,6 +118,9 @@ export interface NavDomain {
   readonly groups: readonly NavGroup[];
   readonly adminOnly?: boolean;
   readonly requiredCapability?: keyof NavigationCapabilities;
+  /** Entire domain hidden unless this server-shared feature flag is on
+   *  (mirrors NavLeaf.requiredFeature — never a dead link that 404s). */
+  readonly requiredFeature?: keyof NavigationFeatures;
 }
 
 /** One of the section-level controls rendered in the top bar. */
@@ -533,6 +537,29 @@ const INTEGRATIONS: NavDomain = {
   groups: [],
 };
 
+/** Home Hospital — acute Hospital-at-Home virtual ward (ACUM-PRD-HAH-001;
+ *  docs/home-hospital/). Hidden entirely unless HOME_HOSPITAL_ENABLED is on,
+ *  matching the server route gate (EnsureHomeHospitalEnabled) so nav and
+ *  route never disagree. Phase 0 ships the Virtual Bed Board; the remaining
+ *  five surfaces land in later phases. */
+const HOME: NavDomain = {
+  key: 'home',
+  label: 'Home Hospital',
+  icon: HeartPulse,
+  dashboardHref: '/home/census',
+  dashboardLabel: 'Virtual Bed Board',
+  matchPrefixes: ['/home'],
+  requiredFeature: 'home_hospital',
+  groups: [
+    {
+      title: 'Operations',
+      items: [
+        { label: 'Virtual Bed Board', href: '/home/census', icon: BedDouble },
+      ],
+    },
+  ],
+};
+
 /** Primary sections in top-bar order. Admin pages live in the user menu. */
 export const NAV_SECTIONS: readonly NavSection[] = [
   {
@@ -546,7 +573,7 @@ export const NAV_SECTIONS: readonly NavSection[] = [
     key: 'workspaces',
     title: 'Workspaces',
     icon: LayoutGrid,
-    domains: [RTDC, EMERGENCY, PERIOPERATIVE, RADIOLOGY, LAB, PHARMACY, TRANSPORT, STAFFING],
+    domains: [RTDC, EMERGENCY, PERIOPERATIVE, RADIOLOGY, LAB, PHARMACY, TRANSPORT, STAFFING, HOME],
   },
   { key: 'study', title: 'Study', icon: BookOpen, domains: [ANALYTICS, IMPROVEMENT] },
   {
@@ -572,6 +599,7 @@ export function isDomainActive(domain: NavDomain, url: string): boolean {
 }
 
 export function isDomainVisible(domain: NavDomain, access: NavigationAccess): boolean {
+  if (domain.requiredFeature && access.features?.[domain.requiredFeature] !== true) return false;
   if (domain.adminOnly) return access.isAdmin;
   if (domain.requiredCapability) return access.can?.[domain.requiredCapability] === true;
   if (domain.key === 'admin') {

--- a/resources/js/iconify-bundle.ts
+++ b/resources/js/iconify-bundle.ts
@@ -307,6 +307,9 @@ const collections: IconifyJSON[] = [
       "home": {
         "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"m2.25 12l8.955-8.955a1.124 1.124 0 0 1 1.59 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25\"/>"
       },
+      "home-modern": {
+        "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"M8.25 21v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21m0 0h4.5V3.545M12.75 21h7.5V10.75M2.25 21h1.5m18 0h-18M2.25 9l4.5-1.636M18.75 3l-1.5.545m0 6.205l3 1m1.5.5l-1.5-.5M6.75 7.364V3h-3v18m3-13.636l10.5-3.819\"/>"
+      },
       "identification": {
         "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"M15 9h3.75M15 12h3.75M15 15h3.75M4.5 19.5h15a2.25 2.25 0 0 0 2.25-2.25V6.75A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25v10.5A2.25 2.25 0 0 0 4.5 19.5m6-10.125a1.875 1.875 0 1 1-3.75 0a1.875 1.875 0 0 1 3.75 0m1.294 6.336a6.7 6.7 0 0 1-3.17.789a6.7 6.7 0 0 1-3.168-.789a3.376 3.376 0 0 1 6.338 0\"/>"
       },
@@ -318,6 +321,12 @@ const collections: IconifyJSON[] = [
       },
       "lock-closed": {
         "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25\"/>"
+      },
+      "magnifying-glass": {
+        "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"m21 21l-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607\"/>"
+      },
+      "map": {
+        "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"M9 6.75V15m6-6v8.25m.503 3.499l4.875-2.438c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934a1.12 1.12 0 0 1-1.006 0L9.503 3.252a1.13 1.13 0 0 0-1.006 0L3.622 5.689A1.13 1.13 0 0 0 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934a1.12 1.12 0 0 1 1.006 0l4.994 2.497c.317.158.69.158 1.006 0\"/>"
       },
       "minus": {
         "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"M5 12h14\"/>"
@@ -745,10 +754,13 @@ export const localIconifyNames = [
   "heroicons:hand-raised",
   "heroicons:heart",
   "heroicons:home",
+  "heroicons:home-modern",
   "heroicons:identification",
   "heroicons:inbox",
   "heroicons:information-circle",
   "heroicons:lock-closed",
+  "heroicons:magnifying-glass",
+  "heroicons:map",
   "heroicons:minus",
   "heroicons:minus-circle",
   "heroicons:minus-small",

--- a/resources/js/types/cockpit.ts
+++ b/resources/js/types/cockpit.ts
@@ -215,7 +215,7 @@ export type CockpitSnapshotSections = z.infer<typeof cockpitSnapshotSectionsSche
 // outside this list are ignored on read, so a mangled deep link degrades to the
 // bare cockpit instead of holding junk state.
 export const cockpitDrillDomains = [
-  'rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial', 'okr',
+  'rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial', 'home', 'okr',
 ] as const;
 export type CockpitDrillDomain = (typeof cockpitDrillDomains)[number];
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -280,6 +280,8 @@ Route::middleware(['web', 'auth', 'throttle:60,1', \App\Http\Middleware\EnsureHo
         Route::post('/episodes/{episodeUuid}/discharge', [\App\Http\Controllers\Api\Home\HomeTransitionController::class, 'discharge']);
         // Logistics — the ONE address-permitted surface.
         Route::get('/logistics', [\App\Http\Controllers\Api\Home\HomeLogisticsController::class, 'index']);
+        // The decant line: home-eligible counts + free-slot forecast (huddle).
+        Route::get('/decant', [\App\Http\Controllers\Api\Home\HomeDecantController::class, 'index']);
     });
 
 // Machine-to-machine ingress only. This route intentionally lives outside the

--- a/routes/api.php
+++ b/routes/api.php
@@ -262,6 +262,12 @@ Route::middleware(['web', 'auth', 'throttle:60,1', \App\Http\Middleware\EnsureHo
         Route::get('/alerts', [\App\Http\Controllers\Api\Home\RpmAlertController::class, 'index']);
         Route::post('/alerts/{alertUuid}/acknowledge', [\App\Http\Controllers\Api\Home\RpmAlertController::class, 'acknowledge']);
         Route::post('/alerts/{alertUuid}/resolve', [\App\Http\Controllers\Api\Home\RpmAlertController::class, 'resolve']);
+        // Escalation workflow — full response timing chain vs the 30-min floor.
+        Route::get('/escalations', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'index']);
+        Route::post('/escalations', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'store']);
+        Route::post('/escalations/{escalationUuid}/dispatch', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'dispatchResponse']);
+        Route::post('/escalations/{escalationUuid}/arrive', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'arrive']);
+        Route::post('/escalations/{escalationUuid}/resolve', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'resolve']);
     });
 
 // Machine-to-machine ingress only. This route intentionally lives outside the

--- a/routes/api.php
+++ b/routes/api.php
@@ -250,6 +250,15 @@ Route::middleware(['web', 'auth', 'throttle:60,1', \App\Http\Middleware\EnsureRo
         Route::post('/tasks/{taskUuid}/transition', [\App\Http\Controllers\Api\Rounds\RoundTaskController::class, 'transition']);
     });
 
+// Home Hospital — virtual-ward live data (ACUM-PRD-HAH-001; docs/home-hospital/).
+// Gated by HOME_HOSPITAL_ENABLED (404 when off). Patient-level payloads travel
+// only on this authenticated API — public Reverb channels carry aggregate
+// pings, never vitals (PHI-free-wire rule).
+Route::middleware(['web', 'auth', 'throttle:60,1', \App\Http\Middleware\EnsureHomeHospitalEnabled::class])
+    ->prefix('home')->group(function () {
+        Route::get('/census', [\App\Http\Controllers\Api\Home\HomeCensusController::class, 'index']);
+    });
+
 // Machine-to-machine ingress only. This route intentionally lives outside the
 // browser-session Patient Flow group and writes through raw -> canonical ->
 // projection/provenance before acknowledging an ADT message.

--- a/routes/api.php
+++ b/routes/api.php
@@ -257,6 +257,11 @@ Route::middleware(['web', 'auth', 'throttle:60,1', \App\Http\Middleware\EnsureRo
 Route::middleware(['web', 'auth', 'throttle:60,1', \App\Http\Middleware\EnsureHomeHospitalEnabled::class])
     ->prefix('home')->group(function () {
         Route::get('/census', [\App\Http\Controllers\Api\Home\HomeCensusController::class, 'index']);
+        Route::get('/command', [\App\Http\Controllers\Api\Home\HomeCommandController::class, 'index']);
+        // Patient-alert acknowledgement workflow — human actions, recorded.
+        Route::get('/alerts', [\App\Http\Controllers\Api\Home\RpmAlertController::class, 'index']);
+        Route::post('/alerts/{alertUuid}/acknowledge', [\App\Http\Controllers\Api\Home\RpmAlertController::class, 'acknowledge']);
+        Route::post('/alerts/{alertUuid}/resolve', [\App\Http\Controllers\Api\Home\RpmAlertController::class, 'resolve']);
     });
 
 // Machine-to-machine ingress only. This route intentionally lives outside the

--- a/routes/api.php
+++ b/routes/api.php
@@ -268,6 +268,18 @@ Route::middleware(['web', 'auth', 'throttle:60,1', \App\Http\Middleware\EnsureHo
         Route::post('/escalations/{escalationUuid}/dispatch', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'dispatchResponse']);
         Route::post('/escalations/{escalationUuid}/arrive', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'arrive']);
         Route::post('/escalations/{escalationUuid}/resolve', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'resolve']);
+        // Referral funnel + eligibility worklists (declines always coded).
+        Route::get('/referrals', [\App\Http\Controllers\Api\Home\HomeReferralController::class, 'index']);
+        Route::post('/referrals', [\App\Http\Controllers\Api\Home\HomeReferralController::class, 'store']);
+        Route::post('/referrals/{referralUuid}/advance', [\App\Http\Controllers\Api\Home\HomeReferralController::class, 'advance']);
+        Route::post('/referrals/{referralUuid}/decline', [\App\Http\Controllers\Api\Home\HomeReferralController::class, 'decline']);
+        // Transitions: inbound checklists, outbound governed handoffs, discharge.
+        Route::get('/transitions', [\App\Http\Controllers\Api\Home\HomeTransitionController::class, 'index']);
+        Route::post('/transitions/{transitionUuid}/checklist', [\App\Http\Controllers\Api\Home\HomeTransitionController::class, 'completeChecklistItem']);
+        Route::post('/episodes/{episodeUuid}/handoff', [\App\Http\Controllers\Api\Home\HomeTransitionController::class, 'startOutbound']);
+        Route::post('/episodes/{episodeUuid}/discharge', [\App\Http\Controllers\Api\Home\HomeTransitionController::class, 'discharge']);
+        // Logistics — the ONE address-permitted surface.
+        Route::get('/logistics', [\App\Http\Controllers\Api\Home\HomeLogisticsController::class, 'index']);
     });
 
 // Machine-to-machine ingress only. This route intentionally lives outside the

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Deployment\DeploymentConsoleController;
 use App\Http\Controllers\DesignController;
 use App\Http\Controllers\EDDashboardController;
+use App\Http\Controllers\HomeDashboardController;
 use App\Http\Controllers\Integrations\IntegrationConsoleController;
 use App\Http\Controllers\LabController;
 use App\Http\Controllers\Operations;
@@ -274,6 +275,15 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
                 ->middleware('can:viewIntegrations')
                 ->name('settings.integrations');
         });
+
+        // Home Hospital — acute Hospital-at-Home virtual ward workspace
+        // (ACUM-PRD-HAH-001; docs/home-hospital/). Gated by
+        // HOME_HOSPITAL_ENABLED (404 when off, nav hidden via features prop).
+        Route::prefix('home')->name('home.')
+            ->middleware(\App\Http\Middleware\EnsureHomeHospitalEnabled::class)
+            ->group(function () {
+                Route::get('/census', [HomeDashboardController::class, 'census'])->name('census');
+            });
 
         // Design Routes
         Route::prefix('design')->name('design.')->group(function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -282,6 +282,7 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
         Route::prefix('home')->name('home.')
             ->middleware(\App\Http\Middleware\EnsureHomeHospitalEnabled::class)
             ->group(function () {
+                Route::get('/command', [HomeDashboardController::class, 'command'])->name('command');
                 Route::get('/census', [HomeDashboardController::class, 'census'])->name('census');
             });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -284,6 +284,9 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
             ->group(function () {
                 Route::get('/command', [HomeDashboardController::class, 'command'])->name('command');
                 Route::get('/census', [HomeDashboardController::class, 'census'])->name('census');
+                Route::get('/referrals', [HomeDashboardController::class, 'referrals'])->name('referrals');
+                Route::get('/transitions', [HomeDashboardController::class, 'transitions'])->name('transitions');
+                Route::get('/logistics', [HomeDashboardController::class, 'logistics'])->name('logistics');
             });
 
         // Design Routes

--- a/tests/Feature/Home/HomeHospitalGatingTest.php
+++ b/tests/Feature/Home/HomeHospitalGatingTest.php
@@ -111,6 +111,6 @@ class HomeHospitalGatingTest extends TestCase
         ];
 
         $this->assertSame($first, $second);
-        $this->assertSame([1, 8, 6, 10], $second);
+        $this->assertSame([1, 8, 8, 10], $second);
     }
 }

--- a/tests/Feature/Home/HomeHospitalGatingTest.php
+++ b/tests/Feature/Home/HomeHospitalGatingTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Feature\Home;
+
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeReferral;
+use App\Models\Home\RpmKit;
+use App\Models\Unit;
+use App\Models\User;
+use Database\Seeders\HomeHospitalDemoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class HomeHospitalGatingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_feature_flag_off_returns_404_and_hides_the_module(): void
+    {
+        config(['home_hospital.enabled' => false]);
+
+        $this->actingAs($this->user)->get('/home/census')->assertNotFound();
+        $this->actingAs($this->user)->getJson('/api/home/census')->assertNotFound();
+    }
+
+    public function test_flag_off_seeder_is_a_no_op(): void
+    {
+        config(['home_hospital.enabled' => false]);
+
+        $this->seed(HomeHospitalDemoSeeder::class);
+
+        $this->assertSame(0, Unit::where('type', 'virtual_home')->count());
+        $this->assertSame(0, HomeEpisode::count());
+    }
+
+    public function test_census_page_renders_the_seeded_virtual_ward(): void
+    {
+        config(['home_hospital.enabled' => true]);
+        $this->seed(HomeHospitalDemoSeeder::class);
+
+        $this->actingAs($this->user)
+            ->get('/home/census')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Home/Census')
+                ->where('unit.abbreviation', 'HOME')
+                ->has('slots', 12)
+                ->where('occupancy.occupied', 8)
+                ->where('occupancy.capacity', 12)
+                ->has('pipeline.counts')
+                ->has('projectedDischarges.next24h')
+            );
+    }
+
+    public function test_api_census_returns_the_same_payload(): void
+    {
+        config(['home_hospital.enabled' => true]);
+        $this->seed(HomeHospitalDemoSeeder::class);
+
+        $this->actingAs($this->user)
+            ->getJson('/api/home/census')
+            ->assertOk()
+            ->assertJsonPath('unit.abbreviation', 'HOME')
+            ->assertJsonPath('occupancy.occupied', 8)
+            ->assertJsonPath('occupancy.capacity', 12)
+            ->assertJsonPath('pipeline.counts.declined', 2);
+    }
+
+    public function test_census_payload_is_pseudonymous(): void
+    {
+        config(['home_hospital.enabled' => true]);
+        $this->seed(HomeHospitalDemoSeeder::class);
+
+        $payload = $this->actingAs($this->user)->getJson('/api/home/census')->json();
+        $json = json_encode($payload, JSON_THROW_ON_ERROR);
+
+        // Operational payloads carry patient_ref + service zones only — never
+        // an MRN or street address (build brief §4.2).
+        $this->assertStringNotContainsString('mrn', strtolower($json));
+        $this->assertStringNotContainsString('address', strtolower($json));
+        $this->assertStringContainsString('HOME-DEMO-001', $json);
+    }
+
+    public function test_demo_seeder_is_idempotent(): void
+    {
+        config(['home_hospital.enabled' => true]);
+
+        $this->seed(HomeHospitalDemoSeeder::class);
+        $first = [
+            Unit::where('type', 'virtual_home')->count(),
+            HomeEpisode::count(),
+            HomeReferral::count(),
+            RpmKit::count(),
+        ];
+
+        $this->seed(HomeHospitalDemoSeeder::class);
+        $second = [
+            Unit::where('type', 'virtual_home')->count(),
+            HomeEpisode::count(),
+            HomeReferral::count(),
+            RpmKit::count(),
+        ];
+
+        $this->assertSame($first, $second);
+        $this->assertSame([1, 8, 6, 10], $second);
+    }
+}

--- a/tests/Feature/Home/HomeIntelligenceTest.php
+++ b/tests/Feature/Home/HomeIntelligenceTest.php
@@ -101,12 +101,15 @@ class HomeIntelligenceTest extends TestCase
         $this->assertGreaterThan(0, $result['source_rows']['prod.home_episodes']);
 
         $activities = DB::table('ocel.events')
-            ->whereIn('activity', ['home-activate', 'home-visit-complete', 'home-escalation-open', 'home-escalation-resolve'])
+            ->whereIn('activity', ['home-refer', 'home-activate', 'home-visit-complete', 'home-escalation-open', 'home-escalation-resolve'])
             ->selectRaw('activity, count(*) AS n')
             ->groupBy('activity')
             ->pluck('n', 'activity');
 
         $this->assertGreaterThanOrEqual(8, (int) ($activities['home-activate'] ?? 0));
+        // The two linked demo referrals anchor the sidecar's
+        // time-to-activation SLA check.
+        $this->assertGreaterThanOrEqual(2, (int) ($activities['home-refer'] ?? 0));
         $this->assertGreaterThan(0, (int) ($activities['home-visit-complete'] ?? 0));
         $this->assertGreaterThan(0, (int) ($activities['home-escalation-resolve'] ?? 0));
 

--- a/tests/Feature/Home/HomeIntelligenceTest.php
+++ b/tests/Feature/Home/HomeIntelligenceTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Tests\Feature\Home;
+
+use App\Domain\Ocel\OcelProjector;
+use App\Models\RtdcPrediction;
+use App\Models\Unit;
+use App\Models\User;
+use App\Services\Eddy\EddyActionService;
+use App\Services\Flow\ForwardProjectionService;
+use Carbon\CarbonImmutable;
+use Database\Seeders\HomeHospitalDemoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class HomeIntelligenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('home_hospital.enabled', true);
+        $this->seed(HomeHospitalDemoSeeder::class);
+        $this->user = User::factory()->create();
+    }
+
+    public function test_decant_endpoint_reports_capacity_and_writes_predictions(): void
+    {
+        $payload = $this->actingAs($this->user)
+            ->getJson('/api/home/decant')
+            ->assertOk()
+            ->json();
+
+        $this->assertTrue($payload['available']);
+        $this->assertSame(2, $payload['freeSlotsNow']); // 12 slots − 8 occupied − 1 blocked − 1 pending
+        $this->assertGreaterThanOrEqual($payload['freeSlotsNow'], $payload['freeSlots24h']);
+        $this->assertGreaterThanOrEqual($payload['freeSlots24h'], $payload['freeSlots48h']);
+        $this->assertSame(8, $payload['activeEpisodes']);
+        $this->assertGreaterThan(0, $payload['avoidedBedDaysMtd']);
+
+        $ward = Unit::where('type', 'virtual_home')->sole();
+        $rows = RtdcPrediction::query()
+            ->where('unit_id', $ward->unit_id)
+            ->where('service_date', now()->toDateString())
+            ->get()
+            ->keyBy('horizon');
+
+        $this->assertArrayHasKey('by_2pm', $rows->all());
+        $this->assertArrayHasKey('by_midnight', $rows->all());
+        $this->assertSame($payload['freeSlotsNow'], (int) $rows['by_2pm']->capacity_now);
+    }
+
+    public function test_forward_projection_carries_home_slot_free_stream_only_when_enabled(): void
+    {
+        $from = CarbonImmutable::now();
+        $to = $from->addHours(48);
+
+        $service = app(ForwardProjectionService::class);
+        $scope = ['type' => 'house', 'floor' => null, 'unit_id' => null, 'patient_ref' => null];
+
+        \Illuminate\Support\Facades\Cache::flush();
+        $items = $service->projections($from, $to, $scope, ['home_slot_free']);
+        $this->assertNotEmpty($items);
+        $this->assertSame('home_slot_free', $items[0]['kind']);
+        $this->assertSame('probable', $items[0]['confidence']);
+        $this->assertSame('home_hospital.expected_discharge', $items[0]['provenance']['service']);
+
+        config()->set('home_hospital.enabled', false);
+        \Illuminate\Support\Facades\Cache::flush();
+        $this->assertSame([], $service->projections($from, $to, $scope, ['home_slot_free']));
+    }
+
+    public function test_all_seven_home_eddy_actions_are_draft_only(): void
+    {
+        $home = [
+            'propose_escalation_response', 'propose_hah_enrollment', 'propose_stepdown_cohort',
+            'propose_visit_reschedule', 'flag_rpm_gap', 'propose_home_discharge', 'flag_transition_barrier',
+        ];
+
+        $catalog = app(EddyActionService::class)->catalog();
+
+        foreach ($home as $action) {
+            $this->assertArrayHasKey($action, $catalog, $action);
+            $this->assertTrue($catalog[$action]['requires_human_approval'], $action);
+            $this->assertTrue($catalog[$action]['draft_only_for_agent_tokens'], $action);
+            $this->assertFalse($catalog[$action]['execution_adapter']['direct_domain_mutation'], $action);
+        }
+
+        // Routing invariant: only the escalation response owns the home. prefix.
+        $this->assertSame('propose_escalation_response', EddyActionService::actionForAlert('home.visit_compliance_today', 'crit'));
+    }
+
+    public function test_ocel_projection_includes_the_home_pathway_when_enabled(): void
+    {
+        $result = app(OcelProjector::class)->project(now()->subDays(14), now());
+
+        $this->assertGreaterThan(0, $result['source_rows']['prod.home_episodes']);
+
+        $activities = DB::table('ocel.events')
+            ->whereIn('activity', ['home-activate', 'home-visit-complete', 'home-escalation-open', 'home-escalation-resolve'])
+            ->selectRaw('activity, count(*) AS n')
+            ->groupBy('activity')
+            ->pluck('n', 'activity');
+
+        $this->assertGreaterThanOrEqual(8, (int) ($activities['home-activate'] ?? 0));
+        $this->assertGreaterThan(0, (int) ($activities['home-visit-complete'] ?? 0));
+        $this->assertGreaterThan(0, (int) ($activities['home-escalation-resolve'] ?? 0));
+
+        $objects = DB::table('ocel.objects')->whereIn('type', ['Home Episode', 'RPM Kit', 'Home Visit', 'Escalation'])->count();
+        $this->assertGreaterThan(0, $objects);
+
+        config()->set('home_hospital.enabled', false);
+        $off = app(OcelProjector::class)->project(now()->subDays(14), now());
+        $this->assertSame(0, $off['source_rows']['prod.home_episodes']);
+    }
+
+    public function test_cms_export_produces_the_study_variables(): void
+    {
+        $path = storage_path('framework/testing/cms-export-'.getmypid().'.json');
+
+        $this->artisan('home:cms-export', [
+            '--from' => now()->subDays(14)->toDateString(),
+            '--output' => $path,
+        ])->assertExitCode(0);
+
+        $report = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        @unlink($path);
+
+        $this->assertSame(8, $report['episodes']['started']);
+        $this->assertNotNull($report['escalations']['response_p90_minutes']);
+        $this->assertSame(100.0, (float) $report['escalations']['within_30min_floor_pct']);
+        $this->assertNotNull($report['visit_compliance']['compliance_pct']);
+        $this->assertArrayHasKey('decline_reasons', $report['equity_selection_bias']);
+        $this->assertArrayHasKey('activation_rate_by_payer', $report['equity_selection_bias']);
+        $this->assertSame(6.2, $report['benchmarks']['escalation_rate_pct']['value']);
+
+        // Pseudonymity holds in the export too: aggregates only.
+        $json = json_encode($report, JSON_THROW_ON_ERROR);
+        $this->assertStringNotContainsString('Street', $json);
+        $this->assertStringNotContainsString('HOME-DEMO-001', $json);
+    }
+
+    public function test_cms_export_refuses_when_module_disabled(): void
+    {
+        config()->set('home_hospital.enabled', false);
+
+        $this->artisan('home:cms-export')->assertExitCode(1);
+    }
+}

--- a/tests/Feature/Home/HomeObservabilityTest.php
+++ b/tests/Feature/Home/HomeObservabilityTest.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace Tests\Feature\Home;
+
+use App\Integrations\Healthcare\DTO\WebhookEnvelope;
+use App\Integrations\Healthcare\Rpm\SyntheticRpmConnector;
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeEscalation;
+use App\Models\Home\RpmAlert;
+use App\Models\Org\Facility;
+use App\Models\Org\Organization;
+use App\Models\User;
+use App\Services\Cockpit\DrillBuilder;
+use App\Services\Eddy\EddyActionService;
+use App\Services\Home\HewsService;
+use App\Services\Home\HomeEscalationService;
+use Database\Seeders\HomeHospitalDemoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\TestCase;
+
+class HomeObservabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('deployment:seed-registry')->assertExitCode(0);
+        $organization = Organization::create([
+            'organization_key' => 'HOME_OBS_IDN', 'name' => 'Home Obs IDN', 'kind' => 'idn',
+        ]);
+        $facility = Facility::create([
+            'organization_id' => $organization->organization_id,
+            'facility_key' => 'HOME_OBS_FACILITY',
+            'facility_name' => 'Home Obs Facility',
+            'idn_role' => 'community_hospital',
+            'review_status' => 'client_verified',
+            'is_active' => true,
+        ]);
+        config()->set('integrations.synthetic.facility_key', $facility->facility_key);
+        config()->set('home_hospital.enabled', true);
+        $this->seed(HomeHospitalDemoSeeder::class);
+        $this->user = User::factory()->create();
+    }
+
+    public function test_demo_seed_opens_exactly_one_critical_alert(): void
+    {
+        $critical = RpmAlert::open()->where('severity', 'critical')->get();
+
+        $this->assertCount(1, $critical);
+        $this->assertSame('HOME-DEMO-001', $critical->first()->patient_ref);
+        $this->assertSame('59408-5.low', $critical->first()->rule_key);
+    }
+
+    public function test_hews_is_deterministic_and_transparent(): void
+    {
+        $episode = HomeEpisode::where('patient_ref', 'HOME-DEMO-001')->firstOrFail();
+
+        $first = app(HewsService::class)->computeForEpisode($episode);
+        $second = app(HewsService::class)->computeForEpisode($episode);
+
+        $this->assertNotNull($first);
+        $this->assertSame($first['score'], $second['score']);
+        $this->assertSame(['news2', 'baseline_deviation', 'trend', 'adherence'], array_keys($first['components']));
+        $this->assertSame($first['score'], (int) array_sum($first['components']));
+        // The deliberately-declining patient never reads low-risk.
+        $this->assertContains($first['band'], ['medium', 'high']);
+        $this->assertGreaterThan(0, $first['components']['trend']);
+    }
+
+    public function test_repeat_breach_dedupes_onto_one_open_alert(): void
+    {
+        $connector = app(SyntheticRpmConnector::class);
+
+        foreach (['TX-DDP-1', 'TX-DDP-2'] as $tx) {
+            $connector->handleWebhook(new WebhookEnvelope(payload: ['messages' => [[
+                'event_type' => 'ObservationRecorded',
+                'patient_ref' => 'HOME-DEMO-002',
+                'loinc_code' => '59408-5',
+                'display' => 'Oxygen saturation',
+                'value' => 86,
+                'unit' => '%',
+                'transmission_id' => $tx,
+                'observed_at' => now()->toIso8601String(),
+            ]]]));
+        }
+
+        $alerts = RpmAlert::query()
+            ->where('patient_ref', 'HOME-DEMO-002')
+            ->where('rule_key', '59408-5.low')
+            ->where('status', 'open')
+            ->get();
+
+        $this->assertCount(1, $alerts);
+        $this->assertSame(2, (int) $alerts->first()->metadata['breach_count']);
+        $this->assertSame('critical', $alerts->first()->severity);
+    }
+
+    public function test_acknowledge_and_resolve_record_the_human(): void
+    {
+        $alert = RpmAlert::open()->where('severity', 'critical')->firstOrFail();
+
+        $this->actingAs($this->user)
+            ->postJson("/api/home/alerts/{$alert->alert_uuid}/acknowledge")
+            ->assertOk()
+            ->assertJsonPath('alert.status', 'acknowledged');
+
+        $this->actingAs($this->user)
+            ->postJson("/api/home/alerts/{$alert->alert_uuid}/resolve")
+            ->assertOk()
+            ->assertJsonPath('alert.status', 'resolved');
+
+        $fresh = $alert->fresh();
+        $this->assertSame($this->user->email, $fresh->acknowledged_by);
+        $this->assertSame($this->user->email, $fresh->resolved_by);
+        $this->assertNotNull($fresh->acknowledged_at);
+        $this->assertNotNull($fresh->resolved_at);
+    }
+
+    public function test_escalation_timing_chain_and_response_minutes(): void
+    {
+        $episode = HomeEpisode::where('patient_ref', 'HOME-DEMO-003')->firstOrFail();
+        $service = app(HomeEscalationService::class);
+
+        $escalation = $service->open($episode, 'critical_vital');
+        $this->assertSame('open', $escalation->status);
+
+        // A second trigger joins the open chain instead of forking.
+        $again = $service->open($episode, 'patient_request');
+        $this->assertSame($escalation->home_escalation_id, $again->home_escalation_id);
+
+        $escalation = $service->markDispatched($escalation, 'field_dispatch');
+        $escalation = $service->markArrived($escalation);
+        $this->assertSame('responding', $escalation->status);
+        $this->assertNotNull($escalation->response_minutes);
+
+        $escalation = $service->resolve($escalation, 'managed_at_home');
+        $this->assertSame('resolved', $escalation->status);
+        $this->assertSame('managed_at_home', $escalation->outcome);
+    }
+
+    public function test_adt_registration_closes_the_open_escalation_with_ed_return(): void
+    {
+        $episode = HomeEpisode::where('patient_ref', 'HOME-DEMO-004')->firstOrFail();
+        $service = app(HomeEscalationService::class);
+        $service->open($episode, 'clinical_deterioration');
+
+        $closed = $service->closeForEdReturn('HOME-DEMO-004');
+
+        $this->assertNotNull($closed);
+        $this->assertSame('resolved', $closed->status);
+        $this->assertSame('ed_return', $closed->outcome);
+        $this->assertSame('adt_ed_registration', $closed->metadata['closed_by']);
+
+        // No open escalation → a stranger's ADT is a no-op.
+        $this->assertNull($service->closeForEdReturn('NOBODY-HOME'));
+        $this->assertSame(0, HomeEscalation::open()->count());
+    }
+
+    public function test_escalation_api_drives_the_chain(): void
+    {
+        $episode = HomeEpisode::where('patient_ref', 'HOME-DEMO-005')->firstOrFail();
+
+        $created = $this->actingAs($this->user)
+            ->postJson('/api/home/escalations', [
+                'episode_uuid' => $episode->episode_uuid,
+                'trigger_type' => 'critical_vital',
+            ])
+            ->assertCreated()
+            ->json('escalation');
+
+        $uuid = $created['escalationUuid'];
+
+        $this->actingAs($this->user)
+            ->postJson("/api/home/escalations/{$uuid}/dispatch", ['response_mode' => 'field_dispatch'])
+            ->assertOk()
+            ->assertJsonPath('escalation.status', 'responding');
+
+        $this->actingAs($this->user)
+            ->postJson("/api/home/escalations/{$uuid}/arrive")
+            ->assertOk();
+
+        $resolved = $this->actingAs($this->user)
+            ->postJson("/api/home/escalations/{$uuid}/resolve", ['outcome' => 'managed_at_home'])
+            ->assertOk()
+            ->json('escalation');
+
+        $this->assertSame('resolved', $resolved['status']);
+        $this->assertIsInt($resolved['responseMinutes']);
+    }
+
+    public function test_cockpit_snapshot_carries_the_home_domain_and_crit_alert(): void
+    {
+        $this->seed(\Database\Seeders\CockpitKpiDefinitionSeeder::class);
+        $snapshot = app(\App\Services\Cockpit\SnapshotBuilder::class)->build();
+
+        $this->assertArrayHasKey('home', $snapshot['domains']);
+        $tiles = collect($snapshot['domains']['home']['tiles']);
+        $unacked = $tiles->firstWhere('key', 'home.unacked_critical_vitals');
+
+        $this->assertNotNull($unacked);
+        $this->assertSame('crit', $unacked['status']);
+        $this->assertSame(1.0, (float) $unacked['value']);
+
+        // The Earned-Red ration: the crit home alert routes to the draft-only
+        // escalation-response proposal — the agent proposes, a human disposes.
+        $this->assertSame(
+            'propose_escalation_response',
+            EddyActionService::actionForAlert('home.unacked_critical_vitals', 'crit'),
+        );
+    }
+
+    public function test_home_domain_absent_when_flag_off(): void
+    {
+        config()->set('home_hospital.enabled', false);
+
+        $snapshot = app(\App\Services\Cockpit\SnapshotBuilder::class)->build();
+
+        $this->assertArrayNotHasKey('home', $snapshot['domains']);
+    }
+
+    public function test_home_drill_builds_ward_board_and_funnel(): void
+    {
+        $this->seed(\Database\Seeders\CockpitKpiDefinitionSeeder::class);
+        app(\App\Services\Cockpit\SnapshotBuilder::class)->build();
+
+        $drill = app(DrillBuilder::class)->build('home');
+
+        $this->assertNotNull($drill);
+        $this->assertSame('Home Hospital — Virtual Ward', $drill['title']);
+        $captions = array_column($drill['tables'], 'caption');
+        $this->assertContains('Virtual ward board', $captions);
+        $this->assertContains('Referral funnel', $captions);
+    }
+
+    public function test_command_page_renders_breach_first(): void
+    {
+        $this->actingAs($this->user)
+            ->get('/home/command')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('Home/Command')
+                ->has('episodes', 8)
+                ->where('episodes.0.patientRef', 'HOME-DEMO-001')
+                ->where('episodes.0.breach', true)
+                ->where('summary.breaches', 1)
+            );
+    }
+
+    public function test_ingested_observation_persists_a_fhir_resource_version(): void
+    {
+        app(SyntheticRpmConnector::class)->handleWebhook(new WebhookEnvelope(payload: ['messages' => [[
+            'event_type' => 'ObservationRecorded',
+            'patient_ref' => 'HOME-DEMO-003',
+            'loinc_code' => '8867-4',
+            'display' => 'Heart rate',
+            'value' => 88,
+            'unit' => 'bpm',
+            'transmission_id' => 'TX-FHIR-1',
+            'observed_at' => now()->toIso8601String(),
+        ]]]));
+
+        $observation = \App\Models\Home\RpmObservation::query()
+            ->where('transmission_id', 'TX-FHIR-1')
+            ->firstOrFail();
+
+        $version = DB::table('fhir.resource_versions')
+            ->where('resource_type', 'Observation')
+            ->where('fhir_id', $observation->observation_uuid)
+            ->first();
+        $this->assertNotNull($version);
+
+        $link = DB::table('fhir.resource_links')
+            ->where('resource_type', 'Observation')
+            ->where('fhir_id', $observation->observation_uuid)
+            ->where('internal_table', 'rpm_observations')
+            ->where('internal_pk', (string) $observation->rpm_observation_id)
+            ->first();
+        $this->assertNotNull($link);
+    }
+}

--- a/tests/Feature/Home/HomeTransitionsTest.php
+++ b/tests/Feature/Home/HomeTransitionsTest.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace Tests\Feature\Home;
+
+use App\Models\Bed;
+use App\Models\Encounter;
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeReferral;
+use App\Models\Unit;
+use App\Models\User;
+use Database\Seeders\HomeHospitalDemoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class HomeTransitionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('home_hospital.enabled', true);
+        $this->seed(HomeHospitalDemoSeeder::class);
+        $this->user = User::factory()->create();
+    }
+
+    public function test_referral_traverses_the_funnel_and_activates_onto_the_virtual_unit(): void
+    {
+        $created = $this->actingAs($this->user)
+            ->postJson('/api/home/referrals', [
+                'patient_ref' => 'FUNNEL-TEST-001',
+                'source' => 'ed_diversion',
+                'screening' => ['condition_code' => 'heart_failure', 'condition_label' => 'Heart Failure', 'acuity_tier' => 3],
+                'service_zone' => 'north',
+            ])
+            ->assertCreated()
+            ->json('referral');
+
+        $uuid = $created['referralUuid'];
+
+        foreach (['screened', 'eligible', 'consented'] as $expected) {
+            $this->actingAs($this->user)
+                ->postJson("/api/home/referrals/{$uuid}/advance")
+                ->assertOk()
+                ->assertJsonPath('referral.status', $expected);
+        }
+
+        $this->actingAs($this->user)
+            ->postJson("/api/home/referrals/{$uuid}/advance")
+            ->assertOk()
+            ->assertJsonPath('referral.status', 'activated');
+
+        $episode = HomeEpisode::query()->where('patient_ref', 'FUNNEL-TEST-001')->sole();
+        $this->assertSame('active', $episode->status);
+        $this->assertSame('heart_failure', $episode->condition_code);
+
+        $encounter = $episode->encounter;
+        $this->assertNotNull($encounter);
+        $this->assertSame('virtual_home', $encounter->unit->type);
+        $this->assertSame('occupied', $encounter->bed->status);
+
+        // Activation opens the inbound checklist and assigns a kit.
+        $this->assertSame(1, $episode->transitions()->where('direction', 'inbound')->count());
+        $this->assertSame(1, $episode->enrollments()->where('status', 'active')->count());
+    }
+
+    public function test_activation_fails_loudly_when_the_ward_is_full(): void
+    {
+        $ward = Unit::where('type', 'virtual_home')->sole();
+        Bed::where('unit_id', $ward->unit_id)->where('status', 'available')
+            ->update(['status' => 'blocked']);
+
+        $referral = HomeReferral::where('patient_ref', 'HOME-REF-103')->sole(); // consented in the demo seed
+
+        $this->actingAs($this->user)
+            ->postJson("/api/home/referrals/{$referral->referral_uuid}/advance")
+            ->assertUnprocessable();
+
+        $this->assertSame('consented', $referral->fresh()->status);
+    }
+
+    public function test_snf_handoff_writes_care_transition_request_and_scored_regional_decision(): void
+    {
+        $episode = HomeEpisode::where('patient_ref', 'HOME-DEMO-001')->sole();
+
+        $response = $this->actingAs($this->user)
+            ->postJson("/api/home/episodes/{$episode->episode_uuid}/handoff", [
+                'receiving_entity_type' => 'snf',
+            ])
+            ->assertCreated()
+            ->json();
+
+        $request = DB::table('prod.transport_requests')
+            ->where('transport_request_id', $response['transportRequestId'])
+            ->first();
+        $this->assertSame('care_transition', $request->request_type);
+        $this->assertSame('HOME-DEMO-001', $request->patient_ref);
+
+        $decision = DB::table('regional.transfer_decisions')
+            ->where('transfer_decision_id', $response['decisionId'])
+            ->first();
+        $this->assertNotNull($decision);
+        $this->assertNotNull($decision->selected_score);
+        $opportunityCost = json_decode((string) $decision->opportunity_cost_payload, true);
+        $this->assertNotEmpty($opportunityCost);
+
+        // A second open handoff for the same episode is rejected.
+        $this->actingAs($this->user)
+            ->postJson("/api/home/episodes/{$episode->episode_uuid}/handoff", [
+                'receiving_entity_type' => 'snf',
+            ])
+            ->assertUnprocessable();
+    }
+
+    public function test_pcp_handoff_needs_no_regional_decision(): void
+    {
+        $episode = HomeEpisode::where('patient_ref', 'HOME-DEMO-002')->sole();
+
+        $response = $this->actingAs($this->user)
+            ->postJson("/api/home/episodes/{$episode->episode_uuid}/handoff", [
+                'receiving_entity_type' => 'pcp',
+            ])
+            ->assertCreated()
+            ->json();
+
+        $this->assertNull($response['decisionId']);
+        $this->assertNotNull($response['transportRequestId']);
+    }
+
+    public function test_routine_discharge_frees_the_slot_and_enrolls_the_30_day_cohort(): void
+    {
+        $episode = HomeEpisode::where('patient_ref', 'HOME-DEMO-003')->sole();
+        $bedId = $episode->encounter->bed_id;
+        $kitId = $episode->enrollments()->sole()->rpm_kit_id;
+
+        $this->actingAs($this->user)
+            ->postJson("/api/home/episodes/{$episode->episode_uuid}/discharge", [
+                'disposition' => 'routine_discharge',
+            ])
+            ->assertOk()
+            ->assertJsonPath('episode.status', 'completed')
+            ->assertJsonPath('episode.disposition', 'routine_discharge');
+
+        $this->assertSame('available', Bed::find($bedId)->status);
+        $this->assertSame('available', \App\Models\Home\RpmKit::find($kitId)->status);
+        $this->assertSame('discharged', $episode->fresh()->encounter->status);
+
+        $cohort = HomeEpisode::query()
+            ->where('patient_ref', 'HOME-DEMO-003')
+            ->where('status', 'active')
+            ->whereHas('program', fn ($q) => $q->where('program_type', 'post_discharge_rpm'))
+            ->sole();
+
+        $this->assertNull($cohort->encounter_id); // no slot — not an avoided bed-day
+        $this->assertSame(30.0, (float) $cohort->target_los_days);
+
+        $plan = $cohort->enrollments()->sole()->monitoring_plan;
+        $this->assertSame(720, (int) $plan['cadence_minutes']['59408-5']); // step-down cadence
+        $this->assertSame(1440, (int) $plan['cadence_minutes']['29463-7']); // daily weight
+    }
+
+    public function test_physical_address_is_confined_to_the_logistics_context(): void
+    {
+        $logistics = json_encode($this->actingAs($this->user)->getJson('/api/home/logistics')->json(), JSON_THROW_ON_ERROR);
+        $this->assertStringContainsString('Street', $logistics);
+
+        foreach (['/api/home/census', '/api/home/command', '/api/home/referrals', '/api/home/transitions', '/api/home/alerts', '/api/home/escalations'] as $endpoint) {
+            $payload = json_encode($this->actingAs($this->user)->getJson($endpoint)->assertOk()->json(), JSON_THROW_ON_ERROR);
+            $this->assertStringNotContainsString('Street', $payload, "Address leaked on {$endpoint}");
+            $this->assertStringNotContainsString('logistics_address', $payload, "Address key leaked on {$endpoint}");
+        }
+    }
+
+    public function test_worklists_surface_live_census_candidates(): void
+    {
+        // ED: one stable boarder (eligible) and one ESI-2 (excluded).
+        DB::table('prod.ed_visits')->insert([
+            ['patient_ref' => 'ED-CAND-01', 'arrived_at' => now()->subHours(5), 'esi_level' => 3,
+                'admit_decision_at' => now()->subHours(2), 'bed_assigned_at' => null,
+                'disposition' => 'admitted', 'created_at' => now(), 'updated_at' => now(), 'is_deleted' => false],
+            ['patient_ref' => 'ED-SICK-01', 'arrived_at' => now()->subHours(1), 'esi_level' => 2,
+                'admit_decision_at' => null, 'bed_assigned_at' => null,
+                'disposition' => null, 'created_at' => now(), 'updated_at' => now(), 'is_deleted' => false],
+        ]);
+
+        // Step-down: a stable med/surg encounter near expected discharge.
+        $unit = Unit::create(['name' => 'Test Med Surg', 'abbreviation' => 'TMS', 'type' => 'med_surg', 'staffed_bed_count' => 4]);
+        Encounter::create([
+            'patient_ref' => 'SD-CAND-01', 'unit_id' => $unit->unit_id, 'admitted_at' => now()->subDays(3),
+            'expected_discharge_date' => now()->addDay()->toDateString(), 'acuity_tier' => 4, 'status' => 'active',
+        ]);
+
+        $payload = $this->actingAs($this->user)->getJson('/api/home/referrals')->assertOk()->json();
+
+        $edRefs = array_column($payload['edCandidates'], 'patientRef');
+        $this->assertContains('ED-CAND-01', $edRefs);
+        $this->assertNotContains('ED-SICK-01', $edRefs);
+        $this->assertTrue(collect($payload['edCandidates'])->firstWhere('patientRef', 'ED-CAND-01')['isBoarding']);
+
+        $sdRefs = array_column($payload['stepDownCandidates'], 'patientRef');
+        $this->assertContains('SD-CAND-01', $sdRefs);
+    }
+}

--- a/tests/Feature/Home/SyntheticRpmConnectorTest.php
+++ b/tests/Feature/Home/SyntheticRpmConnectorTest.php
@@ -47,7 +47,7 @@ class SyntheticRpmConnectorTest extends TestCase
         $this->assertSame(2, $run->messages_received);
         $this->assertSame(2, $run->messages_succeeded);
 
-        $observation = RpmObservation::sole();
+        $observation = RpmObservation::where('transmission_id', 'TX-TEST-0001')->sole();
         $this->assertSame('HOME-DEMO-001', $observation->patient_ref);
         $this->assertSame('59408-5', $observation->loinc_code);
         $this->assertSame(93.0, $observation->value);
@@ -67,7 +67,7 @@ class SyntheticRpmConnectorTest extends TestCase
         $second = $connector->handleWebhook($this->envelope());
 
         $this->assertSame(2, $second->messages_skipped);
-        $this->assertSame(1, RpmObservation::count());
+        $this->assertSame(1, RpmObservation::where('transmission_id', 'TX-TEST-0001')->count());
     }
 
     public function test_observation_for_unknown_patient_dead_letters(): void
@@ -84,7 +84,7 @@ class SyntheticRpmConnectorTest extends TestCase
 
         $this->assertSame('failed', $run->status);
         $this->assertSame(1, $run->messages_failed);
-        $this->assertSame(0, RpmObservation::count());
+        $this->assertSame(0, RpmObservation::where('transmission_id', 'TX-UNKNOWN-0001')->count());
         $this->assertSame(1, DeadLetter::where('failure_stage', 'mapping')->count());
     }
 

--- a/tests/Feature/Home/SyntheticRpmConnectorTest.php
+++ b/tests/Feature/Home/SyntheticRpmConnectorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Home;
+
+use App\Integrations\Healthcare\DTO\WebhookEnvelope;
+use App\Integrations\Healthcare\Rpm\SyntheticRpmConnector;
+use App\Models\Home\RpmDevice;
+use App\Models\Home\RpmObservation;
+use App\Models\Org\Facility;
+use App\Models\Org\Organization;
+use App\Models\Raw\DeadLetter;
+use Database\Seeders\HomeHospitalDemoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SyntheticRpmConnectorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('deployment:seed-registry')->assertExitCode(0);
+        $organization = Organization::create([
+            'organization_key' => 'RPM_TEST_IDN',
+            'name' => 'RPM Test IDN',
+            'kind' => 'idn',
+        ]);
+        $facility = Facility::create([
+            'organization_id' => $organization->organization_id,
+            'facility_key' => 'RPM_TEST_FACILITY',
+            'facility_name' => 'RPM Test Facility',
+            'idn_role' => 'community_hospital',
+            'review_status' => 'client_verified',
+            'is_active' => true,
+        ]);
+        config()->set('integrations.synthetic.facility_key', $facility->facility_key);
+        config()->set('home_hospital.enabled', true);
+        $this->seed(HomeHospitalDemoSeeder::class);
+    }
+
+    public function test_webhook_observation_projects_into_the_rpm_ledger(): void
+    {
+        $run = app(SyntheticRpmConnector::class)->handleWebhook($this->envelope());
+
+        $this->assertSame('completed', $run->status);
+        $this->assertSame(2, $run->messages_received);
+        $this->assertSame(2, $run->messages_succeeded);
+
+        $observation = RpmObservation::sole();
+        $this->assertSame('HOME-DEMO-001', $observation->patient_ref);
+        $this->assertSame('59408-5', $observation->loinc_code);
+        $this->assertSame(93.0, $observation->value);
+        $this->assertSame('ok', $observation->quality_flag);
+        $this->assertNotNull($observation->rpm_enrollment_id);
+
+        $device = RpmDevice::where('serial_number', 'SH100-001-PU')->sole();
+        $this->assertSame(77, $device->battery_pct);
+        $this->assertNotNull($device->last_transmission_at);
+    }
+
+    public function test_replaying_the_same_webhook_is_idempotent(): void
+    {
+        $connector = app(SyntheticRpmConnector::class);
+
+        $connector->handleWebhook($this->envelope());
+        $second = $connector->handleWebhook($this->envelope());
+
+        $this->assertSame(2, $second->messages_skipped);
+        $this->assertSame(1, RpmObservation::count());
+    }
+
+    public function test_observation_for_unknown_patient_dead_letters(): void
+    {
+        $run = app(SyntheticRpmConnector::class)->handleWebhook(new WebhookEnvelope(
+            payload: ['messages' => [[
+                'event_type' => 'ObservationRecorded',
+                'patient_ref' => 'NOT-ENROLLED-999',
+                'loinc_code' => '8867-4',
+                'value' => 120,
+                'transmission_id' => 'TX-UNKNOWN-0001',
+            ]]],
+        ));
+
+        $this->assertSame('failed', $run->status);
+        $this->assertSame(1, $run->messages_failed);
+        $this->assertSame(0, RpmObservation::count());
+        $this->assertSame(1, DeadLetter::where('failure_stage', 'mapping')->count());
+    }
+
+    private function envelope(): WebhookEnvelope
+    {
+        return new WebhookEnvelope(
+            payload: ['messages' => [[
+                'event_type' => 'ObservationRecorded',
+                'patient_ref' => 'HOME-DEMO-001',
+                'loinc_code' => '59408-5',
+                'display' => 'Oxygen saturation',
+                'value' => 93,
+                'unit' => '%',
+                'transmission_id' => 'TX-TEST-0001',
+                'device_serial' => 'SH100-001-PU',
+                'observed_at' => now()->toIso8601String(),
+            ], [
+                'event_type' => 'DeviceStatusChanged',
+                'device_serial' => 'SH100-001-PU',
+                'status' => 'active',
+                'battery_pct' => 77,
+                'transmission_id' => 'TX-TEST-0002',
+            ]]],
+        );
+    }
+}

--- a/tests/js/config/navigationConfig.test.ts
+++ b/tests/js/config/navigationConfig.test.ts
@@ -4,6 +4,7 @@ import {
   NAV_SECTIONS,
   TOP_LEVEL_DASHBOARD,
   isDomainActive,
+  isDomainVisible,
   visibleDomains,
   visibleSections,
   flattenNavigation,
@@ -51,6 +52,7 @@ describe('navigationConfig', () => {
       'pharmacy',
       'transport',
       'staffing',
+      'home',
       'analytics',
       'improvement',
       'integrations',
@@ -71,9 +73,9 @@ describe('navigationConfig', () => {
     }
   });
 
-  it('registers exactly eight workspace domains in the workspaces section', () => {
+  it('registers exactly nine workspace domains in the workspaces section', () => {
     const workspaces = NAV_SECTIONS.find((s) => s.key === 'workspaces')!;
-    expect(workspaces.domains).toHaveLength(8);
+    expect(workspaces.domains).toHaveLength(9);
     expect(workspaces.domains.map((d) => d.key)).toEqual([
       'rtdc',
       'emergency',
@@ -83,6 +85,7 @@ describe('navigationConfig', () => {
       'pharmacy',
       'transport',
       'staffing',
+      'home',
     ]);
   });
 
@@ -98,7 +101,17 @@ describe('navigationConfig', () => {
       pharmacy: '/pharmacy',
       transport: '/transport/dispatch',
       staffing: '/staffing',
+      home: '/home/census',
     });
+  });
+
+  it('hides the Home Hospital domain unless the home_hospital feature is on', () => {
+    const home = NAVIGATION.find((d) => d.key === 'home')!;
+    expect(isDomainVisible(home, { isAdmin: false })).toBe(false);
+    expect(isDomainVisible(home, { isAdmin: false, features: { home_hospital: false } })).toBe(false);
+    expect(isDomainVisible(home, { isAdmin: false, features: { home_hospital: true } })).toBe(true);
+    // Admin does not bypass the feature flag — nav and route gate must agree.
+    expect(isDomainVisible(home, { isAdmin: true })).toBe(false);
   });
 
   it('keeps administration out of the top-level section controls', () => {

--- a/tests/js/config/navigationConfig.test.ts
+++ b/tests/js/config/navigationConfig.test.ts
@@ -101,7 +101,7 @@ describe('navigationConfig', () => {
       pharmacy: '/pharmacy',
       transport: '/transport/dispatch',
       staffing: '/staffing',
-      home: '/home/census',
+      home: '/home/command',
     });
   });
 


### PR DESCRIPTION
## Summary

Implements the **Home Hospital (HOME)** workspace end-to-end per [ACUM-PRD-HAH-001](docs/home-hospital/Zephyrus_Hospital_at_Home_Strategy_and_Design.md) and its codebase-reconciled [build brief](docs/home-hospital/HOME-HOSPITAL-BUILD-PROMPT.md): an acute Hospital-at-Home virtual ward run as *one more altitude of the same instrument* — sharing the census spine, cockpit, alerting, Eddy governance, and Arena process mining. The differentiator is capacity unification: the RTDC huddle now shows home-eligible census next to boarding, with every home episode-day accounted as an avoided occupied bed-day.

Everything ships behind `HOME_HOSPITAL_ENABLED` (default **off**): routes 404, nav hides, the cockpit domain is absent, seeds no-op, and every payload is byte-identical to today.

### Phase 0 · Foundation
- 11 `prod` tables (`home_programs/referrals/episodes`, `rpm_kits/devices/enrollments/observations/alerts`, `home_visits/escalations/transitions`) on house conventions; `rpm_observations` deliberately **unpartitioned** (brief §13 Q5 default, retention note in the migration header)
- Virtual ward = a `prod.units` row (`type=virtual_home`) with beds as program slots — census/huddle machinery unmodified; deliberately **not** in the HospitalManifest (RtdcSeeder soft-trim exempts it) so physical denominators never absorb virtual slots
- Feature gating (config + `EnsureHomeHospitalEnabled` + Inertia `features.home_hospital` + domain-level `requiredFeature` in the nav SSOT), Virtual Bed Board, `SyntheticRpmConnector` (full control-plane lifecycle)

### Phase 1 · Observability MVP
- **HEWS**: deterministic modified NEWS2 + first-24h baseline deviation + trend + adherence — transparent components, operational-triage labeling (never diagnosis)
- Patient alerting with personalized thresholds, one-open-alert-per-rule dedupe, human-recorded ack/resolve; escalation timing chain (`initiated→dispatched→arrived→resolved`); **ADT close-loop**: an admit/register for an escalated home patient resolves the escalation `ed_return`
- Cockpit `home` domain (9 seeded KPIs; Earned-Red ration = 4 alerting rows), `?drill=home`, crit `home.*` → draft-only Eddy `propose_escalation_response`; `/home/command` episode grid sorted by escalation risk (coral only for an unacked critical vital); FHIR US Core Observation persistence

### Phase 2 · Transitions
- `/home/referrals`: live ED (stable-ESI boarders first) + step-down worklists; strict funnel with coded declines; activation claims a locked slot, opens encounter+episode, assigns kit, starts the inbound checklist
- `/home/transitions`: inbound checklists; outbound handoffs via `transport_requests` (`care_transition`) — SNF destinations ride `RegionalTransferService::decide()` (guard widened additively) for a scored `regional.transfer_decisions` row with opportunity-cost payload; routine discharge auto-enrolls the **30-day post-discharge cohort** at step-down cadence
- `/home/logistics`: waiver compliance rail, per-clinician routes, kit inventory — **the single address-permitted surface** (leakage grep-tested on every other endpoint)

### Phase 3 · Intelligence & compliance
- **Home decant line** on the RTDC Global Huddle (home-eligible counts + free-slot forecast next to boarding); forecast upserted into `prod.rtdc_predictions`; `home_slot_free` forward-projection stream
- OCEL projection (`Home Episode`/`RPM Kit`/`Home Visit`/`Escalation` objects, `home-*` verbs) + **Arena `home_hospital` conformance pathway** (referral→activation 24h SLA, 2-visits/day waiver cadence, escalation protocol) — verified against the live pm4py sidecar venv
- All 7 draft-only Eddy actions (the Post-Acute & Care Transition Agent catalog)
- `php artisan home:cms-export`: AHCAH waiver + 2028-study measures incl. the equity block (decline reasons, activation rate by payer, zone) with national benchmarks attached

### Decisions needing reviewer eyes (also in [DEVLOG](docs/DEVLOG-home-hospital-2026-07-17.md))
1. `rpm_observations` unpartitioned + documented retention (no silent new convention)
2. Virtual ward excluded from the HospitalManifest; RtdcSeeder exemption instead
3. Bed slot states map onto the existing CHECK (`dirty` = pending kit setup on this unit)
4. `RegionalTransferService::decide()` guard widened to accept `care_transition`
5. §13 open questions taken at recommended defaults (conditions, 12 slots/3 zones, staffing-agnostic, synthetic vendor, payer matrix placeholder)

## Test plan
- [x] 34 Home Feature tests (262 assertions): gating 404s + flag-off no-ops, seeder idempotency (incl. across the UTC-midnight window), RPM ingest end-to-end / idempotent replay / dead-letter, HEWS determinism, alert dedupe + human-recorded ack, escalation chain + ADT `ed_return` close, referral traverse → episode on the virtual unit, SNF handoff → scored transfer decision, 30-day cohort cadence, **address confinement grep across all non-logistics endpoints**, decant + predictions, `home_slot_free` on/off, 7 draft-only Eddy actions, OCEL pathway on/off, CMS export variables + pseudonymity
- [x] Cockpit + Eddy regression suites green (165/166; the 1 was a worktree `.env.testing` artifact, green after env fix — the pinned 8-domain roster remains the flag-off contract)
- [x] Full vitest 531 (nav roster now 9 workspace domains + feature-gate visibility test); `tsc --noEmit`; `vite build`; `scripts/check-ui-canon.sh` (raw-palette ratchet unchanged); Pint
- [x] Arena pathway logic executed in the real sidecar venv (`/opt/arena-sidecar`): conformant/deviant split + all deviation codes exact
- [x] Dev-DB smokes: cockpit tiles honest (1 crit unacked vital, p90 27min), drill tables, CMS export real numbers, demo seeder run repeatedly incl. through the UTC-midnight boundary
- [ ] Manual browser walkthrough of the six surfaces + huddle decant line (serve via `php -S 127.0.0.1:8012 -t public`; note port 8001 is the Eddy service)
- [ ] Prod enablement AFTER merge per decision: set `HOME_HOSPITAL_ENABLED=true` in prod `.env`, run the 3 migrations via `--path`, `zephyrus:demo-seed`-style seed of `HomeHospitalDemoSeeder`, restart php-fpm — manual-only as always