### PR TITLE
feat: 4D Navigator Phases 1–3 — element identity, navigability, Virtual Rounds integration

### DIFF
--- a/docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md
+++ b/docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md
@@ -246,15 +246,15 @@ Each phase is independently shippable and PR-sized. Frontend checks per project 
 
 **Acceptance:** floor changes are one click/keystroke and frame the floor; search lands the camera on results; power users never touch the mouse for time/floor/focus.
 
-### Phase 3 — Virtual Rounds (≈2–3 days) `feature/flow4d-rounds-integration`
-- [ ] R-1: `?focus_stop={uuid}` handoff wiring → `focusRoundStop` (+ floor-clear retry + fallback toast)
-- [ ] R-2: "Locate in 4D" in RoundsBoard/RoundPatientWorkspace; "Open in Rounds board" action in round-stop inspector
-- [ ] R-5: Rounds HUD chip (run status, progress, awaiting-input)
-- [ ] R-4: queue-number sprites + per-floor route polyline (dashed cross-floor legs)
-- [ ] R-6a: manual tour Prev/Next/Auto (10 s dwell, pause on camera input)
-- [ ] R-3: 30 s scene polling with content-hash rebuild gating + run-complete handling
-- [ ] Tests: `buildRoundStopCells` ordering, tour advance skips unplaceable/deferred stops, deep-link parsing; Pest: scene endpoint unchanged-contract guard
-- [ ] Verify prod flag posture: overlay must remain invisible when `VIRTUAL_ROUNDS_ENABLED` sub-features are off (existing 404 fail-soft)
+### Phase 3 — Virtual Rounds (≈2–3 days) `feature/flow4d-rounds-integration` — **BUILT 2026-07-18**
+- [x] R-1: `?focus_stop={uuid}` handoff wiring → `focusRoundStop` (retry loop while scene/stops load, floor-clear retry, fallback toast "Stop not placeable — open the Rounds board")
+- [x] R-2: "Locate in 4D" per row in RoundsBoard + workspace header; "Open in Rounds board" action in round-stop inspector; board accepts `?patient={uuid}`
+- [x] R-5: Rounds HUD chip (run status + scope, rounded/total, awaiting-input; teal active / amber paused, never coral)
+- [x] R-4: queue-number sprites (skipped/deferred unnumbered) + per-floor route polyline with dashed cross-floor legs (`buildRoundRoute`, non-raycastable layer)
+- [x] R-6a: manual tour Prev/Next/Auto (10 s dwell; OrbitControls 'start' — operator input only — pauses Auto; stops at itinerary end)
+- [x] R-3: 30 s scene polling, visibility-gated, content-hash gate so unchanged payloads never rebuild; run-complete → HUD Complete + toast + polling stops
+- [x] Tests: cells carry floor, route ordering/dashed legs/skip rule, deep-link parsing, HUD render + tour controls; PHPUnit scene contract guard extended (queue_position/unit_id/bed/pinned pinned)
+- [x] Prod flag posture unchanged: overlay stays empty on 404/no-run (fail-soft catch preserved in the polling loop)
 
 **Acceptance:** a rounder can start on the board, jump to the building, walk the itinerary Next-by-Next with live statuses, and jump back — without ever seeing patient identity in the scene layer.
 

--- a/docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md
+++ b/docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md
@@ -226,14 +226,14 @@ Each phase is independently shippable and PR-sized. Frontend checks per project 
 
 **Acceptance:** an operator can always return to now in one click; the two barrier controls are visually and verbally distinct concepts; a 6-hour-old wall session shows correct now/severity.
 
-### Phase 1 — Element Identity System (≈2–3 days) `feature/flow4d-element-identity`
-- [ ] E-2: `sceneVocabulary.ts` (labels, shapes, hexes, descriptions) consumed by NavigatorScene materials
-- [ ] E-2: category material map in `loadModel()` per §5.2 (corridor/patient_room/bed/ED/imaging/elevator/care_unit tints)
-- [ ] E-3: clamp `hashColor` hue to 160–280°
-- [ ] E-1: `NavigatorLegend.tsx` collapsible key rendered from `sceneVocabulary` (sections, worded status meanings, hidden-layer dimming); styles in existing CSS file (no new backdrop-blur file)
-- [ ] E-4: throttled hover raycast + cursor + emissive hover clone + element chip (lens-redacted)
-- [ ] E-5: persistent selection highlight + element-type prefix in inspector title; Escape clears
-- [ ] Tests: sceneVocabulary completeness (every scene layer has a legend entry — assert key parity), hue-clamp property test, legend render & collapse
+### Phase 1 — Element Identity System (≈2–3 days) `feature/flow4d-element-identity` — **BUILT 2026-07-18**
+- [x] E-2: `sceneVocabulary.ts` (labels, shapes, hexes, descriptions) consumed by NavigatorScene materials
+- [x] E-2: category material map in `loadModel()` per §5.2 (corridor/patient_room/bed/ED/imaging/elevator/care_unit tints; floor + unknown keep the model material)
+- [x] E-3: clamp `hashColor` hue to 160–280° (`patientHue` in sceneVocabulary; scene builds the color)
+- [x] E-1: `NavigatorLegend.tsx` collapsible key rendered from `sceneVocabulary` (sections, worded status meanings, hidden-layer dimming); styles in existing CSS file (no new backdrop-blur file)
+- [x] E-4: throttled hover raycast + cursor + emissive hover clone + element chip (identity fields never in the chip; scene-owned div, textContent only; disabled during >60× playback)
+- [x] E-5: persistent selection highlight + element-type prefix in inspector title; Escape clears
+- [x] Tests: sceneVocabulary completeness (layer parity, category coverage, worded statuses), hue-clamp property test, legend render & collapse, elementLabelFor mapping
 
 **Acceptance:** with no training, a user can point at any object, hover it, and read what it is; beds/hallways/rooms/ED are visually distinct; no patient token renders in amber/coral hues.
 

--- a/docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md
+++ b/docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md
@@ -237,12 +237,12 @@ Each phase is independently shippable and PR-sized. Frontend checks per project 
 
 **Acceptance:** with no training, a user can point at any object, hover it, and read what it is; beds/hallways/rooms/ED are visually distinct; no patient token renders in amber/coral hues.
 
-### Phase 2 — Navigability (≈2 days) `feature/flow4d-navigability`
-- [ ] N-4: floor stepper rail with fit-to-floor, keyboard stepping, synced to filter
-- [ ] N-5: search Enter → fly-to matches; match count; empty-state copy
-- [ ] N-6: keyboard shortcuts (H/F/N/?) + shortcut sheet
-- [ ] N-7: 3 persona-keyed saved views (localStorage), chips under transport buttons
-- [ ] Tests: floor-stepper filter sync, search match-count, saved-view round-trip
+### Phase 2 — Navigability (≈2 days) `feature/flow4d-navigability` — **BUILT 2026-07-18**
+- [x] N-4: floor stepper rail with fit-to-floor, keyboard stepping (↑/↓), synced to filter; dropdown also frames via the same path
+- [x] N-5: search Enter → fly-to matches; match count under the field; empty-state copy; Escape clears
+- [x] N-6: keyboard shortcuts (H/F/N/?) + shortcut sheet; OrbitControls arrow-panning enabled on the focused canvas
+- [x] N-7: 3 persona-keyed saved views (localStorage `flow4d.views.{role}`, Zod-validated), chips under transport buttons (restore + save per slot)
+- [x] Tests: floor-rail select/step/All + top-down order, search match-count + Enter/Escape, saved-view round-trip + garbage tolerance, dropdown frame-path
 
 **Acceptance:** floor changes are one click/keystroke and frame the floor; search lands the camera on results; power users never touch the mouse for time/floor/focus.
 

--- a/resources/js/Components/PatientFlowNavigator/NavigatorFloorRail.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorFloorRail.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+/**
+ * Floor stepper rail (N-4): the primary spatial filter as a one-click,
+ * keyboard-steppable control on the right edge. Highest floor on top, "All"
+ * at the bottom; ↑/↓ step floors while any rail button has focus. Selecting
+ * a floor also frames it (fit-to-floor) via the orchestrator's onSelect.
+ */
+
+interface NavigatorFloorRailProps {
+  /** Floors as sorted-ascending strings (the toolbar dropdown's source). */
+  floors: string[];
+  current: string;
+  onSelect: (floor: string) => void;
+}
+
+export default function NavigatorFloorRail({ floors, current, onSelect }: NavigatorFloorRailProps) {
+  if (floors.length === 0) return null;
+
+  // Render top-down: highest floor first, All last — matching the building.
+  const descending = [...floors].reverse();
+
+  const step = (direction: 1 | -1): void => {
+    // ↑ moves up the building (ascending floors); from All, ↑ enters at the bottom floor.
+    const index = floors.indexOf(current);
+    if (current === 'all' || index === -1) {
+      onSelect(direction === 1 ? floors[0] : floors[floors.length - 1]);
+      return;
+    }
+    const next = index + direction;
+    if (next < 0 || next >= floors.length) return;
+    onSelect(floors[next]);
+  };
+
+  const onKeyDown = (event: React.KeyboardEvent): void => {
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      step(1);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      step(-1);
+    }
+  };
+
+  return (
+    <nav className="patient-flow-floor-rail" aria-label="Floor stepper" onKeyDown={onKeyDown}>
+      {descending.map((floor) => (
+        <button
+          key={floor}
+          type="button"
+          aria-pressed={current === floor}
+          className={current === floor ? 'active' : ''}
+          title={`Show floor ${floor} and frame it`}
+          onClick={() => onSelect(floor)}
+        >
+          {floor}
+        </button>
+      ))}
+      <button
+        type="button"
+        aria-pressed={current === 'all'}
+        className={`patient-flow-floor-all ${current === 'all' ? 'active' : ''}`}
+        title="Show every floor"
+        onClick={() => onSelect('all')}
+      >
+        All
+      </button>
+    </nav>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorInspector.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorInspector.tsx
@@ -3,9 +3,11 @@ import React from 'react';
 interface NavigatorInspectorProps {
   title: string;
   rows: Array<[string, string]>;
+  /** Optional deep-link action (e.g. round stop → Rounds board; R-2). */
+  action?: { label: string; href: string } | null;
 }
 
-export default function NavigatorInspector({ title, rows }: NavigatorInspectorProps) {
+export default function NavigatorInspector({ title, rows, action = null }: NavigatorInspectorProps) {
   return (
     <aside className="patient-flow-inspector" aria-live="polite">
       <strong>{title}</strong>
@@ -17,6 +19,11 @@ export default function NavigatorInspector({ title, rows }: NavigatorInspectorPr
           </React.Fragment>
         ))}
       </dl>
+      {action && (
+        <a className="patient-flow-inspector-action" href={action.href}>
+          {action.label} →
+        </a>
+      )}
     </aside>
   );
 }

--- a/resources/js/Components/PatientFlowNavigator/NavigatorLegend.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorLegend.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+import { Key } from 'lucide-react';
+import { LEGEND_SECTIONS } from '@/features/patientFlowNavigator/sceneVocabulary';
+import type { SceneShape } from '@/features/patientFlowNavigator/sceneVocabulary';
+import type { PatientLayerState } from '@/features/patientFlowNavigator/types';
+
+/**
+ * The scene key (finding E-1) — rendered verbatim from sceneVocabulary so the
+ * legend and the materials can never disagree. Collapsed to a "Key" pill by
+ * default (bottom-left, above the status bar); rows for hidden layers dim and
+ * say so. Status colors always appear with their worded meaning.
+ */
+
+interface NavigatorLegendProps {
+  layers: PatientLayerState;
+}
+
+function hex(colorHex: number): string {
+  return `#${colorHex.toString(16).padStart(6, '0')}`;
+}
+
+function LegendGlyph({ shape, colorHex }: { shape: SceneShape; colorHex: number }) {
+  const color = hex(colorHex);
+  switch (shape) {
+    case 'sphere':
+      return <svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="5.5" fill={color} /></svg>;
+    case 'line':
+      return <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M2 12 L14 4" stroke={color} strokeWidth="2" fill="none" /></svg>;
+    case 'disk':
+      return <svg viewBox="0 0 16 16" aria-hidden="true"><ellipse cx="8" cy="8" rx="6.5" ry="3.2" fill={color} opacity="0.8" /></svg>;
+    case 'pip':
+      return <svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="2.4" fill={color} /></svg>;
+    case 'ghost':
+      return <svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="5.5" fill={color} opacity="0.4" stroke={color} strokeDasharray="2 2" /></svg>;
+    case 'pillar':
+      return <svg viewBox="0 0 16 16" aria-hidden="true"><rect x="5.5" y="2" width="5" height="12" rx="1" fill={color} opacity="0.75" /></svg>;
+    case 'diamond':
+      return <svg viewBox="0 0 16 16" aria-hidden="true"><rect x="4.5" y="4.5" width="7" height="7" fill={color} transform="rotate(45 8 8)" /></svg>;
+    case 'ring':
+      return <svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="5" fill="none" stroke={color} strokeWidth="2.4" /></svg>;
+    case 'block':
+      return <svg viewBox="0 0 16 16" aria-hidden="true"><rect x="2.5" y="4" width="11" height="8" rx="1.5" fill={color} opacity="0.85" /></svg>;
+    default:
+      return null;
+  }
+}
+
+export default function NavigatorLegend({ layers }: NavigatorLegendProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="patient-flow-legend">
+      <button
+        type="button"
+        className="patient-flow-legend-toggle"
+        aria-expanded={open}
+        title={open ? 'Collapse the scene key' : 'What do the shapes and colors mean?'}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <Key aria-hidden="true" />
+        Key
+      </button>
+
+      {open && (
+        <div className="patient-flow-legend-panel" role="region" aria-label="Scene key">
+          {LEGEND_SECTIONS.map((section) => (
+            <section key={section.title}>
+              <h3>{section.title}</h3>
+              <ul>
+                {section.entries.map((entry) => {
+                  const hidden = !layers[entry.layer];
+                  return (
+                    <li key={entry.key} className={hidden ? 'legend-hidden' : ''}>
+                      <span className="patient-flow-legend-glyph">
+                        <LegendGlyph shape={entry.shape} colorHex={entry.colorHex} />
+                      </span>
+                      <span className="patient-flow-legend-text">
+                        <strong>{entry.label}{hidden ? ' (hidden)' : ''}</strong>
+                        <small>{entry.description}</small>
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -203,25 +203,33 @@ export class NavigatorScene {
     this.renderer.setSize(width, height);
   };
 
+  // Reused per-cast buffers — the 20 Hz hover path must not allocate.
+  private raycastScratch: THREE.Object3D[] = [];
+
+  private pointerScratch = new THREE.Vector2();
+
   /** The one interactive set — pointerdown select and pointermove hover agree. */
-  private raycastHit(event: PointerEvent): THREE.Mesh | null {
-    const rect = this.renderer.domElement.getBoundingClientRect();
-    const pointer = new THREE.Vector2(
-      ((event.clientX - rect.left) / rect.width) * 2 - 1,
-      -((event.clientY - rect.top) / rect.height) * 2 + 1,
+  private raycastHit(event: PointerEvent, rect?: DOMRect): THREE.Mesh | null {
+    const bounds = rect ?? this.renderer.domElement.getBoundingClientRect();
+    this.pointerScratch.set(
+      ((event.clientX - bounds.left) / bounds.width) * 2 - 1,
+      -((event.clientY - bounds.top) / bounds.height) * 2 + 1,
     );
-    this.raycaster.setFromCamera(pointer, this.camera);
-    const hits = this.raycaster.intersectObjects(
-      [
-        ...this.roundsLayer.children,
-        ...this.barrierLayer.children,
-        ...this.patientLayer.children,
-        ...this.ghostLayer.children,
-        ...this.heatLayer.children,
-        ...this.baseObjects,
-      ].filter((object) => object.visible),
-      false,
-    );
+    this.raycaster.setFromCamera(this.pointerScratch, this.camera);
+    const candidates = this.raycastScratch;
+    candidates.length = 0;
+    const collect = (objects: THREE.Object3D[]): void => {
+      for (const object of objects) {
+        if (object.visible) candidates.push(object);
+      }
+    };
+    collect(this.roundsLayer.children);
+    collect(this.barrierLayer.children);
+    collect(this.patientLayer.children);
+    collect(this.ghostLayer.children);
+    collect(this.heatLayer.children);
+    collect(this.baseObjects);
+    const hits = this.raycaster.intersectObjects(candidates, false);
     return hits.length ? (hits[0].object as THREE.Mesh) : null;
   }
 
@@ -256,7 +264,10 @@ export class NavigatorScene {
     if (now - this.lastHoverCast < 50) return;
     this.lastHoverCast = now;
 
-    const mesh = this.raycastHit(event);
+    // One rect read per cast — the canvas fills the container, so the same
+    // rect anchors both the raycast and the chip position.
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    const mesh = this.raycastHit(event, rect);
     if (!mesh) {
       this.clearHover();
       return;
@@ -268,10 +279,9 @@ export class NavigatorScene {
 
     const label = this.callbacks.hoverLabel?.(this.hitData(mesh)) ?? null;
     if (label) {
-      const containerRect = this.container.getBoundingClientRect();
       this.hoverChip.textContent = label;
-      this.hoverChip.style.left = `${event.clientX - containerRect.left + 14}px`;
-      this.hoverChip.style.top = `${event.clientY - containerRect.top + 12}px`;
+      // transform keeps chip moves compositor-only (no layout per move).
+      this.hoverChip.style.transform = `translate(${event.clientX - rect.left + 14}px, ${event.clientY - rect.top + 12}px)`;
       this.hoverChip.hidden = false;
     } else {
       this.hoverChip.hidden = true;
@@ -901,6 +911,12 @@ export class NavigatorScene {
     const mesh = this.roundStopMeshByUuid.get(roundPatientUuid);
     if (!mesh) return false;
 
+    // A hover/selection clone on this mesh must be released first — otherwise
+    // it would be captured as the "base" and a later clearHover/clearSelection
+    // restore would stomp the focus material.
+    if (this.hoveredMesh === mesh) this.clearHover();
+    if (this.selectedMesh === mesh) this.clearSelection();
+
     // Focused ring gets its own (non-shared) brighter material so the pulse
     // never leaks onto same-status siblings; the clone is disposed on unfocus.
     const base = mesh.material as THREE.MeshStandardMaterial;
@@ -1035,14 +1051,14 @@ export class NavigatorScene {
   private emitCameraText(): void {
     const now = performance.now();
     if (now - this.lastCameraEmit < 150) return;
+    // Re-arm BEFORE the change check so an idle camera costs one comparison
+    // per 150 ms, not string-building work on every animation frame.
+    this.lastCameraEmit = now;
     const position = this.camera.position;
     const target = this.orbit.target;
-    const key = [position.x, position.y, position.z, target.x, target.y, target.z]
-      .map((value) => value.toFixed(0))
-      .join('|');
+    const key = `${position.x.toFixed(0)}|${position.y.toFixed(0)}|${position.z.toFixed(0)}|${target.x.toFixed(0)}|${target.y.toFixed(0)}|${target.z.toFixed(0)}`;
     if (key === this.lastCameraText) return;
     this.lastCameraText = key;
-    this.lastCameraEmit = now;
     this.callbacks.onCameraMove({
       position: { x: position.x, y: position.y, z: position.z },
       target: { x: target.x, y: target.y, z: target.z },
@@ -1174,6 +1190,9 @@ export class NavigatorScene {
     while (group.children.length) {
       const child = group.children.pop() as THREE.Mesh | undefined;
       if (!child) continue;
+      // Sprites share three's module-singleton quad geometry — disposing it
+      // would deallocate a live GPU resource for every sprite in the app.
+      if ((child as unknown as THREE.Sprite).isSprite) continue;
       if (child.geometry && child.geometry !== this.tokenGeometry
         && child.geometry !== this.ghostGeometry
         && child.geometry !== this.heatGeometry

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -4,7 +4,17 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { parseTime, positionFor } from '@/features/patientFlowNavigator/stateProjection';
 import { confidenceOpacity } from '@/features/patientFlowNavigator/projections';
 import type { BarrierCell, BarrierSeverity, ProjectionAnchor } from '@/features/patientFlowNavigator/projections';
-import { ROUND_STOP_COLORS } from '@/features/virtualRounds/roundsScene';
+import {
+  BARRIER_COLORS,
+  BASE_CATEGORY_STYLES,
+  FORECAST_COLOR,
+  GHOST_COLORS,
+  OCCUPANCY_STATUS_COLORS,
+  ROUND_PINNED_COLOR,
+  ROUND_STOP_COLORS,
+  TIMER_PIP_COLORS,
+  patientHue,
+} from '@/features/patientFlowNavigator/sceneVocabulary';
 import type { RoundStopCell } from '@/features/virtualRounds/roundsScene';
 import type {
   OccupancyInsight,
@@ -37,6 +47,12 @@ export interface NavigatorSceneCallbacks {
   onSelect: (data: Record<string, unknown>) => void;
   onCameraMove: (view: CameraView) => void;
   onFrame: (deltaSeconds: number) => void;
+  /**
+   * Operator-readable hover chip text for a hit's userData, or null to hide
+   * the chip. The orchestrator owns this so lens redaction happens outside
+   * the scene; the scene writes it via textContent (never HTML).
+   */
+  hoverLabel?: (data: Record<string, unknown>) => string | null;
 }
 
 export interface GhostRenderItem {
@@ -50,24 +66,8 @@ export interface ForecastHeatCell {
   opacity: number;
 }
 
-/** Future-half palette — cool operational tones only, never coral (§5). */
-const GHOST_COLORS: Record<string, number> = {
-  expected_discharge: 0x2dd4bf, // teal
-  transport_due: 0x38bdf8, // sky
-  evs_due: 0x7dd3fc, // light sky
-  scheduled_or_case: 0x60a5fa, // blue
-};
-
-/**
- * Open-barrier marker palette — the earned-urgency ration (watch sky / warning
- * amber / critical coral), the same status language the 48h Review map paints.
- * Coral is reserved for a barrier standing open past 48h — a real breach.
- */
-const BARRIER_COLORS: Record<BarrierSeverity, { color: number; emissive: number }> = {
-  critical: { color: 0xf06755, emissive: 0x5a140d }, // coral
-  warning: { color: 0xeaa640, emissive: 0x4a2e08 }, // amber
-  watch: { color: 0x38bdf8, emissive: 0x0c3a4d }, // sky
-};
+// Shape/color constants live in features/patientFlowNavigator/sceneVocabulary
+// (§5.1 SSOT) — the legend renders from the same module, so it can never lie.
 
 const BARRIER_SCALE: Record<BarrierSeverity, number> = { critical: 1.3, warning: 1.1, watch: 1 };
 
@@ -115,6 +115,8 @@ export class NavigatorScene {
 
   private roundStopMeshByUuid = new Map<string, THREE.Mesh>();
 
+  private baseCategoryMaterials = new Map<string, THREE.MeshStandardMaterial>();
+
   private focusedRoundStopUuid: string | null = null;
 
   private heatSingleMaterial: THREE.MeshStandardMaterial;
@@ -153,6 +155,24 @@ export class NavigatorScene {
 
   private lastCameraEmit = 0;
 
+  private lastHoverCast = 0;
+
+  private hoverEnabled = true;
+
+  private hoveredMesh: THREE.Mesh | null = null;
+
+  private hoveredOriginalMaterial: THREE.Material | THREE.Material[] | null = null;
+
+  private hoverMaterial: THREE.MeshStandardMaterial | null = null;
+
+  private hoverChip: HTMLDivElement;
+
+  private selectedMesh: THREE.Mesh | null = null;
+
+  private selectedOriginalMaterial: THREE.Material | THREE.Material[] | null = null;
+
+  private selectionMaterial: THREE.MeshStandardMaterial | null = null;
+
   private disposed = false;
 
   private readonly container: HTMLElement;
@@ -167,8 +187,8 @@ export class NavigatorScene {
     this.renderer.setSize(width, height);
   };
 
-  private readonly onPointerDown = (event: PointerEvent): void => {
-    if (event.target !== this.renderer.domElement) return;
+  /** The one interactive set — pointerdown select and pointermove hover agree. */
+  private raycastHit(event: PointerEvent): THREE.Mesh | null {
     const rect = this.renderer.domElement.getBoundingClientRect();
     const pointer = new THREE.Vector2(
       ((event.clientX - rect.left) / rect.width) * 2 - 1,
@@ -186,8 +206,60 @@ export class NavigatorScene {
       ].filter((object) => object.visible),
       false,
     );
-    if (!hits.length) return;
-    this.callbacks.onSelect({ ...(hits[0].object.userData ?? {}) });
+    return hits.length ? (hits[0].object as THREE.Mesh) : null;
+  }
+
+  private hitData(mesh: THREE.Mesh): Record<string, unknown> {
+    return {
+      ...(mesh.userData ?? {}),
+      ...(mesh.name && !mesh.userData?.kind ? { name: mesh.name } : {}),
+    };
+  }
+
+  private readonly onPointerDown = (event: PointerEvent): void => {
+    if (event.target !== this.renderer.domElement) return;
+    const mesh = this.raycastHit(event);
+    if (!mesh) return;
+    // E-5: hover clone must never be captured as a selection "original".
+    this.clearHover();
+    this.applySelection(mesh);
+    this.callbacks.onSelect(this.hitData(mesh));
+  };
+
+  /**
+   * E-4: throttled hover — cursor affordance, emissive lift via a non-shared
+   * clone (the focused-round pattern), and a redacted HTML chip at the cursor.
+   */
+  private readonly onPointerMove = (event: PointerEvent): void => {
+    if (!this.hoverEnabled) return;
+    if (event.target !== this.renderer.domElement) {
+      this.clearHover();
+      return;
+    }
+    const now = performance.now();
+    if (now - this.lastHoverCast < 50) return;
+    this.lastHoverCast = now;
+
+    const mesh = this.raycastHit(event);
+    if (!mesh) {
+      this.clearHover();
+      return;
+    }
+    if (mesh !== this.hoveredMesh) {
+      this.clearHover();
+      this.applyHover(mesh);
+    }
+
+    const label = this.callbacks.hoverLabel?.(this.hitData(mesh)) ?? null;
+    if (label) {
+      const containerRect = this.container.getBoundingClientRect();
+      this.hoverChip.textContent = label;
+      this.hoverChip.style.left = `${event.clientX - containerRect.left + 14}px`;
+      this.hoverChip.style.top = `${event.clientY - containerRect.top + 12}px`;
+      this.hoverChip.hidden = false;
+    } else {
+      this.hoverChip.hidden = true;
+    }
   };
 
   constructor(canvas: HTMLCanvasElement, container: HTMLElement, callbacks: NavigatorSceneCallbacks) {
@@ -238,9 +310,89 @@ export class NavigatorScene {
       opacity: 0.62,
     });
 
+    // Hover chip: scene-owned so the 50 ms hover path never touches React.
+    // Text is always set via textContent with orchestrator-redacted labels.
+    this.hoverChip = document.createElement('div');
+    this.hoverChip.className = 'patient-flow-hover-chip';
+    this.hoverChip.hidden = true;
+    container.appendChild(this.hoverChip);
+
     window.addEventListener('resize', this.onResize);
     this.renderer.domElement.addEventListener('pointerdown', this.onPointerDown);
+    this.renderer.domElement.addEventListener('pointermove', this.onPointerMove);
+    this.renderer.domElement.addEventListener('pointerleave', this.onPointerLeave);
     this.animationId = requestAnimationFrame(this.animate);
+  }
+
+  private readonly onPointerLeave = (): void => {
+    this.clearHover();
+  };
+
+  /** Orchestrator gates hover off during fast playback (perf guard §5.5). */
+  setHoverEnabled(enabled: boolean): void {
+    this.hoverEnabled = enabled;
+    if (!enabled) this.clearHover();
+  }
+
+  private applyHover(mesh: THREE.Mesh): void {
+    this.hoveredMesh = mesh;
+    this.renderer.domElement.style.cursor = 'pointer';
+    // Selected/focused meshes already carry their own highlight clone —
+    // hovering them must not capture that clone as an "original".
+    if (mesh === this.selectedMesh || mesh === this.focusedRoundMesh) return;
+    const material = mesh.material;
+    if (Array.isArray(material) || !(material instanceof THREE.MeshStandardMaterial)) return;
+    this.hoveredOriginalMaterial = material;
+    const clone = material.clone();
+    if (clone.emissive.getHex() === 0) {
+      clone.emissive = clone.color.clone().multiplyScalar(0.35);
+    }
+    clone.emissiveIntensity = Math.max(clone.emissiveIntensity * 1.6, 1.1);
+    mesh.material = clone;
+    this.hoverMaterial = clone;
+  }
+
+  private clearHover(): void {
+    if (this.hoveredMesh && this.hoveredOriginalMaterial) {
+      this.hoveredMesh.material = this.hoveredOriginalMaterial;
+    }
+    this.hoverMaterial?.dispose();
+    this.hoverMaterial = null;
+    this.hoveredOriginalMaterial = null;
+    this.hoveredMesh = null;
+    this.renderer.domElement.style.cursor = '';
+    this.hoverChip.hidden = true;
+  }
+
+  /**
+   * E-5: persistent selection highlight — survives until the next selection,
+   * Escape (orchestrator calls clearSelection), or a rebuild that removes the
+   * mesh. Round stops keep their dedicated focus path.
+   */
+  private applySelection(mesh: THREE.Mesh): void {
+    this.clearSelection();
+    if (mesh === this.focusedRoundMesh) return;
+    const material = mesh.material;
+    if (Array.isArray(material) || !(material instanceof THREE.MeshStandardMaterial)) return;
+    this.selectedMesh = mesh;
+    this.selectedOriginalMaterial = material;
+    const clone = material.clone();
+    if (clone.emissive.getHex() === 0) {
+      clone.emissive = clone.color.clone().multiplyScalar(0.4);
+    }
+    clone.emissiveIntensity = Math.max(clone.emissiveIntensity * 2, 1.8);
+    mesh.material = clone;
+    this.selectionMaterial = clone;
+  }
+
+  clearSelection(): void {
+    if (this.selectedMesh && this.selectedOriginalMaterial) {
+      this.selectedMesh.material = this.selectedOriginalMaterial;
+    }
+    this.selectionMaterial?.dispose();
+    this.selectionMaterial = null;
+    this.selectedOriginalMaterial = null;
+    this.selectedMesh = null;
   }
 
   loadModel(url: string, onLoaded: () => void, onError: () => void): void {
@@ -253,6 +405,16 @@ export class NavigatorScene {
           const mesh = object as THREE.Mesh;
           if (!mesh.isMesh) return;
           this.baseObjects.push(mesh);
+
+          // E-2: glTF extras carry category — beds/corridors/rooms/ED render
+          // as distinct materials (sceneVocabulary §5.2). `floor` and unknown
+          // categories keep the model's own material as the datum plane.
+          const categoryMaterial = this.baseCategoryMaterialFor(String(mesh.userData?.category ?? ''));
+          if (categoryMaterial) {
+            mesh.material = categoryMaterial;
+            return;
+          }
+
           const material = mesh.material;
           if (Array.isArray(material)) {
             mesh.material = material.map((item) => item.clone());
@@ -274,6 +436,28 @@ export class NavigatorScene {
         onError();
       },
     );
+  }
+
+  /** Cached per-category base material, built from the vocabulary SSOT. */
+  private baseCategoryMaterialFor(category: string): THREE.MeshStandardMaterial | null {
+    const style = BASE_CATEGORY_STYLES[category];
+    if (!style) return null;
+    let material = this.baseCategoryMaterials.get(category);
+    if (!material) {
+      const color = new THREE.Color(style.color);
+      material = new THREE.MeshStandardMaterial({
+        color,
+        emissive: style.emissiveScale > 0
+          ? color.clone().multiplyScalar(style.emissiveScale)
+          : new THREE.Color(0x000000),
+        transparent: true,
+        opacity: style.opacity,
+        roughness: 0.78,
+        metalness: 0,
+      });
+      this.baseCategoryMaterials.set(category, material);
+    }
+    return material;
   }
 
   setBaseVisibility(floor: string, layerVisible: boolean): void {
@@ -629,7 +813,7 @@ export class NavigatorScene {
   }
 
   private roundMaterialFor(status: string, pinned: boolean): THREE.MeshStandardMaterial {
-    const colorHex = pinned ? 0xeaa640 : (ROUND_STOP_COLORS[status as keyof typeof ROUND_STOP_COLORS] ?? 0x94a3b8);
+    const colorHex = pinned ? ROUND_PINNED_COLOR : (ROUND_STOP_COLORS[status as keyof typeof ROUND_STOP_COLORS] ?? 0x94a3b8);
     const key = `${colorHex}`;
     let material = this.roundMaterials.get(key);
     if (!material) {
@@ -668,6 +852,12 @@ export class NavigatorScene {
     cancelAnimationFrame(this.animationId);
     window.removeEventListener('resize', this.onResize);
     this.renderer.domElement.removeEventListener('pointerdown', this.onPointerDown);
+    this.renderer.domElement.removeEventListener('pointermove', this.onPointerMove);
+    this.renderer.domElement.removeEventListener('pointerleave', this.onPointerLeave);
+    this.clearHover();
+    this.clearSelection();
+    this.hoverChip.remove();
+    this.baseCategoryMaterials.forEach((material) => material.dispose());
     this.baseObjects.forEach((object) => this.disposeObject(object));
     this.clearGroup(this.patientLayer);
     this.clearGroup(this.trailLayer);
@@ -774,7 +964,7 @@ export class NavigatorScene {
     let material = this.forecastMaterials.get(key);
     if (!material) {
       material = new THREE.MeshStandardMaterial({
-        color: 0x64bfd0,
+        color: FORECAST_COLOR,
         emissive: 0x0f2f36,
         transparent: true,
         opacity,
@@ -788,10 +978,10 @@ export class NavigatorScene {
   private occupancyMaterialFor(status: OccupancyTimerStatus): THREE.MeshStandardMaterial {
     let material = this.occupancyMaterials.get(status);
     if (!material) {
-      const color = status === 'delayed' ? 0xf06755 : status === 'watch' ? 0xe0a33f : 0x77c06f;
+      const { color, emissive } = OCCUPANCY_STATUS_COLORS[status];
       material = new THREE.MeshStandardMaterial({
         color,
-        emissive: status === 'delayed' ? 0x5a140d : status === 'watch' ? 0x4a3210 : 0x143d17,
+        emissive,
         transparent: true,
         opacity: status === 'ok' ? 0.58 : 0.74,
         roughness: 0.52,
@@ -806,7 +996,7 @@ export class NavigatorScene {
   private timerPipMaterialFor(status: OccupancyTimerStatus): THREE.MeshStandardMaterial {
     let material = this.timerPipMaterials.get(status);
     if (!material) {
-      const color = status === 'delayed' ? 0xff8a75 : status === 'watch' ? 0xffd166 : 0x93e088;
+      const color = TIMER_PIP_COLORS[status];
       material = new THREE.MeshStandardMaterial({
         color,
         emissive: color,
@@ -843,6 +1033,11 @@ export class NavigatorScene {
    * rebuilds — they are disposed once, in dispose().
    */
   private clearGroup(group: THREE.Group): void {
+    // A rebuild that removes the hovered/selected mesh must also release its
+    // highlight clone — otherwise the clone dangles and the restore targets a
+    // detached mesh.
+    if (this.hoveredMesh && this.hoveredMesh.parent === group) this.clearHover();
+    if (this.selectedMesh && this.selectedMesh.parent === group) this.clearSelection();
     while (group.children.length) {
       const child = group.children.pop() as THREE.Mesh | undefined;
       if (!child) continue;
@@ -871,10 +1066,11 @@ export class NavigatorScene {
   }
 }
 
+/**
+ * Identity color for a patient token/trail. Hue is clamped to 160°–280° (E-3)
+ * so a token can never impersonate amber/coral status colors — the clamp
+ * itself lives in sceneVocabulary.patientHue with the rest of the grammar.
+ */
 function hashColor(value: string): THREE.Color {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = ((hash << 5) - hash) + value.charCodeAt(index);
-  }
-  return new THREE.Color(`hsl(${Math.abs(hash) % 360}, 70%, 58%)`);
+  return new THREE.Color(`hsl(${patientHue(value)}, 70%, 58%)`);
 }

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -286,6 +286,10 @@ export class NavigatorScene {
     this.orbit.maxPolarAngle = Math.PI * 0.49;
     this.orbit.minDistance = 18;
     this.orbit.maxDistance = 380;
+    // N-6: arrow keys pan while the canvas has focus (click the scene first)
+    // — scoped to the canvas so the floor rail's ↑/↓ stepping never collides.
+    this.renderer.domElement.tabIndex = 0;
+    this.orbit.listenToKeyEvents(this.renderer.domElement);
 
     this.scene.add(new THREE.HemisphereLight(0xf6f0e4, 0x343a36, 2.2));
     const sun = new THREE.DirectionalLight(0xfff5df, 2);
@@ -838,6 +842,29 @@ export class NavigatorScene {
     const radius = Math.max(size.x, size.y, size.z, 24);
     this.orbit.target.copy(center);
     this.camera.position.set(center.x + radius * 1.35, center.y + radius * 1.05, center.z + radius * 1.35);
+    this.orbit.update();
+  }
+
+  /** Fly to the current selection; false when nothing is selected (N-6 `F`). */
+  focusSelection(): boolean {
+    if (!this.selectedMesh) return false;
+    const { x, y, z } = this.selectedMesh.position;
+    this.focusOn([{ x, y, z }]);
+    return true;
+  }
+
+  /** Camera pose snapshot for saved views (N-7). */
+  getCameraView(): CameraView {
+    return {
+      position: { x: this.camera.position.x, y: this.camera.position.y, z: this.camera.position.z },
+      target: { x: this.orbit.target.x, y: this.orbit.target.y, z: this.orbit.target.z },
+    };
+  }
+
+  /** Restore a saved camera pose (N-7). */
+  setCameraView(view: CameraView): void {
+    this.camera.position.set(view.position.x, view.position.y, view.position.z);
+    this.orbit.target.set(view.target.x, view.target.y, view.target.z);
     this.orbit.update();
   }
 

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -15,7 +15,7 @@ import {
   TIMER_PIP_COLORS,
   patientHue,
 } from '@/features/patientFlowNavigator/sceneVocabulary';
-import type { RoundStopCell } from '@/features/virtualRounds/roundsScene';
+import type { RoundRouteSegment, RoundStopCell } from '@/features/virtualRounds/roundsScene';
 import type {
   OccupancyInsight,
   OccupancyTimerStatus,
@@ -53,6 +53,12 @@ export interface NavigatorSceneCallbacks {
    * the scene; the scene writes it via textContent (never HTML).
    */
   hoverLabel?: (data: Record<string, unknown>) => string | null;
+  /**
+   * Fired when the OPERATOR starts moving the camera (OrbitControls 'start' —
+   * never programmatic flights). The tour's Auto mode pauses on this (R-6a:
+   * respect the operator's hand).
+   */
+  onUserCameraStart?: () => void;
 }
 
 export interface GhostRenderItem {
@@ -96,6 +102,16 @@ export class NavigatorScene {
   private barrierLayer = new THREE.Group();
 
   private roundsLayer = new THREE.Group();
+
+  // Route + queue-number annotations live outside the raycast set — they are
+  // wayfinding, not clickable objects.
+  private roundsRouteLayer = new THREE.Group();
+
+  private queueSpriteMaterials = new Map<number, THREE.SpriteMaterial>();
+
+  private routeSolidMaterial: THREE.LineBasicMaterial | null = null;
+
+  private routeDashedMaterial: THREE.LineDashedMaterial | null = null;
 
   private baseObjects: THREE.Object3D[] = [];
 
@@ -299,7 +315,11 @@ export class NavigatorScene {
     grid.position.y = -0.12;
     this.scene.add(grid);
 
-    this.scene.add(this.forecastLayer, this.heatLayer, this.trailLayer, this.ghostLayer, this.patientLayer, this.barrierLayer, this.roundsLayer);
+    this.scene.add(this.forecastLayer, this.heatLayer, this.trailLayer, this.ghostLayer, this.patientLayer, this.barrierLayer, this.roundsLayer, this.roundsRouteLayer);
+
+    // Tour Auto pauses when the OPERATOR grabs the camera; OrbitControls only
+    // dispatches 'start' for real input, never for programmatic flights.
+    this.orbit.addEventListener('start', () => this.callbacks.onUserCameraStart?.());
 
     this.heatSingleMaterial = new THREE.MeshStandardMaterial({
       color: 0x77c06f,
@@ -728,8 +748,9 @@ export class NavigatorScene {
    * scale up; the opaque stop payload rides in userData for the inspector.
    * No patient identifier ever enters this layer (plan §8.1).
    */
-  rebuildRounds(cells: RoundStopCell[], layerVisible: boolean): void {
+  rebuildRounds(cells: RoundStopCell[], route: RoundRouteSegment[], layerVisible: boolean): void {
     this.clearGroup(this.roundsLayer);
+    this.clearGroup(this.roundsRouteLayer);
     this.roundStopMeshByUuid.clear();
     // The focused mesh (if any) was just removed with the group; drop the
     // clone so it never dangles. Focus re-applies below without re-flying.
@@ -762,11 +783,89 @@ export class NavigatorScene {
       };
       this.roundsLayer.add(mesh);
       this.roundStopMeshByUuid.set(stop.round_patient_uuid, mesh);
+
+      // R-4: queue-number billboard above the ring; skipped/deferred stay
+      // dimmed and unnumbered (they are not part of the walk).
+      if (!['skipped', 'deferred'].includes(stop.status)) {
+        const sprite = new THREE.Sprite(this.queueSpriteMaterialFor(stop.queue_position));
+        sprite.position.set(anchor.x, mesh.position.y + 3.1, anchor.z);
+        sprite.scale.set(2.6, 2.6, 1);
+        sprite.userData = { ...mesh.userData };
+        this.roundsLayer.add(sprite);
+      }
+    }
+
+    // R-4: itinerary polyline — solid per-floor runs, dashed cross-floor legs.
+    for (const segment of route) {
+      const points = segment.points.map(
+        (point) => new THREE.Vector3(point.x, point.y + 3.4, point.z),
+      );
+      if (points.length < 2) continue;
+      const geometry = new THREE.BufferGeometry().setFromPoints(points);
+      const line = new THREE.Line(
+        geometry,
+        segment.dashed ? this.routeDashedMaterialFor() : this.routeSolidMaterialFor(),
+      );
+      if (segment.dashed) line.computeLineDistances();
+      this.roundsRouteLayer.add(line);
     }
 
     if (this.focusedRoundStopUuid) {
       this.applyRoundFocus(this.focusedRoundStopUuid, false);
     }
+  }
+
+  /** Cached canvas-texture sprite material for a queue number. */
+  private queueSpriteMaterialFor(queuePosition: number): THREE.SpriteMaterial {
+    let material = this.queueSpriteMaterials.get(queuePosition);
+    if (!material) {
+      const canvas = document.createElement('canvas');
+      canvas.width = 64;
+      canvas.height = 64;
+      const context = canvas.getContext('2d');
+      if (context) {
+        context.beginPath();
+        context.arc(32, 32, 26, 0, Math.PI * 2);
+        context.fillStyle = 'rgba(27, 31, 29, 0.85)';
+        context.fill();
+        context.lineWidth = 3;
+        context.strokeStyle = '#94a3b8';
+        context.stroke();
+        context.font = '600 30px sans-serif';
+        context.textAlign = 'center';
+        context.textBaseline = 'middle';
+        context.fillStyle = '#f3efe5';
+        context.fillText(String(queuePosition), 32, 34);
+      }
+      const texture = new THREE.CanvasTexture(canvas);
+      material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false });
+      this.queueSpriteMaterials.set(queuePosition, material);
+    }
+    return material;
+  }
+
+  private routeSolidMaterialFor(): THREE.LineBasicMaterial {
+    if (!this.routeSolidMaterial) {
+      this.routeSolidMaterial = new THREE.LineBasicMaterial({
+        color: 0x94a3b8,
+        transparent: true,
+        opacity: 0.28,
+      });
+    }
+    return this.routeSolidMaterial;
+  }
+
+  private routeDashedMaterialFor(): THREE.LineDashedMaterial {
+    if (!this.routeDashedMaterial) {
+      this.routeDashedMaterial = new THREE.LineDashedMaterial({
+        color: 0x94a3b8,
+        transparent: true,
+        opacity: 0.28,
+        dashSize: 2.2,
+        gapSize: 2.2,
+      });
+    }
+    return this.routeDashedMaterial;
   }
 
   /**
@@ -893,7 +992,14 @@ export class NavigatorScene {
     this.clearGroup(this.forecastLayer);
     this.clearGroup(this.barrierLayer);
     this.clearGroup(this.roundsLayer);
+    this.clearGroup(this.roundsRouteLayer);
     this.roundStopMeshByUuid.clear();
+    this.queueSpriteMaterials.forEach((material) => {
+      material.map?.dispose();
+      material.dispose();
+    });
+    this.routeSolidMaterial?.dispose();
+    this.routeDashedMaterial?.dispose();
     this.patientMaterials.forEach((material) => material.dispose());
     this.trailMaterials.forEach((material) => material.dispose());
     this.ghostMaterials.forEach((material) => material.dispose());

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -8,6 +8,9 @@ import type {
   PatientLayerState,
 } from '@/features/patientFlowNavigator/types';
 import type { RunStatus } from '@/features/virtualRounds/types';
+// One label map for run states — the 4D HUD and the Rounds board must never
+// word the same status differently.
+import { RUN_STATUS_LABEL } from '@/Components/VirtualRounds/format';
 import { formatDurationMinutes } from '@/lib/duration';
 
 export interface RoundsHudModel {
@@ -17,16 +20,6 @@ export interface RoundsHudModel {
   rounded: number;
   awaitingInput: number;
 }
-
-const RUN_STATUS_LABEL: Record<RunStatus, string> = {
-  draft: 'Draft',
-  scheduled: 'Scheduled',
-  active: 'Active',
-  paused: 'Paused',
-  closing: 'Closing',
-  completed: 'Complete',
-  cancelled: 'Cancelled',
-};
 
 export interface NavigatorMetrics {
   active: number;

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bot, Home, Pause, Play, Radio, ScanSearch } from 'lucide-react';
+import { Bookmark, Bot, Home, Pause, Play, Radio, ScanSearch } from 'lucide-react';
 import type {
   OccupancySummary,
   PatientFlowAmbient,
@@ -49,8 +49,18 @@ interface NavigatorToolbarProps {
   onAskEddy: () => void;
   onSpeedChange: (speed: number) => void;
   onFiltersChange: (patch: Partial<PatientFlowFilters>) => void;
+  /** Explicit floor choice: filters AND frames the floor (N-4). */
+  onFloorSelect: (floor: string) => void;
   onLayerChange: (key: keyof PatientLayerState, value: boolean) => void;
   onBarrierFinderChange: (value: boolean) => void;
+  /** Token count for the active search, null when the field is empty (N-5). */
+  searchMatches: number | null;
+  /** Enter in Find — fly to the matched tokens (N-5). */
+  onSearchSubmit: () => void;
+  /** Which saved-view slots hold a view (N-7). */
+  savedViews: boolean[];
+  onSaveView: (slot: number) => void;
+  onApplyView: (slot: number) => void;
 }
 
 export default function NavigatorToolbar({
@@ -79,8 +89,14 @@ export default function NavigatorToolbar({
   onAskEddy,
   onSpeedChange,
   onFiltersChange,
+  onFloorSelect,
   onLayerChange,
   onBarrierFinderChange,
+  searchMatches,
+  onSearchSubmit,
+  savedViews,
+  onSaveView,
+  onApplyView,
 }: NavigatorToolbarProps) {
   return (
     <aside className="patient-flow-toolbar" aria-label="Navigator controls">
@@ -148,12 +164,37 @@ export default function NavigatorToolbar({
         )}
       </div>
 
+      {/* N-7: three persona-keyed camera bookmarks — restore on the left,
+          save-current on the right of each chip. */}
+      <div className="patient-flow-views" aria-label="Saved views">
+        {savedViews.map((hasView, slot) => (
+          <div className="patient-flow-view-chip" key={`view-slot-${slot}`}>
+            <button
+              type="button"
+              disabled={!hasView}
+              title={hasView ? `Restore view ${slot + 1} (camera, floor, layers)` : `View ${slot + 1} is empty — save one first`}
+              onClick={() => onApplyView(slot)}
+            >
+              View {slot + 1}
+            </button>
+            <button
+              type="button"
+              aria-label={`Save current view to slot ${slot + 1}`}
+              title={hasView ? `Overwrite view ${slot + 1} with the current view` : `Save the current view as view ${slot + 1}`}
+              onClick={() => onSaveView(slot)}
+            >
+              <Bookmark aria-hidden="true" />
+            </button>
+          </div>
+        ))}
+      </div>
+
       <div className="patient-flow-control-grid">
         <label htmlFor="flow-floor">Floor</label>
         <select
           id="flow-floor"
           value={filters.floor}
-          onChange={(event) => onFiltersChange({ floor: event.target.value })}
+          onChange={(event) => onFloorSelect(event.target.value)}
         >
           <option value="all">All</option>
           {floors.map((floor) => (
@@ -199,8 +240,25 @@ export default function NavigatorToolbar({
           type="search"
           placeholder="PT, bed, service"
           value={filters.search}
+          aria-describedby={searchMatches !== null ? 'flow-search-count' : undefined}
           onChange={(event) => onFiltersChange({ search: event.target.value })}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              onSearchSubmit();
+            } else if (event.key === 'Escape') {
+              onFiltersChange({ search: '' });
+            }
+          }}
         />
+
+        {searchMatches !== null && (
+          <small id="flow-search-count" className="patient-flow-search-count" role="status">
+            {searchMatches === 0
+              ? '0 matches — check spelling or floor filter'
+              : `${searchMatches} ${searchMatches === 1 ? 'match' : 'matches'} · Enter flies to them`}
+          </small>
+        )}
 
         {/* Census scope, not a layer (B-2): "Delayed" filters the occupancy
             disks by elapsed-timer signal — distinct from the "Barriers"

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -7,7 +7,26 @@ import type {
   PatientFlowSummary,
   PatientLayerState,
 } from '@/features/patientFlowNavigator/types';
+import type { RunStatus } from '@/features/virtualRounds/types';
 import { formatDurationMinutes } from '@/lib/duration';
+
+export interface RoundsHudModel {
+  status: RunStatus;
+  scopeLabel: string | null;
+  total: number;
+  rounded: number;
+  awaitingInput: number;
+}
+
+const RUN_STATUS_LABEL: Record<RunStatus, string> = {
+  draft: 'Draft',
+  scheduled: 'Scheduled',
+  active: 'Active',
+  paused: 'Paused',
+  closing: 'Closing',
+  completed: 'Complete',
+  cancelled: 'Cancelled',
+};
 
 export interface NavigatorMetrics {
   active: number;
@@ -61,6 +80,12 @@ interface NavigatorToolbarProps {
   savedViews: boolean[];
   onSaveView: (slot: number) => void;
   onApplyView: (slot: number) => void;
+  /** Virtual Rounds run HUD + tour controls (R-5/R-6a); null → no run. */
+  roundsHud: RoundsHudModel | null;
+  tourAuto: boolean;
+  onTourPrev: () => void;
+  onTourNext: () => void;
+  onTourAutoToggle: () => void;
 }
 
 export default function NavigatorToolbar({
@@ -97,6 +122,11 @@ export default function NavigatorToolbar({
   savedViews,
   onSaveView,
   onApplyView,
+  roundsHud,
+  tourAuto,
+  onTourPrev,
+  onTourNext,
+  onTourAutoToggle,
 }: NavigatorToolbarProps) {
   return (
     <aside className="patient-flow-toolbar" aria-label="Navigator controls">
@@ -117,6 +147,36 @@ export default function NavigatorToolbar({
               ? `${new Date(summary.data_extent.first_event_at).toLocaleString()} to ${new Date(summary.data_extent.last_event_at).toLocaleString()}`
               : 'No event extent available'}
           </small>
+        </div>
+      )}
+
+      {/* R-5: run HUD — colored by run state, never coral. Tour controls
+          (R-6a) walk the itinerary; Auto pauses on any camera input. */}
+      {roundsHud && (
+        <div className={`patient-flow-rounds-hud run-${roundsHud.status}`} role="status">
+          <div className="patient-flow-rounds-hud-text">
+            <strong>
+              Rounds · {RUN_STATUS_LABEL[roundsHud.status]}
+              {roundsHud.scopeLabel ? ` · ${roundsHud.scopeLabel}` : ''}
+            </strong>
+            <span>
+              {roundsHud.rounded}/{roundsHud.total} rounded
+              {roundsHud.awaitingInput > 0 ? ` · ${roundsHud.awaitingInput} awaiting input` : ''}
+            </span>
+          </div>
+          <div className="patient-flow-tour-controls">
+            <button type="button" aria-label="Previous round stop" title="Previous round stop" onClick={onTourPrev}>◀</button>
+            <button type="button" aria-label="Next round stop" title="Next round stop" onClick={onTourNext}>▶</button>
+            <button
+              type="button"
+              aria-pressed={tourAuto}
+              className={tourAuto ? 'active' : ''}
+              title="Auto-step the tour every 10 seconds; moving the camera pauses it"
+              onClick={onTourAutoToggle}
+            >
+              Auto
+            </button>
+          </div>
         </div>
       )}
 

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -175,11 +175,12 @@
   color: #7dd3fc;
 }
 
+/* No overflow clipping: the jump buttons extend past the 8px band to reach
+   a 24px hit target (WCAG 2.2 target size). Wash layers carry their own radii. */
 .patient-flow-chronobar-track {
   position: relative;
   height: 8px;
   border-radius: 4px;
-  overflow: hidden;
   background: rgba(255, 255, 255, 0.05);
 }
 
@@ -187,6 +188,7 @@
 .patient-flow-chronobar-past {
   position: absolute;
   inset: 0 auto 0 0;
+  border-radius: 4px 0 0 4px;
   background: rgba(221, 212, 197, 0.14);
 }
 
@@ -194,6 +196,7 @@
 .patient-flow-chronobar-future {
   position: absolute;
   inset: 0 auto 0 0;
+  border-radius: 0 4px 4px 0;
   background: repeating-linear-gradient(
     90deg,
     rgba(125, 211, 252, 0.28) 0 5px,
@@ -205,16 +208,18 @@
 .patient-flow-chronobar-coverage {
   position: absolute;
   inset: 0 auto 0 0;
+  border-radius: 4px;
   background: rgba(224, 163, 63, 0.45);
 }
 
-/* Shift-change detent — a jump button (N-2): 9px hit area, 1px visual line. */
+/* Shift-change detent — a jump button (N-2): 24×24 hit target extending
+   above/below the band, 1px visual line confined to the band. */
 .patient-flow-chronobar-detent {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 9px;
-  margin-left: -4.5px;
+  top: -8px;
+  bottom: -8px;
+  width: 24px;
+  margin-left: -12px;
   padding: 0;
   border: 0;
   background: transparent;
@@ -224,8 +229,8 @@
 .patient-flow-chronobar-detent::after {
   content: '';
   position: absolute;
-  top: 0;
-  bottom: 0;
+  top: 8px;
+  bottom: 8px;
   left: 50%;
   width: 1px;
   margin-left: -0.5px;
@@ -253,14 +258,14 @@
   background: #e0a33f;
 }
 
-/* Open-barrier opened-at marker — also a jump button (N-2): amber notch
-   visual, full-height amber on hover/focus. */
+/* Open-barrier opened-at marker — also a jump button (N-2): 24×24 hit
+   target; amber notch visual, full-band amber on hover/focus. */
 .patient-flow-chronobar-barrier {
   position: absolute;
-  top: 0;
-  bottom: 0;
-  width: 9px;
-  margin-left: -4.5px;
+  top: -8px;
+  bottom: -8px;
+  width: 24px;
+  margin-left: -12px;
   padding: 0;
   border: 0;
   background: transparent;
@@ -270,7 +275,7 @@
 .patient-flow-chronobar-barrier::after {
   content: '';
   position: absolute;
-  top: 0;
+  top: 6px;
   height: 5px;
   left: 50%;
   width: 2px;
@@ -282,7 +287,8 @@
 
 .patient-flow-chronobar-barrier:hover::after,
 .patient-flow-chronobar-barrier:focus-visible::after {
-  height: 100%;
+  top: 8px;
+  height: 8px;
 }
 
 .patient-flow-chronobar-barrier:focus-visible {
@@ -1001,7 +1007,9 @@
 .patient-flow-floor-rail {
   position: absolute;
   z-index: 3;
-  right: 16px;
+  /* Clear of the right-hand feed/inspector column (390px + margins) so a
+     tall inspector never sits under the rail's buttons. */
+  right: 422px;
   top: 50%;
   transform: translateY(-50%);
   display: flex;
@@ -1161,12 +1169,36 @@
   color: #b9b2a6;
 }
 
+.patient-flow-shortcut-sheet:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
+}
+
+.patient-flow-shortcut-close {
+  margin-top: 12px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 5px;
+  background: #2a2f2c;
+  color: #ddd6c7;
+  font-size: 12px;
+  padding: 4px 12px;
+  cursor: pointer;
+}
+
+.patient-flow-shortcut-close:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
+}
+
 /* --- Hover chip (E-4) — scene-owned element, textContent only ------------ */
 
 .patient-flow-hover-chip {
   position: absolute;
+  left: 0;
+  top: 0;
   z-index: 4;
   pointer-events: none;
+  will-change: transform;
   max-width: 260px;
   border: 1px solid rgba(239, 234, 220, 0.22);
   border-radius: 5px;

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -883,6 +883,119 @@
   font-size: 11px;
 }
 
+/* --- Rounds HUD + tour (R-5/R-6a) — run state, never coral ---------------- */
+
+.patient-flow-rounds-hud {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 6px;
+  background: rgba(148, 163, 184, 0.08);
+  padding: 6px 9px;
+  font-size: 11px;
+  color: #ddd6c7;
+}
+
+.patient-flow-rounds-hud.run-active {
+  border-color: rgba(45, 212, 191, 0.45);
+  background: rgba(45, 212, 191, 0.08);
+}
+
+.patient-flow-rounds-hud.run-paused {
+  border-color: rgba(234, 166, 64, 0.45);
+  background: rgba(234, 166, 64, 0.08);
+}
+
+.patient-flow-rounds-hud.run-completed {
+  opacity: 0.75;
+}
+
+.patient-flow-rounds-hud-text {
+  flex: 1;
+  min-width: 0;
+  display: grid;
+  gap: 1px;
+}
+
+.patient-flow-rounds-hud-text strong {
+  color: #f3efe5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.patient-flow-rounds-hud-text span {
+  color: #b9b2a6;
+  font-variant-numeric: tabular-nums;
+}
+
+.patient-flow-tour-controls {
+  display: flex;
+  gap: 4px;
+}
+
+.patient-flow-tour-controls button {
+  min-width: 26px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 5px;
+  background: #2a2f2c;
+  color: #ddd6c7;
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 6px;
+  cursor: pointer;
+}
+
+.patient-flow-tour-controls button.active {
+  border-color: #e0a33f;
+  background: #3a2f1f;
+  color: #ffd795;
+}
+
+.patient-flow-tour-controls button:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 1px;
+}
+
+/* --- Toast (R-1 fallback etc.) — transient, self-dismissing --------------- */
+
+.patient-flow-toast {
+  position: absolute;
+  z-index: 5;
+  left: 50%;
+  bottom: 56px;
+  transform: translateX(-50%);
+  max-width: min(420px, calc(100vw - 32px));
+  border: 1px solid rgba(234, 166, 64, 0.5);
+  border-radius: 6px;
+  background: rgba(27, 31, 29, 0.96);
+  color: #ffd795;
+  font-size: 12px;
+  padding: 7px 12px;
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.3);
+}
+
+/* --- Inspector deep-link action (R-2) ------------------------------------- */
+
+.patient-flow-inspector-action {
+  display: inline-block;
+  margin-top: 10px;
+  color: #7dd3fc;
+  font-size: 12px;
+  text-decoration: none;
+}
+
+.patient-flow-inspector-action:hover {
+  text-decoration: underline;
+}
+
+.patient-flow-inspector-action:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
+}
+
 /* --- Floor stepper rail (N-4) — right edge, top = highest floor ---------- */
 
 .patient-flow-floor-rail {

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -883,6 +883,171 @@
   font-size: 11px;
 }
 
+/* --- Floor stepper rail (N-4) — right edge, top = highest floor ---------- */
+
+.patient-flow-floor-rail {
+  position: absolute;
+  z-index: 3;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: min(70vh, 560px);
+  overflow: auto;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 7px;
+  background: rgba(27, 31, 29, 0.92);
+  padding: 4px;
+}
+
+.patient-flow-floor-rail button {
+  min-width: 30px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: #b9b2a6;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+  padding: 5px 6px;
+  cursor: pointer;
+}
+
+.patient-flow-floor-rail button:hover {
+  background: rgba(255, 255, 255, 0.07);
+  color: #f3efe5;
+}
+
+.patient-flow-floor-rail button.active {
+  background: rgba(224, 163, 63, 0.16);
+  color: #ffd795;
+}
+
+.patient-flow-floor-rail button:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: -2px;
+}
+
+.patient-flow-floor-all {
+  margin-top: 3px;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0 0 5px 5px;
+}
+
+/* --- Search match count (N-5) -------------------------------------------- */
+
+.patient-flow-search-count {
+  grid-column: 2;
+  color: #b9b2a6;
+  font-size: 11px;
+}
+
+/* --- Saved views (N-7) ---------------------------------------------------- */
+
+.patient-flow-views {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.patient-flow-view-chip {
+  display: flex;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 6px;
+  overflow: hidden;
+  background: #202522;
+}
+
+.patient-flow-view-chip button {
+  border: 0;
+  background: transparent;
+  color: #ddd6c7;
+  font-size: 11px;
+  line-height: 1.2;
+  padding: 5px 6px;
+  cursor: pointer;
+}
+
+.patient-flow-view-chip button:first-child {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+}
+
+.patient-flow-view-chip button:first-child:disabled {
+  color: rgba(185, 178, 166, 0.45);
+  cursor: default;
+}
+
+.patient-flow-view-chip button:last-child {
+  border-left: 1px solid rgba(239, 234, 220, 0.14);
+  color: #b9b2a6;
+}
+
+.patient-flow-view-chip button:last-child:hover {
+  color: #ffd795;
+}
+
+.patient-flow-view-chip button svg {
+  width: 12px;
+  height: 12px;
+  display: block;
+}
+
+.patient-flow-view-chip button:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: -2px;
+}
+
+/* --- Shortcut sheet (N-6) — legend chrome, centered ---------------------- */
+
+.patient-flow-shortcut-sheet {
+  position: absolute;
+  z-index: 5;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: min(330px, calc(100vw - 32px));
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  background: rgba(27, 31, 29, 0.96);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.3);
+  padding: 14px;
+}
+
+.patient-flow-shortcut-sheet strong {
+  display: block;
+  margin-bottom: 10px;
+  color: #f3efe5;
+  font-size: 13px;
+}
+
+.patient-flow-shortcut-sheet dl {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  font-size: 12px;
+}
+
+.patient-flow-shortcut-sheet dl div {
+  display: grid;
+  grid-template-columns: 74px 1fr;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.patient-flow-shortcut-sheet dt {
+  color: #ffd795;
+  font-variant-numeric: tabular-nums;
+}
+
+.patient-flow-shortcut-sheet dd {
+  margin: 0;
+  color: #b9b2a6;
+}
+
 /* --- Hover chip (E-4) — scene-owned element, textContent only ------------ */
 
 .patient-flow-hover-chip {
@@ -978,6 +1143,14 @@
   }
 
   .patient-flow-camera {
+    display: none;
+  }
+
+  /* Mobile is triage-level (plan S-3): the desktop-only navigation chrome
+     yields the viewport back to the scene. */
+  .patient-flow-floor-rail,
+  .patient-flow-legend,
+  .patient-flow-views {
     display: none;
   }
 }

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -774,6 +774,134 @@
   padding: 6px 10px;
 }
 
+/* --- Scene key (E-1) — rendered from sceneVocabulary ---------------------- */
+
+.patient-flow-legend {
+  position: absolute;
+  z-index: 3;
+  left: 16px;
+  bottom: 48px;
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: flex-start;
+  gap: 6px;
+}
+
+.patient-flow-legend-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 999px;
+  background: rgba(27, 31, 29, 0.92);
+  color: #ddd6c7;
+  font-size: 12px;
+  padding: 5px 11px;
+  cursor: pointer;
+}
+
+.patient-flow-legend-toggle svg {
+  width: 13px;
+  height: 13px;
+}
+
+.patient-flow-legend-toggle[aria-expanded='true'] {
+  border-color: #e0a33f;
+  color: #ffd795;
+}
+
+.patient-flow-legend-toggle:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
+}
+
+.patient-flow-legend-panel {
+  width: min(270px, calc(100vw - 32px));
+  max-height: min(430px, calc(100vh - 220px));
+  overflow: auto;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  background: rgba(27, 31, 29, 0.94);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.3);
+  padding: 10px 12px;
+}
+
+.patient-flow-legend-panel section + section {
+  margin-top: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  padding-top: 7px;
+}
+
+.patient-flow-legend-panel h3 {
+  margin: 0 0 5px;
+  color: #b9b2a6;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.patient-flow-legend-panel ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 5px;
+}
+
+.patient-flow-legend-panel li {
+  display: grid;
+  grid-template-columns: 20px minmax(0, 1fr);
+  gap: 8px;
+  align-items: start;
+}
+
+.patient-flow-legend-panel li.legend-hidden {
+  opacity: 0.45;
+}
+
+.patient-flow-legend-glyph svg {
+  width: 16px;
+  height: 16px;
+  display: block;
+  margin-top: 1px;
+}
+
+.patient-flow-legend-text {
+  min-width: 0;
+  display: block;
+}
+
+.patient-flow-legend-text strong {
+  display: block;
+  color: #f3efe5;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.patient-flow-legend-text small {
+  color: #b9b2a6;
+  font-size: 11px;
+}
+
+/* --- Hover chip (E-4) — scene-owned element, textContent only ------------ */
+
+.patient-flow-hover-chip {
+  position: absolute;
+  z-index: 4;
+  pointer-events: none;
+  max-width: 260px;
+  border: 1px solid rgba(239, 234, 220, 0.22);
+  border-radius: 5px;
+  background: rgba(27, 31, 29, 0.94);
+  color: #f3efe5;
+  font-size: 12px;
+  line-height: 1.3;
+  padding: 3px 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .patient-flow-error {
   position: absolute;
   z-index: 4;

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -56,10 +56,18 @@ import type {
 } from '@/features/patientFlowNavigator/types';
 import { occupancyInspectorData } from '@/features/patientFlowNavigator/inspector';
 import { elementLabelFor } from '@/features/patientFlowNavigator/sceneVocabulary';
+import {
+  mergeLayers,
+  parseSavedViews,
+  savedViewsKey,
+  serializeSavedViews,
+} from '@/features/patientFlowNavigator/savedViews';
+import type { SavedView } from '@/features/patientFlowNavigator/savedViews';
 import type { PageProps } from '@/types';
 import type { CameraView, NavigatorScene } from './NavigatorScene';
 import NavigatorChronobar from './NavigatorChronobar';
 import NavigatorFeed from './NavigatorFeed';
+import NavigatorFloorRail from './NavigatorFloorRail';
 import NavigatorInspector from './NavigatorInspector';
 import NavigatorLegend from './NavigatorLegend';
 import NavigatorToolbar from './NavigatorToolbar';
@@ -322,6 +330,12 @@ export default function PatientFlowNavigator({
   const [inspectorRows, setInspectorRows] = useState<Array<[string, string]>>([]);
   const [feed, setFeed] = useState<PatientFlowEvent[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [searchMatches, setSearchMatches] = useState<number | null>(null);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const viewsStorageKey = savedViewsKey(lens?.role_id);
+  const [views, setViews] = useState<Array<SavedView | null>>(() =>
+    parseSavedViews(typeof window === 'undefined' ? null : window.localStorage.getItem(viewsStorageKey)),
+  );
 
   const tracks = useMemo(() => rebuildTracks(events), [events]);
 
@@ -534,6 +548,8 @@ export default function PatientFlowNavigator({
       occupiedLocations: occupied
         || new Set((barrierFinderRef.current || useServerOccupancy ? visibleOccupancyInsights.map((item) => item.location) : states.map((state) => state.event.to_location)).filter(Boolean)).size,
     });
+    // N-5: the Find field shows how many tokens the search matched.
+    setSearchMatches(filtersRef.current.search.trim() ? states.length : null);
   }, [dotsPolicy, lens, patientDotsVisible]);
 
   // Keep refs in sync with state, then repaint.
@@ -962,10 +978,12 @@ export default function PatientFlowNavigator({
     sceneRef.current?.setHoverEnabled(!(playing && speed > 60));
   }, [playing, speed]);
 
-  // E-5: Escape clears the in-scene selection highlight and the panel with it.
+  // E-5: Escape clears the in-scene selection highlight and the panel with it
+  // (and closes the shortcut sheet, N-6).
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
       if (event.key !== 'Escape') return;
+      setShortcutsOpen(false);
       sceneRef.current?.clearSelection();
       setInspectorTitle('Select a patient or location');
       setInspectorRows([]);
@@ -982,6 +1000,84 @@ export default function PatientFlowNavigator({
       .map((item) => item.position);
     sceneRef.current?.focusOn(points);
   }, []);
+
+  // N-4: fit-to-floor — frame the selected floor's locations; All = home.
+  const fitToFloor = useCallback((floor: string): void => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    if (floor === 'all') {
+      scene.resetCamera();
+      return;
+    }
+    const points = Object.values(locationsRef.current)
+      .filter((loc) => loc.position_m && String(loc.floor) === floor)
+      .map((loc) => ({ x: loc.position_m!.x, y: loc.position_m!.y ?? 0, z: loc.position_m!.z }));
+    scene.focusOn(points);
+  }, []);
+
+  // Explicit floor choices (rail or dropdown) filter AND frame; handoff-driven
+  // filter writes deliberately do not move the camera.
+  const handleFloorSelect = useCallback((floor: string): void => {
+    setFilters((prev) => ({ ...prev, floor }));
+    fitToFloor(floor);
+  }, [fitToFloor]);
+
+  // N-5: Enter in Find flies to the bbox of the matched tokens.
+  const focusSearchMatches = useCallback((): void => {
+    const points = lastVisibleStatesRef.current.map((state) => state.position);
+    if (points.length) sceneRef.current?.focusOn(points);
+  }, []);
+
+  // N-7: three persona-keyed camera/floor/layers bookmarks.
+  const saveView = useCallback((slot: number): void => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    setViews((prev) => {
+      const next = [...prev];
+      next[slot] = {
+        camera: scene.getCameraView(),
+        floor: filtersRef.current.floor,
+        layers: { ...layersRef.current },
+      };
+      try {
+        window.localStorage.setItem(viewsStorageKey, serializeSavedViews(next));
+      } catch {
+        // Storage unavailable: the view still works for this session.
+      }
+      return next;
+    });
+  }, [viewsStorageKey]);
+
+  const applyView = useCallback((slot: number): void => {
+    const view = views[slot];
+    if (!view) return;
+    setFilters((prev) => ({ ...prev, floor: view.floor }));
+    setLayers((prev) => mergeLayers(prev, view.layers));
+    sceneRef.current?.setCameraView(view.camera);
+  }, [views]);
+
+  // N-6: keyboard map — H home, F focus selection (else active patients),
+  // N now, ? shortcut sheet. Typing contexts are left alone.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName;
+      if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      const key = event.key.toLowerCase();
+      if (key === 'h') {
+        sceneRef.current?.resetCamera();
+      } else if (key === 'f') {
+        if (!sceneRef.current?.focusSelection()) focusActivePatients();
+      } else if (key === 'n') {
+        if (!historical) handleScrub(nowMsRef.current);
+      } else if (event.key === '?') {
+        setShortcutsOpen((value) => !value);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [focusActivePatients, handleScrub, historical]);
 
   const askEddy = useCallback((): void => {
     const serviceLines = occupancy.serviceLines.length > 0
@@ -1077,9 +1173,15 @@ export default function PatientFlowNavigator({
         onFocusDelayed={focusDelayed}
         onSpeedChange={setSpeed}
         onFiltersChange={(patch) => setFilters((prev) => ({ ...prev, ...patch }))}
+        onFloorSelect={handleFloorSelect}
         onLayerChange={(key, value) => setLayers((prev) => ({ ...prev, [key]: value }))}
         onBarrierFinderChange={setBarrierFinder}
         onAskEddy={askEddy}
+        searchMatches={searchMatches}
+        onSearchSubmit={focusSearchMatches}
+        savedViews={views.map((view) => view !== null)}
+        onSaveView={saveView}
+        onApplyView={applyView}
       />
 
       <NavigatorFeed feed={feed} redactIdentity={dotsPolicy !== null && dotsPolicy !== 'full'} />
@@ -1087,6 +1189,24 @@ export default function PatientFlowNavigator({
       <NavigatorInspector title={inspectorTitle} rows={inspectorRows} />
 
       <NavigatorLegend layers={layers} />
+
+      <NavigatorFloorRail floors={floors} current={filters.floor} onSelect={handleFloorSelect} />
+
+      {shortcutsOpen && (
+        <div className="patient-flow-shortcut-sheet" role="dialog" aria-label="Keyboard shortcuts">
+          <strong>Keyboard shortcuts</strong>
+          <dl>
+            <div><dt>H</dt><dd>Home view</dd></div>
+            <div><dt>F</dt><dd>Focus selection (or active patients)</dd></div>
+            <div><dt>N</dt><dd>Jump to now</dd></div>
+            <div><dt>↑ ↓</dt><dd>Step floors (floor rail focused)</dd></div>
+            <div><dt>← → ↑ ↓</dt><dd>Pan the camera (click the scene first)</dd></div>
+            <div><dt>Enter</dt><dd>In Find: fly to matches</dd></div>
+            <div><dt>Esc</dt><dd>Clear selection · close panels</dd></div>
+            <div><dt>?</dt><dd>Toggle this sheet</dd></div>
+          </dl>
+        </div>
+      )}
 
       <div className="patient-flow-statusbar">
         <span>{status}</span>

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -36,8 +36,9 @@ import { buildOccupancyInsights } from '@/features/patientFlowNavigator/occupanc
 import { useEddyStore } from '@/stores/eddyStore';
 import { fetchRoundRuns, fetchRoundScene } from '@/features/virtualRounds/api';
 import { runsResponseSchema, sceneResponseSchema } from '@/features/virtualRounds/schemas';
-import { buildRoundStopCells } from '@/features/virtualRounds/roundsScene';
+import { buildRoundRoute, buildRoundStopCells } from '@/features/virtualRounds/roundsScene';
 import type { RoundStop } from '@/features/virtualRounds/roundsScene';
+import type { RunSummary } from '@/features/virtualRounds/types';
 import type {
   FlowLens,
   FlowPatientDots,
@@ -114,15 +115,17 @@ const EMPTY_OCCUPANCY_SUMMARY: OccupancySummary = {
   topBarriers: [],
 };
 
-interface HandoffParams {
+export interface HandoffParams {
   floor: string | null;
   unitRef: string | null;
   t: number | null;
+  /** Rounds board → 4D deep link: fly to this round stop once placed (R-1). */
+  focusStop: string | null;
 }
 
-/** Mobile→web A3 handoff: ?persona=&scope=&t= (persona is resolved server-side). */
-function parseHandoff(): HandoffParams {
-  const empty: HandoffParams = { floor: null, unitRef: null, t: null };
+/** Mobile→web A3 handoff: ?persona=&scope=&t=&focus_stop= (persona is resolved server-side). Exported for tests. */
+export function parseHandoff(): HandoffParams {
+  const empty: HandoffParams = { floor: null, unitRef: null, t: null, focusStop: null };
   if (typeof window === 'undefined') return empty;
   const params = new URLSearchParams(window.location.search);
 
@@ -142,7 +145,7 @@ function parseHandoff(): HandoffParams {
     if (Number.isFinite(parsed)) t = parsed;
   }
 
-  return { floor, unitRef, t };
+  return { floor, unitRef, t, focusStop: params.get('focus_stop') };
 }
 
 function defaultLayersForLens(lens: FlowLens | null | undefined): PatientLayerState {
@@ -332,6 +335,19 @@ export default function PatientFlowNavigator({
   const [error, setError] = useState<string | null>(null);
   const [searchMatches, setSearchMatches] = useState<number | null>(null);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [roundsRun, setRoundsRun] = useState<RunSummary | null>(null);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [inspectorAction, setInspectorAction] = useState<{ label: string; href: string } | null>(null);
+  const [tourAuto, setTourAuto] = useState(false);
+  const [focusTick, setFocusTick] = useState(0);
+  const roundsVersionRef = useRef(0);
+  const roundsSceneHashRef = useRef('');
+  const roundsRunUuidRef = useRef<string | null>(null);
+  const roundsCompleteAnnouncedRef = useRef(false);
+  const pendingFocusStopRef = useRef<string | null>(handoff.focusStop);
+  const focusFloorClearedRef = useRef(false);
+  const focusAttemptsRef = useRef(0);
+  const tourIndexRef = useRef<number | null>(null);
   const viewsStorageKey = savedViewsKey(lens?.role_id);
   const [views, setViews] = useState<Array<SavedView | null>>(() =>
     parseSavedViews(typeof window === 'undefined' ? null : window.localStorage.getItem(viewsStorageKey)),
@@ -470,7 +486,9 @@ export default function PatientFlowNavigator({
       eventsRef.current.length,
       projectionsRef.current.length,
       barriersRef.current.length,
-      roundStopsRef.current.length,
+      // Content version, not length: a status flip with the same stop count
+      // must still rebuild the rings (R-3).
+      roundsVersionRef.current,
       Object.keys(locationsRef.current).length,
     ].join('|');
     if (bucketKey === lastBucketKeyRef.current) return;
@@ -536,11 +554,12 @@ export default function PatientFlowNavigator({
     scene.rebuildBarriers(barrierCells, layersRef.current.barriers);
 
     // Round-stop rings — present-state like barriers: shown at every scrub
-    // position, floor-filtered, opaque tokens only (plan §8.1).
+    // position, floor-filtered, opaque tokens only (plan §8.1). The route
+    // polyline and queue numbers ride the same rebuild (R-4).
     const roundCells = layersRef.current.rounds
       ? buildRoundStopCells(roundStopsRef.current, index, floorFilter)
       : [];
-    scene.rebuildRounds(roundCells, layersRef.current.rounds);
+    scene.rebuildRounds(roundCells, buildRoundRoute(roundCells), layersRef.current.rounds);
 
     setMetrics({
       active: barrierFinderRef.current ? visibleOccupancyInsights.length : (useServerOccupancy ? occupancySummary.active : states.length),
@@ -802,10 +821,15 @@ export default function PatientFlowNavigator({
   // Virtual Rounds overlay (plan §8.1) — the most recent open run's scene
   // stops, opaque tokens only. Feature flag off (404), no run, or any failure
   // simply leaves the overlay empty; the navigator never degrades.
+  // R-3: polled every 30 s (mirroring the board's cadence) with a content-hash
+  // gate so unchanged payloads never trigger a layer rebuild; when the run
+  // closes, the HUD announces completion and polling stops.
   useEffect(() => {
     let cancelled = false;
+    let timer: number | null = null;
 
     async function loadRoundsOverlay(): Promise<void> {
+      if (document.visibilityState === 'hidden') return;
       try {
         const runsPayload = runsResponseSchema.safeParse(await fetchRoundRuns());
         if (!runsPayload.success || cancelled) return;
@@ -813,23 +837,52 @@ export default function PatientFlowNavigator({
         const openRun = runsPayload.data.data.find((run) =>
           ['active', 'paused', 'draft', 'scheduled'].includes(run.status),
         );
-        if (!openRun) return;
+        if (!openRun) {
+          if (roundsRunUuidRef.current && !roundsCompleteAnnouncedRef.current) {
+            roundsCompleteAnnouncedRef.current = true;
+            setRoundsRun((prev) => (prev ? { ...prev, status: 'completed' } : prev));
+            setToastMessage('Rounds run complete');
+            if (timer !== null) window.clearInterval(timer);
+          }
+          return;
+        }
+        roundsRunUuidRef.current = openRun.run_uuid;
 
         const scenePayload = sceneResponseSchema.safeParse(await fetchRoundScene(openRun.run_uuid));
         if (!scenePayload.success || cancelled) return;
 
-        setRoundStops(scenePayload.data.data.stops);
+        setRoundsRun(scenePayload.data.data.run);
+        const stops = scenePayload.data.data.stops;
+        const hash = JSON.stringify(stops);
+        if (hash !== roundsSceneHashRef.current) {
+          roundsSceneHashRef.current = hash;
+          roundsVersionRef.current += 1;
+          setRoundStops(stops);
+        }
       } catch {
-        if (!cancelled) setRoundStops([]);
+        // Transient poll failure: keep the last overlay rather than blanking
+        // an active itinerary; the initial state is already empty.
       }
     }
 
     void loadRoundsOverlay();
+    timer = window.setInterval(() => void loadRoundsOverlay(), 30_000);
+    const onVisibility = (): void => void loadRoundsOverlay();
+    document.addEventListener('visibilitychange', onVisibility);
 
     return () => {
       cancelled = true;
+      if (timer !== null) window.clearInterval(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, []);
+
+  // Toasts self-dismiss; anything durable belongs in the HUD or status bar.
+  useEffect(() => {
+    if (!toastMessage) return;
+    const timer = window.setTimeout(() => setToastMessage(null), 6000);
+    return () => window.clearTimeout(timer);
+  }, [toastMessage]);
 
   // Handoff scope=unit:{id|abbr} → that unit's floor, once derivable.
   useEffect(() => {
@@ -872,7 +925,14 @@ export default function PatientFlowNavigator({
           );
           setInspectorTitle(element && element !== name ? `${element} · ${name}` : name);
           setInspectorRows(flattenInspector(redacted));
+          // R-2: a round-stop selection links straight back to the board.
+          setInspectorAction(
+            data.kind === 'round-stop' && typeof data.round_patient_uuid === 'string'
+              ? { label: 'Open in Rounds board', href: `/rtdc/virtual-rounds?patient=${data.round_patient_uuid}` }
+              : null,
+          );
         },
+        onUserCameraStart: () => setTourAuto(false),
         // E-4 hover chip: element type + a non-identity name. Identity fields
         // NEVER appear here regardless of lens (stricter than the inspector).
         hoverLabel: (data) => {
@@ -987,6 +1047,7 @@ export default function PatientFlowNavigator({
       sceneRef.current?.clearSelection();
       setInspectorTitle('Select a patient or location');
       setInspectorRows([]);
+      setInspectorAction(null);
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
@@ -1078,6 +1139,120 @@ export default function PatientFlowNavigator({
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [focusActivePatients, handleScrub, historical]);
+
+  // ---- Virtual Rounds integration (Phase 3) --------------------------------
+
+  // R-1: focus a round stop once its ring is actually placed. The scene and
+  // the stops load independently, so retry on a short interval; if the stop
+  // is unplaceable, clear the floor filter once and retry, then fall back to
+  // a toast pointing at the board.
+  const requestStopFocus = useCallback((uuid: string): void => {
+    pendingFocusStopRef.current = uuid;
+    focusFloorClearedRef.current = false;
+    setFocusTick((value) => value + 1);
+  }, []);
+
+  useEffect(() => {
+    const uuid = pendingFocusStopRef.current;
+    if (!uuid || roundStops.length === 0) return;
+    focusAttemptsRef.current = 0;
+    const timer = window.setInterval(() => {
+      const scene = sceneRef.current;
+      focusAttemptsRef.current += 1;
+      if (scene && scene.focusRoundStop(uuid)) {
+        pendingFocusStopRef.current = null;
+        window.clearInterval(timer);
+        return;
+      }
+      if (scene && !focusFloorClearedRef.current) {
+        focusFloorClearedRef.current = true;
+        setFilters((prev) => (prev.floor === 'all' ? prev : { ...prev, floor: 'all' }));
+        return;
+      }
+      if (focusAttemptsRef.current >= 15) {
+        pendingFocusStopRef.current = null;
+        window.clearInterval(timer);
+        sceneRef.current?.focusRoundStop(null);
+        setToastMessage('Stop not placeable — open the Rounds board');
+      }
+    }, 600);
+    return () => window.clearInterval(timer);
+  }, [roundStops, focusTick]);
+
+  // R-6a: manual tour — queue order among placeable, walkable stops.
+  const tourStops = useMemo(
+    () => buildRoundStopCells(roundStops, placementIndex, 'all')
+      .filter((cell) => !['skipped', 'deferred'].includes(cell.stop.status))
+      .sort((a, b) => a.stop.queue_position - b.stop.queue_position),
+    [placementIndex, roundStops],
+  );
+
+  const showStopInspector = useCallback((stop: RoundStop): void => {
+    const data: Record<string, unknown> = {
+      kind: 'round-stop',
+      round_patient_uuid: stop.round_patient_uuid,
+      status: stop.status,
+      queue_position: stop.queue_position,
+      priority_band: stop.priority_band,
+      ...(stop.bed ? { bed: stop.bed } : {}),
+      ...(stop.pinned ? { pinned: true } : {}),
+      ...(stop.discharge_ready ? { discharge_ready: true } : {}),
+      ...(stop.missing_input ? { missing_input: true } : {}),
+    };
+    setInspectorTitle(`Round stop · #${stop.queue_position}`);
+    setInspectorRows(flattenInspector(redactSelection(data, dotsPolicy)));
+    setInspectorAction({
+      label: 'Open in Rounds board',
+      href: `/rtdc/virtual-rounds?patient=${stop.round_patient_uuid}`,
+    });
+  }, [dotsPolicy]);
+
+  const tourStep = useCallback((direction: 1 | -1): void => {
+    if (tourStops.length === 0) return;
+    const previous = tourIndexRef.current;
+    const next = previous === null
+      ? (direction === 1 ? 0 : tourStops.length - 1)
+      : Math.min(tourStops.length - 1, Math.max(0, previous + direction));
+    tourIndexRef.current = next;
+    const cell = tourStops[next];
+    requestStopFocus(cell.stop.round_patient_uuid);
+    showStopInspector(cell.stop);
+  }, [requestStopFocus, showStopInspector, tourStops]);
+
+  const toggleTourAuto = useCallback((): void => {
+    setTourAuto((value) => {
+      const next = !value;
+      if (next && tourIndexRef.current === null) tourStep(1);
+      return next;
+    });
+  }, [tourStep]);
+
+  // Auto mode: 10 s dwell, stops at the end of the itinerary; any operator
+  // camera input pauses it (wired via the scene's onUserCameraStart).
+  useEffect(() => {
+    if (!tourAuto) return;
+    const timer = window.setInterval(() => {
+      if (tourIndexRef.current !== null && tourIndexRef.current >= tourStops.length - 1) {
+        setTourAuto(false);
+        return;
+      }
+      tourStep(1);
+    }, 10_000);
+    return () => window.clearInterval(timer);
+  }, [tourAuto, tourStep, tourStops.length]);
+
+  // R-5: run HUD — status, progress, and awaiting-input, straight from the
+  // opaque stops (never coral; a round state is work, not a breach).
+  const roundsHud = useMemo(() => {
+    if (!roundsRun || roundStops.length === 0) return null;
+    return {
+      status: roundsRun.status,
+      scopeLabel: roundsRun.scope_label,
+      total: roundStops.length,
+      rounded: roundStops.filter((stop) => stop.status === 'rounded').length,
+      awaitingInput: roundStops.filter((stop) => stop.status === 'awaiting_input').length,
+    };
+  }, [roundsRun, roundStops]);
 
   const askEddy = useCallback((): void => {
     const serviceLines = occupancy.serviceLines.length > 0
@@ -1182,13 +1357,22 @@ export default function PatientFlowNavigator({
         savedViews={views.map((view) => view !== null)}
         onSaveView={saveView}
         onApplyView={applyView}
+        roundsHud={roundsHud}
+        tourAuto={tourAuto}
+        onTourPrev={() => tourStep(-1)}
+        onTourNext={() => tourStep(1)}
+        onTourAutoToggle={toggleTourAuto}
       />
 
       <NavigatorFeed feed={feed} redactIdentity={dotsPolicy !== null && dotsPolicy !== 'full'} />
 
-      <NavigatorInspector title={inspectorTitle} rows={inspectorRows} />
+      <NavigatorInspector title={inspectorTitle} rows={inspectorRows} action={inspectorAction} />
 
       <NavigatorLegend layers={layers} />
+
+      {toastMessage && (
+        <div className="patient-flow-toast" role="status">{toastMessage}</div>
+      )}
 
       <NavigatorFloorRail floors={floors} current={filters.floor} onSelect={handleFloorSelect} />
 

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -55,11 +55,13 @@ import type {
   ProjectionItem,
 } from '@/features/patientFlowNavigator/types';
 import { occupancyInspectorData } from '@/features/patientFlowNavigator/inspector';
+import { elementLabelFor } from '@/features/patientFlowNavigator/sceneVocabulary';
 import type { PageProps } from '@/types';
 import type { CameraView, NavigatorScene } from './NavigatorScene';
 import NavigatorChronobar from './NavigatorChronobar';
 import NavigatorFeed from './NavigatorFeed';
 import NavigatorInspector from './NavigatorInspector';
+import NavigatorLegend from './NavigatorLegend';
 import NavigatorToolbar from './NavigatorToolbar';
 import type { LayerControl, NavigatorMetrics } from './NavigatorToolbar';
 import './PatientFlowNavigator.css';
@@ -845,10 +847,24 @@ export default function PatientFlowNavigator({
       scene = new SceneClass(canvas, container, {
         onSelect: (data) => {
           const redacted = redactSelection(data, dotsPolicy);
-          setInspectorTitle(String(
-            redacted.patient_display_id ?? redacted.label ?? redacted.name ?? redacted.code ?? redacted.kind ?? 'Selected',
-          ));
+          // E-5: panel and scene agree — the title carries the element type
+          // the selection highlight is pointing at.
+          const element = elementLabelFor(data);
+          const name = String(
+            redacted.patient_display_id ?? redacted.label ?? redacted.name ?? redacted.code
+              ?? redacted.location_name ?? redacted.location ?? redacted.kind ?? 'Selected',
+          );
+          setInspectorTitle(element && element !== name ? `${element} · ${name}` : name);
           setInspectorRows(flattenInspector(redacted));
+        },
+        // E-4 hover chip: element type + a non-identity name. Identity fields
+        // NEVER appear here regardless of lens (stricter than the inspector).
+        hoverLabel: (data) => {
+          const element = elementLabelFor(data);
+          if (!element) return null;
+          const name = data.label ?? data.bed ?? data.bed_code ?? data.location_name
+            ?? data.location ?? data.name ?? data.unit ?? data.status ?? null;
+          return name !== null && String(name) !== element ? `${element} · ${String(name)}` : element;
         },
         onCameraMove: handleCameraMove,
         onFrame: (delta) => {
@@ -867,6 +883,7 @@ export default function PatientFlowNavigator({
         },
       });
       sceneRef.current = scene;
+      scene.setHoverEnabled(!(playingRef.current && speedRef.current > 60));
       lastBucketKeyRef.current = '';
       scene.loadModel(
         summary.model_url,
@@ -938,6 +955,23 @@ export default function PatientFlowNavigator({
     const scene = sceneRef.current;
     if (!scene) return;
     scene.focusOn(lastVisibleStatesRef.current.map((state) => state.position));
+  }, []);
+
+  // E-4 perf guard: hover raycasts pause during fast playback.
+  useEffect(() => {
+    sceneRef.current?.setHoverEnabled(!(playing && speed > 60));
+  }, [playing, speed]);
+
+  // E-5: Escape clears the in-scene selection highlight and the panel with it.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') return;
+      sceneRef.current?.clearSelection();
+      setInspectorTitle('Select a patient or location');
+      setInspectorRows([]);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
   }, []);
 
   // B-4: the explicit camera action for the Delayed-only census scope — the
@@ -1051,6 +1085,8 @@ export default function PatientFlowNavigator({
       <NavigatorFeed feed={feed} redactIdentity={dotsPolicy !== null && dotsPolicy !== 'full'} />
 
       <NavigatorInspector title={inspectorTitle} rows={inspectorRows} />
+
+      <NavigatorLegend layers={layers} />
 
       <div className="patient-flow-statusbar">
         <span>{status}</span>

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -304,6 +304,7 @@ export default function PatientFlowNavigator({
   const lastVisibleStatesRef = useRef<PatientVisibleState[]>([]);
   const lastOccupancyInsightsRef = useRef<OccupancyInsight[]>([]);
   const lastBucketKeyRef = useRef('');
+  const lastRoundsKeyRef = useRef('');
   const lastTimeEmitRef = useRef(0);
   const scopeAppliedRef = useRef(false);
   const inspectorInitializedRef = useRef(false);
@@ -325,7 +326,9 @@ export default function PatientFlowNavigator({
   const [live, setLive] = useState(false);
   const [status, setStatus] = useState('Loading');
   const [cameraPlace, setCameraPlace] = useState('');
-  const [cameraDebug, setCameraDebug] = useState('');
+  // Raw xyz debug readout is title-attribute-only — written via ref so a
+  // camera emit never re-renders the tree when the place label is unchanged.
+  const cameraSpanRef = useRef<HTMLSpanElement | null>(null);
   const [metrics, setMetrics] = useState<NavigatorMetrics>({ active: 0, events: 0, occupiedLocations: 0 });
   const [occupancy, setOccupancy] = useState<OccupancySummary>(EMPTY_OCCUPANCY_SUMMARY);
   const [forecast, setForecast] = useState<ForecastAggregates | null>(null);
@@ -343,15 +346,41 @@ export default function PatientFlowNavigator({
   const roundsVersionRef = useRef(0);
   const roundsSceneHashRef = useRef('');
   const roundsRunUuidRef = useRef<string | null>(null);
-  const roundsCompleteAnnouncedRef = useRef(false);
+  const roundsFailCountRef = useRef(0);
   const pendingFocusStopRef = useRef<string | null>(handoff.focusStop);
   const focusFloorClearedRef = useRef(false);
   const focusAttemptsRef = useRef(0);
   const tourIndexRef = useRef<number | null>(null);
+  // Tour anchor is the stop UUID, not the array index — the stops list
+  // reorders and shrinks on every 30 s poll.
+  const tourUuidRef = useRef<string | null>(null);
+  const tourAutoRef = useRef(false);
+  const tourStepRef = useRef<(direction: 1 | -1) => void>(() => {});
+  // Live-follow is an explicit mode, not a proximity guess: entered at
+  // bootstrap (fresh source) or by scrubbing to now; any deliberate scrub
+  // elsewhere leaves it.
+  const followNowRef = useRef(handoff.t === null);
   const viewsStorageKey = savedViewsKey(lens?.role_id);
-  const [views, setViews] = useState<Array<SavedView | null>>(() =>
-    parseSavedViews(typeof window === 'undefined' ? null : window.localStorage.getItem(viewsStorageKey)),
-  );
+  const [views, setViews] = useState<Array<SavedView | null>>(() => {
+    // Blocked storage (kiosk privacy mode, sandboxed embed) must degrade to
+    // empty slots, never crash the navigator at mount.
+    try {
+      return parseSavedViews(typeof window === 'undefined' ? null : window.localStorage.getItem(viewsStorageKey));
+    } catch {
+      return parseSavedViews(null);
+    }
+  });
+
+  // If the persona lens changes without a remount, re-read that persona's
+  // slots — otherwise a save would clobber the new persona's bookmarks with
+  // the old persona's array.
+  useEffect(() => {
+    try {
+      setViews(parseSavedViews(window.localStorage.getItem(viewsStorageKey)));
+    } catch {
+      setViews(parseSavedViews(null));
+    }
+  }, [viewsStorageKey]);
 
   const tracks = useMemo(() => rebuildTracks(events), [events]);
 
@@ -555,11 +584,17 @@ export default function PatientFlowNavigator({
 
     // Round-stop rings — present-state like barriers: shown at every scrub
     // position, floor-filtered, opaque tokens only (plan §8.1). The route
-    // polyline and queue numbers ride the same rebuild (R-4).
-    const roundCells = layersRef.current.rounds
-      ? buildRoundStopCells(roundStopsRef.current, index, floorFilter)
-      : [];
-    scene.rebuildRounds(roundCells, buildRoundRoute(roundCells), layersRef.current.rounds);
+    // polyline and queue numbers ride the same rebuild (R-4). The layer is
+    // time-independent, so it rebuilds on its OWN key (content version /
+    // floor / visibility), not on every minute bucket.
+    const roundsKey = `${roundsVersionRef.current}|${floorFilter}|${layersRef.current.rounds ? 1 : 0}`;
+    if (roundsKey !== lastRoundsKeyRef.current) {
+      lastRoundsKeyRef.current = roundsKey;
+      const roundCells = layersRef.current.rounds
+        ? buildRoundStopCells(roundStopsRef.current, index, floorFilter)
+        : [];
+      scene.rebuildRounds(roundCells, buildRoundRoute(roundCells), layersRef.current.rounds);
+    }
 
     setMetrics({
       active: barrierFinderRef.current ? visibleOccupancyInsights.length : (useServerOccupancy ? occupancySummary.active : states.length),
@@ -604,11 +639,13 @@ export default function PatientFlowNavigator({
     refreshScene();
   }, [nowMs, refreshScene]);
 
-  // Live-follow: slide the 48h window with wall-clock now, but only when the
-  // operator is parked at now — a deliberate scrub position is never yanked,
-  // and a playback sweep passing near now is not "parked".
+  // Live-follow: slide the 48h window with wall-clock now, but only in
+  // explicit follow mode (entered at bootstrap or by scrubbing to now) — a
+  // deliberate scrub near now, a playback sweep, or a connected replay
+  // stream is never yanked.
   useEffect(() => {
-    if (historical || playingRef.current) return;
+    if (historical || playingRef.current || liveRef.current) return;
+    if (!followNowRef.current) return;
     if (Math.abs(currentTimeRef.current - nowMs) >= 90_000) return;
     setTimeWindow({ start: nowMs - LIVE_WINDOW_HALF_MS, end: nowMs + LIVE_WINDOW_HALF_MS });
     currentTimeRef.current = nowMs;
@@ -674,10 +711,11 @@ export default function PatientFlowNavigator({
   // to the orbit target names what the operator is looking at. Raw coordinates
   // survive in the status-bar title attribute for debugging.
   const handleCameraMove = useCallback((view: CameraView): void => {
-    setCameraDebug(
-      `camera x ${Math.round(view.position.x)} y ${Math.round(view.position.y)} z ${Math.round(view.position.z)}`
-      + ` · target x ${Math.round(view.target.x)} z ${Math.round(view.target.z)}`,
-    );
+    if (cameraSpanRef.current) {
+      cameraSpanRef.current.title =
+        `camera x ${Math.round(view.position.x)} y ${Math.round(view.position.y)} z ${Math.round(view.position.z)}`
+        + ` · target x ${Math.round(view.target.x)} z ${Math.round(view.target.z)}`;
+    }
 
     // Wide framing (home / fit-to-floor distance) is an overview, and naming
     // the incidentally-nearest unit there would mislead.
@@ -822,57 +860,73 @@ export default function PatientFlowNavigator({
   // stops, opaque tokens only. Feature flag off (404), no run, or any failure
   // simply leaves the overlay empty; the navigator never degrades.
   // R-3: polled every 30 s (mirroring the board's cadence) with a content-hash
-  // gate so unchanged payloads never trigger a layer rebuild; when the run
-  // closes, the HUD announces completion and polling stops.
+  // gate (run identity + status + stops) so unchanged payloads never touch
+  // React state or the scene. Polling NEVER stops — a wall display must pick
+  // up tomorrow's run after today's completes; the open→closed transition
+  // announces completion exactly once per run (uuid ref nulled on announce).
   useEffect(() => {
     let cancelled = false;
-    let timer: number | null = null;
 
     async function loadRoundsOverlay(): Promise<void> {
       if (document.visibilityState === 'hidden') return;
       try {
         const runsPayload = runsResponseSchema.safeParse(await fetchRoundRuns());
         if (!runsPayload.success || cancelled) return;
+        roundsFailCountRef.current = 0;
 
         const openRun = runsPayload.data.data.find((run) =>
-          ['active', 'paused', 'draft', 'scheduled'].includes(run.status),
+          ['active', 'paused', 'closing', 'draft', 'scheduled'].includes(run.status),
         );
         if (!openRun) {
-          if (roundsRunUuidRef.current && !roundsCompleteAnnouncedRef.current) {
-            roundsCompleteAnnouncedRef.current = true;
+          if (roundsRunUuidRef.current !== null) {
+            roundsRunUuidRef.current = null;
             setRoundsRun((prev) => (prev ? { ...prev, status: 'completed' } : prev));
             setToastMessage('Rounds run complete');
-            if (timer !== null) window.clearInterval(timer);
           }
           return;
+        }
+        if (roundsRunUuidRef.current !== openRun.run_uuid) {
+          // New run (or first run): drop the previous run's content hash so
+          // its scene payload always applies.
+          roundsSceneHashRef.current = '';
         }
         roundsRunUuidRef.current = openRun.run_uuid;
 
         const scenePayload = sceneResponseSchema.safeParse(await fetchRoundScene(openRun.run_uuid));
         if (!scenePayload.success || cancelled) return;
 
-        setRoundsRun(scenePayload.data.data.run);
-        const stops = scenePayload.data.data.stops;
-        const hash = JSON.stringify(stops);
+        const { run, stops } = scenePayload.data.data;
+        const hash = `${run.run_uuid}|${run.status}|${JSON.stringify(stops)}`;
         if (hash !== roundsSceneHashRef.current) {
           roundsSceneHashRef.current = hash;
           roundsVersionRef.current += 1;
+          setRoundsRun(run);
           setRoundStops(stops);
         }
       } catch {
-        // Transient poll failure: keep the last overlay rather than blanking
-        // an active itinerary; the initial state is already empty.
+        if (cancelled) return;
+        // Transient failure keeps the last overlay (never blank an active
+        // itinerary on one blip) — but a persistently failing source must not
+        // present hours-stale rings as truth.
+        roundsFailCountRef.current += 1;
+        if (roundsFailCountRef.current >= 5 && roundsRunUuidRef.current !== null) {
+          roundsRunUuidRef.current = null;
+          roundsSceneHashRef.current = '';
+          roundsVersionRef.current += 1;
+          setRoundsRun(null);
+          setRoundStops([]);
+        }
       }
     }
 
     void loadRoundsOverlay();
-    timer = window.setInterval(() => void loadRoundsOverlay(), 30_000);
+    const timer = window.setInterval(() => void loadRoundsOverlay(), 30_000);
     const onVisibility = (): void => void loadRoundsOverlay();
     document.addEventListener('visibilitychange', onVisibility);
 
     return () => {
       cancelled = true;
-      if (timer !== null) window.clearInterval(timer);
+      window.clearInterval(timer);
       document.removeEventListener('visibilitychange', onVisibility);
     };
   }, []);
@@ -961,10 +1015,12 @@ export default function PatientFlowNavigator({
       sceneRef.current = scene;
       scene.setHoverEnabled(!(playingRef.current && speedRef.current > 60));
       lastBucketKeyRef.current = '';
+      lastRoundsKeyRef.current = '';
       scene.loadModel(
         summary.model_url,
         () => {
           lastBucketKeyRef.current = '';
+          lastRoundsKeyRef.current = '';
           refreshScene();
         },
         () => {
@@ -1020,7 +1076,11 @@ export default function PatientFlowNavigator({
 
   const handleScrub = useCallback((timeMs: number): void => {
     disconnectLive();
-    applyTime(Math.min(windowEnd, Math.max(windowStart, timeMs)));
+    const bounded = Math.min(windowEnd, Math.max(windowStart, timeMs));
+    // Scrubbing to now (Now button, or landing on it) enters live-follow;
+    // scrubbing anywhere else is a deliberate position that must never slide.
+    followNowRef.current = Math.abs(bounded - nowMsRef.current) < 5_000;
+    applyTime(bounded);
   }, [applyTime, disconnectLive, windowEnd, windowStart]);
 
   const resetCamera = useCallback((): void => {
@@ -1038,20 +1098,9 @@ export default function PatientFlowNavigator({
     sceneRef.current?.setHoverEnabled(!(playing && speed > 60));
   }, [playing, speed]);
 
-  // E-5: Escape clears the in-scene selection highlight and the panel with it
-  // (and closes the shortcut sheet, N-6).
-  useEffect(() => {
-    const onKeyDown = (event: KeyboardEvent): void => {
-      if (event.key !== 'Escape') return;
-      setShortcutsOpen(false);
-      sceneRef.current?.clearSelection();
-      setInspectorTitle('Select a patient or location');
-      setInspectorRows([]);
-      setInspectorAction(null);
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
+  // Escape is handled with the other shortcuts below (N-6) so the same
+  // typing-context guard applies — Escape inside the Find field must clear
+  // only the field, never the operator's selection.
 
   // B-4: the explicit camera action for the Delayed-only census scope — the
   // operator asks for the flight; the checkbox never causes it.
@@ -1062,14 +1111,13 @@ export default function PatientFlowNavigator({
     sceneRef.current?.focusOn(points);
   }, []);
 
-  // N-4: fit-to-floor — frame the selected floor's locations; All = home.
+  // N-4: fit-to-floor — frame the selected floor's locations. Choosing All
+  // widens the FILTER only; it never discards the operator's framing (Home
+  // is the explicit reset).
   const fitToFloor = useCallback((floor: string): void => {
     const scene = sceneRef.current;
     if (!scene) return;
-    if (floor === 'all') {
-      scene.resetCamera();
-      return;
-    }
+    if (floor === 'all') return;
     const points = Object.values(locationsRef.current)
       .filter((loc) => loc.position_m && String(loc.floor) === floor)
       .map((loc) => ({ x: loc.position_m!.x, y: loc.position_m!.y ?? 0, z: loc.position_m!.z }));
@@ -1089,25 +1137,24 @@ export default function PatientFlowNavigator({
     if (points.length) sceneRef.current?.focusOn(points);
   }, []);
 
-  // N-7: three persona-keyed camera/floor/layers bookmarks.
+  // N-7: three persona-keyed camera/floor/layers bookmarks. The updater
+  // stays pure — persistence happens outside setState.
   const saveView = useCallback((slot: number): void => {
     const scene = sceneRef.current;
     if (!scene) return;
-    setViews((prev) => {
-      const next = [...prev];
-      next[slot] = {
-        camera: scene.getCameraView(),
-        floor: filtersRef.current.floor,
-        layers: { ...layersRef.current },
-      };
-      try {
-        window.localStorage.setItem(viewsStorageKey, serializeSavedViews(next));
-      } catch {
-        // Storage unavailable: the view still works for this session.
-      }
-      return next;
-    });
-  }, [viewsStorageKey]);
+    const next = [...views];
+    next[slot] = {
+      camera: scene.getCameraView(),
+      floor: filtersRef.current.floor,
+      layers: { ...layersRef.current },
+    };
+    setViews(next);
+    try {
+      window.localStorage.setItem(viewsStorageKey, serializeSavedViews(next));
+    } catch {
+      // Storage unavailable: the view still works for this session.
+    }
+  }, [views, viewsStorageKey]);
 
   const applyView = useCallback((slot: number): void => {
     const view = views[slot];
@@ -1117,14 +1164,24 @@ export default function PatientFlowNavigator({
     sceneRef.current?.setCameraView(view.camera);
   }, [views]);
 
-  // N-6: keyboard map — H home, F focus selection (else active patients),
-  // N now, ? shortcut sheet. Typing contexts are left alone.
+  // N-6/E-5: the ONE window keymap — H home, F focus selection (else active
+  // patients), N now, ? shortcut sheet, Escape clear selection + close
+  // panels. Typing contexts are left alone for every key, Escape included
+  // (inside Find, Escape clears only the field via the input's own handler).
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
       const target = event.target as HTMLElement | null;
       const tag = target?.tagName;
       if (tag === 'INPUT' || tag === 'SELECT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
       if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (event.key === 'Escape') {
+        setShortcutsOpen(false);
+        sceneRef.current?.clearSelection();
+        setInspectorTitle('Select a patient or location');
+        setInspectorRows([]);
+        setInspectorAction(null);
+        return;
+      }
       const key = event.key.toLowerCase();
       if (key === 'h') {
         sceneRef.current?.resetCamera();
@@ -1155,16 +1212,23 @@ export default function PatientFlowNavigator({
   useEffect(() => {
     const uuid = pendingFocusStopRef.current;
     if (!uuid || roundStops.length === 0) return;
+    // Focusing a stop implies wanting to SEE the rounds layer.
+    if (!layersRef.current.rounds) {
+      setLayers((prev) => (prev.rounds ? prev : { ...prev, rounds: true }));
+    }
     focusAttemptsRef.current = 0;
     const timer = window.setInterval(() => {
       const scene = sceneRef.current;
-      focusAttemptsRef.current += 1;
-      if (scene && scene.focusRoundStop(uuid)) {
+      // Scene/model still loading: wait without burning the attempt budget —
+      // the budget measures real placement failures, not load time.
+      if (!scene) return;
+      if (scene.focusRoundStop(uuid)) {
         pendingFocusStopRef.current = null;
         window.clearInterval(timer);
         return;
       }
-      if (scene && !focusFloorClearedRef.current) {
+      focusAttemptsRef.current += 1;
+      if (!focusFloorClearedRef.current) {
         focusFloorClearedRef.current = true;
         setFilters((prev) => (prev.floor === 'all' ? prev : { ...prev, floor: 'all' }));
         return;
@@ -1172,7 +1236,7 @@ export default function PatientFlowNavigator({
       if (focusAttemptsRef.current >= 15) {
         pendingFocusStopRef.current = null;
         window.clearInterval(timer);
-        sceneRef.current?.focusRoundStop(null);
+        scene.focusRoundStop(null);
         setToastMessage('Stop not placeable — open the Rounds board');
       }
     }, 600);
@@ -1209,37 +1273,53 @@ export default function PatientFlowNavigator({
 
   const tourStep = useCallback((direction: 1 | -1): void => {
     if (tourStops.length === 0) return;
-    const previous = tourIndexRef.current;
-    const next = previous === null
-      ? (direction === 1 ? 0 : tourStops.length - 1)
-      : Math.min(tourStops.length - 1, Math.max(0, previous + direction));
+    // Anchor by uuid — the stops list reorders/shrinks on every poll, so a
+    // raw index would silently skip or repeat a bed after a queue change.
+    const anchored = tourUuidRef.current
+      ? tourStops.findIndex((cell) => cell.stop.round_patient_uuid === tourUuidRef.current)
+      : -1;
+    const base = anchored !== -1
+      ? anchored
+      : (tourIndexRef.current ?? (direction === 1 ? -1 : tourStops.length));
+    const next = Math.min(tourStops.length - 1, Math.max(0, base + direction));
     tourIndexRef.current = next;
+    tourUuidRef.current = tourStops[next].stop.round_patient_uuid;
     const cell = tourStops[next];
     requestStopFocus(cell.stop.round_patient_uuid);
     showStopInspector(cell.stop);
   }, [requestStopFocus, showStopInspector, tourStops]);
 
+  const tourStopsRef = useRef(tourStops);
+  useEffect(() => {
+    tourStopsRef.current = tourStops;
+    tourStepRef.current = tourStep;
+    tourAutoRef.current = tourAuto;
+  }, [tourAuto, tourStep, tourStops]);
+
+  // State updaters must stay pure — the first-step side effect runs outside.
   const toggleTourAuto = useCallback((): void => {
-    setTourAuto((value) => {
-      const next = !value;
-      if (next && tourIndexRef.current === null) tourStep(1);
-      return next;
-    });
-  }, [tourStep]);
+    const enabling = !tourAutoRef.current;
+    tourAutoRef.current = enabling;
+    setTourAuto(enabling);
+    if (enabling && tourUuidRef.current === null) tourStepRef.current(1);
+  }, []);
 
   // Auto mode: 10 s dwell, stops at the end of the itinerary; any operator
-  // camera input pauses it (wired via the scene's onUserCameraStart).
+  // camera input pauses it (wired via the scene's onUserCameraStart). The
+  // interval reads refs so a 30 s poll delta never resets the dwell.
   useEffect(() => {
     if (!tourAuto) return;
     const timer = window.setInterval(() => {
-      if (tourIndexRef.current !== null && tourIndexRef.current >= tourStops.length - 1) {
+      const stops = tourStopsRef.current;
+      const index = tourIndexRef.current;
+      if (index !== null && index >= stops.length - 1) {
         setTourAuto(false);
         return;
       }
-      tourStep(1);
+      tourStepRef.current(1);
     }, 10_000);
     return () => window.clearInterval(timer);
-  }, [tourAuto, tourStep, tourStops.length]);
+  }, [tourAuto]);
 
   // R-5: run HUD — status, progress, and awaiting-input, straight from the
   // opaque stops (never coral; a round state is work, not a breach).
@@ -1377,7 +1457,13 @@ export default function PatientFlowNavigator({
       <NavigatorFloorRail floors={floors} current={filters.floor} onSelect={handleFloorSelect} />
 
       {shortcutsOpen && (
-        <div className="patient-flow-shortcut-sheet" role="dialog" aria-label="Keyboard shortcuts">
+        <div
+          className="patient-flow-shortcut-sheet"
+          role="dialog"
+          aria-label="Keyboard shortcuts"
+          tabIndex={-1}
+          ref={(node) => node?.focus()}
+        >
           <strong>Keyboard shortcuts</strong>
           <dl>
             <div><dt>H</dt><dd>Home view</dd></div>
@@ -1389,13 +1475,20 @@ export default function PatientFlowNavigator({
             <div><dt>Esc</dt><dd>Clear selection · close panels</dd></div>
             <div><dt>?</dt><dd>Toggle this sheet</dd></div>
           </dl>
+          <button
+            type="button"
+            className="patient-flow-shortcut-close"
+            onClick={() => setShortcutsOpen(false)}
+          >
+            Close
+          </button>
         </div>
       )}
 
       <div className="patient-flow-statusbar">
         <span>{status}</span>
         <span>{ambient ? `Ambient ${Math.round(ambient.summary.averageConfidence * 100)}% ${ambient.summary.confidenceLevel}` : 'Ambient pending'}</span>
-        <span className="patient-flow-camera" title={cameraDebug}>{cameraPlace}</span>
+        <span ref={cameraSpanRef} className="patient-flow-camera">{cameraPlace}</span>
       </div>
     </section>
   );

--- a/resources/js/Components/VirtualRounds/RoundPatientWorkspace.tsx
+++ b/resources/js/Components/VirtualRounds/RoundPatientWorkspace.tsx
@@ -106,10 +106,20 @@ export default function RoundPatientWorkspace({
               <span className="tabular-nums">{formatWindow(patient.eta_window_start, patient.eta_window_end)}</span>
             </p>
           </div>
-          <span
-            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${PATIENT_STATUS_CLASS[patient.status]}`}
-          >
-            {PATIENT_STATUS_LABEL[patient.status]}
+          <span className="inline-flex items-center gap-2">
+            {/* R-2: jump to this stop's ring in the 4D navigator. */}
+            <a
+              href={`/rtdc/patient-flow-navigator?focus_stop=${patient.round_patient_uuid}`}
+              className="text-xs font-medium text-healthcare-primary hover:underline dark:text-healthcare-primary-dark"
+              title="Locate this stop in the 4D navigator"
+            >
+              Locate in 4D
+            </a>
+            <span
+              className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${PATIENT_STATUS_CLASS[patient.status]}`}
+            >
+              {PATIENT_STATUS_LABEL[patient.status]}
+            </span>
           </span>
         </div>
 

--- a/resources/js/Components/VirtualRounds/RoundsBoard.tsx
+++ b/resources/js/Components/VirtualRounds/RoundsBoard.tsx
@@ -2,7 +2,7 @@
 // quiet, optimized for repeated scanning). Each row explains its own priority
 // and shows exactly which requirement is missing; a progress percentage never
 // hides that.
-import { AlertTriangle, CheckCircle2, HelpCircle, ListTodo, Pin } from 'lucide-react';
+import { AlertTriangle, Box, CheckCircle2, HelpCircle, ListTodo, Pin } from 'lucide-react';
 import type { BoardPatient } from '@/features/virtualRounds/types';
 import {
   formatWindow,
@@ -40,6 +40,9 @@ export default function RoundsBoard({ patients, selectedUuid, lens, onSelect }: 
             <th scope="col" className="px-3 py-2">Priority</th>
             <th scope="col" className="px-3 py-2">Window</th>
             <th scope="col" className="px-3 py-2">Needs</th>
+            <th scope="col" className="px-3 py-2">
+              <span className="sr-only">Locate in 4D</span>
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -126,6 +129,18 @@ export default function RoundsBoard({ patients, selectedUuid, lens, onSelect }: 
                       patient.open_question_count === 0 &&
                       patient.open_task_count === 0 && <span>—</span>}
                   </span>
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {/* R-2: jump to this stop's ring in the 4D navigator. */}
+                  <a
+                    href={`/rtdc/patient-flow-navigator?focus_stop=${patient.round_patient_uuid}`}
+                    className="inline-flex rounded-md p-1 text-healthcare-text-secondary hover:bg-healthcare-hover hover:text-healthcare-text-primary dark:text-healthcare-text-secondary-dark dark:hover:bg-healthcare-hover-dark dark:hover:text-healthcare-text-primary-dark"
+                    title="Locate in 4D navigator"
+                    aria-label={`Locate queue position ${patient.queue_position} in the 4D navigator`}
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    <Box className="h-3.5 w-3.5" aria-hidden />
+                  </a>
                 </td>
               </tr>
             );

--- a/resources/js/Pages/RTDC/VirtualRounds.tsx
+++ b/resources/js/Pages/RTDC/VirtualRounds.tsx
@@ -46,7 +46,12 @@ export default function VirtualRounds() {
   const [scopeKey, setScopeKey] = useState<string | null>(null);
   const [templateUuid, setTemplateUuid] = useState<string | null>(null);
   const [runUuid, setRunUuid] = useState<string | null>(null);
-  const [selectedPatientUuid, setSelectedPatientUuid] = useState<string | null>(null);
+  // R-2: 4D ring → board deep link (?patient={round_patient_uuid}); the
+  // workspace fetches by uuid directly, so this works regardless of scope.
+  const [selectedPatientUuid, setSelectedPatientUuid] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null;
+    return new URLSearchParams(window.location.search).get('patient');
+  });
   const [conflictMessage, setConflictMessage] = useState<string | null>(null);
 
   const templatesQuery = useRoundTemplates();

--- a/resources/js/Pages/RTDC/VirtualRounds.tsx
+++ b/resources/js/Pages/RTDC/VirtualRounds.tsx
@@ -2,7 +2,7 @@
 // operational surface: dense, quiet, optimized for repeated scanning. All
 // server state flows through TanStack Query as `unknown` and is parsed with
 // Zod at this boundary; a malformed payload degrades to an inline card.
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import RTDCPageLayout from '@/Components/RTDC/RTDCPageLayout';
@@ -88,6 +88,18 @@ export default function VirtualRounds() {
     const parsed = boardSchema.safeParse(boardQuery.data);
     return parsed.success ? parsed.data : null;
   }, [boardQuery.data]);
+
+  // A deep-linked uuid that is not on the displayed run's board (other
+  // scope, stale run) must not pin a foreign patient beside this board —
+  // pin/transition would submit THIS board's queue version for it. Fall back
+  // to the board's own first patient instead.
+  useEffect(() => {
+    if (!selectedPatientUuid || !board) return;
+    const onBoard = board.data.patients.some(
+      (patient) => patient.round_patient_uuid === selectedPatientUuid,
+    );
+    if (!onBoard) setSelectedPatientUuid(null);
+  }, [board, selectedPatientUuid]);
 
   const effectiveSelectedUuid =
     selectedPatientUuid ?? board?.data.patients[0]?.round_patient_uuid ?? null;

--- a/resources/js/features/patientFlowNavigator/savedViews.ts
+++ b/resources/js/features/patientFlowNavigator/savedViews.ts
@@ -1,0 +1,54 @@
+// Saved views (N-7): three persona-keyed camera/floor/layers bookmarks in
+// localStorage. Pure parse/serialize helpers so the round-trip is unit-tested
+// without a scene; garbage in storage degrades to empty slots, never a crash.
+import { z } from 'zod';
+import type { PatientLayerState } from './types';
+
+const vectorSchema = z.object({ x: z.number(), y: z.number(), z: z.number() });
+
+const savedViewSchema = z.object({
+  camera: z.object({ position: vectorSchema, target: vectorSchema }),
+  floor: z.string(),
+  layers: z.object({
+    base: z.boolean(),
+    tokens: z.boolean(),
+    trails: z.boolean(),
+    heat: z.boolean(),
+    ghosts: z.boolean(),
+    barriers: z.boolean(),
+    rounds: z.boolean(),
+  }),
+});
+
+export type SavedView = z.infer<typeof savedViewSchema>;
+
+export const SAVED_VIEW_SLOTS = 3;
+
+export function savedViewsKey(role: string | null | undefined): string {
+  return `flow4d.views.${role ?? 'house'}`;
+}
+
+/** Parse a storage payload into exactly SAVED_VIEW_SLOTS slots (null = empty). */
+export function parseSavedViews(raw: string | null): Array<SavedView | null> {
+  const empty: Array<SavedView | null> = Array.from({ length: SAVED_VIEW_SLOTS }, () => null);
+  if (!raw) return empty;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return empty;
+    return empty.map((_, index) => {
+      const candidate = savedViewSchema.safeParse(parsed[index]);
+      return candidate.success ? candidate.data : null;
+    });
+  } catch {
+    return empty;
+  }
+}
+
+export function serializeSavedViews(views: Array<SavedView | null>): string {
+  return JSON.stringify(views.slice(0, SAVED_VIEW_SLOTS));
+}
+
+/** Layers restore defensively — unknown keys dropped, current state fills gaps. */
+export function mergeLayers(current: PatientLayerState, saved: SavedView['layers']): PatientLayerState {
+  return { ...current, ...saved };
+}

--- a/resources/js/features/patientFlowNavigator/sceneVocabulary.ts
+++ b/resources/js/features/patientFlowNavigator/sceneVocabulary.ts
@@ -1,0 +1,356 @@
+// Scene vocabulary — the single source of truth for every shape/color the 4D
+// Navigator renders (advancement plan §5.1). NavigatorScene builds materials
+// from these constants and NavigatorLegend renders rows from LEGEND_SECTIONS,
+// so one edit updates both — the legend can never lie about the scene.
+//
+// Pure data: no three.js import, so the legend and tests stay in the main
+// bundle while the scene chunk lazy-loads.
+import type { BarrierSeverity } from './projections';
+import type { OccupancyTimerStatus, PatientLayerState } from './types';
+import { ROUND_STOP_COLORS } from '@/features/virtualRounds/roundsScene';
+
+// ---------------------------------------------------------------------------
+// Color constants consumed by NavigatorScene materials
+// ---------------------------------------------------------------------------
+
+/** Future-half ghost palette — cool operational tones only, never coral. */
+export const GHOST_COLORS: Record<string, number> = {
+  expected_discharge: 0x2dd4bf, // teal
+  transport_due: 0x38bdf8, // sky
+  evs_due: 0x7dd3fc, // light sky
+  scheduled_or_case: 0x60a5fa, // blue
+};
+
+/**
+ * Open-barrier marker palette — the earned-urgency ration (watch sky /
+ * warning amber / critical coral), the same status language the 48h Review
+ * map paints. Coral is reserved for a barrier standing open past 48h.
+ */
+export const BARRIER_COLORS: Record<BarrierSeverity, { color: number; emissive: number }> = {
+  critical: { color: 0xf06755, emissive: 0x5a140d }, // coral
+  warning: { color: 0xeaa640, emissive: 0x4a2e08 }, // amber
+  watch: { color: 0x38bdf8, emissive: 0x0c3a4d }, // sky
+};
+
+/** Census disk status colors (green ok / amber watch / coral delayed). */
+export const OCCUPANCY_STATUS_COLORS: Record<OccupancyTimerStatus, { color: number; emissive: number }> = {
+  ok: { color: 0x77c06f, emissive: 0x143d17 },
+  watch: { color: 0xe0a33f, emissive: 0x4a3210 },
+  delayed: { color: 0xf06755, emissive: 0x5a140d },
+};
+
+/** Timer pip colors — brighter siblings of the disk statuses. */
+export const TIMER_PIP_COLORS: Record<OccupancyTimerStatus, number> = {
+  ok: 0x93e088,
+  watch: 0xffd166,
+  delayed: 0xff8a75,
+};
+
+/** Predicted-census pillar (future half). */
+export const FORECAST_COLOR = 0x64bfd0;
+
+export { ROUND_STOP_COLORS };
+
+/** Pinned round stops render amber regardless of state. */
+export const ROUND_PINNED_COLOR = 0xeaa640;
+
+/**
+ * Patient-token identity hue is clamped to 160°–280° (teal → blue → violet)
+ * so a token can never impersonate amber/coral status colors (finding E-3).
+ */
+export const PATIENT_HUE_MIN = 160;
+export const PATIENT_HUE_SPAN = 120;
+
+/** Deterministic identity hue for a patient id, inside the clamped range. */
+export function patientHue(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = ((hash << 5) - hash) + value.charCodeAt(index);
+  }
+  return PATIENT_HUE_MIN + (Math.abs(hash) % PATIENT_HUE_SPAN);
+}
+
+// ---------------------------------------------------------------------------
+// Base-model category treatments (plan §5.2) — glTF `extras.category` is
+// already in mesh.userData; these tints make hallway/room/bed/ED legible.
+// All tints stay in the blue/slate operational family. `floor` and unknown
+// categories keep the model's own material (clone + opacity) as the datum.
+// ---------------------------------------------------------------------------
+
+export interface BaseCategoryStyle {
+  color: number;
+  opacity: number;
+  /** Emissive as a fraction of color (0 = none). */
+  emissiveScale: number;
+}
+
+export const BASE_CATEGORY_STYLES: Record<string, BaseCategoryStyle> = {
+  corridor: { color: 0x3d434b, opacity: 0.35, emissiveScale: 0 }, // circulation reads as negative space
+  patient_room: { color: 0x59616d, opacity: 0.6, emissiveScale: 0 }, // the default "room"
+  bed: { color: 0x7189a8, opacity: 0.85, emissiveScale: 0.12 }, // the care asset
+  care_unit: { color: 0x475569, opacity: 0.16, emissiveScale: 0 }, // grouping shell, not object
+  emergency_department: { color: 0x4f8dab, opacity: 0.55, emissiveScale: 0.06 }, // high-tempo zone
+  imaging: { color: 0x5b7db1, opacity: 0.55, emissiveScale: 0.06 }, // interventional
+  procedure_room: { color: 0x5b7db1, opacity: 0.55, emissiveScale: 0.06 },
+  procedure_support: { color: 0x5b7db1, opacity: 0.45, emissiveScale: 0 },
+  elevator: { color: 0x9aa1a6, opacity: 0.85, emissiveScale: 0 }, // vertical circulation landmark
+  helipad: { color: 0x4a4f4c, opacity: 0.5, emissiveScale: 0 }, // context only
+  support_infrastructure: { color: 0x4a4f4c, opacity: 0.5, emissiveScale: 0 },
+};
+
+// ---------------------------------------------------------------------------
+// Element labels — `userData.kind` → operator-readable element type, used by
+// the hover chip and the inspector title prefix (findings E-4/E-5).
+// ---------------------------------------------------------------------------
+
+export const ELEMENT_LABELS: Record<string, string> = {
+  'patient-token': 'Patient',
+  'patient-trail': 'Movement trail',
+  'occupancy-marker': 'Census disk',
+  'occupancy-timer': 'Timer',
+  'projection-ghost': 'Projection',
+  'forecast-heat': 'Forecast census',
+  barrier: 'Open barrier',
+  'round-stop': 'Round stop',
+};
+
+export const CATEGORY_LABELS: Record<string, string> = {
+  floor: 'Floor plate',
+  corridor: 'Corridor',
+  patient_room: 'Patient room',
+  bed: 'Bed',
+  care_unit: 'Care unit shell',
+  emergency_department: 'Emergency department',
+  imaging: 'Imaging',
+  procedure_room: 'Procedure room',
+  procedure_support: 'Procedure support',
+  elevator: 'Elevator',
+  helipad: 'Helipad',
+  support_infrastructure: 'Support infrastructure',
+};
+
+/** Operator-readable element type for any raycast hit's userData. */
+export function elementLabelFor(data: Record<string, unknown>): string | null {
+  const kind = typeof data.kind === 'string' ? data.kind : null;
+  if (kind && ELEMENT_LABELS[kind]) return ELEMENT_LABELS[kind];
+  const category = typeof data.category === 'string' ? data.category : null;
+  if (category && CATEGORY_LABELS[category]) return CATEGORY_LABELS[category];
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Legend (finding E-1) — rendered verbatim by NavigatorLegend. Every entry
+// carries the layer it belongs to so hidden layers can dim their rows, and
+// status colors always appear WITH their worded meaning (never color alone).
+// ---------------------------------------------------------------------------
+
+export type SceneShape =
+  | 'sphere'
+  | 'line'
+  | 'disk'
+  | 'pip'
+  | 'ghost'
+  | 'pillar'
+  | 'diamond'
+  | 'ring'
+  | 'block';
+
+export interface LegendEntry {
+  key: string;
+  label: string;
+  shape: SceneShape;
+  colorHex: number;
+  description: string;
+  /** Scene layer this element lives on (`base` = the building itself). */
+  layer: keyof PatientLayerState;
+}
+
+export interface LegendSection {
+  title: string;
+  entries: LegendEntry[];
+}
+
+export const LEGEND_SECTIONS: LegendSection[] = [
+  {
+    title: 'People & movement',
+    entries: [
+      {
+        key: 'patient-token',
+        label: 'Patient',
+        shape: 'sphere',
+        colorHex: 0x2d9db4, // representative mid-range identity hue
+        description: 'One patient. Color is identity (teal→violet only), never status.',
+        layer: 'tokens',
+      },
+      {
+        key: 'patient-trail',
+        label: 'Movement trail',
+        shape: 'line',
+        colorHex: 0x2d9db4,
+        description: 'Where that patient has been up to the scrubbed time.',
+        layer: 'trails',
+      },
+    ],
+  },
+  {
+    title: 'Occupancy & timers',
+    entries: [
+      {
+        key: 'occupancy-ok',
+        label: 'Occupied — on track',
+        shape: 'disk',
+        colorHex: OCCUPANCY_STATUS_COLORS.ok.color,
+        description: 'Disk radius grows with stay length. Green means on track.',
+        layer: 'heat',
+      },
+      {
+        key: 'occupancy-watch',
+        label: 'Occupied — watch',
+        shape: 'disk',
+        colorHex: OCCUPANCY_STATUS_COLORS.watch.color,
+        description: 'Amber means a timer is approaching its target.',
+        layer: 'heat',
+      },
+      {
+        key: 'occupancy-delayed',
+        label: 'Occupied — delayed',
+        shape: 'disk',
+        colorHex: OCCUPANCY_STATUS_COLORS.delayed.color,
+        description: 'Coral means a timer is past target — an elapsed-time signal, not a verified barrier.',
+        layer: 'heat',
+      },
+      {
+        key: 'occupancy-timer',
+        label: 'Timer pip',
+        shape: 'pip',
+        colorHex: TIMER_PIP_COLORS.watch,
+        description: 'Up to four individual timers around a disk, same status colors.',
+        layer: 'heat',
+      },
+    ],
+  },
+  {
+    title: 'Barriers',
+    entries: [
+      {
+        key: 'barrier-watch',
+        label: 'Open barrier — under 24h',
+        shape: 'diamond',
+        colorHex: BARRIER_COLORS.watch.color,
+        description: 'A logged operational barrier (sky). Severity is earned from open-age.',
+        layer: 'barriers',
+      },
+      {
+        key: 'barrier-warning',
+        label: 'Open barrier — 24h+',
+        shape: 'diamond',
+        colorHex: BARRIER_COLORS.warning.color,
+        description: 'Amber: standing open a full day.',
+        layer: 'barriers',
+      },
+      {
+        key: 'barrier-critical',
+        label: 'Open barrier — 48h+',
+        shape: 'diamond',
+        colorHex: BARRIER_COLORS.critical.color,
+        description: 'Coral: a real breach — two days unresolved. Larger diamond, same meaning.',
+        layer: 'barriers',
+      },
+    ],
+  },
+  {
+    title: 'Forecast',
+    entries: [
+      {
+        key: 'projection-ghost',
+        label: 'Projected event',
+        shape: 'ghost',
+        colorHex: GHOST_COLORS.expected_discharge,
+        description: 'Translucent sphere in the future half — discharge (teal), transport (sky), EVS (light sky), OR case (blue). Opacity = confidence.',
+        layer: 'ghosts',
+      },
+      {
+        key: 'forecast-heat',
+        label: 'Predicted census',
+        shape: 'pillar',
+        colorHex: FORECAST_COLOR,
+        description: 'Cyan pillar per unit; height = predicted census at the scrubbed future time.',
+        layer: 'ghosts',
+      },
+    ],
+  },
+  {
+    title: 'Rounds',
+    entries: [
+      {
+        key: 'round-stop',
+        label: 'Round stop',
+        shape: 'ring',
+        colorHex: ROUND_STOP_COLORS.queued,
+        description: 'Flat ring = a Virtual Rounds visit. Slate queued, blue in progress, amber awaiting input, sky ready for review, teal rounded.',
+        layer: 'rounds',
+      },
+      {
+        key: 'round-stop-pinned',
+        label: 'Pinned round stop',
+        shape: 'ring',
+        colorHex: ROUND_PINNED_COLOR,
+        description: 'Amber, slightly larger: pinned for attention.',
+        layer: 'rounds',
+      },
+    ],
+  },
+  {
+    title: 'Building',
+    entries: [
+      {
+        key: 'category-bed',
+        label: 'Bed',
+        shape: 'block',
+        colorHex: BASE_CATEGORY_STYLES.bed.color,
+        description: 'Slate-blue: the care asset.',
+        layer: 'base',
+      },
+      {
+        key: 'category-patient_room',
+        label: 'Patient room',
+        shape: 'block',
+        colorHex: BASE_CATEGORY_STYLES.patient_room.color,
+        description: 'Neutral slate room volume.',
+        layer: 'base',
+      },
+      {
+        key: 'category-corridor',
+        label: 'Corridor',
+        shape: 'block',
+        colorHex: BASE_CATEGORY_STYLES.corridor.color,
+        description: 'Darker slate — circulation reads as negative space.',
+        layer: 'base',
+      },
+      {
+        key: 'category-emergency_department',
+        label: 'Emergency department',
+        shape: 'block',
+        colorHex: BASE_CATEGORY_STYLES.emergency_department.color,
+        description: 'Muted sky zone tint.',
+        layer: 'base',
+      },
+      {
+        key: 'category-imaging',
+        label: 'Imaging / procedures',
+        shape: 'block',
+        colorHex: BASE_CATEGORY_STYLES.imaging.color,
+        description: 'Muted blue interventional zones.',
+        layer: 'base',
+      },
+      {
+        key: 'category-elevator',
+        label: 'Elevator',
+        shape: 'block',
+        colorHex: BASE_CATEGORY_STYLES.elevator.color,
+        description: 'Light neutral landmark, visible on every floor filter.',
+        layer: 'base',
+      },
+    ],
+  },
+];

--- a/resources/js/features/patientFlowNavigator/sceneVocabulary.ts
+++ b/resources/js/features/patientFlowNavigator/sceneVocabulary.ts
@@ -178,7 +178,7 @@ export const LEGEND_SECTIONS: LegendSection[] = [
         key: 'patient-token',
         label: 'Patient',
         shape: 'sphere',
-        colorHex: 0x2d9db4, // representative mid-range identity hue
+        colorHex: 0x49c6df, // a true renderable token tone: hsl(190, 70%, 58%)
         description: 'One patient. Color is identity (teal→violet only), never status.',
         layer: 'tokens',
       },
@@ -186,7 +186,7 @@ export const LEGEND_SECTIONS: LegendSection[] = [
         key: 'patient-trail',
         label: 'Movement trail',
         shape: 'line',
-        colorHex: 0x2d9db4,
+        colorHex: 0x49c6df,
         description: 'Where that patient has been up to the scrubbed time.',
         layer: 'trails',
       },

--- a/resources/js/features/virtualRounds/roundsScene.ts
+++ b/resources/js/features/virtualRounds/roundsScene.ts
@@ -107,6 +107,9 @@ export function buildRoundRoute(cells: RoundStopCell[]): RoundRouteSegment[] {
       runFloor = cell.floor;
     } else {
       run.push(cell.anchor);
+      // A known floor claims a run that started floor-unknown — otherwise a
+      // null-floored first stop would swallow every later floor change.
+      if (cell.floor !== null) runFloor = cell.floor;
     }
   }
   if (run.length > 1) segments.push({ points: run, dashed: false });

--- a/resources/js/features/virtualRounds/roundsScene.ts
+++ b/resources/js/features/virtualRounds/roundsScene.ts
@@ -13,6 +13,8 @@ export type RoundStop = z.infer<typeof roundStopSchema>;
 export interface RoundStopCell {
   anchor: ProjectionAnchor;
   stop: RoundStop;
+  /** Resolved floor for the anchor (route grouping); null when unknown. */
+  floor: number | null;
 }
 
 /**
@@ -64,8 +66,50 @@ export function buildRoundStopCells(
       continue;
     }
 
-    cells.push({ anchor, stop });
+    cells.push({ anchor, stop, floor });
   }
 
   return cells;
+}
+
+// ---------------------------------------------------------------------------
+// Route polyline (R-4): stable-ordering visualization of the itinerary —
+// NOT path-finding (routing graphs are explicitly deferred). Solid runs
+// connect consecutive same-floor stops; a floor change emits a dashed leg.
+// Skipped/deferred stops are not part of the walk.
+// ---------------------------------------------------------------------------
+
+export interface RoundRouteSegment {
+  points: ProjectionAnchor[];
+  dashed: boolean;
+}
+
+export function buildRoundRoute(cells: RoundStopCell[]): RoundRouteSegment[] {
+  const ordered = cells
+    .filter((cell) => !['skipped', 'deferred'].includes(cell.stop.status))
+    .sort((a, b) => a.stop.queue_position - b.stop.queue_position);
+
+  const segments: RoundRouteSegment[] = [];
+  let run: ProjectionAnchor[] = [];
+  let runFloor: number | null = null;
+
+  for (const cell of ordered) {
+    if (run.length === 0) {
+      run = [cell.anchor];
+      runFloor = cell.floor;
+      continue;
+    }
+    const floorChanged = cell.floor !== null && runFloor !== null && cell.floor !== runFloor;
+    if (floorChanged) {
+      if (run.length > 1) segments.push({ points: run, dashed: false });
+      segments.push({ points: [run[run.length - 1], cell.anchor], dashed: true });
+      run = [cell.anchor];
+      runFloor = cell.floor;
+    } else {
+      run.push(cell.anchor);
+    }
+  }
+  if (run.length > 1) segments.push({ points: run, dashed: false });
+
+  return segments;
 }

--- a/tests/Feature/Rounds/RoundProjectionTest.php
+++ b/tests/Feature/Rounds/RoundProjectionTest.php
@@ -48,6 +48,12 @@ class RoundProjectionTest extends TestCase
             $this->assertArrayHasKey('round_patient_uuid', $stop);
             $this->assertArrayHasKey('status', $stop);
             $this->assertArrayHasKey('priority_band', $stop);
+            // The 4D navigator's queue sprites, route polyline, and tour
+            // (flow4d Phase 3) place stops by these fields — contract guard.
+            $this->assertArrayHasKey('queue_position', $stop);
+            $this->assertArrayHasKey('unit_id', $stop);
+            $this->assertArrayHasKey('bed', $stop);
+            $this->assertArrayHasKey('pinned', $stop);
             $this->assertArrayNotHasKey('patient_ref', $stop);
             $this->assertArrayNotHasKey('patient_label', $stop);
         }

--- a/tests/js/patientFlow/NavigatorFloorRail.test.tsx
+++ b/tests/js/patientFlow/NavigatorFloorRail.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import NavigatorFloorRail from '@/Components/PatientFlowNavigator/NavigatorFloorRail';
+
+describe('NavigatorFloorRail (N-4)', () => {
+  it('selects a floor in one click and offers All', () => {
+    const onSelect = vi.fn();
+    render(<NavigatorFloorRail floors={['1', '2', '3']} current="all" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '2' }));
+    expect(onSelect).toHaveBeenCalledWith('2');
+
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+    expect(onSelect).toHaveBeenCalledWith('all');
+  });
+
+  it('renders highest floor on top and marks the current floor', () => {
+    render(<NavigatorFloorRail floors={['1', '2', '3']} current="2" onSelect={vi.fn()} />);
+
+    const labels = screen.getAllByRole('button').map((button) => button.textContent);
+    expect(labels).toEqual(['3', '2', '1', 'All']);
+    expect(screen.getByRole('button', { name: '2' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: '2' })).toHaveAttribute('title', 'Show floor 2 and frame it');
+  });
+
+  it('steps floors with arrow keys (↑ up the building, ↓ down)', () => {
+    const onSelect = vi.fn();
+    render(<NavigatorFloorRail floors={['1', '2', '3']} current="2" onSelect={onSelect} />);
+
+    const rail = screen.getByRole('navigation', { name: 'Floor stepper' });
+    fireEvent.keyDown(rail, { key: 'ArrowUp' });
+    expect(onSelect).toHaveBeenLastCalledWith('3');
+    fireEvent.keyDown(rail, { key: 'ArrowDown' });
+    expect(onSelect).toHaveBeenLastCalledWith('1');
+  });
+
+  it('enters the building from All at the matching end', () => {
+    const onSelect = vi.fn();
+    render(<NavigatorFloorRail floors={['1', '2', '3']} current="all" onSelect={onSelect} />);
+
+    const rail = screen.getByRole('navigation', { name: 'Floor stepper' });
+    fireEvent.keyDown(rail, { key: 'ArrowUp' });
+    expect(onSelect).toHaveBeenLastCalledWith('1');
+    fireEvent.keyDown(rail, { key: 'ArrowDown' });
+    expect(onSelect).toHaveBeenLastCalledWith('3');
+  });
+
+  it('renders nothing when no floors are known yet', () => {
+    const { container } = render(<NavigatorFloorRail floors={[]} current="all" onSelect={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tests/js/patientFlow/NavigatorLegend.test.tsx
+++ b/tests/js/patientFlow/NavigatorLegend.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import NavigatorLegend from '@/Components/PatientFlowNavigator/NavigatorLegend';
+import type { PatientLayerState } from '@/features/patientFlowNavigator/types';
+
+const ALL_ON: PatientLayerState = {
+  base: true,
+  tokens: true,
+  trails: true,
+  heat: true,
+  ghosts: true,
+  barriers: true,
+  rounds: true,
+};
+
+describe('NavigatorLegend (E-1)', () => {
+  it('collapses to a Key pill by default and expands on demand', () => {
+    render(<NavigatorLegend layers={ALL_ON} />);
+
+    const toggle = screen.getByRole('button', { name: 'Key' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByRole('region', { name: 'Scene key' })).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    const panel = screen.getByRole('region', { name: 'Scene key' });
+    expect(panel).toBeInTheDocument();
+
+    // Sections and the shape grammar are present.
+    expect(screen.getByText('People & movement')).toBeInTheDocument();
+    expect(screen.getByText('Barriers')).toBeInTheDocument();
+    expect(screen.getByText('Building')).toBeInTheDocument();
+    expect(screen.getByText('Open barrier — 48h+')).toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    expect(screen.queryByRole('region', { name: 'Scene key' })).not.toBeInTheDocument();
+  });
+
+  it('dims entries for layers that are toggled off and says (hidden)', () => {
+    render(<NavigatorLegend layers={{ ...ALL_ON, rounds: false }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Key' }));
+    expect(screen.getByText('Round stop (hidden)')).toBeInTheDocument();
+    // A visible layer's entries carry no suffix.
+    expect(screen.getByText('Patient')).toBeInTheDocument();
+    expect(screen.queryByText('Patient (hidden)')).not.toBeInTheDocument();
+  });
+});

--- a/tests/js/patientFlow/NavigatorToolbar.test.tsx
+++ b/tests/js/patientFlow/NavigatorToolbar.test.tsx
@@ -52,6 +52,9 @@ function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorT
     onSearchSubmit: vi.fn(),
     onSaveView: vi.fn(),
     onApplyView: vi.fn(),
+    onTourPrev: vi.fn(),
+    onTourNext: vi.fn(),
+    onTourAutoToggle: vi.fn(),
   };
 
   render(
@@ -75,6 +78,8 @@ function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorT
       eddyEnabled={false}
       searchMatches={null}
       savedViews={[false, false, false]}
+      roundsHud={null}
+      tourAuto={false}
       {...handlers}
       {...overrides}
     />,
@@ -187,6 +192,29 @@ describe('NavigatorToolbar floor select (N-4)', () => {
     fireEvent.change(screen.getByLabelText('Floor'), { target: { value: '2' } });
     expect(handlers.onFloorSelect).toHaveBeenCalledWith('2');
     expect(handlers.onFiltersChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('NavigatorToolbar rounds HUD (R-5/R-6a)', () => {
+  it('renders run status, progress, awaiting-input, and tour controls', () => {
+    const handlers = renderToolbar({
+      roundsHud: { status: 'active', scopeLabel: '5 East', total: 7, rounded: 3, awaitingInput: 2 },
+    });
+
+    expect(screen.getByText('Rounds · Active · 5 East')).toBeInTheDocument();
+    expect(screen.getByText('3/7 rounded · 2 awaiting input')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next round stop' }));
+    expect(handlers.onTourNext).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Previous round stop' }));
+    expect(handlers.onTourPrev).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Auto' }));
+    expect(handlers.onTourAutoToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders no HUD without a loaded run', () => {
+    renderToolbar();
+    expect(screen.queryByText(/Rounds ·/)).not.toBeInTheDocument();
   });
 });
 

--- a/tests/js/patientFlow/NavigatorToolbar.test.tsx
+++ b/tests/js/patientFlow/NavigatorToolbar.test.tsx
@@ -46,8 +46,12 @@ function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorT
     onAskEddy: vi.fn(),
     onSpeedChange: vi.fn(),
     onFiltersChange: vi.fn(),
+    onFloorSelect: vi.fn(),
     onLayerChange: vi.fn(),
     onBarrierFinderChange: vi.fn(),
+    onSearchSubmit: vi.fn(),
+    onSaveView: vi.fn(),
+    onApplyView: vi.fn(),
   };
 
   render(
@@ -69,6 +73,8 @@ function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorT
       metrics={{ active: 12, events: 40, occupiedLocations: 9 }}
       occupancy={occupancy}
       eddyEnabled={false}
+      searchMatches={null}
+      savedViews={[false, false, false]}
       {...handlers}
       {...overrides}
     />,
@@ -133,6 +139,54 @@ describe('NavigatorToolbar delayed-only state (B-3/B-4)', () => {
 
     expect(screen.queryByText(/Filtered: delayed locations only/)).not.toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+});
+
+describe('NavigatorToolbar search (N-5)', () => {
+  it('shows the match count and flies to matches on Enter', () => {
+    const handlers = renderToolbar({
+      filters: { floor: 'all', serviceLine: 'all', category: 'all', search: 'PT-4' },
+      searchMatches: 3,
+    });
+
+    expect(screen.getByText('3 matches · Enter flies to them')).toBeInTheDocument();
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'Enter' });
+    expect(handlers.onSearchSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers a spelling/floor hint on zero matches and clears on Escape', () => {
+    const handlers = renderToolbar({
+      filters: { floor: 'all', serviceLine: 'all', category: 'all', search: 'zzz' },
+      searchMatches: 0,
+    });
+
+    expect(screen.getByText('0 matches — check spelling or floor filter')).toBeInTheDocument();
+    fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'Escape' });
+    expect(handlers.onFiltersChange).toHaveBeenCalledWith({ search: '' });
+  });
+});
+
+describe('NavigatorToolbar saved views (N-7)', () => {
+  it('restores only filled slots and saves to any slot', () => {
+    const handlers = renderToolbar({ savedViews: [true, false, false] });
+
+    fireEvent.click(screen.getByRole('button', { name: 'View 1' }));
+    expect(handlers.onApplyView).toHaveBeenCalledWith(0);
+
+    expect(screen.getByRole('button', { name: 'View 2' })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save current view to slot 3' }));
+    expect(handlers.onSaveView).toHaveBeenCalledWith(2);
+  });
+});
+
+describe('NavigatorToolbar floor select (N-4)', () => {
+  it('routes the dropdown through the frame-the-floor path', () => {
+    const handlers = renderToolbar({ floors: ['1', '2'] });
+
+    fireEvent.change(screen.getByLabelText('Floor'), { target: { value: '2' } });
+    expect(handlers.onFloorSelect).toHaveBeenCalledWith('2');
+    expect(handlers.onFiltersChange).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/js/patientFlow/handoff.test.ts
+++ b/tests/js/patientFlow/handoff.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { parseHandoff } from '@/Components/PatientFlowNavigator/PatientFlowNavigator';
+
+/** R-1 deep-link parsing: board → 4D handoff params. */
+
+function setSearch(search: string): void {
+  window.history.replaceState(null, '', `/rtdc/patient-flow-navigator${search}`);
+}
+
+describe('parseHandoff', () => {
+  afterEach(() => setSearch(''));
+
+  it('reads focus_stop alongside the existing scope/t params', () => {
+    setSearch('?focus_stop=abc-123&scope=floor:3&t=2026-07-18T12:00:00Z');
+    const handoff = parseHandoff();
+    expect(handoff.focusStop).toBe('abc-123');
+    expect(handoff.floor).toBe('3');
+    expect(handoff.t).toBe(Date.parse('2026-07-18T12:00:00Z'));
+  });
+
+  it('yields null focus_stop when absent', () => {
+    setSearch('?scope=unit:5e');
+    const handoff = parseHandoff();
+    expect(handoff.focusStop).toBeNull();
+    expect(handoff.unitRef).toBe('5e');
+  });
+});

--- a/tests/js/patientFlow/savedViews.test.ts
+++ b/tests/js/patientFlow/savedViews.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SAVED_VIEW_SLOTS,
+  mergeLayers,
+  parseSavedViews,
+  savedViewsKey,
+  serializeSavedViews,
+} from '@/features/patientFlowNavigator/savedViews';
+import type { SavedView } from '@/features/patientFlowNavigator/savedViews';
+
+const view: SavedView = {
+  camera: {
+    position: { x: 88, y: 104, z: 162 },
+    target: { x: 0, y: 48, z: 0 },
+  },
+  floor: '3',
+  layers: { base: true, tokens: true, trails: false, heat: true, ghosts: false, barriers: true, rounds: true },
+};
+
+describe('saved views (N-7)', () => {
+  it('round-trips through serialize/parse', () => {
+    const stored = serializeSavedViews([null, view, null]);
+    expect(parseSavedViews(stored)).toEqual([null, view, null]);
+  });
+
+  it('always yields exactly the slot count', () => {
+    expect(parseSavedViews(null)).toHaveLength(SAVED_VIEW_SLOTS);
+    expect(parseSavedViews(serializeSavedViews([view, view, view]))).toHaveLength(SAVED_VIEW_SLOTS);
+  });
+
+  it('degrades garbage storage to empty slots, never a crash', () => {
+    expect(parseSavedViews('not json')).toEqual([null, null, null]);
+    expect(parseSavedViews('{"a":1}')).toEqual([null, null, null]);
+    expect(parseSavedViews('[{"camera":"bogus"}]')).toEqual([null, null, null]);
+    // A valid slot next to a corrupt one survives.
+    const mixed = JSON.stringify([{ nope: true }, view, 42]);
+    expect(parseSavedViews(mixed)).toEqual([null, view, null]);
+  });
+
+  it('keys storage by persona role with a house default', () => {
+    expect(savedViewsKey('charge_nurse')).toBe('flow4d.views.charge_nurse');
+    expect(savedViewsKey(null)).toBe('flow4d.views.house');
+    expect(savedViewsKey(undefined)).toBe('flow4d.views.house');
+  });
+
+  it('merges saved layers over current state without dropping keys', () => {
+    const current = { base: true, tokens: false, trails: true, heat: false, ghosts: true, barriers: false, rounds: false };
+    expect(mergeLayers(current, view.layers)).toEqual(view.layers);
+  });
+});

--- a/tests/js/patientFlow/sceneVocabulary.test.ts
+++ b/tests/js/patientFlow/sceneVocabulary.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BASE_CATEGORY_STYLES,
+  CATEGORY_LABELS,
+  ELEMENT_LABELS,
+  LEGEND_SECTIONS,
+  PATIENT_HUE_MIN,
+  PATIENT_HUE_SPAN,
+  elementLabelFor,
+  patientHue,
+} from '@/features/patientFlowNavigator/sceneVocabulary';
+import type { PatientLayerState } from '@/features/patientFlowNavigator/types';
+
+/**
+ * §5.1 SSOT guarantees: the legend covers every scene layer, the identity hue
+ * can never impersonate status colors, and every GLB category is accounted
+ * for. If a new layer or category ships without a legend entry, these fail.
+ */
+
+const ALL_LAYERS: Array<keyof PatientLayerState> = [
+  'base',
+  'tokens',
+  'trails',
+  'heat',
+  'ghosts',
+  'barriers',
+  'rounds',
+];
+
+describe('legend completeness (E-1)', () => {
+  it('covers every scene layer with at least one legend entry', () => {
+    const coveredLayers = new Set(
+      LEGEND_SECTIONS.flatMap((section) => section.entries.map((entry) => entry.layer)),
+    );
+    for (const layer of ALL_LAYERS) {
+      expect(coveredLayers.has(layer), `layer "${layer}" has no legend entry`).toBe(true);
+    }
+  });
+
+  it('gives every entry a distinct key, a label, and a worded description', () => {
+    const entries = LEGEND_SECTIONS.flatMap((section) => section.entries);
+    const keys = entries.map((entry) => entry.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    for (const entry of entries) {
+      expect(entry.label.length).toBeGreaterThan(0);
+      expect(entry.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('words the status meanings — status is never color alone', () => {
+    const descriptions = LEGEND_SECTIONS.flatMap((section) => section.entries)
+      .map((entry) => `${entry.label} ${entry.description}`)
+      .join(' ');
+    for (const word of ['Amber', 'Coral', 'Green']) {
+      expect(descriptions).toContain(word);
+    }
+  });
+});
+
+describe('patient identity hue clamp (E-3)', () => {
+  it('stays inside 160°–280° for arbitrary ids', () => {
+    const samples = [
+      '',
+      'a',
+      'PT-000001',
+      'PT-999999',
+      'encounter:5f2c-88ab',
+      '5-212',
+      'zzzzzzzzzzzzzzzzzzzzzzzz',
+      '☃ unicode ☃',
+      ...Array.from({ length: 500 }, (_, index) => `patient-${index * 7919}`),
+    ];
+    for (const sample of samples) {
+      const hue = patientHue(sample);
+      expect(hue).toBeGreaterThanOrEqual(PATIENT_HUE_MIN);
+      expect(hue).toBeLessThan(PATIENT_HUE_MIN + PATIENT_HUE_SPAN);
+    }
+  });
+
+  it('is deterministic per id', () => {
+    expect(patientHue('PT-42')).toBe(patientHue('PT-42'));
+  });
+});
+
+describe('base category coverage (E-2)', () => {
+  it('styles or deliberately excludes every labeled category', () => {
+    // `floor` keeps the model material as the datum plane — the only allowed gap.
+    for (const category of Object.keys(CATEGORY_LABELS)) {
+      if (category === 'floor') continue;
+      expect(BASE_CATEGORY_STYLES[category], `category "${category}" has no style`).toBeDefined();
+    }
+  });
+
+  it('keeps base opacities at or below 0.85 so status layers keep priority', () => {
+    for (const [category, style] of Object.entries(BASE_CATEGORY_STYLES)) {
+      expect(style.opacity, `category "${category}" opacity`).toBeLessThanOrEqual(0.85);
+    }
+  });
+});
+
+describe('elementLabelFor (E-4/E-5)', () => {
+  it('names every scene element kind', () => {
+    for (const kind of Object.keys(ELEMENT_LABELS)) {
+      expect(elementLabelFor({ kind })).toBe(ELEMENT_LABELS[kind]);
+    }
+  });
+
+  it('falls back to the building category, then null', () => {
+    expect(elementLabelFor({ category: 'bed' })).toBe('Bed');
+    expect(elementLabelFor({ category: 'emergency_department' })).toBe('Emergency department');
+    expect(elementLabelFor({})).toBeNull();
+    expect(elementLabelFor({ kind: 'unknown-kind' })).toBeNull();
+  });
+});

--- a/tests/js/virtualRounds/roundsScene.test.ts
+++ b/tests/js/virtualRounds/roundsScene.test.ts
@@ -162,4 +162,14 @@ describe('buildRoundRoute (R-4)', () => {
     const cells = buildRoundStopCells([stop({})], index(), 'all');
     expect(buildRoundRoute(cells)).toEqual([]);
   });
+
+  it('adopts the first known floor after a floor-unknown start so later changes still dash', () => {
+    // Route built directly from cells: floor-null start, then floor 3, then floor 4.
+    const route = buildRoundRoute([
+      { anchor: { x: 0, y: 2, z: 0 }, floor: null, stop: stop({ round_patient_uuid: 'unknown', queue_position: 1 }) },
+      { anchor: { x: 10, y: 2, z: 20 }, floor: 3, stop: stop({ round_patient_uuid: 'f3', queue_position: 2 }) },
+      { anchor: { x: -5, y: 2, z: 8 }, floor: 4, stop: stop({ round_patient_uuid: 'f4', queue_position: 3 }) },
+    ]);
+    expect(route.map((segment) => segment.dashed)).toEqual([false, true]);
+  });
 });

--- a/tests/js/virtualRounds/roundsScene.test.ts
+++ b/tests/js/virtualRounds/roundsScene.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ProjectionPlacementIndex } from '@/features/patientFlowNavigator/projections';
 import {
+  buildRoundRoute,
   buildRoundStopCells,
   ROUND_STOP_COLORS,
   type RoundStop,
@@ -94,5 +95,71 @@ describe('buildRoundStopCells', () => {
       expect(ROUND_STOP_COLORS[status]).toBeDefined();
       expect(ROUND_STOP_COLORS[status]).not.toBe(CORAL);
     }
+  });
+
+  it('carries the resolved floor on each cell for route grouping (R-4)', () => {
+    const cells = buildRoundStopCells([stop({ bed: '5E-01' }), stop({ round_patient_uuid: 'u7', unit_id: 7, bed: null })], index(), 'all');
+    expect(cells.map((cell) => cell.floor)).toEqual([3, 4]);
+  });
+});
+
+describe('buildRoundRoute (R-4)', () => {
+  it('connects same-floor stops in queue order as one solid run', () => {
+    const cells = buildRoundStopCells(
+      [
+        stop({ round_patient_uuid: 'second', unit_id: 5, queue_position: 2, bed: '5E-01' }),
+        stop({ round_patient_uuid: 'first', unit_id: 5, queue_position: 1 }),
+      ],
+      index(),
+      'all',
+    );
+    const route = buildRoundRoute(cells);
+    expect(route).toHaveLength(1);
+    expect(route[0].dashed).toBe(false);
+    // Queue order, not input order: unit centroid (pos 1) then bed (pos 2).
+    expect(route[0].points).toEqual([
+      { x: 10, y: 2, z: 20 },
+      { x: 12, y: 2, z: 22 },
+    ]);
+  });
+
+  it('emits a dashed leg for a floor change — stable ordering, not path-finding', () => {
+    const cells = buildRoundStopCells(
+      [
+        stop({ round_patient_uuid: 'f3a', unit_id: 5, queue_position: 1 }),
+        stop({ round_patient_uuid: 'f3b', unit_id: 5, queue_position: 2, bed: '5E-01' }),
+        stop({ round_patient_uuid: 'f4', unit_id: 7, queue_position: 3 }),
+      ],
+      index(),
+      'all',
+    );
+    const route = buildRoundRoute(cells);
+    expect(route.map((segment) => segment.dashed)).toEqual([false, true]);
+    expect(route[1].points).toEqual([
+      { x: 12, y: 2, z: 22 },
+      { x: -5, y: 2, z: 8 },
+    ]);
+  });
+
+  it('excludes skipped and deferred stops from the walk (R-6a skip rule)', () => {
+    const cells = buildRoundStopCells(
+      [
+        stop({ round_patient_uuid: 'a', unit_id: 5, queue_position: 1 }),
+        stop({ round_patient_uuid: 'skip', unit_id: 5, queue_position: 2, bed: '5E-01', status: 'skipped' }),
+        stop({ round_patient_uuid: 'defer', unit_id: 7, queue_position: 3, status: 'deferred' }),
+        stop({ round_patient_uuid: 'b', unit_id: 5, queue_position: 4, bed: '5E-01' }),
+      ],
+      index(),
+      'all',
+    );
+    const route = buildRoundRoute(cells);
+    expect(route).toHaveLength(1);
+    expect(route[0].points).toHaveLength(2);
+    expect(route[0].dashed).toBe(false);
+  });
+
+  it('yields no segments for a single placeable stop', () => {
+    const cells = buildRoundStopCells([stop({})], index(), 'all');
+    expect(buildRoundRoute(cells)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Phases 1–3 of [docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md](docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md), stacked on #38 (Phase 0) as three clean commits. Base will be retargeted to `main` once #38 merges.

### Phase 1 — Element Identity System
- `sceneVocabulary.ts` is the single source of truth for every shape/color; scene materials and the new legend both render from it
- GLB category materials from glTF extras: beds slate-blue, corridors dark slate, ED muted sky, imaging/procedures muted blue, elevators light neutral — hallway/room/bed/ED finally legible
- `hashColor` hue clamped 160–280° so patient tokens can never impersonate amber/coral status
- Collapsible **Key** legend (bottom-left pill), worded status meanings, hidden layers dim with "(hidden)"
- Hover: 50 ms-throttled raycast, cursor affordance, emissive lift, scene-owned chip (identity never shown); persistent selection highlight + element-type inspector prefix; Escape clears

### Phase 2 — Navigability
- Floor stepper rail (right edge, ↑/↓ steps, fit-to-floor framing); the dropdown routes through the same path
- Search: Enter flies to matches, match count + zero-match hint, Escape clears
- Keyboard map H/F/N/? + shortcut sheet; OrbitControls arrow panning on the focused canvas
- Three persona-keyed saved views in localStorage (camera+floor+layers, Zod-validated)

### Phase 3 — Virtual Rounds integration (payloads stay patient-free)
- `?focus_stop={uuid}` deep link wires the dead `focusRoundStop()` seam (floor-clear retry + toast fallback)
- "Locate in 4D" on board rows + workspace; round-stop inspector links back with `?patient=`
- Rounds HUD chip (status/scope, rounded/total, awaiting-input; never coral) with tour **Prev/Next/Auto** (10 s dwell, pauses on operator camera input)
- Queue-number sprites + itinerary polyline (solid per-floor, dashed cross-floor; stable ordering, not path-finding)
- Scene polling every 30 s, visibility-gated, content-hash rebuild gate; run completion announces + stops polling
- PHPUnit scene contract guard extended to pin `queue_position`/`unit_id`/`bed`/`pinned`

## Test plan
- [x] 577 vitest tests pass (34 new across vocabulary/legend/floor-rail/saved-views/route/handoff/HUD)
- [x] `php artisan test --filter=RoundProjectionTest` — 7 pass
- [x] `npx tsc --noEmit`, `npx vite build`, `scripts/check-ui-canon.sh` all clean
- [ ] Browser verification on prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)