### PR TITLE
fix: 4D navigator lens collapse — house default + CAD unit-code bridge

### DIFF
--- a/app/Services/Mobile/MobilePersonaCatalog.php
+++ b/app/Services/Mobile/MobilePersonaCatalog.php
@@ -122,6 +122,16 @@ class MobilePersonaCatalog
 
     private function defaultForUser(?User $user): string
     {
+        // A broad-access operator with no explicit persona gets the HOUSE
+        // lens, not the first unit persona: allowedForUser() lists every
+        // role, and defaulting to allowed[0] (charge_nurse, unit depth) made
+        // the 4D navigator silently collapse to one auto-selected unit for
+        // admins (2026-07-19). house_supervisor also matches the mobile
+        // catalog default pinned by MobileRoleCatalogParityTest.
+        if ($this->isBroadAccessUser($user)) {
+            return 'house_supervisor';
+        }
+
         $allowed = $this->allowedForUser($user);
 
         return $allowed[0] ?? 'house_supervisor';

--- a/app/Services/PatientFlow/FlowEventRepository.php
+++ b/app/Services/PatientFlow/FlowEventRepository.php
@@ -7,6 +7,7 @@ use App\Models\PatientFlow\FlowEncounter;
 use App\Models\PatientFlow\FlowEvent;
 use App\Models\PatientFlow\PatientIdentity;
 use App\Models\Unit;
+use App\Support\Hospital\HospitalManifest;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -210,8 +211,25 @@ class FlowEventRepository
         }
 
         $spaceId = $event->to_facility_space_id !== null ? (int) $event->to_facility_space_id : null;
+        if ($spaceId !== null && isset($this->unitIdsBySpace[$spaceId])) {
+            return $this->unitIdsBySpace[$spaceId];
+        }
 
-        return $spaceId !== null ? ($this->unitIdsBySpace[$spaceId] ?? null) : null;
+        // Scene-code prefix fallback: ED bays and other spaces without a
+        // unit_code attribute lead with the unit's CAD prefix in their scene
+        // code ('ED-TRIAGE-002' → 'ED'). Without this, every ED event carried
+        // unit_id null and vanished under unit-depth lenses (2026-07-19).
+        $locationCode = isset($location['location_code']) && is_scalar($location['location_code'])
+            ? strtoupper(trim((string) $location['location_code']))
+            : null;
+        if ($locationCode !== null && $locationCode !== '') {
+            $prefix = explode('-', $locationCode, 2)[0];
+            if (isset($this->unitIdsByCode[$prefix])) {
+                return $this->unitIdsByCode[$prefix];
+            }
+        }
+
+        return null;
     }
 
     private function loadUnitMaps(): void
@@ -235,6 +253,21 @@ class FlowEventRepository
 
         foreach (Bed::query()->where('is_deleted', false)->whereNotNull('facility_space_id')->get(['facility_space_id', 'unit_id']) as $bed) {
             $this->unitIdsBySpace[(int) $bed->facility_space_id] = (int) $bed->unit_id;
+        }
+
+        // Manifest CAD bridge: facility spaces carry the CAD vocabulary in
+        // attributes.unit_code (MICU3, MS5B, TEL7A) while prod.units carries
+        // operational abbreviations (MICU, 5E, 7E). The two never string-match,
+        // which left ~78% of flow events with unit_id null — invisible under
+        // any unit-depth lens (2026-07-19). The hospital manifest is the
+        // authoritative abbr↔cad_code pairing.
+        foreach ((new HospitalManifest)->units() as $manifestUnit) {
+            $abbr = strtoupper(trim((string) ($manifestUnit['abbr'] ?? '')));
+            $cad = strtoupper(trim((string) ($manifestUnit['cad_code'] ?? '')));
+            if ($abbr === '' || $cad === '' || $cad === $abbr || ! isset($this->unitIdsByCode[$abbr])) {
+                continue;
+            }
+            $this->unitIdsByCode[$cad] = $this->unitIdsByCode[$abbr];
         }
     }
 

--- a/tests/Feature/Mobile/PersonaDefaultTest.php
+++ b/tests/Feature/Mobile/PersonaDefaultTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\Mobile;
+
+use App\Models\User;
+use App\Services\Mobile\MobilePersonaCatalog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+/**
+ * Default-persona resolution (4D navigator lens-collapse fix, 2026-07-19):
+ * a broad-access operator with no explicit persona must land on the HOUSE
+ * lens. Defaulting to allowedForUser()[0] gave admins charge_nurse — a
+ * unit-depth lens whose scope auto-selects the first unit, silently
+ * collapsing the navigator to one section of one floor.
+ */
+class PersonaDefaultTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function resolvedPersona(User $user, array $query = []): string
+    {
+        $request = Request::create('/api/patient-flow/summary', 'GET', $query);
+        $request->setUserResolver(fn () => $user);
+
+        return app(MobilePersonaCatalog::class)->fromRequest($request);
+    }
+
+    private function activeUser(string $role): User
+    {
+        return User::factory()->create([
+            'role' => $role,
+            'is_active' => true,
+            'must_change_password' => false,
+        ]);
+    }
+
+    public function test_broad_access_user_defaults_to_the_house_lens(): void
+    {
+        $this->assertSame('house_supervisor', $this->resolvedPersona($this->activeUser('superuser')));
+        $this->assertSame('house_supervisor', $this->resolvedPersona($this->activeUser('admin')));
+    }
+
+    public function test_broad_access_user_can_still_assume_an_explicit_persona(): void
+    {
+        $persona = $this->resolvedPersona($this->activeUser('superuser'), ['persona' => 'charge_nurse']);
+        $this->assertSame('charge_nurse', $persona);
+    }
+
+    public function test_role_scoped_user_keeps_their_own_persona_default(): void
+    {
+        $this->assertSame('charge_nurse', $this->resolvedPersona($this->activeUser('charge_nurse')));
+    }
+}

--- a/tests/Feature/PatientFlow/FlowEventUnitBridgeTest.php
+++ b/tests/Feature/PatientFlow/FlowEventUnitBridgeTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\PatientFlow;
+
+use App\Models\PatientFlow\FlowEvent;
+use App\Services\PatientFlow\FlowEventRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+/**
+ * Unit-id resolution bridge (4D navigator lens-collapse fix, 2026-07-19):
+ * facility spaces speak the CAD vocabulary (MICU3, MS5B, ED-TRIAGE-002)
+ * while prod.units speaks operational abbreviations (MICU, 5E, ED). Without
+ * the manifest bridge and the scene-code-prefix fallback, ~78% of flow
+ * events serialized unit_id = null and were dropped by every unit-depth
+ * lens (rowInScope / canViewPatientRow).
+ */
+class FlowEventUnitBridgeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedUnit(string $abbreviation, string $name): int
+    {
+        return (int) DB::table('prod.units')->insertGetId([
+            'name' => $name,
+            'abbreviation' => $abbreviation,
+            'type' => 'med_surg',
+            'staffed_bed_count' => 10,
+            'ratio_floor' => 4,
+            'access_standard_minutes' => 120,
+            'is_deleted' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ], 'unit_id');
+    }
+
+    private function seedSpace(string $sceneCode, ?string $unitCode, int $floor): int
+    {
+        return (int) DB::table('hosp_space.facility_spaces')->insertGetId([
+            'space_code' => 'ZEPHYRUS-500:'.$sceneCode,
+            'space_name' => $sceneCode,
+            'space_category' => 'bed',
+            'floor_number' => $floor,
+            'status' => 'active',
+            'geometry' => json_encode([
+                'source_object_code' => $sceneCode,
+                'position_ft' => ['x' => 10.0, 'z' => 20.0, 'level' => $floor * 14],
+            ]),
+            'attributes' => json_encode($unitCode !== null ? ['unit_code' => $unitCode] : []),
+        ], 'facility_space_id');
+    }
+
+    private function seedEvent(string $id, int $spaceId, string $sourceCode): FlowEvent
+    {
+        DB::table('flow_core.patient_identities')->insert([
+            'patient_ref' => 'pat-'.$id,
+            'patient_display_ref' => 'PT-'.$id,
+            'identifier_hash' => hash('sha256', $id),
+            'deidentified' => true,
+            'metadata' => '{}',
+        ]);
+
+        return FlowEvent::create([
+            'flow_event_id' => $id,
+            'event_category' => 'movement',
+            'event_type' => 'transfer',
+            'patient_ref' => 'pat-'.$id,
+            'patient_display_ref' => 'PT-'.$id,
+            'occurred_at' => now()->subHour(),
+            'to_source_location_code' => $sourceCode,
+            'to_facility_space_id' => $spaceId,
+        ]);
+    }
+
+    public function test_cad_unit_code_resolves_through_the_manifest_bridge(): void
+    {
+        // Manifest pairs MICU (prod.units) ↔ MICU3 (CAD attribute).
+        $unitId = $this->seedUnit('MICU', '3 West — Medical ICU (MICU)');
+        $spaceId = $this->seedSpace('MICU3-B001', 'MICU3', 3);
+        $event = $this->seedEvent('evt-micu-1', $spaceId, 'MICU3-B001');
+
+        $row = app(FlowEventRepository::class)->serializeEvent($event->fresh(['toFacilitySpace']));
+
+        $this->assertSame($unitId, $row['unit_id']);
+    }
+
+    public function test_scene_code_prefix_resolves_spaces_without_a_unit_code(): void
+    {
+        // ED bays carry no unit_code attribute; their scene codes lead with 'ED-'.
+        $unitId = $this->seedUnit('ED', '1 — Emergency Department');
+        $spaceId = $this->seedSpace('ED-TRIAGE-002', null, 1);
+        $event = $this->seedEvent('evt-ed-1', $spaceId, 'ED-TRIAGE-002');
+
+        $row = app(FlowEventRepository::class)->serializeEvent($event->fresh(['toFacilitySpace']));
+
+        $this->assertSame($unitId, $row['unit_id']);
+    }
+
+    public function test_unbridged_spaces_still_serialize_null_unit_id(): void
+    {
+        // PACU support spaces belong to no nursing unit — null is correct.
+        $this->seedUnit('MICU', '3 West — Medical ICU (MICU)');
+        $spaceId = $this->seedSpace('PACU-02', null, 2);
+        $event = $this->seedEvent('evt-pacu-1', $spaceId, 'PACU-02');
+
+        $row = app(FlowEventRepository::class)->serializeEvent($event->fresh(['toFacilitySpace']));
+
+        $this->assertNull($row['unit_id']);
+    }
+}

--- a/tests/Feature/PatientFlow/PatientFlowApiTest.php
+++ b/tests/Feature/PatientFlow/PatientFlowApiTest.php
@@ -407,11 +407,14 @@ class PatientFlowApiTest extends TestCase
             ->getJson('/api/patient-flow/events')
             ->assertOk();
 
+        // Broad-access default is the HOUSE lens (full dots), not the first
+        // unit persona — charge_nurse-by-default collapsed the 4D navigator
+        // to one auto-selected unit (2026-07-19 lens-collapse fix).
         $this->actingAs($superuser)
             ->getJson('/api/patient-flow/occupancy')
             ->assertOk()
-            ->assertJsonPath('lens.role_id', 'charge_nurse')
-            ->assertJsonPath('lens.patient_dots', 'unit');
+            ->assertJsonPath('lens.role_id', 'house_supervisor')
+            ->assertJsonPath('lens.patient_dots', 'full');
     }
 
     private function insertFlowEventAt(string $time, int $sequence): void


### PR DESCRIPTION
## Summary
Prod's 4D navigator showed patients in only one section of one floor. Measured root cause (tinker replication against prod): **79 of 4,430 events passed the lens — all MICU, floor 3.**

- **Fix A:** broad-access users defaulted to `allowedForUser()[0]` = `charge_nurse` (unit depth, scope auto-selects the first unit = MICU). Now: broad access with no explicit persona → `house_supervisor` (full house) — matching the Android catalog default already pinned in MobileRoleCatalogParityTest. Explicit `?persona=`/header behavior unchanged; role-scoped users keep their own default.
- **Fix B:** ~78% of events serialized `unit_id = null` because facility spaces speak CAD (`MICU3`, `MS5B`, `TEL7A`, `ED-*`) while `prod.units` speaks operational abbreviations (`MICU`, `5E`, `7E`). `loadUnitMaps()` now folds the hospital manifest's authoritative `abbr↔cad_code` pairs into the code map, and `unitIdForEvent()` gains a scene-code-prefix fallback (`ED-TRIAGE-002` → `ED`). Unit-depth lenses (charge nurse) now see their actual unit hospital-wide; PACU/support spaces correctly stay null.

## Test plan
- [x] Pint clean
- [x] 36 passed / 1,080 assertions across PersonaDefaultTest (new), FlowEventUnitBridgeTest (new), FlowWindowTest, PatientFlowOperationalBarrierProjectionTest, PatientFlowApiTest (superuser-lens assertions updated to the new intended default)
- [ ] CI 15/15
- [ ] Deploy + prod replication re-run (expect: default role house_supervisor, depth full, 4,430/4,430 events pass; charge_nurse+MICU scope passes all MICU3 events)