### PR TITLE
feat: 4D Navigator Phase 0 — barrier-toggle truth, time navigation, long-session correctness

### DIFF
--- a/docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md
+++ b/docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md
@@ -1,0 +1,289 @@
+# Patient Flow 4D Navigator — Deep Review & Advancement Plan
+
+**Date:** 2026-07-18
+**Surface:** `/rtdc/patient-flow-navigator` (Pages/RTDC/PatientFlowNavigator.tsx → Components/PatientFlowNavigator/*)
+**Scope:** Navigability, element legibility, the dual Barrier toggles, Virtual Rounds integration, long-session correctness.
+**Related plans:** `docs/hummingbird/FLOW-WINDOW-PLAN.md` (shipped Phases 0–5), `docs/superpowers/plans/2026-07-11-virtual-rounds-4d-eddy-implementation-plan.md` (§5.2 guided camera — unbuilt).
+
+---
+
+## 1. Executive Summary
+
+The 4D Navigator is architecturally sound — a thin React orchestrator, a lazy-chunked three.js scene, bucketed rebuilds, a disciplined 48h Chronobar, and correct lens/identity redaction. Its problems are **legibility and connection**, not engineering:
+
+1. **The scene has a rich shape grammar nobody can learn.** Six shape vocabularies (sphere / line / disk / pip / diamond / ring / pillar) encode six data concepts, but there is no legend, no hover feedback, and no selection highlight. A first-time operator sees colored geometry with no key.
+2. **The building itself is illegible.** The GLB carries 1,472 nodes with full semantic extras — `corridor`, `patient_room`, `bed`, `care_unit`, `emergency_department`, `imaging`, `procedure_room`, `elevator`, `helipad`, plus clinical attributes (ICU-capable, telemetry, negative-pressure) — yet the renderer paints everything one translucent gray (floors 0.56, all else 0.72). Hallways, beds, and rooms are visually identical.
+3. **The two "barrier" controls are two different data concepts sharing one word** (see §3). The split is deliberate (HFE wrong-toggle fix) but the naming and grouping still invite confusion.
+4. **Patient token colors violate the earned-urgency ration.** `hashColor()` assigns any hue 0–360, so a patient can randomly render coral or amber — the colors reserved for breach and warning.
+5. **Virtual Rounds and the 4D scene are disconnected.** The rounds layer renders rings, but `focusRoundStop()` is dead code (zero call sites), there is no link in either direction between the Rounds board and the navigator, the overlay is fetched once and goes stale during an active round, and the promised guided tour (§5.2) does not exist.
+6. **Long sessions drift.** `nowMs` is frozen at mount; after hours on a wall display the gold now-marker, ghost gating, and barrier severity are all wrong. Barriers and projections are fetched once, never refreshed.
+
+The plan below fixes these in five phases, each independently shippable.
+
+---
+
+## 2. Current State — Architecture Map
+
+| Piece | File | Role |
+|---|---|---|
+| Page wrapper | `resources/js/Pages/RTDC/PatientFlowNavigator.tsx` | DashboardLayout `fullBleed`; passes `flowLens` + `flowUnits` Inertia props |
+| Orchestrator | `resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx` | Data fetching, 48h time model, playback/live, filters, layer state, inspector redaction |
+| Scene | `resources/js/Components/PatientFlowNavigator/NavigatorScene.ts` | Only importer of `three`; lazy chunk; 7 layers (forecast, heat, trails, ghosts, patients, barriers, rounds) |
+| Toolbar | `NavigatorToolbar.tsx` | Source status, chronobar slot, transport buttons, filters, layer switches, metrics, occupancy rollup |
+| Chronobar | `NavigatorChronobar.tsx` | 48h window, shift detents, coverage band, barrier ticks, forecast HUD |
+| Inspector / Feed | `NavigatorInspector.tsx`, `NavigatorFeed.tsx` | Click-to-inspect key/value panel; recent-event feed |
+| Placement logic | `features/patientFlowNavigator/projections.ts` | Placement index, ghost selection, barrier cells + severity |
+| Occupancy | `features/patientFlowNavigator/occupancyInsights.ts` + server `/occupancy` | Disk + timer-pip insight model |
+| Rounds overlay | `features/virtualRounds/roundsScene.ts` | `buildRoundStopCells`, `ROUND_STOP_COLORS` |
+| Backend | `PatientFlowController` (`/api/patient-flow/*`), `RoundRunController::scene()` (`/api/rounds/runs/{uuid}/scene`) | Locations from `hosp_space.facility_spaces`; barriers from `prod.barriers`; stops patient-free |
+| Model | `public/facility-models/zep-500/hospital_model.glb` (771 KB, 1,472 nodes / 30 meshes) | glTF `extras` → `Object3D.userData` (already proven: the `floor` opacity branch reads it) |
+
+**Current scene vocabulary (undocumented, in-code only):**
+
+| Shape | Layer | Meaning | Color rule |
+|---|---|---|---|
+| Sphere (r 1.65) | patients | Patient token | `hashColor(patientId)` — any hue ⚠ |
+| Line | trails | Patient movement history | same hash color, 0.55 α |
+| Flat cylinder disk | heat | Occupancy + stay duration (radius = √stay-hours) | green ok / amber watch / coral delayed |
+| Tiny pip cylinder ×4 | heat | Individual timers around a disk | same status colors |
+| Translucent sphere | ghosts | Future projection (discharge / transport / EVS / OR case) | teal / sky / light-sky / blue, opacity = confidence |
+| Translucent pillar | forecast | Predicted census per unit (height = census) | cyan |
+| Octahedron (diamond) | barriers | Registered open barrier (`prod.barriers`) | sky <24h / amber ≥24h / coral ≥48h open-age |
+| Torus ring (flat) | rounds | Virtual Rounds stop | slate/blue/amber/sky/teal by status; amber ring = pinned |
+
+This table does not exist anywhere a user can see. That is finding E-1.
+
+---
+
+## 3. The Two Barrier Toggles — Investigation & Verdict
+
+**Answer to "there are two for some reason?":** yes, deliberately — they control different things — but the execution still confuses.
+
+| Control | Identity | What it actually does |
+|---|---|---|
+| **"Barriers"** layer switch (`flow-layer-barriers`, added in `layerControls`, PatientFlowNavigator.tsx:364) | A **visibility toggle** for one scene layer | Shows/hides the floating octahedron markers of *registered operational barriers* — real `prod.barriers` rows (category medical/logistical/placement/social, owner, reason code) fetched from `/api/patient-flow/barriers`. Severity is earned from open-age (projections.ts:143 — ≥48h coral, ≥24h amber, else sky). |
+| **"Find barriers"** switch (`flow-barrier-finder`, NavigatorToolbar.tsx:214–225) | A **filter + camera mode**, not a layer | Filters the *census/occupancy disks* down to locations matching `isBarrierOrDelay()` (PatientFlowNavigator.tsx:228 — status ≠ ok, blockers present, or any timer late), rewrites the "Active" metric denominator (line 493), and **auto-flies the camera** to the delayed set on enable (lines 522–527). It operates on elapsed-timer *signals*, which the toolbar itself disclaims: *"Elapsed occupancy signal; not a verified operational barrier"* (NavigatorToolbar.tsx:247). |
+
+The comment at NavigatorToolbar.tsx:222 shows the split already survived one HFE audit (two controls must never share one accessible name). The **residual defects**:
+
+- **B-1 (High):** Near-synonym labels for different data concepts. "Barriers" = logged operational barriers; "Find barriers" = *delays*. A charge nurse cannot predict which switch does what, and the word "barrier" is used for both the verified and the unverified signal.
+- **B-2 (Medium):** "Find barriers" sits **inside the Layers fieldset** though it is not a layer — it's a census filter. Wrong grouping teaches the wrong mental model.
+- **B-3 (Medium):** Enabling it silently changes the meaning of the "Active" metric and hides non-delayed disks — with no visible "filtered" state beyond the switch itself.
+- **B-4 (Low):** The camera auto-fly is a hidden side effect of a checkbox. Checkboxes should not move the camera.
+
+**Remediation (Phase 0):**
+1. Rename "Find barriers" → **"Delayed only"** and move it out of the Layers fieldset into the filter grid (next to Floor/Service/Event), presented as a census-scope control: `Census: All | Delayed`. Keep distinct ids/names.
+2. Keep the "Barriers" layer switch as-is but retitle its tooltip: *"Logged operational barriers (diamond markers)"*.
+3. When Delayed-only is active, show a dismissible **filter chip** near the metrics block: `Filtered: delayed locations only (N)` — the metric relabels from "Active" to "Delayed".
+4. Replace the auto-fly with an explicit **"Focus delayed"** button (icon: ScanSearch) enabled while the filter is on; first enable may still offer one fly via the button's pulse, never via the checkbox.
+
+---
+
+## 4. Findings Catalog
+
+Severity: **H**igh (blocks comprehension/decisions) / **M**edium (slows or misleads) / **L**ow (polish).
+
+### E — Element legibility
+- **E-1 (H):** No legend/key anywhere. Shape+color grammar (table §2) is unlearnable in-product. → Phase 1.
+- **E-2 (H):** Base model renders all categories identically; GLB extras (`category`, `unit_code`, `service_line`, `bed_code`, acuity flags) are already in `userData` but unused except `floor`/`elevator`. Hallway vs room vs bed vs ED indistinguishable. → Phase 1.
+- **E-3 (H):** `hashColor()` (NavigatorScene.ts:862) can assign coral/amber hues to patient tokens, colliding with the status ration ("when something turns coral, it means it" — DESIGN.md). → Phase 1.
+- **E-4 (M):** No hover affordance — raycast only on `pointerdown`. Users cannot discover what is clickable; nothing names an element until after a click. → Phase 1.
+- **E-5 (M):** No in-scene selection highlight — clicking populates the inspector but the scene shows nothing (rounds focus is the only exception). → Phase 1.
+- **E-6 (M):** No in-scene labels: 16 floors, 23 care units, zero signage. Unit identity only appears after clicking a disk. → Phase 2.
+- **E-7 (L):** Status is color-coded in-scene without a paired shape/label cue at the mesh level (canon: never color alone). The severity *is* shape-scaled (`BARRIER_SCALE`) and the inspector carries labels, but disks rely on color only. Legend + hover chips (E-1/E-4) are the compensating controls; note in legend copy. → Phase 1.
+
+### N — Navigability
+- **N-1 (H):** No **"Now"** button. Once scrubbed, returning to the present requires pixel-precise slider dragging. → Phase 0.
+- **N-2 (M):** Chronobar shift detents and barrier ticks are `aria-hidden` decorations — not clickable, not focusable. They look like affordances and aren't. → Phase 0.
+- **N-3 (M):** Camera readout is raw `x/y/z` (NavigatorScene.ts:710) — operator-hostile debug text. Should read like a place: `Floor 3 · 3W Med-Surg`. → Phase 0.
+- **N-4 (M):** Floor selection is a small dropdown; no fast floor stepping, no fit-to-floor on change, no keyboard path for the primary spatial filter. → Phase 2.
+- **N-5 (M):** Search filters tokens but never moves the camera; no result count; Enter does nothing. → Phase 2.
+- **N-6 (L):** No double-click-to-focus, no keyboard shortcuts (Home/F/?, arrows), no shortcut help. → Phase 2.
+- **N-7 (L):** No saved views (persona-relevant camera bookmarks: ED, ICU, Home). → Phase 2.
+- **N-8 (L):** "Live" Radio button streams a **stored replay** (honest in the status bar, less so on the button). Retitle "Replay stream". → Phase 0.
+
+### R — Virtual Rounds
+- **R-1 (H):** `focusRoundStop()` (NavigatorScene.ts:584) has **zero call sites** — the guided-camera seam shipped and was never wired. → Phase 3.
+- **R-2 (H):** No path from Rounds board → 4D (no "Locate in 4D") and no path from a 4D ring → Rounds board (inspector shows the opaque uuid and stops there). → Phase 3.
+- **R-3 (M):** Rounds overlay is a one-shot fetch on mount (PatientFlowNavigator.tsx:665–692) while the Rounds board polls at 30 s (`features/virtualRounds/hooks.ts:57`). During an active run the rings show stale statuses. → Phase 3.
+- **R-4 (M):** Queue order (`queue_position`) is invisible in-scene — no numbering, no route. A rounder cannot see the itinerary spatially. → Phase 3.
+- **R-5 (M):** No run-progress HUD in the navigator (run status, N of M rounded, awaiting-input count). → Phase 3.
+- **R-6 (L):** Guided tour (auto-stepping camera per §5.2 of the rounds plan) unbuilt; Eddy tour runner unbuilt (deferred — see Phase 4). 
+
+### S — System / long-session correctness
+- **S-1 (H):** `nowMs` frozen at mount (PatientFlowNavigator.tsx:243). Now-marker, `ghostsAt` gating, forecast gating, and barrier open-age severity all drift on long-lived sessions (prod is a 6h-refresh demo wall). → Phase 0.
+- **S-2 (M):** Barriers fetched once (no polling); projections fetched once. Occupancy already refetches on time change. → Phase 0.
+- **S-3 (L):** Mobile: toolbar may cover 64% of the viewport; feed/metrics/rollup hidden. Acceptable triage today; collapsible accordion later. → Phase 4.
+
+---
+
+## 5. Design — Element Identity System (Phase 1)
+
+Goal: **any operator can name any element within 5 seconds**, via three reinforcing mechanisms: differentiated materials, a legend, and hover identification. All colors stay inside the operational family (slate/blue/sky/teal); amber/coral remain status-only; gold remains focus-only; crimson never enters the scene.
+
+### 5.1 Single source of truth: `sceneVocabulary.ts`
+New module `resources/js/features/patientFlowNavigator/sceneVocabulary.ts` exporting every shape/color constant currently scattered in NavigatorScene.ts (`BARRIER_COLORS`, `GHOST_COLORS`, occupancy/timer/forecast material params, `ROUND_STOP_COLORS` re-export) **plus** the new base-category palette, each entry carrying `{ key, label, shape, colorHex, description }`. NavigatorScene consumes it for materials; the legend renders from it. One edit updates both — the legend can never lie.
+
+### 5.2 Base-model category materials
+In `loadModel()` traversal, replace the two-way opacity split with a category material map (mesh.userData.category is already populated from glTF extras):
+
+| Category | Treatment (dark scene, additive to base 0x-gray) | Rationale |
+|---|---|---|
+| `floor` | current beige-gray, α 0.56 | unchanged datum plane |
+| `corridor` | darker, desaturated slate, α 0.35 | circulation reads as negative space |
+| `patient_room` | neutral slate, α 0.60 | the default "room" |
+| `bed` | slate-**blue** tint, α 0.85, subtle emissive | the care asset — most important base element |
+| `care_unit` | very low-α unit shell tint | grouping, not object |
+| `emergency_department` | **sky** tint, α 0.55 | high-tempo zone identity |
+| `imaging` / `procedure_room` / `procedure_support` | **blue** tint, α 0.55 | interventional zones |
+| `elevator` | light neutral, α 0.85 (already always-visible) | vertical circulation landmark |
+| `helipad` / `support_infrastructure` | dim neutral | context only |
+
+Implementation: category → `MeshStandardMaterial` cache (mirrors existing material caches); fall back to today's 0.72 default for unknown categories. **No backend change required.**
+
+### 5.3 Patient token palette fix
+Constrain `hashColor()` hue to **160°–280°** (teal → blue → violet): `hue = 160 + (hash % 120)`. Tokens stay individually distinguishable but can never impersonate amber/coral status. (Alternative considered — color by service line — rejected for v1: trails need per-patient identity continuity; service line already lives on the disks and inspector.)
+
+### 5.4 Legend panel (`NavigatorLegend.tsx`)
+- Collapsible overlay (default collapsed to a `Key` pill, bottom-left above the status bar; expanded ≈ 260 px panel).
+- Renders from `sceneVocabulary.ts`: one row per element — shape glyph (small inline SVG: circle / line / disk / diamond / ring / pillar / pip), color chip, label, one-line description. Sections: *People & movement*, *Occupancy & timers*, *Barriers*, *Forecast*, *Rounds*, *Building*.
+- Status colors always shown **with their worded meaning** (canon: never color alone).
+- Styles appended to the existing `PatientFlowNavigator.css` (no new backdrop-blur file — the canon script gates NEW files; this CSS already carries the overlay treatment).
+- Rows for layers currently toggled off render dimmed with "(hidden)".
+
+### 5.5 Hover + selection
+- **Hover:** throttled (≥50 ms) `pointermove` raycast against the same interactive set as `onPointerDown`. On hit: `cursor: pointer`, emissive-intensity boost via a shared hover clone (the focused-round-material pattern at NavigatorScene.ts:608 already proves the clone-and-dispose approach), and a lightweight HTML chip near the cursor: `{elementLabel} · {name}` (e.g. `Bed · 5-212`, `Open barrier · EVS delay`, `Round stop · queued`). Chip text comes from `sceneVocabulary` + userData; no identity fields ever (lens redaction applies before display).
+- **Selection:** persist the highlight on the clicked object until the next selection/Escape; inspector title gains the element-type prefix so panel and scene agree.
+- Perf guard: raycast skips when pointer is over an overlay panel; hover disabled while `playing` at >60×.
+
+---
+
+## 6. Design — Navigability (Phases 0 & 2)
+
+### 6.1 Time navigation (Phase 0)
+- **"Now" button** on the chronobar row (gold accent, `SkipForward`-style icon): `onScrub(nowMs)` + disconnect replay. Disabled in historical mode.
+- **Clickable detents & barrier ticks:** convert to `<button>`s with aria-labels ("Jump to Fri 07:00 shift change", "Jump to barrier opened 14:32"); click scrubs to that instant.
+- **Relabel** the Radio button: title "Stream stored replay", active label "REPLAY".
+
+### 6.2 Spatial context (Phase 0)
+Replace the `x y z` readout with **place context**: on camera settle (existing 150 ms throttle), find the nearest unit centroid to `orbit.target` within its floor → `Floor 3 · 3W Med-Surg` (from `placementIndex.unitAnchors` + `flowUnits` names). Raw xyz moves to the title attribute for debugging.
+
+### 6.3 Floor & search (Phase 2)
+- **Floor stepper:** compact vertical rail (right edge, `B2 B1 1 2 … PH | All`), current floor highlighted, click or ↑/↓ (when focused) to step; changing floor triggers **fit-to-floor** (bbox of that floor's locations via `focusOn`). The dropdown stays for form-based selection; both drive the same filter.
+- **Search fly-to:** Enter in the Find field flies to the bbox of matched states; show `N matches` under the field; Escape clears. No match → shake-free inline "0 matches — check spelling or floor filter".
+- **Keyboard map + help:** `H` home, `F` focus selection, `N` now, `?` opens a shortcut sheet (reuses legend panel chrome). Document OrbitControls' built-in arrow-key panning.
+- **Saved views:** 3 slots in `localStorage` keyed by persona (`flow4d.views.{role}`): save current camera+floor+layers; render as small chips under the transport buttons.
+
+---
+
+## 7. Design — Virtual Rounds Integration (Phase 3)
+
+Make the navigator a **first-class rounding surface**: see the itinerary, walk it, and jump between board and building in one click. All payloads stay patient-free (opaque `round_patient_uuid` only — plan §8.1 doctrine unchanged).
+
+### 7.1 Bidirectional deep links
+- **Navigator accepts `?focus_stop={uuid}`** (extend `parseHandoff()`): after stops load, call `focusRoundStop(uuid)`; if unplaceable (wrong floor/no anchor), clear the floor filter and retry once, else toast "Stop not placeable — open the board".
+- **Rounds board → 4D:** "Locate in 4D" icon-button per patient row in `RoundsBoard.tsx` / `RoundPatientWorkspace.tsx` → `/rtdc/patient-flow-navigator?focus_stop={uuid}`.
+- **4D ring → board:** the round-stop inspector gains an action link "Open in Rounds board" → `/rtdc/virtual-rounds?patient={uuid}` (board already deep-links patient workspaces; wire the query param if absent).
+
+### 7.2 Rounds HUD + itinerary rendering
+- **Rounds HUD chip** (top of toolbar when a run is loaded): run status, `rounded / total`, awaiting-input count, colored by run state (never coral).
+- **Queue numbering:** small billboard sprite (`1`, `2`, …) above each ring from `queue_position`; skipped/deferred render dimmed without numbers.
+- **Route polyline:** a low-α slate line connecting stops in queue order per floor (cross-floor legs dashed & dropped at the elevator node). This is stable-ordering visualization, **not** path-finding (the rounds plan explicitly defers routing graphs).
+
+### 7.3 Guided tour mode (manual first, Eddy later)
+- HUD gains `◀ Prev · Next ▶` plus `Auto` (10 s dwell, pauses on any user camera input — respect the operator's hand).
+- `Next` advances by queue order among placeable stops, calls `focusRoundStop`, and updates the inspector with that stop's payload.
+- Tour state is client-only; no `tours` table needed for v1. The Eddy-narrated tour (structured evidence per stop, checkpoint persistence) remains Phase 4 / the separate rounds plan.
+
+### 7.4 Freshness
+- Poll `GET /api/rounds/runs/{uuid}/scene` every **30 s** while a run is loaded (mirror `hooks.ts:57`), diff by `round_patient_uuid`, rebuild the layer only on change (bucket key already covers `roundStops.length`; extend with a content hash). Reverb channel upgrade deferred to Phase 4.
+- Run completion → HUD announces "Run complete", rings fade to rounded/dim, polling stops.
+
+---
+
+## 8. Design — Long-Session Correctness (Phase 0)
+
+- **S-1 nowMs drift:** hold `nowMs` in state, refreshed every 60 s (`setInterval`); chronobar window recomputes `[now−24h, now+24h]` in live-follow only when the user is *at* now (|current−now| < 90 s) so a deliberate scrub position is never yanked. Barrier severity and ghost gating consume the fresh value automatically once it flows from state.
+- **S-2 polling:** barriers every 120 s; projections every 5 min; both keep the existing fail-soft catch (empty overlay, never a dead navigator). Add `document.visibilityState` gating so background tabs don't poll.
+
+---
+
+## 9. Implementation Plan & TODO
+
+Each phase is independently shippable and PR-sized. Frontend checks per project canon: `npx tsc --noEmit` **and** `npx vite build` (stricter), `scripts/check-ui-canon.sh`, then `./deploy.sh --frontend`.
+
+### Phase 0 — Truth & quick wins (≈1 day) `feature/flow4d-phase0-truth` — **BUILT 2026-07-18**
+- [x] B-1/B-2: rename "Find barriers" → "Delayed only"; move from Layers fieldset to the filter grid as `Census: All | Delayed` segmented control (distinct ids preserved: `flow-census-all` / `flow-census-delayed`)
+- [x] B-3: active-filter chip `Filtered: delayed locations only (N)`; metric label "Active" → "Delayed" while filtered
+- [x] B-4: remove checkbox auto-fly; add explicit "Focus" button on the filter chip (rendered only while filtered)
+- [x] N-1: "Now" button on chronobar (disabled when historical)
+- [x] N-2: detents + barrier ticks become focusable jump buttons with aria-labels
+- [x] N-3: camera readout → `Floor · Unit` place context (xyz demoted to title attr; wide framing reads `House view` / `Floor N · overview`)
+- [x] N-8: "Live" → "Replay stream" labeling (button retitled "Stream stored replay"; chronobar shows `Replay stream ·` while connected)
+- [x] S-1: `nowMs` state + 60 s refresh; gated live-follow window slide (skipped while historical, playing, or scrubbed >90 s from now); scene no longer torn down on window changes (onFrame reads refs)
+- [x] S-2: poll barriers (120 s) + projections (5 min) with visibility gating
+- [x] Tests: chronobar jump buttons + Now button, `barrierSeverity` with moving now, filter-chip render + census scope + replay labeling (new `NavigatorToolbar.test.tsx`)
+
+**Acceptance:** an operator can always return to now in one click; the two barrier controls are visually and verbally distinct concepts; a 6-hour-old wall session shows correct now/severity.
+
+### Phase 1 — Element Identity System (≈2–3 days) `feature/flow4d-element-identity`
+- [ ] E-2: `sceneVocabulary.ts` (labels, shapes, hexes, descriptions) consumed by NavigatorScene materials
+- [ ] E-2: category material map in `loadModel()` per §5.2 (corridor/patient_room/bed/ED/imaging/elevator/care_unit tints)
+- [ ] E-3: clamp `hashColor` hue to 160–280°
+- [ ] E-1: `NavigatorLegend.tsx` collapsible key rendered from `sceneVocabulary` (sections, worded status meanings, hidden-layer dimming); styles in existing CSS file (no new backdrop-blur file)
+- [ ] E-4: throttled hover raycast + cursor + emissive hover clone + element chip (lens-redacted)
+- [ ] E-5: persistent selection highlight + element-type prefix in inspector title; Escape clears
+- [ ] Tests: sceneVocabulary completeness (every scene layer has a legend entry — assert key parity), hue-clamp property test, legend render & collapse
+
+**Acceptance:** with no training, a user can point at any object, hover it, and read what it is; beds/hallways/rooms/ED are visually distinct; no patient token renders in amber/coral hues.
+
+### Phase 2 — Navigability (≈2 days) `feature/flow4d-navigability`
+- [ ] N-4: floor stepper rail with fit-to-floor, keyboard stepping, synced to filter
+- [ ] N-5: search Enter → fly-to matches; match count; empty-state copy
+- [ ] N-6: keyboard shortcuts (H/F/N/?) + shortcut sheet
+- [ ] N-7: 3 persona-keyed saved views (localStorage), chips under transport buttons
+- [ ] Tests: floor-stepper filter sync, search match-count, saved-view round-trip
+
+**Acceptance:** floor changes are one click/keystroke and frame the floor; search lands the camera on results; power users never touch the mouse for time/floor/focus.
+
+### Phase 3 — Virtual Rounds (≈2–3 days) `feature/flow4d-rounds-integration`
+- [ ] R-1: `?focus_stop={uuid}` handoff wiring → `focusRoundStop` (+ floor-clear retry + fallback toast)
+- [ ] R-2: "Locate in 4D" in RoundsBoard/RoundPatientWorkspace; "Open in Rounds board" action in round-stop inspector
+- [ ] R-5: Rounds HUD chip (run status, progress, awaiting-input)
+- [ ] R-4: queue-number sprites + per-floor route polyline (dashed cross-floor legs)
+- [ ] R-6a: manual tour Prev/Next/Auto (10 s dwell, pause on camera input)
+- [ ] R-3: 30 s scene polling with content-hash rebuild gating + run-complete handling
+- [ ] Tests: `buildRoundStopCells` ordering, tour advance skips unplaceable/deferred stops, deep-link parsing; Pest: scene endpoint unchanged-contract guard
+- [ ] Verify prod flag posture: overlay must remain invisible when `VIRTUAL_ROUNDS_ENABLED` sub-features are off (existing 404 fail-soft)
+
+**Acceptance:** a rounder can start on the board, jump to the building, walk the itinerary Next-by-Next with live statuses, and jump back — without ever seeing patient identity in the scene layer.
+
+### Phase 4 — Deferred / ambitious (not scheduled)
+- Reverb-pushed rounds + barrier updates (replace polling)
+- Eddy-narrated guided tour w/ checkpoint persistence (`tours` table, per rounds plan §6)
+- Unit-code billboard labels w/ LOD gating; minimap / floor-stack widget
+- Mobile collapsible toolbar accordion (S-3)
+- Cockpit mount-anywhere embed of a read-only navigator face
+- Bed-level clinical-capability lens (ICU-capable / neg-pressure tints from GLB extras) for surge planning
+
+---
+
+## 10. Canon Compliance Guardrails
+
+- **Two-System Rule:** all new tints stay in the blue/slate operational family; gold only for focus (now-marker, focus ring), crimson never in-scene.
+- **Earned urgency:** amber/coral remain exclusively status (timer watch/late, barrier ≥24h/≥48h). The E-3 hue clamp *removes* an existing violation.
+- **Never color alone:** every status color is paired with shape (diamond scale, ring state, disk radius) and worded meaning in legend, hover chip, and inspector.
+- **No new backdrop-blur files:** legend/HUD styles live in `PatientFlowNavigator.css`; no `text-[Npx]` utilities (overlay CSS uses stylesheet font-sizes, ≥11 px matching existing).
+- **Scene hex palette** remains a sanctioned data-driven exception, but every hex is now centralized in `sceneVocabulary.ts` and mirrors the `--critical/--warning/--success/--info` vocabulary.
+- **Identity redaction:** hover chips and tour HUD reuse `redactSelection`; rounds layer stays opaque-uuid-only.
+- **A11y (WCAG 2.2 AA pragmatic):** all new controls are real buttons/inputs with names; chronobar ticks become focusable; the toolbar/inspector remain the non-3D equivalent of scene state.
+
+## 11. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Hover raycast per pointermove on low-end wall hardware | 50 ms throttle, skip during playback >60×, raycast only visible layers |
+| Category materials wash out the status layers | keep base α ≤ 0.85 and emissive ≈ 0; status/barrier/rounds layers keep emissive priority |
+| Window slide (S-1) fighting an operator mid-scrub | slide only when parked at now (<90 s delta) |
+| Rounds polling load | 30 s interval, visibility-gated, stops when run closes |
+| Sweep-style regressions | sequential small PRs on feature branches; no long-lived worktrees (Worktree Agent Protocol) |

--- a/resources/js/Components/PatientFlowNavigator/NavigatorChronobar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorChronobar.tsx
@@ -16,6 +16,8 @@ interface NavigatorChronobarProps {
   forecast: ForecastAggregates | null;
   /** When each open barrier began, for past-half ticks. */
   barrierTicks?: number[];
+  /** True while the stored-replay stream is connected (N-8: never "live"). */
+  replaying?: boolean;
   onScrub: (timeMs: number) => void;
 }
 
@@ -71,6 +73,7 @@ export default function NavigatorChronobar({
   freshness,
   forecast,
   barrierTicks = [],
+  replaying = false,
   onScrub,
 }: NavigatorChronobarProps) {
   const span = Math.max(1, windowEnd - windowStart);
@@ -90,47 +93,71 @@ export default function NavigatorChronobar({
 
   return (
     <div className="patient-flow-chronobar">
-      <output>
-        <span>{fmtTime(currentTime)}</span>
-        <span className={`patient-flow-chronobar-rel ${inFuture ? 'future' : ''}`}>
-          {historical
-            ? `Historical replay · ${relativeLabel(currentTime, nowMs)}`
-            : `${inFuture ? 'Projected · ' : ''}${relativeLabel(currentTime, nowMs)}`}
-        </span>
-      </output>
+      <div className="patient-flow-chronobar-head">
+        <output>
+          <span>{fmtTime(currentTime)}</span>
+          <span className={`patient-flow-chronobar-rel ${inFuture ? 'future' : ''}`}>
+            {historical
+              ? `Historical replay · ${relativeLabel(currentTime, nowMs)}`
+              : `${replaying ? 'Replay stream · ' : ''}${inFuture ? 'Projected · ' : ''}${relativeLabel(currentTime, nowMs)}`}
+          </span>
+        </output>
+        <button
+          type="button"
+          className="patient-flow-chronobar-now-button"
+          disabled={historical}
+          title={historical ? 'Unavailable in historical replay' : 'Jump to now'}
+          onClick={() => onScrub(nowMs)}
+        >
+          Now
+        </button>
+      </div>
 
-      <div className="patient-flow-chronobar-track" aria-hidden="true">
-        <div className="patient-flow-chronobar-past" style={{ width: historical ? '100%' : `${pct(nowMs)}%` }} />
+      {/* Detents and barrier ticks are jump buttons (N-2); the wash layers
+          underneath stay decorative. */}
+      <div className="patient-flow-chronobar-track">
+        <div aria-hidden="true" className="patient-flow-chronobar-past" style={{ width: historical ? '100%' : `${pct(nowMs)}%` }} />
         {!historical && (
           <div
+            aria-hidden="true"
             className="patient-flow-chronobar-future"
             style={{ left: `${pct(nowMs)}%`, width: `${100 - pct(nowMs)}%` }}
           />
         )}
         {coverage && (
           <div
+            aria-hidden="true"
             className="patient-flow-chronobar-coverage"
             style={{ left: `${pct(coverage.start)}%`, width: `${pct(coverage.end) - pct(coverage.start)}%` }}
           />
         )}
-        {detents.map((detent) => (
-          <span
-            key={detent}
-            className="patient-flow-chronobar-detent"
-            style={{ left: `${pct(detent)}%` }}
-            title={new Date(detent).toLocaleString([], { weekday: 'short', hour: '2-digit', minute: '2-digit', second: '2-digit' })}
-          />
-        ))}
+        {detents.map((detent) => {
+          const detentLabel = new Date(detent).toLocaleString([], { weekday: 'short', hour: '2-digit', minute: '2-digit' });
+          return (
+            <button
+              key={detent}
+              type="button"
+              className="patient-flow-chronobar-detent"
+              style={{ left: `${pct(detent)}%` }}
+              title={`Jump to ${detentLabel} shift change`}
+              aria-label={`Jump to ${detentLabel} shift change`}
+              onClick={() => onScrub(detent)}
+            />
+          );
+        })}
         {barrierTicks.map((tick, index) => (
-          <span
+          <button
             key={`barrier-${index}-${tick}`}
+            type="button"
             className="patient-flow-chronobar-barrier"
             style={{ left: `${pct(tick)}%` }}
-            title={`Barrier opened ${fmtTime(tick)}`}
+            title={`Jump to barrier opened ${fmtTime(tick)}`}
+            aria-label={`Jump to barrier opened ${fmtTime(tick)}`}
+            onClick={() => onScrub(tick)}
           />
         ))}
         {!historical && nowMs >= windowStart && nowMs <= windowEnd && (
-          <span className="patient-flow-chronobar-now" style={{ left: `${pct(nowMs)}%` }} title="Now" />
+          <span aria-hidden="true" className="patient-flow-chronobar-now" style={{ left: `${pct(nowMs)}%` }} title="Now" />
         )}
       </div>
 

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -28,9 +28,14 @@ import { formatDurationMinutes, formatRelativeDurationMinutes } from '@/lib/dura
  * are cached and reused across rebuilds.
  */
 
+export interface CameraView {
+  position: { x: number; y: number; z: number };
+  target: { x: number; y: number; z: number };
+}
+
 export interface NavigatorSceneCallbacks {
   onSelect: (data: Record<string, unknown>) => void;
-  onCameraMove: (text: string) => void;
+  onCameraMove: (view: CameraView) => void;
   onFrame: (deltaSeconds: number) => void;
 }
 
@@ -707,11 +712,18 @@ export class NavigatorScene {
   private emitCameraText(): void {
     const now = performance.now();
     if (now - this.lastCameraEmit < 150) return;
-    const text = `x ${this.camera.position.x.toFixed(0)} y ${this.camera.position.y.toFixed(0)} z ${this.camera.position.z.toFixed(0)}`;
-    if (text === this.lastCameraText) return;
-    this.lastCameraText = text;
+    const position = this.camera.position;
+    const target = this.orbit.target;
+    const key = [position.x, position.y, position.z, target.x, target.y, target.z]
+      .map((value) => value.toFixed(0))
+      .join('|');
+    if (key === this.lastCameraText) return;
+    this.lastCameraText = key;
     this.lastCameraEmit = now;
-    this.callbacks.onCameraMove(text);
+    this.callbacks.onCameraMove({
+      position: { x: position.x, y: position.y, z: position.z },
+      target: { x: target.x, y: target.y, z: target.z },
+    });
   }
 
   private materialForPatient(patientId: string): THREE.MeshStandardMaterial {

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -19,6 +19,8 @@ export interface LayerControl {
   key: keyof PatientLayerState;
   label: string;
   id: string;
+  /** Optional tooltip disambiguating the layer (e.g. Barriers vs Delayed). */
+  title?: string;
 }
 
 interface NavigatorToolbarProps {
@@ -43,6 +45,7 @@ interface NavigatorToolbarProps {
   onToggleLive: () => void;
   onResetCamera: () => void;
   onFocusPatients: () => void;
+  onFocusDelayed: () => void;
   onAskEddy: () => void;
   onSpeedChange: (speed: number) => void;
   onFiltersChange: (patch: Partial<PatientFlowFilters>) => void;
@@ -72,6 +75,7 @@ export default function NavigatorToolbar({
   onToggleLive,
   onResetCamera,
   onFocusPatients,
+  onFocusDelayed,
   onAskEddy,
   onSpeedChange,
   onFiltersChange,
@@ -114,7 +118,9 @@ export default function NavigatorToolbar({
         <button
           className={`patient-flow-icon-button ${live ? 'active' : ''}`}
           type="button"
-          title="Stream latest stored events"
+          title="Stream stored replay (not a live feed)"
+          aria-label="Stream stored replay"
+          aria-pressed={live}
           onClick={onToggleLive}
         >
           <Radio />
@@ -195,11 +201,44 @@ export default function NavigatorToolbar({
           value={filters.search}
           onChange={(event) => onFiltersChange({ search: event.target.value })}
         />
+
+        {/* Census scope, not a layer (B-2): "Delayed" filters the occupancy
+            disks by elapsed-timer signal — distinct from the "Barriers"
+            layer's logged prod.barriers markers (B-1). A span, not a label:
+            the radios carry their own names (All / Delayed). */}
+        <span className="patient-flow-control-caption">Census</span>
+        <div
+          className="patient-flow-census-toggle"
+          role="radiogroup"
+          aria-label="Census scope"
+          title="Elapsed occupancy signal; not a verified operational barrier"
+        >
+          <label className={barrierFinder ? '' : 'active'}>
+            <input
+              id="flow-census-all"
+              type="radio"
+              name="flow-census"
+              checked={!barrierFinder}
+              onChange={() => onBarrierFinderChange(false)}
+            />
+            All
+          </label>
+          <label className={barrierFinder ? 'active' : ''}>
+            <input
+              id="flow-census-delayed"
+              type="radio"
+              name="flow-census"
+              checked={barrierFinder}
+              onChange={() => onBarrierFinderChange(true)}
+            />
+            Delayed
+          </label>
+        </div>
       </div>
 
       <fieldset className="patient-flow-layer-grid">
         <legend>Layers</legend>
-        {layerControls.map(({ key, label, id }) => (
+        {layerControls.map(({ key, label, id, title }) => (
           <div className="patient-flow-checkbox-row" key={key}>
             <input
               id={id}
@@ -208,25 +247,36 @@ export default function NavigatorToolbar({
               checked={layers[key]}
               onChange={(event) => onLayerChange(key, event.target.checked)}
             />
-            <label htmlFor={id}>{label}</label>
+            <label htmlFor={id} title={title}>{label}</label>
           </div>
         ))}
-        <div className="patient-flow-checkbox-row">
-          <input
-            id="flow-barrier-finder"
-            type="checkbox"
-            role="switch"
-            checked={barrierFinder}
-            onChange={(event) => onBarrierFinderChange(event.target.checked)}
-          />
-          {/* Distinct from the "Barriers" layer toggle above — two controls must
-              never share one accessible name (HFE audit: wrong-toggle risk). */}
-          <label htmlFor="flow-barrier-finder" title="Highlight every barrier and delay in the scene">Find barriers</label>
-        </div>
       </fieldset>
 
+      {/* B-3: the Delayed-only census scope announces itself and relabels the
+          metric — and the camera flight is an explicit action (B-4). */}
+      {barrierFinder && (
+        <div className="patient-flow-filter-chip" role="status">
+          <span>Filtered: delayed locations only ({metrics.active})</span>
+          <button
+            type="button"
+            title="Fly the camera to the delayed locations"
+            onClick={onFocusDelayed}
+          >
+            Focus
+          </button>
+          <button
+            type="button"
+            aria-label="Clear delayed-only filter"
+            title="Clear delayed-only filter"
+            onClick={() => onBarrierFinderChange(false)}
+          >
+            ×
+          </button>
+        </div>
+      )}
+
       <div className="patient-flow-metrics">
-        <div><span>{metrics.active}</span><small>Active</small></div>
+        <div><span>{metrics.active}</span><small>{barrierFinder ? 'Delayed' : 'Active'}</small></div>
         <div><span>{metrics.events}</span><small>Events</small></div>
         <div><span>{metrics.occupiedLocations}</span><small>Locations</small></div>
         <div><span>{ambient?.summary.eventCount ?? summary?.ambient_signals ?? 0}</span><small>Ambient</small></div>

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -122,6 +122,41 @@
   gap: 6px;
 }
 
+.patient-flow-chronobar-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.patient-flow-chronobar-head output {
+  flex: 1;
+  min-width: 0;
+}
+
+/* One-click return to the present (N-1) — gold, the now/focus accent. */
+.patient-flow-chronobar-now-button {
+  flex: 0 0 auto;
+  border: 1px solid rgba(224, 163, 63, 0.55);
+  border-radius: 5px;
+  background: rgba(224, 163, 63, 0.12);
+  color: #ffd795;
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 9px;
+  cursor: pointer;
+}
+
+.patient-flow-chronobar-now-button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.patient-flow-chronobar-now-button:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
+}
+
 .patient-flow-chronobar output {
   min-height: 20px;
   display: flex;
@@ -173,12 +208,40 @@
   background: rgba(224, 163, 63, 0.45);
 }
 
+/* Shift-change detent — a jump button (N-2): 9px hit area, 1px visual line. */
 .patient-flow-chronobar-detent {
   position: absolute;
   top: 0;
   bottom: 0;
+  width: 9px;
+  margin-left: -4.5px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.patient-flow-chronobar-detent::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
   width: 1px;
+  margin-left: -0.5px;
   background: rgba(239, 234, 220, 0.4);
+}
+
+.patient-flow-chronobar-detent:hover::after,
+.patient-flow-chronobar-detent:focus-visible::after {
+  width: 3px;
+  margin-left: -1.5px;
+  background: #e0a33f;
+}
+
+.patient-flow-chronobar-detent:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px rgba(224, 163, 63, 0.8);
 }
 
 .patient-flow-chronobar-now {
@@ -190,16 +253,41 @@
   background: #e0a33f;
 }
 
-/* Open-barrier opened-at marker: a short amber notch from the top edge. */
+/* Open-barrier opened-at marker — also a jump button (N-2): amber notch
+   visual, full-height amber on hover/focus. */
 .patient-flow-chronobar-barrier {
   position: absolute;
-  top: -2px;
+  top: 0;
+  bottom: 0;
+  width: 9px;
+  margin-left: -4.5px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.patient-flow-chronobar-barrier::after {
+  content: '';
+  position: absolute;
+  top: 0;
   height: 5px;
+  left: 50%;
   width: 2px;
   margin-left: -1px;
   border-radius: 1px;
   background: #eaa640;
   box-shadow: 0 0 3px rgba(234, 166, 64, 0.7);
+}
+
+.patient-flow-chronobar-barrier:hover::after,
+.patient-flow-chronobar-barrier:focus-visible::after {
+  height: 100%;
+}
+
+.patient-flow-chronobar-barrier:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 1px rgba(234, 166, 64, 0.8);
 }
 
 .patient-flow-chronobar input[type='range'] {
@@ -298,6 +386,7 @@
 }
 
 .patient-flow-control-grid label,
+.patient-flow-control-caption,
 .patient-flow-layer-grid legend,
 .patient-flow-checkbox-row label,
 .patient-flow-feed,
@@ -324,6 +413,86 @@
 .patient-flow-icon-button:focus-visible {
   border-color: #64bfd0;
   box-shadow: 0 0 0 2px rgba(100, 191, 208, 0.25);
+}
+
+/* Census scope segmented control (B-2) — a filter, deliberately styled unlike
+   the layer switches so the two "barrier" concepts can't be confused. */
+.patient-flow-census-toggle {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  height: 34px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 6px;
+  overflow: hidden;
+  background: #202522;
+}
+
+.patient-flow-census-toggle label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  cursor: pointer;
+  user-select: none;
+  color: #b9b2a6;
+}
+
+.patient-flow-census-toggle label.active {
+  background: rgba(224, 163, 63, 0.16);
+  color: #ffd795;
+}
+
+.patient-flow-control-grid .patient-flow-census-toggle input[type='radio'] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.patient-flow-census-toggle label:has(input:focus-visible) {
+  outline: 2px solid #e0a33f;
+  outline-offset: -2px;
+}
+
+/* Active-filter chip (B-3): the scene is scoped; say so, offer the exits. */
+.patient-flow-filter-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  border: 1px solid rgba(224, 163, 63, 0.5);
+  border-radius: 6px;
+  background: rgba(224, 163, 63, 0.1);
+  color: #ffd795;
+  font-size: 12px;
+  padding: 5px 8px;
+}
+
+.patient-flow-filter-chip span {
+  flex: 1;
+  min-width: 0;
+}
+
+.patient-flow-filter-chip button {
+  flex: 0 0 auto;
+  border: 1px solid rgba(224, 163, 63, 0.55);
+  border-radius: 5px;
+  background: transparent;
+  color: #ffd795;
+  font-size: 11px;
+  line-height: 1.2;
+  padding: 2px 7px;
+  cursor: pointer;
+}
+
+.patient-flow-filter-chip button:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 1px;
 }
 
 .patient-flow-layer-grid {

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -56,7 +56,7 @@ import type {
 } from '@/features/patientFlowNavigator/types';
 import { occupancyInspectorData } from '@/features/patientFlowNavigator/inspector';
 import type { PageProps } from '@/types';
-import type { NavigatorScene } from './NavigatorScene';
+import type { CameraView, NavigatorScene } from './NavigatorScene';
 import NavigatorChronobar from './NavigatorChronobar';
 import NavigatorFeed from './NavigatorFeed';
 import NavigatorInspector from './NavigatorInspector';
@@ -240,11 +240,16 @@ export default function PatientFlowNavigator({
 }: PatientFlowNavigatorProps) {
   // Fresh sources use the wall-clock 48h window. Stale sources move to an
   // explicit historical window after bootstrap so their replay stays usable.
-  const nowMs = useMemo(() => Date.now(), []);
+  // The mount instant anchors bootstrap; `nowMs` then advances in state every
+  // 60s so now-marker, ghost gating, and barrier open-age severity stay honest
+  // on long-lived wall sessions (S-1).
+  const mountedAtMs = useMemo(() => Date.now(), []);
+  const [nowMs, setNowMs] = useState(mountedAtMs);
+  const nowMsRef = useRef(mountedAtMs);
   const handoff = useMemo(() => parseHandoff(), []);
   const [timeWindow, setTimeWindow] = useState({
-    start: nowMs - LIVE_WINDOW_HALF_MS,
-    end: nowMs + LIVE_WINDOW_HALF_MS,
+    start: mountedAtMs - LIVE_WINDOW_HALF_MS,
+    end: mountedAtMs + LIVE_WINDOW_HALF_MS,
   });
   const windowStart = timeWindow.start;
   const windowEnd = timeWindow.end;
@@ -306,7 +311,8 @@ export default function PatientFlowNavigator({
   const [playing, setPlaying] = useState(false);
   const [live, setLive] = useState(false);
   const [status, setStatus] = useState('Loading');
-  const [cameraText, setCameraText] = useState('');
+  const [cameraPlace, setCameraPlace] = useState('');
+  const [cameraDebug, setCameraDebug] = useState('');
   const [metrics, setMetrics] = useState<NavigatorMetrics>({ active: 0, events: 0, occupiedLocations: 0 });
   const [occupancy, setOccupancy] = useState<OccupancySummary>(EMPTY_OCCUPANCY_SUMMARY);
   const [forecast, setForecast] = useState<ForecastAggregates | null>(null);
@@ -317,12 +323,32 @@ export default function PatientFlowNavigator({
 
   const tracks = useMemo(() => rebuildTracks(events), [events]);
 
+  // S-1: advance wall-clock now every 60s. The ref updates in the same tick so
+  // any repaint that fires before the effects run already sees the fresh value.
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      nowMsRef.current = Date.now();
+      setNowMs(nowMsRef.current);
+    }, 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+
   const dataStart = useMemo(() => (events.length ? parseTime(events[0].occurred_at) : null), [events]);
   const dataEnd = useMemo(
     () => (events.length ? parseTime(events[events.length - 1].occurred_at) : null),
     [events],
   );
   const historical = summary?.source.freshness === 'stale' && dataEnd !== null;
+
+  // Mirrored into refs for the scene's onFrame closure, so the three.js scene
+  // is NOT torn down and rebuilt when the live window slides (S-1) or the
+  // source flips historical after bootstrap.
+  const historicalRef = useRef(false);
+  const windowRef = useRef(timeWindow);
+  useEffect(() => {
+    historicalRef.current = historical;
+    windowRef.current = timeWindow;
+  }, [historical, timeWindow]);
 
   // When each open barrier began, for chronobar ticks (past half only).
   const barrierTicks = useMemo(
@@ -361,7 +387,14 @@ export default function PatientFlowNavigator({
       );
     }
     controls.push({ key: 'heat', label: 'Census', id: 'flow-layer-census' });
-    controls.push({ key: 'barriers', label: 'Barriers', id: 'flow-layer-barriers' });
+    // "Barriers" here = the diamond markers for logged prod.barriers rows —
+    // a different concept from the "Delayed only" census scope (B-1).
+    controls.push({
+      key: 'barriers',
+      label: 'Barriers',
+      id: 'flow-layer-barriers',
+      title: 'Logged operational barriers (diamond markers)',
+    });
     if (!lens || (lens.layers.includes('projections') && lens.projection_kinds.length > 0)) {
       controls.push({ key: 'ghosts', label: 'Forecast', id: 'flow-layer-forecast' });
     }
@@ -374,10 +407,13 @@ export default function PatientFlowNavigator({
   }, [lens, patientDotsVisible, roundStops.length]);
 
   // ---- scene refresh: cheap per-frame tokens, bucketed heavy layers -------
+  // Reads wall-clock now from the ref so the callback identity stays stable
+  // across S-1 ticks (the scene effect must not rebuild three.js every 60s).
   const refreshScene = useCallback(() => {
     const scene = sceneRef.current;
     if (!scene) return;
 
+    const wallNowMs = nowMsRef.current;
     const timeMs = currentTimeRef.current;
     const states = patientStatesAt(tracksRef.current, locationsRef.current, timeMs, filtersRef.current);
     const localOccupancy = buildOccupancyInsights(
@@ -411,6 +447,7 @@ export default function PatientFlowNavigator({
     // layers, or datasets change — not every animation frame.
     const bucketKey = [
       Math.floor(timeMs / 60_000),
+      Math.floor(wallNowMs / 60_000),
       JSON.stringify(filtersRef.current),
       JSON.stringify(layersRef.current),
       barrierFinderRef.current ? 'barriers' : 'all',
@@ -437,7 +474,7 @@ export default function PatientFlowNavigator({
     const index = placementIndexRef.current;
     const floorFilter = filtersRef.current.floor;
     const ghostItems = layersRef.current.ghosts
-      ? ghostsAt(projectionsRef.current, nowMs, timeMs).filter((item) => {
+      ? ghostsAt(projectionsRef.current, wallNowMs, timeMs).filter((item) => {
           if (floorFilter === 'all') return true;
           const floor = floorForProjection(item, index);
           return floor !== null && String(floor) === floorFilter;
@@ -454,7 +491,7 @@ export default function PatientFlowNavigator({
     scene.rebuildGhosts(ghostTokens, layersRef.current.ghosts);
 
     const aggregates = layersRef.current.ghosts
-      ? aggregatesAt(projectionsRef.current, nowMs, timeMs)
+      ? aggregatesAt(projectionsRef.current, wallNowMs, timeMs)
       : null;
     const heatCells = aggregates
       ? [...aggregates.censusByUnit.entries()]
@@ -471,14 +508,14 @@ export default function PatientFlowNavigator({
           })
           .filter((cell): cell is NonNullable<typeof cell> => cell !== null)
       : [];
-    scene.rebuildForecastHeat(heatCells, layersRef.current.ghosts && timeMs > nowMs);
-    setForecast(aggregates && timeMs > nowMs ? aggregates : null);
+    scene.rebuildForecastHeat(heatCells, layersRef.current.ghosts && timeMs > wallNowMs);
+    setForecast(aggregates && timeMs > wallNowMs ? aggregates : null);
     setOccupancy(occupancySummary);
 
     // Open-barrier markers — present-state, so shown at every scrub position
     // (not gated on past/future), just placed on their unit + floor-filtered.
     const barrierCells = layersRef.current.barriers
-      ? buildBarrierCells(barriersRef.current, index, floorFilter, nowMs)
+      ? buildBarrierCells(barriersRef.current, index, floorFilter, wallNowMs)
       : [];
     scene.rebuildBarriers(barrierCells, layersRef.current.barriers);
 
@@ -495,7 +532,7 @@ export default function PatientFlowNavigator({
       occupiedLocations: occupied
         || new Set((barrierFinderRef.current || useServerOccupancy ? visibleOccupancyInsights.map((item) => item.location) : states.map((state) => state.event.to_location)).filter(Boolean)).size,
     });
-  }, [dotsPolicy, lens, nowMs, patientDotsVisible]);
+  }, [dotsPolicy, lens, patientDotsVisible]);
 
   // Keep refs in sync with state, then repaint.
   useEffect(() => {
@@ -515,17 +552,31 @@ export default function PatientFlowNavigator({
     refreshScene();
   }, [events, locations, filters, layers, barrierFinder, projections, barriers, roundStops, speed, playing, live, tracks, placementIndex, refreshScene]);
 
+  // B-4: no camera side effect here — flying to the delayed set is an explicit
+  // "Focus" action on the filter chip, never a consequence of toggling scope.
   useEffect(() => {
     barrierFinderRef.current = barrierFinder;
     lastBucketKeyRef.current = '';
     refreshScene();
-    if (barrierFinder) {
-      const points = lastOccupancyInsightsRef.current
-        .filter(isBarrierOrDelay)
-        .map((item) => item.position);
-      sceneRef.current?.focusOn(points);
-    }
   }, [barrierFinder, refreshScene]);
+
+  // S-1: repaint when wall-clock now advances (the now-minute is part of the
+  // heavy-layer bucket key, so severity and gating rebuild with the fresh now).
+  useEffect(() => {
+    nowMsRef.current = nowMs;
+    refreshScene();
+  }, [nowMs, refreshScene]);
+
+  // Live-follow: slide the 48h window with wall-clock now, but only when the
+  // operator is parked at now — a deliberate scrub position is never yanked,
+  // and a playback sweep passing near now is not "parked".
+  useEffect(() => {
+    if (historical || playingRef.current) return;
+    if (Math.abs(currentTimeRef.current - nowMs) >= 90_000) return;
+    setTimeWindow({ start: nowMs - LIVE_WINDOW_HALF_MS, end: nowMs + LIVE_WINDOW_HALF_MS });
+    currentTimeRef.current = nowMs;
+    setCurrentTime(nowMs);
+  }, [historical, nowMs]);
 
   // Repaint when the displayed time changes. The ref is the source of truth
   // (playback advances it per frame); scrub/live paths write it via applyTime.
@@ -582,6 +633,54 @@ export default function PatientFlowNavigator({
     setCurrentTime(timeMs);
   }, []);
 
+  // N-3: the camera readout speaks place, not xyz — the nearest unit centroid
+  // to the orbit target names what the operator is looking at. Raw coordinates
+  // survive in the status-bar title attribute for debugging.
+  const handleCameraMove = useCallback((view: CameraView): void => {
+    setCameraDebug(
+      `camera x ${Math.round(view.position.x)} y ${Math.round(view.position.y)} z ${Math.round(view.position.z)}`
+      + ` · target x ${Math.round(view.target.x)} z ${Math.round(view.target.z)}`,
+    );
+
+    // Wide framing (home / fit-to-floor distance) is an overview, and naming
+    // the incidentally-nearest unit there would mislead.
+    const range = Math.hypot(
+      view.position.x - view.target.x,
+      view.position.y - view.target.y,
+      view.position.z - view.target.z,
+    );
+    if (range > 150) {
+      const floorFilter = filtersRef.current.floor;
+      setCameraPlace(floorFilter === 'all' ? 'House view' : `Floor ${floorFilter} · overview`);
+      return;
+    }
+
+    const index = placementIndexRef.current;
+    let bestUnitId: number | null = null;
+    let bestDistSq = Number.POSITIVE_INFINITY;
+    for (const [unitId, anchor] of index.unitAnchors) {
+      const dx = anchor.x - view.target.x;
+      const dz = anchor.z - view.target.z;
+      const distSq = dx * dx + dz * dz;
+      if (distSq < bestDistSq) {
+        bestDistSq = distSq;
+        bestUnitId = unitId;
+      }
+    }
+    if (bestUnitId === null) {
+      setCameraPlace('');
+      return;
+    }
+
+    const unit = units.find((candidate) => candidate.unit_id === bestUnitId);
+    const unitLabel = unit?.name
+      ?? unit?.unit_code?.toUpperCase()
+      ?? index.unitCodeById.get(bestUnitId)?.toUpperCase()
+      ?? `Unit ${bestUnitId}`;
+    const floor = index.unitFloors.get(bestUnitId);
+    setCameraPlace(floor !== undefined ? `Floor ${floor} · ${unitLabel}` : unitLabel);
+  }, [units]);
+
   // ---- data bootstrap ------------------------------------------------------
   useEffect(() => {
     let cancelled = false;
@@ -597,7 +696,7 @@ export default function PatientFlowNavigator({
         ]);
         if (cancelled) return;
 
-        const prepared = prepareReplay(summaryData, eventData, nowMs, handoff.t);
+        const prepared = prepareReplay(summaryData, eventData, mountedAtMs, handoff.t);
         const { events: sortedEvents, timeline } = prepared;
         setSummary(summaryData);
         setAmbient(ambientData);
@@ -623,39 +722,62 @@ export default function PatientFlowNavigator({
     return () => {
       cancelled = true;
     };
-  }, [applyTime, handoff.t, nowMs, patientDotsVisible]);
+  }, [applyTime, handoff.t, mountedAtMs, patientDotsVisible]);
 
   // Projection stream (future half) — lens-clamped server-side; a failure
-  // only disables ghosts, never the navigator.
+  // only disables ghosts, never the navigator. Re-polled every 5 min (S-2);
+  // hidden tabs skip the poll and catch up on the visibilitychange that
+  // brings them back.
   useEffect(() => {
     let cancelled = false;
-    fetchPatientFlowProjections(lens ? { persona: lens.role_id } : {})
-      .then((payload) => {
-        if (cancelled) return;
-        const allowed = lens ? new Set(lens.projection_kinds) : null;
-        setProjections(payload.projections.filter((item) => !allowed || allowed.has(item.kind)));
-      })
-      .catch(() => {
-        if (!cancelled) setProjections([]);
-      });
+
+    const load = (): void => {
+      if (document.visibilityState === 'hidden') return;
+      fetchPatientFlowProjections(lens ? { persona: lens.role_id } : {})
+        .then((payload) => {
+          if (cancelled) return;
+          const allowed = lens ? new Set(lens.projection_kinds) : null;
+          setProjections(payload.projections.filter((item) => !allowed || allowed.has(item.kind)));
+        })
+        .catch(() => {
+          if (!cancelled) setProjections([]);
+        });
+    };
+
+    load();
+    const timer = window.setInterval(load, 300_000);
+    document.addEventListener('visibilitychange', load);
     return () => {
       cancelled = true;
+      window.clearInterval(timer);
+      document.removeEventListener('visibilitychange', load);
     };
   }, [lens]);
 
   // Open barriers overlay — aggregate + patient-free (no lens needed); a failure
-  // only hides the overlay, never the navigator.
+  // only hides the overlay, never the navigator. Re-polled every 120 s (S-2)
+  // with the same visibility gating so wall displays see new/closed barriers.
   useEffect(() => {
     let cancelled = false;
-    fetchPatientFlowBarriers()
-      .then((payload) => {
-        if (!cancelled) setBarriers(payload.open_barriers);
-      })
-      .catch(() => {
-        if (!cancelled) setBarriers([]);
-      });
+
+    const load = (): void => {
+      if (document.visibilityState === 'hidden') return;
+      fetchPatientFlowBarriers()
+        .then((payload) => {
+          if (!cancelled) setBarriers(payload.open_barriers);
+        })
+        .catch(() => {
+          if (!cancelled) setBarriers([]);
+        });
+    };
+
+    load();
+    const timer = window.setInterval(load, 120_000);
+    document.addEventListener('visibilitychange', load);
     return () => {
       cancelled = true;
+      window.clearInterval(timer);
+      document.removeEventListener('visibilitychange', load);
     };
   }, []);
 
@@ -728,12 +850,13 @@ export default function PatientFlowNavigator({
           ));
           setInspectorRows(flattenInspector(redacted));
         },
-        onCameraMove: setCameraText,
+        onCameraMove: handleCameraMove,
         onFrame: (delta) => {
           if (!playingRef.current || liveRef.current) return;
           const next = currentTimeRef.current + delta * speedRef.current * 60 * 1000;
-          const replayEnd = historical ? windowEnd : Math.min(nowMs, windowEnd);
-          const bounded = next > replayEnd ? windowStart : next;
+          const { start, end } = windowRef.current;
+          const replayEnd = historicalRef.current ? end : Math.min(nowMsRef.current, end);
+          const bounded = next > replayEnd ? start : next;
           currentTimeRef.current = bounded;
           const wallNow = performance.now();
           if (wallNow - lastTimeEmitRef.current > 150) {
@@ -765,7 +888,7 @@ export default function PatientFlowNavigator({
       sceneRef.current = null;
       scene?.dispose();
     };
-  }, [summary?.model_url, dotsPolicy, historical, nowMs, windowEnd, windowStart, refreshScene]);
+  }, [summary?.model_url, dotsPolicy, handleCameraMove, refreshScene]);
 
   // ---- playback / live -----------------------------------------------------
   const disconnectLive = useCallback((): void => {
@@ -815,6 +938,15 @@ export default function PatientFlowNavigator({
     const scene = sceneRef.current;
     if (!scene) return;
     scene.focusOn(lastVisibleStatesRef.current.map((state) => state.position));
+  }, []);
+
+  // B-4: the explicit camera action for the Delayed-only census scope — the
+  // operator asks for the flight; the checkbox never causes it.
+  const focusDelayed = useCallback((): void => {
+    const points = lastOccupancyInsightsRef.current
+      .filter(isBarrierOrDelay)
+      .map((item) => item.position);
+    sceneRef.current?.focusOn(points);
   }, []);
 
   const askEddy = useCallback((): void => {
@@ -884,6 +1016,7 @@ export default function PatientFlowNavigator({
             freshness={summary?.source.freshness ?? 'missing'}
             forecast={forecast}
             barrierTicks={barrierTicks}
+            replaying={live}
             onScrub={handleScrub}
           />
         )}
@@ -907,6 +1040,7 @@ export default function PatientFlowNavigator({
         onToggleLive={() => (live ? disconnectLive() : connectLive())}
         onResetCamera={resetCamera}
         onFocusPatients={focusActivePatients}
+        onFocusDelayed={focusDelayed}
         onSpeedChange={setSpeed}
         onFiltersChange={(patch) => setFilters((prev) => ({ ...prev, ...patch }))}
         onLayerChange={(key, value) => setLayers((prev) => ({ ...prev, [key]: value }))}
@@ -921,7 +1055,7 @@ export default function PatientFlowNavigator({
       <div className="patient-flow-statusbar">
         <span>{status}</span>
         <span>{ambient ? `Ambient ${Math.round(ambient.summary.averageConfidence * 100)}% ${ambient.summary.confidenceLevel}` : 'Ambient pending'}</span>
-        <span className="patient-flow-camera">{cameraText}</span>
+        <span className="patient-flow-camera" title={cameraDebug}>{cameraPlace}</span>
       </div>
     </section>
   );

--- a/tests/js/patientFlow/NavigatorChronobar.test.tsx
+++ b/tests/js/patientFlow/NavigatorChronobar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import NavigatorChronobar from '@/Components/PatientFlowNavigator/NavigatorChronobar';
 
@@ -50,5 +50,107 @@ describe('NavigatorChronobar', () => {
 
     expect(screen.getByText('Projected · now +1 hr 30 min 31 sec')).toBeInTheDocument();
     expect(screen.queryByText(/1\.5h/)).not.toBeInTheDocument();
+  });
+
+  it('N-1: the Now button scrubs back to now in one click', () => {
+    const now = Date.parse('2026-07-09T12:00:00Z');
+    const onScrub = vi.fn();
+
+    render(
+      <NavigatorChronobar
+        windowStart={now - 24 * 3_600_000}
+        windowEnd={now + 24 * 3_600_000}
+        nowMs={now}
+        currentTime={now - 6 * 3_600_000}
+        dataStart={now - 24 * 3_600_000}
+        dataEnd={now}
+        historical={false}
+        freshness="fresh"
+        forecast={null}
+        onScrub={onScrub}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Now' }));
+    expect(onScrub).toHaveBeenCalledWith(now);
+  });
+
+  it('N-1: the Now button is disabled in historical replay', () => {
+    const dataStart = Date.parse('2026-07-02T00:00:00Z');
+    const dataEnd = Date.parse('2026-07-05T00:00:00Z');
+
+    render(
+      <NavigatorChronobar
+        windowStart={dataStart}
+        windowEnd={dataEnd}
+        nowMs={Date.parse('2026-07-09T12:00:00Z')}
+        currentTime={dataEnd}
+        dataStart={dataStart}
+        dataEnd={dataEnd}
+        historical
+        freshness="stale"
+        forecast={null}
+        onScrub={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Now' })).toBeDisabled();
+  });
+
+  it('N-2: shift detents and barrier ticks are focusable jump buttons', () => {
+    const now = Date.parse('2026-07-09T12:00:00Z');
+    const barrierOpened = now - 5 * 3_600_000;
+    const onScrub = vi.fn();
+
+    render(
+      <NavigatorChronobar
+        windowStart={now - 24 * 3_600_000}
+        windowEnd={now + 24 * 3_600_000}
+        nowMs={now}
+        currentTime={now}
+        dataStart={now - 24 * 3_600_000}
+        dataEnd={now}
+        historical={false}
+        freshness="fresh"
+        forecast={null}
+        barrierTicks={[barrierOpened]}
+        onScrub={onScrub}
+      />,
+    );
+
+    // A 48h window always spans at least one 07:00/19:00 shift change.
+    const detents = screen.getAllByRole('button', { name: /shift change$/ });
+    expect(detents.length).toBeGreaterThan(0);
+    fireEvent.click(detents[0]);
+    expect(onScrub).toHaveBeenCalledTimes(1);
+    const jumpedTo = onScrub.mock.calls[0][0] as number;
+    expect(jumpedTo).toBeGreaterThanOrEqual(now - 24 * 3_600_000);
+    expect(jumpedTo).toBeLessThanOrEqual(now + 24 * 3_600_000);
+
+    fireEvent.click(screen.getByRole('button', { name: /Jump to barrier opened/ }));
+    expect(onScrub).toHaveBeenLastCalledWith(barrierOpened);
+  });
+
+  it('N-8: labels the connected stream as a replay, never live', () => {
+    const now = Date.parse('2026-07-09T12:00:00Z');
+
+    render(
+      <NavigatorChronobar
+        windowStart={now - 24 * 3_600_000}
+        windowEnd={now + 24 * 3_600_000}
+        nowMs={now}
+        currentTime={now}
+        dataStart={now - 24 * 3_600_000}
+        dataEnd={now}
+        historical={false}
+        freshness="fresh"
+        forecast={null}
+        replaying
+        onScrub={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Replay stream ·/)).toBeInTheDocument();
+    expect(screen.queryByText(/\bLive\b/)).not.toBeInTheDocument();
   });
 });

--- a/tests/js/patientFlow/NavigatorToolbar.test.tsx
+++ b/tests/js/patientFlow/NavigatorToolbar.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import NavigatorToolbar from '@/Components/PatientFlowNavigator/NavigatorToolbar';
+import type { LayerControl } from '@/Components/PatientFlowNavigator/NavigatorToolbar';
+import type { OccupancySummary } from '@/features/patientFlowNavigator/types';
+
+/**
+ * Phase 0 barrier-toggle disambiguation (plan §3): "Delayed only" is a census
+ * scope in the filter grid, the "Barriers" layer keeps its own switch, an
+ * active scope announces itself with a chip, and the camera never moves as a
+ * checkbox side effect (Focus is an explicit action).
+ */
+
+const occupancy: OccupancySummary = {
+  active: 0,
+  delayed: 0,
+  watch: 0,
+  transportDelays: 0,
+  evsDelays: 0,
+  readyToMove: 0,
+  avgStayMinutes: 0,
+  serviceLines: [],
+  persona: { transport: 0, evs: 0, bedManager: 0, capacity: 0 },
+  topBarriers: [],
+};
+
+const layerControls: LayerControl[] = [
+  { key: 'base', label: 'Model', id: 'flow-layer-model' },
+  { key: 'heat', label: 'Census', id: 'flow-layer-census' },
+  {
+    key: 'barriers',
+    label: 'Barriers',
+    id: 'flow-layer-barriers',
+    title: 'Logged operational barriers (diamond markers)',
+  },
+];
+
+function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorToolbar>> = {}) {
+  const handlers = {
+    onTogglePlay: vi.fn(),
+    onToggleLive: vi.fn(),
+    onResetCamera: vi.fn(),
+    onFocusPatients: vi.fn(),
+    onFocusDelayed: vi.fn(),
+    onAskEddy: vi.fn(),
+    onSpeedChange: vi.fn(),
+    onFiltersChange: vi.fn(),
+    onLayerChange: vi.fn(),
+    onBarrierFinderChange: vi.fn(),
+  };
+
+  render(
+    <NavigatorToolbar
+      summary={null}
+      ambient={null}
+      lensTitle={null}
+      chronobar={<div />}
+      playing={false}
+      live={false}
+      speed={60}
+      filters={{ floor: 'all', serviceLine: 'all', category: 'all', search: '' }}
+      floors={[]}
+      services={[]}
+      categories={[]}
+      layers={{ base: true, tokens: true, trails: true, heat: true, ghosts: true, barriers: true, rounds: true }}
+      layerControls={layerControls}
+      barrierFinder={false}
+      metrics={{ active: 12, events: 40, occupiedLocations: 9 }}
+      occupancy={occupancy}
+      eddyEnabled={false}
+      {...handlers}
+      {...overrides}
+    />,
+  );
+
+  return handlers;
+}
+
+describe('NavigatorToolbar census scope (B-1/B-2)', () => {
+  it('offers Census: All | Delayed as a filter, not a layer — "Find barriers" is gone', () => {
+    const handlers = renderToolbar();
+
+    expect(screen.queryByLabelText('Find barriers')).not.toBeInTheDocument();
+
+    const scope = screen.getByRole('radiogroup', { name: 'Census scope' });
+    expect(scope).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'All' })).toBeChecked();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Delayed' }));
+    expect(handlers.onBarrierFinderChange).toHaveBeenCalledWith(true);
+  });
+
+  it('keeps the Barriers layer switch with its disambiguating tooltip', () => {
+    renderToolbar();
+
+    const barrierLayer = screen.getByRole('switch', { name: 'Barriers' });
+    expect(barrierLayer).toBeInTheDocument();
+    expect(screen.getByText('Barriers')).toHaveAttribute(
+      'title',
+      'Logged operational barriers (diamond markers)',
+    );
+  });
+});
+
+describe('NavigatorToolbar delayed-only state (B-3/B-4)', () => {
+  it('shows the filter chip with the count and relabels Active → Delayed', () => {
+    renderToolbar({ barrierFinder: true });
+
+    expect(screen.getByText('Filtered: delayed locations only (12)')).toBeInTheDocument();
+    // The metric cell carrying the filtered count is labeled Delayed, not Active.
+    expect(screen.getByText('12').nextElementSibling).toHaveTextContent('Delayed');
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+  });
+
+  it('flies the camera only via the explicit Focus action', () => {
+    const handlers = renderToolbar({ barrierFinder: true });
+
+    expect(handlers.onFocusDelayed).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Focus' }));
+    expect(handlers.onFocusDelayed).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismissing the chip clears the delayed-only scope', () => {
+    const handlers = renderToolbar({ barrierFinder: true });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear delayed-only filter' }));
+    expect(handlers.onBarrierFinderChange).toHaveBeenCalledWith(false);
+  });
+
+  it('renders no chip and the plain Active metric when unfiltered', () => {
+    renderToolbar();
+
+    expect(screen.queryByText(/Filtered: delayed locations only/)).not.toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+});
+
+describe('NavigatorToolbar replay labeling (N-8)', () => {
+  it('names the stream button as a stored replay, never live', () => {
+    renderToolbar();
+
+    const replayButton = screen.getByRole('button', { name: 'Stream stored replay' });
+    expect(replayButton).toHaveAttribute('aria-pressed', 'false');
+    expect(replayButton).toHaveAttribute('title', 'Stream stored replay (not a live feed)');
+  });
+});

--- a/tests/js/patientFlowNavigator/barrierProjection.test.ts
+++ b/tests/js/patientFlowNavigator/barrierProjection.test.ts
@@ -60,6 +60,13 @@ describe('barrierSeverity', () => {
   it('treats a missing opened_at as freshly open (watch)', () => {
     expect(barrierSeverity(null, NOW)).toBe('watch');
   });
+
+  it('escalates the same barrier as wall-clock now advances (S-1 moving now)', () => {
+    const openedAt = NOW - 20 * HOUR;
+    expect(barrierSeverity(openedAt, NOW)).toBe('watch');
+    expect(barrierSeverity(openedAt, NOW + 5 * HOUR)).toBe('warning');
+    expect(barrierSeverity(openedAt, NOW + 29 * HOUR)).toBe('critical');
+  });
 });
 
 describe('buildBarrierCells', () => {


### PR DESCRIPTION
## Summary

Phase 0 ("Truth & quick wins") of [docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md](docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md), which is included in this PR.

**The two "barrier" controls become two visibly different concepts (B-1..B-4):**
- "Find barriers" is renamed and moved out of the Layers fieldset into the filter grid as a `Census: All | Delayed` segmented control — it filters occupancy disks by elapsed-timer signal, which was never a layer
- The "Barriers" layer switch stays put with a disambiguating tooltip: *Logged operational barriers (diamond markers)*
- While filtered, a chip announces `Filtered: delayed locations only (N)` and the "Active" metric relabels to "Delayed"
- The checkbox no longer moves the camera; flying to the delayed set is an explicit **Focus** action on the chip

**Time & spatial navigation (N-1/N-2/N-3/N-8):**
- Gold **Now** button on the chronobar (disabled in historical replay)
- Shift detents and barrier-opened ticks are now focusable jump buttons with aria-labels
- Camera readout speaks place — `Floor 3 · 3W Med-Surg` from the nearest unit anchor to the orbit target (`House view` / `Floor N · overview` when framed wide); raw xyz survives in the title attribute
- The stream button is retitled "Stream stored replay" and the chronobar prefixes `Replay stream ·` while connected — it never claims to be live

**Long-session correctness (S-1/S-2):**
- `nowMs` is state, refreshed every 60 s — now-marker, ghost/forecast gating, and barrier open-age severity stay honest on 6-hour wall sessions
- The 48h live window slides with now only when the operator is parked at now (never yanks a deliberate scrub, skips during playback/historical)
- Barriers poll every 120 s, projections every 5 min, both visibility-gated
- Side fix: the three.js scene is no longer disposed/rebuilt when the time window changes (onFrame reads refs)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vite build` clean
- [x] `scripts/check-ui-canon.sh` passes (new CSS reuses the file's existing gold/amber overlay vocabulary)
- [x] `npx vitest run` — 543/543, including new chronobar jump-button, moving-now severity, and toolbar census-scope/chip suites
- [ ] Browser check on dev: scrub away → Now returns; toggle Delayed census scope; leave a session open >2 min and confirm the now-marker moves

🤖 Generated with [Claude Code](https://claude.com/claude-code)