### PR TITLE
feat: 4D Navigator soak diagnostics hook + hover-label identity guard

### DIFF
--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -1132,6 +1132,17 @@ export class NavigatorScene {
     this.orbit.update();
   }
 
+  /** Renderer memory/draw counters for the H4 soak hook (soakHook.ts). */
+  debugInfo(): { geometries: number; textures: number; calls: number; triangles: number } {
+    const { memory, render } = this.renderer.info;
+    return {
+      geometries: memory.geometries,
+      textures: memory.textures,
+      calls: render.calls,
+      triangles: render.triangles,
+    };
+  }
+
   dispose(): void {
     this.disposed = true;
     cancelAnimationFrame(this.animationId);

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -56,7 +56,8 @@ import type {
   ProjectionItem,
 } from '@/features/patientFlowNavigator/types';
 import { occupancyInspectorData, patientTokenInspectorData } from '@/features/patientFlowNavigator/inspector';
-import { elementLabelFor } from '@/features/patientFlowNavigator/sceneVocabulary';
+import { elementLabelFor, hoverLabelFor } from '@/features/patientFlowNavigator/sceneVocabulary';
+import { installSoakHook } from '@/features/patientFlowNavigator/soakHook';
 import {
   mergeLayers,
   parseSavedViews,
@@ -344,6 +345,7 @@ export default function PatientFlowNavigator({
   const [inspectorAction, setInspectorAction] = useState<{ label: string; href: string } | null>(null);
   const [tourAuto, setTourAuto] = useState(false);
   const [focusTick, setFocusTick] = useState(0);
+  const roundsRunRef = useRef<RunSummary | null>(null);
   const roundsVersionRef = useRef(0);
   const roundsSceneHashRef = useRef('');
   const roundsRunUuidRef = useRef<string | null>(null);
@@ -650,6 +652,20 @@ export default function PatientFlowNavigator({
     nowMsRef.current = nowMs;
     refreshScene();
   }, [nowMs, refreshScene]);
+
+  // H4 soak hook: pull-based diagnostics for scripts/soak-flow4d.mjs. Getters
+  // read refs so one install on mount stays current; nowDeltaMs is only
+  // meaningful in follow mode (a deliberate scrub is not clock drift).
+  useEffect(() => {
+    roundsRunRef.current = roundsRun;
+  }, [roundsRun]);
+  useEffect(() => installSoakHook({
+    rendererInfo: () => sceneRef.current?.debugInfo() ?? null,
+    nowDeltaMs: () => (followNowRef.current ? Date.now() - nowMsRef.current : null),
+    roundsRun: () => (roundsRunRef.current
+      ? { uuid: roundsRunRef.current.run_uuid, status: roundsRunRef.current.status }
+      : null),
+  }), []);
 
   // Live-follow: slide the 48h window with wall-clock now, but only in
   // explicit follow mode (entered at bootstrap or by scrubbing to now) — a
@@ -999,15 +1015,9 @@ export default function PatientFlowNavigator({
           );
         },
         onUserCameraStart: () => setTourAuto(false),
-        // E-4 hover chip: element type + a non-identity name. Identity fields
-        // NEVER appear here regardless of lens (stricter than the inspector).
-        hoverLabel: (data) => {
-          const element = elementLabelFor(data);
-          if (!element) return null;
-          const name = data.label ?? data.bed ?? data.bed_code ?? data.location_name
-            ?? data.location ?? data.name ?? data.unit ?? data.status ?? null;
-          return name !== null && String(name) !== element ? `${element} · ${String(name)}` : element;
-        },
+        // E-4 hover chip: identity-free by construction AND by guard test —
+        // hoverLabelFor lives in sceneVocabulary, pinned by hoverLabel.test.ts.
+        hoverLabel: hoverLabelFor,
         onCameraMove: handleCameraMove,
         onFrame: (delta) => {
           if (!playingRef.current || liveRef.current) return;

--- a/resources/js/features/patientFlowNavigator/sceneVocabulary.ts
+++ b/resources/js/features/patientFlowNavigator/sceneVocabulary.ts
@@ -138,6 +138,20 @@ export function elementLabelFor(data: Record<string, unknown>): string | null {
   return null;
 }
 
+/**
+ * Hover-chip text (finding E-4): element type + a non-identity name. Identity
+ * fields (patient_display_id / patient_id / encounter_id) NEVER appear here
+ * regardless of lens — stricter than the inspector, which redacts by policy.
+ * Pinned by tests/js/patientFlow/hoverLabel.test.ts (HFE closure H5.2).
+ */
+export function hoverLabelFor(data: Record<string, unknown>): string | null {
+  const element = elementLabelFor(data);
+  if (!element) return null;
+  const name = data.label ?? data.bed ?? data.bed_code ?? data.location_name
+    ?? data.location ?? data.name ?? data.unit ?? data.status ?? null;
+  return name !== null && String(name) !== element ? `${element} · ${String(name)}` : element;
+}
+
 // ---------------------------------------------------------------------------
 // Legend (finding E-1) — rendered verbatim by NavigatorLegend. Every entry
 // carries the layer it belongs to so hidden layers can dim their rows, and

--- a/resources/js/features/patientFlowNavigator/soakHook.ts
+++ b/resources/js/features/patientFlowNavigator/soakHook.ts
@@ -1,0 +1,43 @@
+/**
+ * Read-only field-diagnostics hook consumed by scripts/soak-flow4d.mjs
+ * (HFE closure H4.1 — docs/FLOW-4D-HFE-CLOSURE-PLAN-2026-07-19.md).
+ *
+ * Exposes renderer memory/draw counters, now-marker wall-clock delta, and the
+ * active rounds run (opaque uuid + status only — identity never crosses this
+ * boundary). Getters are pull-based so installing costs nothing per frame.
+ */
+
+export interface SoakRendererInfo {
+  geometries: number;
+  textures: number;
+  calls: number;
+  triangles: number;
+}
+
+export interface SoakRoundsRun {
+  uuid: string;
+  status: string;
+}
+
+export interface Flow4dSoakHook {
+  rendererInfo: () => SoakRendererInfo | null;
+  nowDeltaMs: () => number | null;
+  roundsRun: () => SoakRoundsRun | null;
+}
+
+declare global {
+  interface Window {
+    __FLOW4D_SOAK__?: Flow4dSoakHook;
+  }
+}
+
+/** Installs the hook on window; returns an uninstaller that only removes its
+ * own installation (a later install wins and is left untouched). */
+export function installSoakHook(hook: Flow4dSoakHook): () => void {
+  window.__FLOW4D_SOAK__ = hook;
+  return () => {
+    if (window.__FLOW4D_SOAK__ === hook) {
+      delete window.__FLOW4D_SOAK__;
+    }
+  };
+}

--- a/tests/js/patientFlow/hoverLabel.test.ts
+++ b/tests/js/patientFlow/hoverLabel.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CATEGORY_LABELS,
+  ELEMENT_LABELS,
+  hoverLabelFor,
+} from '@/features/patientFlowNavigator/sceneVocabulary';
+
+/**
+ * H5.2 — the missing identity guard, pinned as a test.
+ *
+ * The hover chip is stricter than the inspector: the inspector redacts by
+ * lens policy, the hover chip NEVER carries identity for anyone. That was
+ * previously enforced by construction only; this test asserts that
+ * hoverLabelFor never emits patient_display_id / patient_id / encounter_id
+ * for any element kind or GLB category, no matter what the userData carries.
+ */
+
+const IDENTITY_FIELDS = {
+  patient_display_id: 'IDENT-DISPLAY-SENTINEL',
+  patient_id: 'IDENT-UUID-SENTINEL',
+  encounter_id: 'IDENT-ENCOUNTER-SENTINEL',
+};
+
+const SENTINELS = Object.values(IDENTITY_FIELDS);
+
+function expectNoIdentity(label: string | null): void {
+  for (const sentinel of SENTINELS) {
+    expect(label ?? '').not.toContain(sentinel);
+  }
+}
+
+describe('hoverLabelFor identity exclusion (H5.2)', () => {
+  it('never emits identity for any element kind, even with no other name source', () => {
+    for (const kind of Object.keys(ELEMENT_LABELS)) {
+      const label = hoverLabelFor({ kind, ...IDENTITY_FIELDS });
+      expect(label).toBe(ELEMENT_LABELS[kind]);
+      expectNoIdentity(label);
+    }
+  });
+
+  it('never emits identity for any GLB category', () => {
+    for (const category of Object.keys(CATEGORY_LABELS)) {
+      const label = hoverLabelFor({ category, ...IDENTITY_FIELDS });
+      expect(label).toBe(CATEGORY_LABELS[category]);
+      expectNoIdentity(label);
+    }
+  });
+
+  it('prefers the non-identity name and still excludes identity alongside it', () => {
+    const label = hoverLabelFor({
+      kind: 'occupancy-marker',
+      location_name: 'MedSurg 3 East',
+      ...IDENTITY_FIELDS,
+    });
+    expect(label).toBe('Census disk · MedSurg 3 East');
+    expectNoIdentity(label);
+  });
+
+  it('labels a bed by its code, never by its occupant', () => {
+    const label = hoverLabelFor({
+      category: 'bed',
+      bed: 'B-312',
+      ...IDENTITY_FIELDS,
+    });
+    expect(label).toBe('Bed · B-312');
+    expectNoIdentity(label);
+  });
+
+  it('returns null for unknown userData instead of falling back to arbitrary fields', () => {
+    expect(hoverLabelFor(IDENTITY_FIELDS)).toBeNull();
+  });
+
+  it('collapses a name identical to the element label', () => {
+    expect(hoverLabelFor({ kind: 'patient-token', label: 'Patient' })).toBe('Patient');
+  });
+});

--- a/tests/js/patientFlow/soakHook.test.ts
+++ b/tests/js/patientFlow/soakHook.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { installSoakHook } from '@/features/patientFlowNavigator/soakHook';
+import type { Flow4dSoakHook } from '@/features/patientFlowNavigator/soakHook';
+
+function stubHook(overrides: Partial<Flow4dSoakHook> = {}): Flow4dSoakHook {
+  return {
+    rendererInfo: () => null,
+    nowDeltaMs: () => null,
+    roundsRun: () => null,
+    ...overrides,
+  };
+}
+
+describe('installSoakHook (H4.1)', () => {
+  afterEach(() => {
+    delete window.__FLOW4D_SOAK__;
+  });
+
+  it('installs the hook and passes getters through', () => {
+    const uninstall = installSoakHook(stubHook({
+      rendererInfo: () => ({ geometries: 12, textures: 4, calls: 60, triangles: 20_000 }),
+      nowDeltaMs: () => 1_500,
+      roundsRun: () => ({ uuid: 'run-uuid', status: 'active' }),
+    }));
+
+    expect(window.__FLOW4D_SOAK__?.rendererInfo()).toEqual({ geometries: 12, textures: 4, calls: 60, triangles: 20_000 });
+    expect(window.__FLOW4D_SOAK__?.nowDeltaMs()).toBe(1_500);
+    expect(window.__FLOW4D_SOAK__?.roundsRun()).toEqual({ uuid: 'run-uuid', status: 'active' });
+    uninstall();
+  });
+
+  it('uninstall removes its own installation', () => {
+    const uninstall = installSoakHook(stubHook());
+    expect(window.__FLOW4D_SOAK__).toBeDefined();
+    uninstall();
+    expect(window.__FLOW4D_SOAK__).toBeUndefined();
+  });
+
+  it('a stale uninstaller leaves a newer installation in place', () => {
+    const first = installSoakHook(stubHook());
+    const second = stubHook({ nowDeltaMs: () => 42 });
+    installSoakHook(second);
+    first();
+    expect(window.__FLOW4D_SOAK__).toBe(second);
+    expect(window.__FLOW4D_SOAK__?.nowDeltaMs()).toBe(42);
+  });
+});


### PR DESCRIPTION
## HFE closure H4.1 + H5.2

Two small, independent hardening items from [the HFE closure plan](docs/FLOW-4D-HFE-CLOSURE-PLAN-2026-07-19.md):

### `window.__FLOW4D_SOAK__` diagnostics hook (H4.1)
Pull-based, read-only getters consumed by `scripts/soak-flow4d.mjs` (already on main, feature-detects the hook):
- `rendererInfo()` — three.js renderer memory/draw counters via `NavigatorScene.debugInfo()`
- `nowDeltaMs()` — now-marker wall-clock delta, **only in follow mode** (a deliberate scrub is not clock drift)
- `roundsRun()` — active run as **opaque uuid + status only**; identity never crosses this boundary

Installed once on mount reading refs, uninstalled on unmount; a stale uninstaller never removes a newer installation.

### Hover-label identity guard (H5.2)
`hoverLabelFor` extracted from the inline closure into `sceneVocabulary.ts` (the scene-vocabulary SSOT) and pinned by `tests/js/patientFlow/hoverLabel.test.ts`: identity fields (`patient_display_id`/`patient_id`/`encounter_id`) never reach the hover chip for **any** element kind or GLB category — the one doctrine guard the plan called out as enforced by construction only.

## Verification
- 593/593 vitest (+9 new), `tsc --noEmit`, `vite build`, `check-ui-canon.sh` all green
- Post-merge: `./deploy.sh --frontend`; unblocks H4 soak/census runs (wall box + soak account still needed)