### PR TITLE
feat: 4D Navigator HFE audit rulings — F-1/F-2/F-3

### DIFF
--- a/app/Http/Controllers/Api/Rounds/RoundRunController.php
+++ b/app/Http/Controllers/Api/Rounds/RoundRunController.php
@@ -7,10 +7,13 @@ use App\Http\Requests\Rounds\CreateRunRequest;
 use App\Http\Requests\Rounds\ReconcileCohortRequest;
 use App\Http\Requests\Rounds\ReorderQueueRequest;
 use App\Models\Rounds\RoundRun;
+use App\Services\Flow\FlowLensService;
+use App\Services\Mobile\MobilePersonaCatalog;
 use App\Services\Rounds\RoundAuthorizationService;
 use App\Services\Rounds\RoundCohortBuilder;
 use App\Services\Rounds\RoundCommandService;
 use App\Services\Rounds\RoundProjectionService;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -21,6 +24,8 @@ class RoundRunController extends RoundsController
         private readonly RoundCommandService $commands,
         private readonly RoundAuthorizationService $authorization,
         private readonly RoundCohortBuilder $cohortBuilder,
+        private readonly MobilePersonaCatalog $personas,
+        private readonly FlowLensService $flowLens,
     ) {
         parent::__construct($projection);
     }
@@ -84,7 +89,28 @@ class RoundRunController extends RoundsController
         $run = $this->resolveRun($runUuid);
         $this->authorization->assertCanViewRun($request->user(), $run);
 
-        return response()->json($this->projection->scene($run, $request->user()));
+        // F-2 ruling: resolve the caller's flow lens (same ?persona= /
+        // X-Hummingbird-Role / user-default chain as EnforceFlowLens);
+        // aggregate personas (patient_dots = none) get the centroid-redacted
+        // projection. Persona is a REDACTION refinement here, not an access
+        // gate — assertCanViewRun above already decided access. An explicitly
+        // requested but unauthorized persona is a 403 (mirroring the
+        // middleware); a rounds-native user with no persona at all keeps the
+        // full-detail contract.
+        $aggregate = false;
+        $explicit = $request->query('persona')
+            ?? $request->headers->get('X-Hummingbird-Role')
+            ?? $request->input('persona');
+        try {
+            $lens = $this->flowLens->lensFor($this->personas->fromRequest($request));
+            $aggregate = ($lens['patient_dots'] ?? 'full') === 'none';
+        } catch (AuthorizationException $exception) {
+            if ($explicit !== null) {
+                return response()->json(['message' => $exception->getMessage()], 403);
+            }
+        }
+
+        return response()->json($this->projection->scene($run, $request->user(), $aggregate));
     }
 
     public function start(Request $request, string $runUuid): JsonResponse

--- a/app/Services/PatientFlow/OccupancyInsightProjector.php
+++ b/app/Services/PatientFlow/OccupancyInsightProjector.php
@@ -9,8 +9,6 @@ class OccupancyInsightProjector
 {
     private const LONG_STAY_WARN_MINUTES = 8 * 60;
 
-    private const LONG_STAY_DELAY_MINUTES = 18 * 60;
-
     private const READY_MOVE_WINDOW_MINUTES = 30;
 
     private const OVERDUE_TIMER_WINDOW_MINUTES = 4 * 60;
@@ -451,9 +449,10 @@ class OccupancyInsightProjector
 
     private function stayTimer(float $stayMinutes): array
     {
-        $status = $stayMinutes >= self::LONG_STAY_DELAY_MINUTES
-            ? 'delayed'
-            : ($stayMinutes >= self::LONG_STAY_WARN_MINUTES ? 'watch' : 'ok');
+        // F-3 ruling (2026-07-19): inferred, duration-only risk is capped at
+        // watch — coral requires a verified breach (earned-urgency doctrine).
+        // Per-service validated stay targets are the planned refinement.
+        $status = $stayMinutes >= self::LONG_STAY_WARN_MINUTES ? 'watch' : 'ok';
         $definition = $this->barriers->definition('long_stay_capacity_risk');
 
         return [

--- a/app/Services/Rounds/RoundProjectionService.php
+++ b/app/Services/Rounds/RoundProjectionService.php
@@ -130,9 +130,14 @@ class RoundProjectionService
      * 4D overlay projection: opaque tokens + location + round state only.
      * No patient identifier ever appears here, for any lens (plan §8.1).
      *
+     * F-2 ruling (2026-07-19): under an aggregate flow lens (patient_dots =
+     * none) bed-level context is also stripped — bed + queue + status is
+     * re-identifiable at ward level on a shared wall. Aggregate stops anchor
+     * at unit centroids (the client falls back automatically when bed is null).
+     *
      * @return array{data: array<string, mixed>, meta: array<string, mixed>}
      */
-    public function scene(RoundRun $run, User $viewer): array
+    public function scene(RoundRun $run, User $viewer, bool $aggregate = false): array
     {
         $patients = $run->patients()->orderBy('queue_position')->get();
 
@@ -145,8 +150,8 @@ class RoundProjectionService
             'missing_input' => collect($patient->priority_reasons)->contains(fn ($r) => ($r['code'] ?? null) === 'missing_required_input'),
             'queue_position' => $patient->queue_position,
             'unit_id' => $patient->snapshot_unit_id,
-            'facility_space_id' => $patient->snapshot_facility_space_id,
-            'bed' => $patient->snapshot_bed,
+            'facility_space_id' => $aggregate ? null : $patient->snapshot_facility_space_id,
+            'bed' => $aggregate ? null : $patient->snapshot_bed,
         ])->values()->all();
 
         return $this->envelope($run, $viewer, [

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -730,6 +730,7 @@ export default function PatientFlowNavigator({
     const timer = window.setTimeout(() => {
       fetchPatientFlowOccupancy({
         asOf,
+        persona: lens.role_id,
         floor: filters.floor !== 'all' ? filters.floor : undefined,
         service_line: filters.serviceLine !== 'all' ? filters.serviceLine : undefined,
         category: filters.category !== 'all' ? filters.category : undefined,
@@ -827,11 +828,15 @@ export default function PatientFlowNavigator({
     async function bootstrap(): Promise<void> {
       try {
         setStatus('Loading data');
+        // F-1 ruling: every lensed request forwards the page persona so the
+        // resolved lens can never diverge from the rendered page.
         const [summaryData, locationData, eventData, ambientData] = await Promise.all([
-          fetchPatientFlowSummary(),
-          fetchPatientFlowLocations(),
-          patientDotsVisible ? fetchPatientFlowEvents({ limit: 20000 }) : Promise.resolve([]),
-          fetchPatientFlowAmbient(),
+          fetchPatientFlowSummary(lens?.role_id),
+          fetchPatientFlowLocations(lens?.role_id),
+          patientDotsVisible
+            ? fetchPatientFlowEvents({ limit: 20000, persona: lens?.role_id })
+            : Promise.resolve([]),
+          fetchPatientFlowAmbient(lens?.role_id),
         ]);
         if (cancelled) return;
 
@@ -956,7 +961,9 @@ export default function PatientFlowNavigator({
         }
         roundsRunUuidRef.current = openRun.run_uuid;
 
-        const scenePayload = sceneResponseSchema.safeParse(await fetchRoundScene(openRun.run_uuid));
+        const scenePayload = sceneResponseSchema.safeParse(
+          await fetchRoundScene(openRun.run_uuid, lens?.role_id),
+        );
         if (!scenePayload.success || cancelled) return;
 
         const { run, stops } = scenePayload.data.data;
@@ -1043,9 +1050,12 @@ export default function PatientFlowNavigator({
           );
           setInspectorTitle(element && element !== name ? `${element} · ${name}` : name);
           setInspectorRows(flattenInspector(redacted));
-          // R-2: a round-stop selection links straight back to the board.
+          // R-2: a round-stop selection links straight back to the board —
+          // except under an aggregate lens (F-2: no patient-specific deep
+          // link on a patient_dots=none wall).
           setInspectorAction(
             data.kind === 'round-stop' && typeof data.round_patient_uuid === 'string'
+              && dotsPolicy !== 'none'
               ? { label: 'Open in Rounds board', href: `/rtdc/virtual-rounds?patient=${data.round_patient_uuid}` }
               : null,
           );
@@ -1113,7 +1123,7 @@ export default function PatientFlowNavigator({
       return;
     }
     eventSourceRef.current?.close();
-    const source = createPatientFlowEventSource({ replay: 180, interval: 0.65 });
+    const source = createPatientFlowEventSource({ replay: 180, interval: 0.65, persona: lens?.role_id });
     eventSourceRef.current = source;
     source.addEventListener('patient-flow', (message) => {
       const event = JSON.parse((message as MessageEvent<string>).data) as PatientFlowEvent;
@@ -1341,10 +1351,10 @@ export default function PatientFlowNavigator({
     };
     setInspectorTitle(`Round stop · #${stop.queue_position}`);
     setInspectorRows(flattenInspector(redactSelection(data, dotsPolicy)));
-    setInspectorAction({
-      label: 'Open in Rounds board',
-      href: `/rtdc/virtual-rounds?patient=${stop.round_patient_uuid}`,
-    });
+    // F-2: no patient-specific deep link under an aggregate lens.
+    setInspectorAction(dotsPolicy !== 'none'
+      ? { label: 'Open in Rounds board', href: `/rtdc/virtual-rounds?patient=${stop.round_patient_uuid}` }
+      : null);
   }, [dotsPolicy]);
 
   const tourStep = useCallback((direction: 1 | -1): void => {

--- a/resources/js/Pages/RTDC/PatientFlowNavigator.tsx
+++ b/resources/js/Pages/RTDC/PatientFlowNavigator.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
-import { Head } from '@inertiajs/react';
+import React, { useEffect, useRef } from 'react';
+import { Head, router } from '@inertiajs/react';
 import DashboardLayout from '@/Components/Dashboard/DashboardLayout';
 import PatientFlowNavigatorView from '@/Components/PatientFlowNavigator/PatientFlowNavigator';
+import { commandRoleForLens, navigatorUrlForRole } from '@/features/patientFlowNavigator/personaBridge';
+import { useCommandCenterStore } from '@/stores/commandCenterStore';
 import type { FlowLens, FlowUnitSummary } from '@/features/patientFlowNavigator/types';
 
 interface PatientFlowNavigatorPageProps {
@@ -13,6 +15,31 @@ interface PatientFlowNavigatorPageProps {
 // (fullBleed — the 4D navigator needs the uncapped width). The Flow Window lens +
 // unit summaries (flow-window Phase 4) pass through to the navigator view.
 export default function PatientFlowNavigator({ flowLens = null, flowUnits = [] }: PatientFlowNavigatorPageProps) {
+  const role = useCommandCenterStore((s) => s.role);
+  const setRole = useCommandCenterStore((s) => s.setRole);
+  const lensRole = flowLens?.role_id ?? null;
+  const mountedRef = useRef(false);
+
+  // F-1 ruling: one canonical persona state. On mount/lens change the SERVER
+  // lens is the truth the switcher tabs must reflect …
+  useEffect(() => {
+    const derived = commandRoleForLens(lensRole);
+    setRole(derived);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lensRole]);
+
+  // … and a subsequent switch on THIS page is a full server persona
+  // transition through EnforceFlowLens — never a client-only relabel.
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      return;
+    }
+    if (role === commandRoleForLens(lensRole)) return;
+    router.visit(navigatorUrlForRole(window.location.href, role), { preserveScroll: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [role]);
+
   return (
     <DashboardLayout fullBleed>
       <Head title="Patient Flow 4D Navigator - RTDC" />

--- a/resources/js/features/patientFlowNavigator/api.ts
+++ b/resources/js/features/patientFlowNavigator/api.ts
@@ -22,15 +22,22 @@ export interface PatientFlowEventQuery {
   service_line?: string;
   floor?: string;
   limit?: number;
+  /** F-1 ruling: forward the page persona so EnforceFlowLens resolves the
+   * SAME lens the page was rendered with, never the caller's default. */
+  persona?: string;
 }
 
-export async function fetchPatientFlowSummary(): Promise<PatientFlowSummary> {
-  const response = await axios.get<PatientFlowSummary>('/api/patient-flow/summary');
+export async function fetchPatientFlowSummary(persona?: string): Promise<PatientFlowSummary> {
+  const response = await axios.get<PatientFlowSummary>('/api/patient-flow/summary', {
+    params: persona ? { persona } : {},
+  });
   return response.data;
 }
 
-export async function fetchPatientFlowLocations(): Promise<PatientFlowLocations> {
-  const response = await axios.get<PatientFlowLocations>('/api/patient-flow/locations');
+export async function fetchPatientFlowLocations(persona?: string): Promise<PatientFlowLocations> {
+  const response = await axios.get<PatientFlowLocations>('/api/patient-flow/locations', {
+    params: persona ? { persona } : {},
+  });
   return response.data;
 }
 
@@ -60,8 +67,10 @@ export async function fetchPatientFlowState(asOf?: string): Promise<PatientFlowS
   return response.data;
 }
 
-export async function fetchPatientFlowAmbient(): Promise<PatientFlowAmbient> {
-  const response = await axios.get<PatientFlowAmbient>('/api/patient-flow/ambient');
+export async function fetchPatientFlowAmbient(persona?: string): Promise<PatientFlowAmbient> {
+  const response = await axios.get<PatientFlowAmbient>('/api/patient-flow/ambient', {
+    params: persona ? { persona } : {},
+  });
   return response.data;
 }
 
@@ -339,10 +348,13 @@ export async function fetchPatientFlowFhirBundle(eventId: string): Promise<Recor
   return response.data;
 }
 
-export function createPatientFlowEventSource(options: { replay?: number; interval?: number } = {}): EventSource {
+export function createPatientFlowEventSource(
+  options: { replay?: number; interval?: number; persona?: string } = {},
+): EventSource {
   const params = new URLSearchParams();
   if (options.replay) params.set('replay', String(options.replay));
   if (options.interval) params.set('interval', String(options.interval));
+  if (options.persona) params.set('persona', options.persona);
   const suffix = params.toString() ? `?${params.toString()}` : '';
 
   return new EventSource(`/api/patient-flow/stream/adt${suffix}`);

--- a/resources/js/features/patientFlowNavigator/occupancyInsights.ts
+++ b/resources/js/features/patientFlowNavigator/occupancyInsights.ts
@@ -11,7 +11,6 @@ import type {
 } from './types';
 
 const LONG_STAY_WARN_MINUTES = 8 * 60;
-const LONG_STAY_DELAY_MINUTES = 18 * 60;
 const READY_MOVE_WINDOW_MINUTES = 30;
 const OVERDUE_TIMER_WINDOW_MINUTES = 4 * 60;
 
@@ -140,9 +139,10 @@ function projectionTimer(item: ProjectionItem, timeMs: number): OccupancyTimer {
 }
 
 function stayTimer(stayMinutes: number): OccupancyTimer {
-  const status: OccupancyTimerStatus = stayMinutes >= LONG_STAY_DELAY_MINUTES
-    ? 'delayed'
-    : stayMinutes >= LONG_STAY_WARN_MINUTES ? 'watch' : 'ok';
+  // F-3 ruling (2026-07-19): inferred duration-only risk caps at watch —
+  // coral requires a verified breach (earned-urgency doctrine). Mirrors the
+  // server cap in OccupancyInsightProjector::stayTimer().
+  const status: OccupancyTimerStatus = stayMinutes >= LONG_STAY_WARN_MINUTES ? 'watch' : 'ok';
 
   return {
     kind: 'stay',

--- a/resources/js/features/patientFlowNavigator/personaBridge.ts
+++ b/resources/js/features/patientFlowNavigator/personaBridge.ts
@@ -1,0 +1,22 @@
+// F-1 ruling (2026-07-19): the RoleSwitcher and the server flow lens must be
+// ONE canonical persona state on the navigator page. The switcher's two live
+// roles map onto flow personas (command → the viewer's default/house lens,
+// executive → the aggregate executive lens); a switch performs a full server
+// transition through EnforceFlowLens via ?persona=, never a client-only
+// relabel that leaves the scene on another persona's redaction.
+import type { CommandRole } from '@/stores/commandCenterStore';
+
+/** The switcher role implied by the server-resolved lens. */
+export function commandRoleForLens(lensRole: string | null | undefined): CommandRole {
+  return lensRole === 'executive' ? 'executive' : 'command';
+}
+
+/** The navigator URL that performs the server persona transition. */
+export function navigatorUrlForRole(href: string, role: CommandRole): string {
+  const url = new URL(href);
+  if (role === 'executive') url.searchParams.set('persona', 'executive');
+  else url.searchParams.delete('persona');
+  // The client-only ?role= reflection is superseded by the server transition.
+  url.searchParams.delete('role');
+  return `${url.pathname}${url.search}`;
+}

--- a/resources/js/features/virtualRounds/api.ts
+++ b/resources/js/features/virtualRounds/api.ts
@@ -37,8 +37,12 @@ export async function fetchRoundBoard(runUuid: string): Promise<unknown> {
   return res.data;
 }
 
-export async function fetchRoundScene(runUuid: string): Promise<unknown> {
-  const res = await axios.get(`/api/rounds/runs/${runUuid}/scene`);
+// F-2 ruling: persona forwards the page lens so aggregate personas
+// (patient_dots = none) receive the centroid-redacted projection.
+export async function fetchRoundScene(runUuid: string, persona?: string): Promise<unknown> {
+  const res = await axios.get(`/api/rounds/runs/${runUuid}/scene`, {
+    params: persona ? { persona } : {},
+  });
   return res.data;
 }
 

--- a/tests/Feature/PatientFlow/PatientFlowOperationalBarrierProjectionTest.php
+++ b/tests/Feature/PatientFlow/PatientFlowOperationalBarrierProjectionTest.php
@@ -183,16 +183,19 @@ class PatientFlowOperationalBarrierProjectionTest extends TestCase
             ->getJson('/api/patient-flow/occupancy?asOf=2026-06-26T00:00:00Z')
             ->assertOk()
             ->assertJsonPath('summary.active', 1)
-            ->assertJsonPath('summary.delayed', 1)
+            // F-3 ruling: an inferred duration-only risk caps at watch — it
+            // never counts as delayed (coral) without verification.
+            ->assertJsonPath('summary.delayed', 0)
+            ->assertJsonPath('summary.watch', 1)
             ->assertJsonPath('summary.duration_risks', 1)
             ->assertJsonPath('summary.verified_barriers', 0)
             ->assertJsonPath('summary.top_barriers', [])
-            ->assertJsonPath('occupancy.0.primary_status', 'delayed')
+            ->assertJsonPath('occupancy.0.primary_status', 'watch')
             ->assertJsonPath('occupancy.0.blockers', [])
             ->assertJsonPath('occupancy.0.barrier_codes', [])
             ->assertJsonPath('occupancy.0.barrier_reasons', [])
             ->assertJsonPath('occupancy.0.verified_barriers', [])
-            ->assertJsonPath('occupancy.0.duration_risk.status', 'delayed')
+            ->assertJsonPath('occupancy.0.duration_risk.status', 'watch')
             ->assertJsonPath('occupancy.0.duration_risk.classification', 'duration_risk')
             ->assertJsonPath('occupancy.0.duration_risk.risk_code', 'long_stay_capacity_risk')
             ->assertJsonPath('occupancy.0.duration_risk.verified', false)
@@ -204,6 +207,8 @@ class PatientFlowOperationalBarrierProjectionTest extends TestCase
         $this->assertSame('long_stay_capacity_risk', $stayTimer['risk_code']);
         $this->assertSame('duration_risk', $stayTimer['classification']);
         $this->assertFalse($stayTimer['verified']);
+        // The amber cap itself (F-3): unverified stay pressure is watch, never delayed.
+        $this->assertSame('watch', $stayTimer['status']);
     }
 
     /** @return array{User, int, int, string, string} */

--- a/tests/Feature/Rounds/RoundProjectionTest.php
+++ b/tests/Feature/Rounds/RoundProjectionTest.php
@@ -66,6 +66,30 @@ class RoundProjectionTest extends TestCase
         $this->assertNotNull($flags);
     }
 
+    public function test_scene_projection_strips_bed_level_context_for_aggregate_lenses(): void
+    {
+        // F-2 ruling (2026-07-19): under patient_dots = none, bed + queue +
+        // status is re-identifiable at ward level on a shared wall — the
+        // projection anchors at unit centroids (bed/facility_space stripped).
+        $run = \App\Models\Rounds\RoundRun::query()->where('run_uuid', $this->runUuid)->firstOrFail();
+        $scene = app(\App\Services\Rounds\RoundProjectionService::class)
+            ->scene($run, $this->chargeNurse, aggregate: true);
+
+        $this->assertCount(3, $scene['data']['stops']);
+        foreach ($scene['data']['stops'] as $stop) {
+            $this->assertNull($stop['bed']);
+            $this->assertNull($stop['facility_space_id']);
+            // The overlay still works: opaque anchor identity + unit centroid.
+            $this->assertArrayHasKey('round_patient_uuid', $stop);
+            $this->assertNotNull($stop['unit_id']);
+        }
+
+        // The full-detail path is unchanged (contract test above still pins bed).
+        $full = app(\App\Services\Rounds\RoundProjectionService::class)
+            ->scene($run, $this->chargeNurse);
+        $this->assertNotNull(collect($full['data']['stops'])->firstWhere('bed'));
+    }
+
     public function test_broad_access_admin_sees_detail_without_unit_assignment(): void
     {
         $board = $this->actingAs($this->admin)

--- a/tests/js/patientFlow/occupancyInsights.test.ts
+++ b/tests/js/patientFlow/occupancyInsights.test.ts
@@ -49,3 +49,19 @@ describe('patient flow occupancy duration precision', () => {
       .toBeCloseTo(31 / 60, 8);
   });
 });
+
+describe('inferred long-stay urgency cap (F-3 ruling)', () => {
+  it('caps a 20h duration-only stay at watch — never delayed without verification', () => {
+    const result = buildOccupancyInsights(
+      [state('long', 20 * 3_600)],
+      {},
+      [],
+      NOW,
+      undefined,
+    );
+
+    const stay = result.insights[0].timers.find((timer) => timer.kind === 'stay');
+    expect(stay?.status).toBe('watch');
+    expect(result.insights[0].timers.some((timer) => timer.status === 'delayed')).toBe(false);
+  });
+});

--- a/tests/js/patientFlow/personaBridge.test.ts
+++ b/tests/js/patientFlow/personaBridge.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { commandRoleForLens, navigatorUrlForRole } from '@/features/patientFlowNavigator/personaBridge';
+
+/**
+ * F-1 ruling (audit 2026-07-19): the RoleSwitcher and the server flow lens
+ * are ONE canonical persona state on the navigator page. These helpers pin
+ * the mapping and the transition URL.
+ */
+
+describe('commandRoleForLens', () => {
+  it('maps the executive lens to the Executive tab', () => {
+    expect(commandRoleForLens('executive')).toBe('executive');
+  });
+
+  it('maps every non-executive lens (and no lens) to Command', () => {
+    expect(commandRoleForLens(null)).toBe('command');
+    expect(commandRoleForLens(undefined)).toBe('command');
+    expect(commandRoleForLens('charge_nurse')).toBe('command');
+    expect(commandRoleForLens('house_supervisor')).toBe('command');
+  });
+});
+
+describe('navigatorUrlForRole', () => {
+  const base = 'https://zephyrus.test/rtdc/patient-flow-navigator';
+
+  it('performs the executive transition via ?persona=', () => {
+    expect(navigatorUrlForRole(base, 'executive'))
+      .toBe('/rtdc/patient-flow-navigator?persona=executive');
+  });
+
+  it('drops persona for the Command (default lens) transition', () => {
+    expect(navigatorUrlForRole(`${base}?persona=executive`, 'command'))
+      .toBe('/rtdc/patient-flow-navigator');
+  });
+
+  it('preserves unrelated params and strips the client-only ?role=', () => {
+    const href = `${base}?scope=unit%3A7&role=executive&focus_stop=abc`;
+    const url = navigatorUrlForRole(href, 'executive');
+    expect(url).toContain('persona=executive');
+    expect(url).toContain('scope=unit%3A7');
+    expect(url).toContain('focus_stop=abc');
+    expect(url).not.toContain('role=');
+  });
+});


### PR DESCRIPTION
## Summary
Implements all three [SU] rulings from the independent HFE audit (docs/audits/2026-07-19-flow4d-codex-hfe-audit.md):

- **F-1 — server persona transition.** RoleSwitcher ↔ flow lens become ONE canonical persona state on the navigator page: the switcher reflects the server-resolved lens, and switching performs a full Inertia `?persona=` transition through EnforceFlowLens. Every lensed request (summary, locations, events, ambient, occupancy, SSE, rounds scene) now forwards the page persona (`personaBridge.ts` + 5 tests).
- **F-2 — centroid + server redaction.** Under `patient_dots = none` the rounds scene projection strips `bed`/`facility_space_id` server-side (stops fall back to unit centroids in the existing client placement) and the client suppresses the patient-specific board deep link. Persona on the scene route is a redaction refinement, not an access gate: explicit bad persona → 403; rounds-native users with no persona keep the full-detail contract. New sentinel test.
- **F-3 — inferred capped at amber.** `verified:false` duration-only stay risk maxes at `watch` on BOTH the server projector and the client mirror — coral requires a verified breach. Pinned by updated PHPUnit assertions + a new vitest guard.

## Test plan
- [x] Pint clean (5 files)
- [x] `php artisan test` — PatientFlowOperationalBarrierProjectionTest + RoundProjectionTest: 10 passed, 138 assertions
- [x] 610/610 vitest post-rebase (base 604 + personaBridge 5 + amber-cap 1)
- [x] tsc --noEmit, vite build, check-ui-canon.sh clean
- [ ] CI 15/15
- [ ] Deploy + live verification