### PR TITLE
fix: 4D Navigator HFE audit quick fixes (F-3/F-8/F-9/F-10/F-11/F-12)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,9 @@ jobs:
       - name: Vite production build
         run: bash scripts/capture-release-evidence.sh frontend-build npx vite build
 
+      - name: UI canon check
+        run: bash scripts/capture-release-evidence.sh frontend-ui-canon bash scripts/check-ui-canon.sh
+
       - name: Upload frontend evidence
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md
+++ b/docs/FLOW-4D-NAVIGATOR-ADVANCEMENT-PLAN-2026-07-18.md
@@ -290,9 +290,13 @@ Each phase is independently shippable and PR-sized. Frontend checks per project 
 
 ## 12. HFE Decisions Register (closure plan H5.2)
 
-One row per doctrine: why the invariant exists, and the *named automated guard* that
-breaks in CI if a future change violates it. A new contributor should read this table
-before "simplifying" anything that looks redundant — most of the redundancy is the point.
+One row per doctrine: why the invariant exists, and the *named guard*. Guards come in
+two kinds (audit F-12): **CI guards** — the Vitest/PHPUnit suites and `check-ui-canon.sh`
+(wired into the frontend CI job 2026-07-19) break the build on violation — and
+**field guards** — the H4 soak / urgency-census scripts, which only observe the live
+wall and are labeled as such in their rows; they gate field acceptance, not merges.
+A new contributor should read this table before "simplifying" anything that looks
+redundant — most of the redundancy is the point.
 
 | Doctrine | Rationale | Automated guard |
 |---|---|---|

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -185,6 +185,8 @@ export default function NavigatorToolbar({
           className={`patient-flow-icon-button ${playing ? 'active' : ''}`}
           type="button"
           title={playing ? 'Pause replay' : 'Play replay in the displayed window'}
+          aria-label={playing ? 'Pause replay' : 'Play replay'}
+          aria-pressed={playing}
           onClick={onTogglePlay}
         >
           {playing ? <Pause /> : <Play />}
@@ -199,13 +201,20 @@ export default function NavigatorToolbar({
         >
           <Radio />
         </button>
-        <button className="patient-flow-icon-button" type="button" title="Reset view" onClick={onResetCamera}>
+        <button
+          className="patient-flow-icon-button"
+          type="button"
+          title="Reset view"
+          aria-label="Reset view"
+          onClick={onResetCamera}
+        >
           <Home />
         </button>
         <button
           className="patient-flow-icon-button"
           type="button"
           title="Focus active patients"
+          aria-label="Focus active patients"
           onClick={onFocusPatients}
         >
           <ScanSearch />
@@ -215,6 +224,7 @@ export default function NavigatorToolbar({
             className="patient-flow-icon-button"
             type="button"
             title="Ask Eddy about timer and service-line pressure"
+            aria-label="Ask Eddy about timer and service-line pressure"
             onClick={onAskEddy}
           >
             <Bot />

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -137,6 +137,7 @@
 /* One-click return to the present (N-1) — gold, the now/focus accent. */
 .patient-flow-chronobar-now-button {
   flex: 0 0 auto;
+  min-height: 24px;
   border: 1px solid rgba(224, 163, 63, 0.55);
   border-radius: 5px;
   background: rgba(224, 163, 63, 0.12);
@@ -414,11 +415,12 @@
   outline: none;
 }
 
+/* Gold focus per canon (audit F-9) — focus is the one gold-only semantic. */
 .patient-flow-control-grid select:focus,
 .patient-flow-control-grid input:focus,
 .patient-flow-icon-button:focus-visible {
-  border-color: #64bfd0;
-  box-shadow: 0 0 0 2px rgba(100, 191, 208, 0.25);
+  border-color: #e0a33f;
+  box-shadow: 0 0 0 2px rgba(224, 163, 63, 0.25);
 }
 
 /* Census scope segmented control (B-2) — a filter, deliberately styled unlike
@@ -540,8 +542,8 @@
   box-sizing: border-box !important;
   position: relative;
   flex: 0 0 auto;
-  width: 34px !important;
-  height: 20px !important;
+  width: 40px !important;
+  height: 24px !important;
   min-height: 0 !important;
   padding: 0 !important;
   margin: 0 !important;
@@ -557,9 +559,9 @@
   content: '';
   position: absolute;
   top: 50%;
-  left: 2px;
-  width: 14px;
-  height: 14px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
   background: #f4f5f7;
   transform: translateY(-50%);
@@ -573,7 +575,7 @@
 }
 
 .patient-flow-checkbox-row input[type='checkbox']:checked::after {
-  left: calc(100% - 16px);
+  left: calc(100% - 21px);
 }
 
 .patient-flow-checkbox-row input[type='checkbox']:focus-visible {
@@ -596,10 +598,13 @@
   background: rgba(255, 255, 255, 0.03);
 }
 
+/* 600 is the heaviest loaded Figtree weight (700 renders faux-bold);
+   tabular-nums stops live-update jitter (audit F-10). */
 .patient-flow-metrics span {
   display: block;
   font-size: 20px;
-  font-weight: 700;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }
 
 .patient-flow-metrics small {
@@ -1050,6 +1055,7 @@
 
 .patient-flow-floor-rail button {
   min-width: 30px;
+  min-height: 24px;
   border: 0;
   border-radius: 5px;
   background: transparent;

--- a/scripts/check-ui-canon.sh
+++ b/scripts/check-ui-canon.sh
@@ -2,7 +2,8 @@
 # check-ui-canon.sh — Zephyrus UI consistency guardrail.
 #
 # Fails (exit 1) on unambiguous token-canon violations in resources/js
-# (the Design swatch gallery is exempt). Wire into CI or a pre-commit hook.
+# (the Design swatch gallery is exempt). Runs in CI (frontend job "UI canon
+# check", wired 2026-07-19 per HFE audit F-12); also suitable as a pre-commit hook.
 # The interactive impeccable design hook remains the broad-judgment layer;
 # this script is the unambiguous floor that survives worktree/CI commits
 # where the interactive hook does not run.

--- a/scripts/soak-flow4d.mjs
+++ b/scripts/soak-flow4d.mjs
@@ -131,15 +131,21 @@ async function main() {
     }
   });
 
+  // Context-loss sentinel must be (re)installed after EVERY navigation — a
+  // re-login replaces the document and would silently drop it (audit F-11).
+  async function armContextLossSentinel() {
+    await page.evaluate(() => {
+      document.querySelector('canvas')?.addEventListener('webglcontextlost', () => {
+        window.__FLOW4D_CONTEXT_LOST__ = true;
+      });
+    });
+  }
+
   await login(page, config);
   const navigatorUrl = `${config.baseUrl}${NAVIGATOR_PATH}${config.persona ? `?persona=${config.persona}` : ''}`;
   await page.goto(navigatorUrl, { waitUntil: 'networkidle' });
   await page.waitForSelector('canvas', { timeout: 60_000 });
-  await page.evaluate(() => {
-    document.querySelector('canvas')?.addEventListener('webglcontextlost', () => {
-      window.__FLOW4D_CONTEXT_LOST__ = true;
-    });
-  });
+  await armContextLossSentinel();
 
   const totalSamples = Math.max(1, Math.round((durationHours * 60) / sampleMinutes));
   console.log(`Soaking ${navigatorUrl} for ${durationHours}h, sampling every ${sampleMinutes}min → ${outDir}`);
@@ -155,6 +161,7 @@ async function main() {
       await login(page, config);
       await page.goto(navigatorUrl, { waitUntil: 'networkidle' });
       await page.waitForSelector('canvas', { timeout: 60_000 });
+      await armContextLossSentinel();
     }
     const sample = await captureSample(page, i);
     samples.push(sample);

--- a/scripts/urgency-census-flow4d.mjs
+++ b/scripts/urgency-census-flow4d.mjs
@@ -51,6 +51,14 @@ async function captureSample(page, config, index) {
 
   const insights = occupancy.json.occupancy ?? [];
   const timers = insights.flatMap((insight) => insight.timers ?? []);
+  // Rendered urgency OBJECTS, not just disks (audit F-3): a delayed location
+  // draws a coral disk AND a coral triangle sprite, and every delayed/watch
+  // timer draws its own pip. Disk-only shares materially understate what an
+  // operator actually sees on the wall.
+  const delayedDisks = insights.filter((i) => i?.primary_status === 'delayed').length;
+  const watchDisks = insights.filter((i) => i?.primary_status === 'watch').length;
+  const delayedTimers = timers.filter((t) => t?.status === 'delayed').length;
+  const watchTimers = timers.filter((t) => t?.status === 'watch').length;
   return {
     sample: {
       index,
@@ -61,6 +69,11 @@ async function captureSample(page, config, index) {
       timer_status: tally(timers, 'status'),
       open_barriers: barriers.json.count ?? 0,
       barrier_categories: tally(barriers.json.open_barriers ?? [], 'category'),
+      rendered: {
+        coral_objects: delayedDisks * 2 + delayedTimers,
+        amber_objects: watchDisks + watchTimers,
+        status_objects: insights.length + delayedDisks + timers.length,
+      },
     },
   };
 }
@@ -70,6 +83,14 @@ function share(samples, status) {
   const shares = samples
     .filter((s) => s.disks > 0)
     .map((s) => (s.disk_status[status] ?? 0) / s.disks);
+  return shares.length ? shares.reduce((a, b) => a + b, 0) / shares.length : 0;
+}
+
+function objectShare(samples, key) {
+  // The verdict input (audit F-3): share of RENDERED status objects.
+  const shares = samples
+    .filter((s) => (s.rendered?.status_objects ?? 0) > 0)
+    .map((s) => s.rendered[key] / s.rendered.status_objects);
   return shares.length ? shares.reduce((a, b) => a + b, 0) / shares.length : 0;
 }
 
@@ -107,19 +128,21 @@ async function main() {
     if (i < totalSamples - 1) await sleep(sampleMinutes * 60_000);
   }
 
-  const coralShare = share(samples, 'delayed');
-  const amberShare = share(samples, 'watch');
+  const coralObjectShare = objectShare(samples, 'coral_objects');
+  const amberObjectShare = objectShare(samples, 'amber_objects');
   const exceeded = [];
-  if (coralShare > coralMax) exceeded.push(`coral ${(coralShare * 100).toFixed(1)}% > ${coralMax * 100}%`);
-  if (amberShare > amberMax) exceeded.push(`amber ${(amberShare * 100).toFixed(1)}% > ${amberMax * 100}%`);
+  if (coralObjectShare > coralMax) exceeded.push(`coral ${(coralObjectShare * 100).toFixed(1)}% > ${coralMax * 100}%`);
+  if (amberObjectShare > amberMax) exceeded.push(`amber ${(amberObjectShare * 100).toFixed(1)}% > ${amberMax * 100}%`);
 
   const summary = {
     started: samples[0]?.at,
     finished: new Date().toISOString(),
     samples: samples.length,
     relogins,
-    time_weighted_coral_share: Number(coralShare.toFixed(4)),
-    time_weighted_amber_share: Number(amberShare.toFixed(4)),
+    time_weighted_coral_object_share: Number(coralObjectShare.toFixed(4)),
+    time_weighted_amber_object_share: Number(amberObjectShare.toFixed(4)),
+    disk_only_coral_share: Number(share(samples, 'delayed').toFixed(4)),
+    disk_only_amber_share: Number(share(samples, 'watch').toFixed(4)),
     thresholds: { coral_max: coralMax, amber_max: amberMax },
     verdict: exceeded.length ? `EXCEEDED: ${exceeded.join('; ')}` : 'WITHIN GUIDELINES',
   };

--- a/tests/js/patientFlow/NavigatorToolbar.test.tsx
+++ b/tests/js/patientFlow/NavigatorToolbar.test.tsx
@@ -252,3 +252,17 @@ describe('NavigatorToolbar replay labeling (N-8)', () => {
     expect(replayButton).toHaveAttribute('title', 'Stream stored replay (not a live feed)');
   });
 });
+
+describe('NavigatorToolbar icon-button accessible names (audit F-8)', () => {
+  it('exposes explicit accessible names on every icon action, not title-only', () => {
+    renderToolbar({ eddyEnabled: true });
+
+    const play = screen.getByRole('button', { name: 'Play replay' });
+    expect(play).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: 'Reset view' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Focus active patients' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Ask Eddy about timer and service-line pressure' }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
Fix-now tranche from the independent Codex HFE audit (docs/audits/2026-07-19-flow4d-codex-hfe-audit.md — all 12 findings verified + dispositioned):

- **F-12** — `check-ui-canon.sh` is now a real CI guard (frontend job step; this PR exercises it). Register §12 intro now distinguishes CI guards from field guards.
- **F-9 (partial)** — navigator overlay focus ring cyan → gold (canon: gold is the focus semantic; the same file already used gold everywhere else).
- **F-10** — 24px minimum targets (chronobar Now, layer switches → 40×24 pill/18px knob, floor-rail buttons); metrics `tabular-nums` + `font-weight` 700→600 (700 is not a loaded Figtree weight — faux-bold caught during verification).
- **F-8 (partial)** — explicit `aria-label`/`aria-pressed` on the toolbar icon buttons, pinned by a new accessible-names test.
- **F-3 (partial)** — urgency census verdict now counts rendered coral/amber **objects** (delayed disk + triangle + timer pips), not disks alone; disk-only shares retained as reference fields.
- **F-11 (partial)** — soak script re-arms the `webglcontextlost` sentinel after a re-login navigation.

Remaining audit items are dispositioned in the archive: F-4-overlay/F-5/F-7 → H3 probes; F-1/F-2/F-3-core/F-9-theme → [SU] rulings; F-6/F-8-list/F-9-motion/F-11-app/F-12-browser-test → queued follow-up.

## Test plan
- [x] 594/594 vitest (+1 accessible-names guard)
- [x] node --check on both field scripts
- [x] tsc --noEmit, vite build, check-ui-canon.sh all clean
- [ ] CI green (including the NEW canon step proving itself)
- [ ] Deploy + live verification