### PR TITLE
feat: 4D Navigator first-run intro tour (HFE closure H5.1)

### DIFF
--- a/resources/js/Components/PatientFlowNavigator/NavigatorIntro.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorIntro.tsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { IntroStop } from '@/features/patientFlowNavigator/introTour';
+
+interface AnchorRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface NavigatorIntroProps {
+  stops: IntroStop[];
+  index: number;
+  onIndexChange: (index: number) => void;
+  onDismiss: () => void;
+}
+
+/**
+ * Coach-mark card for the first-run intro (H5.1). Each stop outlines its
+ * anchored control with a gold-tint ring (the filter-chip "notice" treatment,
+ * deliberately outside the status-color space) and explains it in the card.
+ * A missing anchor (layout variant, jsdom) degrades to the card alone.
+ */
+export default function NavigatorIntro({ stops, index, onIndexChange, onDismiss }: NavigatorIntroProps) {
+  // The stop list can shrink if the rounds run unloads mid-intro.
+  const clamped = Math.min(index, stops.length - 1);
+  const stop = stops[clamped] ?? null;
+  const [anchorRect, setAnchorRect] = useState<AnchorRect | null>(null);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    cardRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (!stop) return undefined;
+    const measure = (): void => {
+      const rect = document.querySelector(stop.anchor)?.getBoundingClientRect();
+      setAnchorRect(
+        rect && rect.width > 0
+          ? { top: rect.top, left: rect.left, width: rect.width, height: rect.height }
+          : null,
+      );
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, [stop]);
+
+  if (!stop) return null;
+  const last = clamped === stops.length - 1;
+
+  return (
+    <>
+      {anchorRect && (
+        <div
+          className="patient-flow-intro-ring"
+          aria-hidden="true"
+          style={{
+            top: anchorRect.top - 4,
+            left: anchorRect.left - 4,
+            width: anchorRect.width + 8,
+            height: anchorRect.height + 8,
+          }}
+        />
+      )}
+      <div
+        className="patient-flow-intro"
+        role="dialog"
+        aria-label="Navigator introduction"
+        tabIndex={-1}
+        ref={cardRef}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') onDismiss();
+        }}
+      >
+        <strong>{stop.title}</strong>
+        <p>{stop.body}</p>
+        <div className="patient-flow-intro-footer">
+          <span className="patient-flow-intro-count">{clamped + 1} of {stops.length}</span>
+          <div className="patient-flow-intro-buttons">
+            <button type="button" onClick={onDismiss}>Skip</button>
+            {clamped > 0 && (
+              <button type="button" onClick={() => onIndexChange(clamped - 1)}>Back</button>
+            )}
+            {last ? (
+              <button type="button" className="patient-flow-intro-primary" onClick={onDismiss}>Done</button>
+            ) : (
+              <button type="button" className="patient-flow-intro-primary" onClick={() => onIndexChange(clamped + 1)}>Next</button>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -1360,3 +1360,93 @@
     display: none;
   }
 }
+
+/* --- First-run intro tour (HFE closure H5.1) ------------------------------ */
+
+.patient-flow-shortcut-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.patient-flow-intro {
+  position: absolute;
+  z-index: 6;
+  left: 50%;
+  bottom: 88px;
+  transform: translateX(-50%);
+  width: min(360px, calc(100vw - 32px));
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  background: rgba(27, 31, 29, 0.96);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.3);
+  padding: 14px;
+}
+
+.patient-flow-intro:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
+}
+
+.patient-flow-intro strong {
+  display: block;
+  margin-bottom: 6px;
+  color: #f3efe5;
+  font-size: 13px;
+}
+
+.patient-flow-intro p {
+  margin: 0 0 12px;
+  color: #b9b2a6;
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.patient-flow-intro-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.patient-flow-intro-count {
+  color: #b9b2a6;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.patient-flow-intro-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.patient-flow-intro-buttons button {
+  min-height: 24px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 5px;
+  background: #2a2f2c;
+  color: #ddd6c7;
+  font-size: 12px;
+  padding: 4px 12px;
+  cursor: pointer;
+}
+
+.patient-flow-intro-buttons button:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
+}
+
+.patient-flow-intro-buttons .patient-flow-intro-primary {
+  border-color: rgba(224, 163, 63, 0.5);
+  background: rgba(224, 163, 63, 0.16);
+  color: #ffd795;
+}
+
+/* Anchor outline: the filter-chip "notice" gold tint — deliberately NOT a
+   status color, so the intro can never counterfeit urgency. */
+.patient-flow-intro-ring {
+  position: fixed;
+  z-index: 6;
+  border: 2px solid rgba(224, 163, 63, 0.75);
+  border-radius: 8px;
+  box-shadow: 0 0 0 4px rgba(224, 163, 63, 0.15);
+  pointer-events: none;
+}

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -65,12 +65,20 @@ import {
   serializeSavedViews,
 } from '@/features/patientFlowNavigator/savedViews';
 import type { SavedView } from '@/features/patientFlowNavigator/savedViews';
+import {
+  INTRO_SEEN,
+  introStops,
+  introTourKey,
+  persistIntroSeen,
+  shouldAutoStartIntro,
+} from '@/features/patientFlowNavigator/introTour';
 import type { PageProps } from '@/types';
 import type { CameraView, NavigatorScene } from './NavigatorScene';
 import NavigatorChronobar from './NavigatorChronobar';
 import NavigatorFeed from './NavigatorFeed';
 import NavigatorFloorRail from './NavigatorFloorRail';
 import NavigatorInspector from './NavigatorInspector';
+import NavigatorIntro from './NavigatorIntro';
 import NavigatorLegend from './NavigatorLegend';
 import NavigatorToolbar from './NavigatorToolbar';
 import type { LayerControl, NavigatorMetrics } from './NavigatorToolbar';
@@ -384,6 +392,34 @@ export default function PatientFlowNavigator({
       setViews(parseSavedViews(null));
     }
   }, [viewsStorageKey]);
+
+  // H5.1 first-run intro: persona-keyed one-time dismissal under
+  // `flow4d.tour.{role}`. Blocked storage never auto-starts (introTour.ts) —
+  // a kiosk wall on the 6h demo refresh must not loop the welcome card.
+  const introStorageKey = introTourKey(lens?.role_id);
+  const [introOpen, setIntroOpen] = useState(() =>
+    shouldAutoStartIntro(() => window.localStorage.getItem(introTourKey(lens?.role_id))),
+  );
+  const [introIndex, setIntroIndex] = useState(0);
+  const introOpenRef = useRef(introOpen);
+  useEffect(() => {
+    introOpenRef.current = introOpen;
+  }, [introOpen]);
+
+  // A persona switch without a remount re-evaluates that persona's dismissal.
+  useEffect(() => {
+    setIntroIndex(0);
+    setIntroOpen(shouldAutoStartIntro(() => window.localStorage.getItem(introStorageKey)));
+  }, [introStorageKey]);
+
+  const dismissIntro = useCallback(() => {
+    if (!introOpenRef.current) return;
+    setIntroOpen(false);
+    persistIntroSeen(() => window.localStorage.setItem(introStorageKey, INTRO_SEEN));
+  }, [introStorageKey]);
+
+  const roundsActive = roundsRun !== null;
+  const introStopList = useMemo(() => introStops(roundsActive), [roundsActive]);
 
   const tracks = useMemo(() => rebuildTracks(events), [events]);
 
@@ -1215,6 +1251,7 @@ export default function PatientFlowNavigator({
       if (event.metaKey || event.ctrlKey || event.altKey) return;
       if (event.key === 'Escape') {
         setShortcutsOpen(false);
+        dismissIntro();
         sceneRef.current?.clearSelection();
         setInspectorTitle('Select a patient or location');
         setInspectorRows([]);
@@ -1234,7 +1271,7 @@ export default function PatientFlowNavigator({
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [focusActivePatients, handleScrub, historical]);
+  }, [dismissIntro, focusActivePatients, handleScrub, historical]);
 
   // ---- Virtual Rounds integration (Phase 3) --------------------------------
 
@@ -1523,14 +1560,36 @@ export default function PatientFlowNavigator({
             <div><dt>Esc</dt><dd>Clear selection · close panels</dd></div>
             <div><dt>?</dt><dd>Toggle this sheet</dd></div>
           </dl>
-          <button
-            type="button"
-            className="patient-flow-shortcut-close"
-            onClick={() => setShortcutsOpen(false)}
-          >
-            Close
-          </button>
+          <div className="patient-flow-shortcut-actions">
+            <button
+              type="button"
+              className="patient-flow-shortcut-close"
+              onClick={() => {
+                setShortcutsOpen(false);
+                setIntroIndex(0);
+                setIntroOpen(true);
+              }}
+            >
+              Replay intro
+            </button>
+            <button
+              type="button"
+              className="patient-flow-shortcut-close"
+              onClick={() => setShortcutsOpen(false)}
+            >
+              Close
+            </button>
+          </div>
         </div>
+      )}
+
+      {introOpen && (
+        <NavigatorIntro
+          stops={introStopList}
+          index={introIndex}
+          onIndexChange={setIntroIndex}
+          onDismiss={dismissIntro}
+        />
       )}
 
       <div className="patient-flow-statusbar">

--- a/resources/js/features/patientFlowNavigator/introTour.ts
+++ b/resources/js/features/patientFlowNavigator/introTour.ts
@@ -47,7 +47,7 @@ const BASE_STOPS: IntroStop[] = [
   {
     id: 'chronobar',
     title: 'Time travel',
-    body: 'Drag anywhere on the bar to scrub the last 48 hours. Now snaps back to live, and the small ticks jump straight to shift changes and barrier events.',
+    body: 'Drag anywhere on the bar to review the past 24 hours or preview the projected next 24. Now returns to the present, and the small ticks jump straight to shift changes and barrier events.',
     anchor: '.patient-flow-chronobar',
   },
   {

--- a/resources/js/features/patientFlowNavigator/introTour.ts
+++ b/resources/js/features/patientFlowNavigator/introTour.ts
@@ -1,0 +1,77 @@
+// First-run guided intro (HFE closure H5.1). The legend answers "what is
+// this?"; the intro answers "what can I do?" — five coach-mark stops over the
+// live controls. Storage semantics mirror savedViews: guarded access, and
+// blocked storage (kiosk privacy mode) means the dismissal could never
+// persist, so the intro NEVER auto-starts there — a wall display on the 6h
+// demo-refresh cycle must not loop the welcome card forever.
+
+export interface IntroStop {
+  id: string;
+  title: string;
+  body: string;
+  /** CSS selector of the control the stop points at (existing stable overlay classes). */
+  anchor: string;
+}
+
+export const INTRO_SEEN = 'seen';
+
+export function introTourKey(role: string | null | undefined): string {
+  return `flow4d.tour.${role ?? 'house'}`;
+}
+
+/** Auto-start only when storage is readable AND records no prior visit. */
+export function shouldAutoStartIntro(read: () => string | null): boolean {
+  try {
+    return read() === null;
+  } catch {
+    return false;
+  }
+}
+
+/** Any close (Done, Skip, Escape) is the one-time dismissal. */
+export function persistIntroSeen(write: () => void): void {
+  try {
+    write();
+  } catch {
+    // Blocked storage: the dismissal holds for this mount only.
+  }
+}
+
+const BASE_STOPS: IntroStop[] = [
+  {
+    id: 'census',
+    title: 'Census scope',
+    body: 'All shows every occupied location; Delayed narrows the disks to breached timers only. When the narrow scope is on, a chip above the scene says so and offers the way back.',
+    anchor: '.patient-flow-census-toggle',
+  },
+  {
+    id: 'chronobar',
+    title: 'Time travel',
+    body: 'Drag anywhere on the bar to scrub the last 48 hours. Now snaps back to live, and the small ticks jump straight to shift changes and barrier events.',
+    anchor: '.patient-flow-chronobar',
+  },
+  {
+    id: 'legend',
+    title: 'Key',
+    body: 'Every shape in the scene is listed here: disks are occupancy, triangles mark delays, diamonds are barriers, rings are rounds stops.',
+    anchor: '.patient-flow-legend',
+  },
+  {
+    id: 'floors',
+    title: 'Floors & shortcuts',
+    body: 'Step floors here or with the arrow keys. Press ? any time for the full keyboard list — H frames the house, F flies to your selection, N returns to now.',
+    anchor: '.patient-flow-floor-rail',
+  },
+];
+
+const ROUNDS_STOP: IntroStop = {
+  id: 'rounds',
+  title: 'Virtual rounds',
+  body: 'A rounds run is loaded: walk it stop-to-stop with Prev and Next, or switch on Auto to let the camera advance for you.',
+  anchor: '.patient-flow-rounds-hud',
+};
+
+/** The rounds stop renders only when a run is actually loaded (plan H5.1). */
+export function introStops(roundsActive: boolean): IntroStop[] {
+  return roundsActive ? [...BASE_STOPS, ROUNDS_STOP] : BASE_STOPS;
+}

--- a/tests/js/patientFlow/introTour.test.tsx
+++ b/tests/js/patientFlow/introTour.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import NavigatorIntro from '@/Components/PatientFlowNavigator/NavigatorIntro';
+import {
+  INTRO_SEEN,
+  introStops,
+  introTourKey,
+  persistIntroSeen,
+  shouldAutoStartIntro,
+} from '@/features/patientFlowNavigator/introTour';
+
+/**
+ * H5.1 first-run intro: persona-keyed one-time dismissal, rounds stop only
+ * when a run is loaded, and blocked storage (kiosk privacy mode on the wall)
+ * degrading to "never auto-start" — the 6h demo refresh must not loop the
+ * welcome card.
+ */
+
+describe('introTour helpers', () => {
+  it('keys dismissal per persona, defaulting to house', () => {
+    expect(introTourKey(null)).toBe('flow4d.tour.house');
+    expect(introTourKey(undefined)).toBe('flow4d.tour.house');
+    expect(introTourKey('charge_nurse')).toBe('flow4d.tour.charge_nurse');
+  });
+
+  it('auto-starts only on a readable, unseen store', () => {
+    expect(shouldAutoStartIntro(() => null)).toBe(true);
+    expect(shouldAutoStartIntro(() => INTRO_SEEN)).toBe(false);
+  });
+
+  it('blocked storage never auto-starts (kiosk wall, 6h refresh)', () => {
+    expect(
+      shouldAutoStartIntro(() => {
+        throw new Error('storage disabled');
+      }),
+    ).toBe(false);
+  });
+
+  it('persists the dismissal, degrading silently when storage is blocked', () => {
+    const write = vi.fn();
+    persistIntroSeen(write);
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(() =>
+      persistIntroSeen(() => {
+        throw new Error('storage disabled');
+      }),
+    ).not.toThrow();
+  });
+
+  it('includes the rounds stop only when a run is loaded', () => {
+    const withoutRounds = introStops(false);
+    const withRounds = introStops(true);
+    expect(withoutRounds).toHaveLength(4);
+    expect(withoutRounds.some((stop) => stop.id === 'rounds')).toBe(false);
+    expect(withRounds).toHaveLength(5);
+    expect(withRounds[withRounds.length - 1].id).toBe('rounds');
+  });
+
+  it('anchors every stop to an existing overlay class selector', () => {
+    for (const stop of introStops(true)) {
+      expect(stop.anchor.startsWith('.patient-flow-')).toBe(true);
+      expect(stop.title.length).toBeGreaterThan(0);
+      expect(stop.body.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('NavigatorIntro', () => {
+  const stops = introStops(false);
+
+  it('renders the current stop with a tabular step count', () => {
+    render(
+      <NavigatorIntro stops={stops} index={0} onIndexChange={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.getByRole('dialog', { name: 'Navigator introduction' })).toBeTruthy();
+    expect(screen.getByText('Census scope')).toBeTruthy();
+    expect(screen.getByText('1 of 4')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Back' })).toBeNull();
+  });
+
+  it('advances with Next and retreats with Back', () => {
+    const onIndexChange = vi.fn();
+    const { rerender } = render(
+      <NavigatorIntro stops={stops} index={0} onIndexChange={onIndexChange} onDismiss={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    expect(onIndexChange).toHaveBeenCalledWith(1);
+    rerender(
+      <NavigatorIntro stops={stops} index={2} onIndexChange={onIndexChange} onDismiss={vi.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onIndexChange).toHaveBeenCalledWith(1);
+  });
+
+  it('offers Done instead of Next on the last stop, and Done dismisses', () => {
+    const onDismiss = vi.fn();
+    render(
+      <NavigatorIntro
+        stops={stops}
+        index={stops.length - 1}
+        onIndexChange={vi.fn()}
+        onDismiss={onDismiss}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Next' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses via Skip and via Escape on the card', () => {
+    const onDismiss = vi.fn();
+    render(
+      <NavigatorIntro stops={stops} index={1} onIndexChange={vi.fn()} onDismiss={onDismiss} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onDismiss).toHaveBeenCalledTimes(2);
+  });
+
+  it('clamps when the stop list shrinks (rounds run unloads mid-intro)', () => {
+    render(
+      <NavigatorIntro stops={stops} index={4} onIndexChange={vi.fn()} onDismiss={vi.fn()} />,
+    );
+    expect(screen.getByText('Floors & shortcuts')).toBeTruthy();
+    expect(screen.getByText('4 of 4')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- 5-stop coach-mark intro over the live controls: ① Census scope + chip, ② chronobar Now + jump ticks, ③ Key legend, ④ floor rail + \`?\` keymap, ⑤ Rounds HUD (renders only when a run is loaded)
- Persona-keyed one-time dismissal in \`flow4d.tour.{role}\` localStorage (savedViews guarded pattern); **blocked storage never auto-starts** — a kiosk wall on the 6h demo refresh must not loop the welcome card
- Re-launchable via **Replay intro** in the shortcut sheet; Escape dismisses through the same one-time path (global keymap + card-local)
- Hand-rolled in the sanctioned overlay style — the closure plan's "react-joyride is already a dependency" premise was stale (it never was in Zephyrus); no new dependency added
- Anchor ring uses the filter-chip gold-tint "notice" treatment — deliberately outside the status-color space so the intro can never counterfeit urgency; 24px min-height buttons; gold :focus-visible

## Test plan
- [x] 604/604 vitest (+11: helper persona keying, blocked-storage degradation, rounds-stop gating, component next/back/done/skip/escape, shrink-clamp)
- [x] npx tsc --noEmit clean
- [x] npx vite build clean
- [x] scripts/check-ui-canon.sh passed (raw-palette ratchet ≤76 held)
- [ ] CI 15/15
- [ ] Deploy + live chunk verification