### PR TITLE
feat(cockpit): sector expansion — 12 gauged panels + Radiology/Lab/Pharmacy/Hospital@Home + OKRs 9→13

### DIFF
--- a/app/Domain/Cockpit/Metrics/FlowMetrics.php
+++ b/app/Domain/Cockpit/Metrics/FlowMetrics.php
@@ -3,16 +3,12 @@
 namespace App\Domain\Cockpit\Metrics;
 
 use App\Domain\Cockpit\SnapshotContext;
-use App\Enums\CockpitStatus;
 use App\Models\Flow\DischargeLoungeStay;
 use App\Models\Transport\TransportRequest;
 use App\Services\Cockpit\MaterializedMetricsReader;
 use App\Services\Cockpit\StatusEngine;
 use App\Services\DashboardService;
 use App\Services\Evs\EvsOperationsService;
-use App\Services\Lab\LabCockpitHealthService;
-use App\Services\Pharmacy\PharmacyCockpitHealthService;
-use App\Services\Radiology\RadiologyCockpitHealthService;
 use App\Services\Transport\TransportOperationsService;
 use App\Support\Cockpit\MetricValue;
 use App\Support\Hospital\HospitalManifest;
@@ -25,6 +21,11 @@ use Illuminate\Support\Facades\DB;
  * TransportOperationsService; dirty beds + bed turnaround (avg/p90) from
  * EvsOperationsService; discharge lounge census from
  * prod.discharge_lounge_stays (chair capacity from the hospital manifest).
+ *
+ * The ancillary imaging/lab/pharmacy aggregates that once rode in this domain
+ * moved to their own first-class sectors (RadiologyMetrics / LabMetrics /
+ * PharmacyMetrics) in the 2026-07-19 expansion; the seeded `flow.ancillary_*`
+ * keys are unchanged, only their domain section moved.
  */
 class FlowMetrics extends BaseMetrics
 {
@@ -35,9 +36,6 @@ class FlowMetrics extends BaseMetrics
         private readonly DashboardService $dashboard,
         private readonly HospitalManifest $manifest,
         private readonly MaterializedMetricsReader $mv,
-        private readonly RadiologyCockpitHealthService $radiology,
-        private readonly LabCockpitHealthService $laboratory,
-        private readonly PharmacyCockpitHealthService $pharmacy,
     ) {
         parent::__construct($engine);
     }
@@ -64,9 +62,6 @@ class FlowMetrics extends BaseMetrics
         // wait at a shared hand-off, mined object-centrically and cached in
         // arena.performance_signals. Null (tile absent) whenever the Arena is off.
         $worstHandoff = $this->mv->value('flow.worst_handoff_wait');
-        $radiology = $this->radiologyHealth();
-        $laboratory = $this->laboratoryHealth();
-        $pharmacy = $this->pharmacyHealth();
 
         return $this->compact([
             $this->fromLegacy($ctx, 'flow.dc_before_noon', 'dbn'),
@@ -99,321 +94,7 @@ class FlowMetrics extends BaseMetrics
                 $worstHandoff,
                 ['sub' => $this->handoffContext()],
             ),
-            $radiology === null ? null : $this->radiologyMetric(
-                $ctx,
-                'flow.ancillary_rad_open_breaches',
-                $radiology['openBreaches'],
-                'Open imaging SLA breaches',
-            ),
-            $radiology === null ? null : $this->radiologyMetric(
-                $ctx,
-                'flow.ancillary_rad_oldest_unread',
-                $radiology['oldestUnread'],
-                $this->unreadContext($radiology['oldestUnread']),
-            ),
-            $radiology === null ? null : $this->radiologyMetric(
-                $ctx,
-                'flow.ancillary_rad_scanners_down',
-                $radiology['scannersDown'],
-                $radiology['scannersDown']['scannerTotal'].' active scanners',
-            ),
-            $laboratory === null ? null : $this->laboratoryMetric(
-                $ctx,
-                'flow.ancillary_lab_stat_compliance',
-                $laboratory['statCompliance'],
-                (int) $laboratory['statCompliance']['statCompliant'].' of '.(int) $laboratory['statCompliance']['statOrders'].' STAT within governed SLA',
-            ),
-            $laboratory === null ? null : $this->laboratoryMetric(
-                $ctx,
-                'flow.ancillary_lab_oldest_decision_pending',
-                $laboratory['oldestDecisionPending'],
-                $this->decisionPendingContext($laboratory['oldestDecisionPending']),
-            ),
-            $laboratory === null ? null : $this->laboratoryMetric(
-                $ctx,
-                'flow.ancillary_lab_critical_callbacks',
-                $laboratory['criticalCallbacks'],
-                $this->criticalCallbackContext($laboratory['criticalCallbacks']),
-            ),
-            $pharmacy === null ? null : $this->pharmacyMetric(
-                $ctx,
-                'flow.ancillary_rx_verification_queue',
-                $pharmacy['verificationQueue'],
-                $this->verificationQueueContext($pharmacy['verificationQueue']),
-            ),
-            $pharmacy === null ? null : $this->pharmacyMetric(
-                $ctx,
-                'flow.ancillary_rx_oldest_stat',
-                $pharmacy['oldestStat'],
-                'Oldest open STAT medication',
-            ),
-            $pharmacy === null ? null : $this->pharmacyMetric(
-                $ctx,
-                'flow.ancillary_rx_sepsis_at_risk',
-                $pharmacy['sepsisAtRisk'],
-                $this->sepsisAtRiskContext($pharmacy['sepsisAtRisk']),
-            ),
-            $pharmacy === null ? null : $this->pharmacyMetric(
-                $ctx,
-                'flow.ancillary_rx_shortage_stockouts',
-                $pharmacy['shortageStockouts'],
-                $this->shortageStockoutContext($pharmacy['shortageStockouts']),
-            ),
         ]);
-    }
-
-    /** @return array<string, mixed>|null */
-    private function radiologyHealth(): ?array
-    {
-        try {
-            return $this->radiology->build();
-        } catch (\Throwable) {
-            return null;
-        }
-    }
-
-    /** @return array<string, mixed>|null */
-    private function laboratoryHealth(): ?array
-    {
-        try {
-            return $this->laboratory->build();
-        } catch (\Throwable) {
-            return null;
-        }
-    }
-
-    /** @return array<string, mixed>|null */
-    private function pharmacyHealth(): ?array
-    {
-        try {
-            return $this->pharmacy->build();
-        } catch (\Throwable) {
-            return null;
-        }
-    }
-
-    /**
-     * Emit one Pharmacy Flow-domain metric from the aggregate health contract.
-     * A value that is null (e.g. sepsis-at-risk with a stale administration
-     * tail) is skipped rather than rendered as a fabricated zero; when the
-     * governing source is not fresh the tile is demoted to a last-known,
-     * NORMAL, degraded/unknown state so unavailable evidence can never earn
-     * green or an alert.
-     *
-     * @param  array<string, mixed>  $fact
-     */
-    private function pharmacyMetric(SnapshotContext $ctx, string $key, array $fact, string $context): ?MetricValue
-    {
-        $value = $fact['value'] ?? null;
-        $sourceState = (string) ($fact['sourceState'] ?? 'missing');
-        $sourceCutoffAt = $fact['sourceCutoffAt'] ?? null;
-        if (! is_numeric($value) || ($sourceCutoffAt === null && in_array($sourceState, ['missing', 'error'], true))) {
-            return null;
-        }
-
-        $current = $sourceState === 'fresh';
-        $metadata = [
-            'provenance' => 'live',
-            'dataState' => $current ? 'current' : ($sourceState === 'missing' ? 'unknown' : 'degraded'),
-            'sourceState' => $sourceState,
-            'sourceCutoffAt' => $sourceCutoffAt,
-            'sourceLabel' => (string) ($fact['sourceLabel'] ?? 'Pharmacy operational feeds'),
-            'workspaceHref' => $this->pharmacyWorkspaceHref($key),
-        ];
-        foreach (['hourNormDepth', 'oldestAgeMinutes', 'openBreaches', 'openWarnings', 'administrationState', 'administrationCutoffAt', 'shortageOrders', 'coverageState'] as $aggregate) {
-            if (array_key_exists($aggregate, $fact)) {
-                $metadata[$aggregate] = $fact[$aggregate];
-            }
-        }
-
-        return $this->fromKey($ctx, $key, (float) $value, [
-            'display' => $this->pharmacyDisplay($key, (float) $value),
-            'sub' => $current ? $context : 'Last known · '.str_replace('_', ' ', $sourceState).' · '.$context,
-            'updatedAt' => $sourceCutoffAt ?? $ctx->nowIso,
-            'metadata' => $metadata,
-            ...($current ? [] : ['status' => CockpitStatus::NORMAL]),
-        ]);
-    }
-
-    private function pharmacyDisplay(string $key, float $value): ?string
-    {
-        $count = (int) $value;
-
-        return match ($key) {
-            'flow.ancillary_rx_verification_queue' => $count.' '.($count === 1 ? 'order' : 'orders'),
-            'flow.ancillary_rx_sepsis_at_risk' => $count.' '.($count === 1 ? 'order' : 'orders'),
-            'flow.ancillary_rx_shortage_stockouts' => $count.' '.($count === 1 ? 'station' : 'stations'),
-            default => null,
-        };
-    }
-
-    private function pharmacyWorkspaceHref(string $key): string
-    {
-        return match ($key) {
-            'flow.ancillary_rx_oldest_stat' => '/pharmacy?lens=stat&source=cockpit',
-            'flow.ancillary_rx_sepsis_at_risk' => '/pharmacy?lens=sepsis&source=cockpit',
-            'flow.ancillary_rx_shortage_stockouts' => '/pharmacy?lens=shortage&source=cockpit',
-            default => '/pharmacy?source=cockpit',
-        };
-    }
-
-    /** @param array<string, mixed> $fact */
-    private function verificationQueueContext(array $fact): string
-    {
-        $context = (int) ($fact['value'] ?? 0).' awaiting verification';
-        $norm = $fact['hourNormDepth'] ?? null;
-        $oldest = $fact['oldestAgeMinutes'] ?? null;
-        $context .= $norm === null ? '' : ' · hour norm '.(int) $norm;
-
-        return $oldest === null ? $context : $context.' · oldest '.(int) $oldest.' min';
-    }
-
-    /** @param array<string, mixed> $fact */
-    private function sepsisAtRiskContext(array $fact): string
-    {
-        $breaches = (int) ($fact['openBreaches'] ?? 0);
-        $warnings = $fact['openWarnings'] ?? null;
-        $context = $breaches.' breached';
-
-        return $warnings === null ? $context : $context.' · '.(int) $warnings.' warning';
-    }
-
-    /** @param array<string, mixed> $fact */
-    private function shortageStockoutContext(array $fact): string
-    {
-        $shortageOrders = (int) ($fact['shortageOrders'] ?? 0);
-
-        return $shortageOrders.' shortage '.($shortageOrders === 1 ? 'order' : 'orders').' affected';
-    }
-
-    /** @param array<string, mixed> $fact */
-    private function radiologyMetric(SnapshotContext $ctx, string $key, array $fact, string $context): ?MetricValue
-    {
-        $value = $fact['value'] ?? null;
-        $sourceState = (string) ($fact['sourceState'] ?? 'missing');
-        $sourceCutoffAt = $fact['sourceCutoffAt'] ?? null;
-
-        if (! is_numeric($value) || ($sourceCutoffAt === null && in_array($sourceState, ['missing', 'error'], true))) {
-            return null;
-        }
-
-        $current = $sourceState === 'fresh';
-        $sub = $current ? $context : 'Last known · '.str_replace('_', ' ', $sourceState).' · '.$context;
-        $metadata = [
-            'provenance' => 'live',
-            'dataState' => $current ? 'current' : ($sourceState === 'missing' ? 'unknown' : 'degraded'),
-            'sourceState' => $sourceState,
-            'sourceCutoffAt' => $sourceCutoffAt,
-            'sourceLabel' => (string) ($fact['sourceLabel'] ?? 'Radiology operational feeds'),
-            'workspaceHref' => '/radiology',
-        ];
-        if (isset($fact['byPriority']) && is_array($fact['byPriority'])) {
-            $metadata['unreadByPriority'] = $fact['byPriority'];
-        }
-
-        return $this->fromKey($ctx, $key, (float) $value, [
-            'display' => $this->radiologyDisplay($key, (float) $value),
-            'sub' => $sub,
-            'updatedAt' => $sourceCutoffAt ?? $ctx->nowIso,
-            'metadata' => $metadata,
-            ...($current ? [] : ['status' => CockpitStatus::NORMAL]),
-        ]);
-    }
-
-    private function radiologyDisplay(string $key, float $value): ?string
-    {
-        $count = (int) $value;
-
-        return match ($key) {
-            'flow.ancillary_rad_open_breaches' => $count.' '.($count === 1 ? 'order' : 'orders'),
-            'flow.ancillary_rad_scanners_down' => $count.' '.($count === 1 ? 'scanner' : 'scanners'),
-            default => null,
-        };
-    }
-
-    /** @param array<string, mixed> $fact */
-    private function laboratoryMetric(SnapshotContext $ctx, string $key, array $fact, string $context): ?MetricValue
-    {
-        $value = $fact['value'] ?? null;
-        $sourceState = (string) ($fact['sourceState'] ?? 'missing');
-        $sourceCutoffAt = $fact['sourceCutoffAt'] ?? null;
-        if (! is_numeric($value) || ($sourceCutoffAt === null && in_array($sourceState, ['missing', 'error'], true))) {
-            return null;
-        }
-
-        $current = $sourceState === 'fresh';
-        $metadata = [
-            'provenance' => 'live',
-            'dataState' => $current ? 'current' : ($sourceState === 'missing' ? 'unknown' : 'degraded'),
-            'sourceState' => $sourceState,
-            'sourceCutoffAt' => $sourceCutoffAt,
-            'sourceLabel' => (string) ($fact['sourceLabel'] ?? 'Laboratory operational feeds'),
-            'workspaceHref' => $this->laboratoryWorkspaceHref($key),
-        ];
-        foreach (['statOrders', 'statCompliant', 'pendingCount', 'byDecisionClass', 'atRiskCount', 'oldestOpenAgeMinutes', 'byState', 'coverageState'] as $aggregate) {
-            if (array_key_exists($aggregate, $fact)) {
-                $metadata[$aggregate] = $fact[$aggregate];
-            }
-        }
-
-        return $this->fromKey($ctx, $key, (float) $value, [
-            'display' => $this->laboratoryDisplay($key, (float) $value),
-            'sub' => $current ? $context : 'Last known · '.str_replace('_', ' ', $sourceState).' · '.$context,
-            'updatedAt' => $sourceCutoffAt ?? $ctx->nowIso,
-            'metadata' => $metadata,
-            ...($current ? [] : ['status' => CockpitStatus::NORMAL]),
-        ]);
-    }
-
-    private function laboratoryDisplay(string $key, float $value): ?string
-    {
-        if ($key !== 'flow.ancillary_lab_critical_callbacks') {
-            return null;
-        }
-        $count = (int) $value;
-
-        return $count.' '.($count === 1 ? 'callback' : 'callbacks');
-    }
-
-    private function laboratoryWorkspaceHref(string $key): string
-    {
-        return match ($key) {
-            'flow.ancillary_lab_stat_compliance' => '/lab?priority=stat&source=cockpit',
-            'flow.ancillary_lab_oldest_decision_pending' => '/lab/pending-decisions?source=cockpit',
-            'flow.ancillary_lab_critical_callbacks' => '/lab?lens=critical_callbacks&source=cockpit',
-            default => '/lab?source=cockpit',
-        };
-    }
-
-    /** @param array<string, mixed> $fact */
-    private function decisionPendingContext(array $fact): string
-    {
-        $classes = collect($fact['byDecisionClass'] ?? [])->map(
-            fn (array $row): string => str_replace('_', ' ', (string) $row['decisionClass']).' '.(int) $row['count'],
-        )->implode(' · ');
-        $context = (int) ($fact['pendingCount'] ?? 0).' decision gates';
-
-        return $classes === '' ? $context : $context.' · '.$classes;
-    }
-
-    /** @param array<string, mixed> $fact */
-    private function criticalCallbackContext(array $fact): string
-    {
-        $context = (int) ($fact['atRiskCount'] ?? 0).' at risk';
-        $oldest = $fact['oldestOpenAgeMinutes'] ?? null;
-
-        return $oldest === null ? $context : $context.' · oldest '.(int) $oldest.' min';
-    }
-
-    /** @param array<string, mixed> $fact */
-    private function unreadContext(array $fact): string
-    {
-        $byPriority = collect($fact['byPriority'] ?? [])->map(
-            fn (array $row): string => strtoupper((string) $row['priority']).' '.(int) $row['count'],
-        )->implode(' · ');
-        $context = (int) ($fact['unreadCount'] ?? 0).' unread';
-
-        return $byPriority === '' ? $context : $context.' · '.$byPriority;
     }
 
     /**

--- a/app/Domain/Cockpit/Metrics/LabMetrics.php
+++ b/app/Domain/Cockpit/Metrics/LabMetrics.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Domain\Cockpit\Metrics;
+
+use App\Domain\Cockpit\SnapshotContext;
+use App\Enums\CockpitStatus;
+use App\Services\Cockpit\StatusEngine;
+use App\Services\Lab\LabCockpitHealthService;
+use App\Support\Cockpit\MetricValue;
+
+/**
+ * Laboratory domain provider (sector expansion 2026-07-19). The ancillary lab
+ * aggregates — formerly Flow sub-tiles — promoted to a first-class cockpit
+ * sector. Emits the SAME governed `flow.ancillary_lab_*` keys (seeded catalog,
+ * admin-tuned edges, and accrued history preserved); only the domain section
+ * changes from `flow` to `lab`.
+ *
+ * Aggregate-only: composes LabCockpitHealthService verbatim, so the house wall
+ * can never create a second cohort or expose a result. Freshness discipline:
+ * stale/degraded sources demote to last-known NORMAL; missing/error with no
+ * cutoff emits nothing; an all-empty domain is ABSENT.
+ */
+class LabMetrics extends BaseMetrics
+{
+    public function __construct(
+        StatusEngine $engine,
+        private readonly LabCockpitHealthService $laboratory,
+    ) {
+        parent::__construct($engine);
+    }
+
+    public function domain(): string
+    {
+        return 'lab';
+    }
+
+    /** @return list<MetricValue> */
+    public function metrics(SnapshotContext $ctx): array
+    {
+        $laboratory = $this->health();
+
+        if ($laboratory === null) {
+            return [];
+        }
+
+        return $this->compact([
+            $this->metric(
+                $ctx,
+                'flow.ancillary_lab_stat_compliance',
+                $laboratory['statCompliance'],
+                (int) $laboratory['statCompliance']['statCompliant'].' of '.(int) $laboratory['statCompliance']['statOrders'].' STAT within governed SLA',
+            ),
+            $this->metric(
+                $ctx,
+                'flow.ancillary_lab_oldest_decision_pending',
+                $laboratory['oldestDecisionPending'],
+                $this->decisionPendingContext($laboratory['oldestDecisionPending']),
+            ),
+            $this->metric(
+                $ctx,
+                'flow.ancillary_lab_critical_callbacks',
+                $laboratory['criticalCallbacks'],
+                $this->criticalCallbackContext($laboratory['criticalCallbacks']),
+            ),
+        ]);
+    }
+
+    /** @return array<string, mixed>|null */
+    private function health(): ?array
+    {
+        try {
+            return $this->laboratory->build();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /** @param array<string, mixed> $fact */
+    private function metric(SnapshotContext $ctx, string $key, array $fact, string $context): ?MetricValue
+    {
+        $value = $fact['value'] ?? null;
+        $sourceState = (string) ($fact['sourceState'] ?? 'missing');
+        $sourceCutoffAt = $fact['sourceCutoffAt'] ?? null;
+        if (! is_numeric($value) || ($sourceCutoffAt === null && in_array($sourceState, ['missing', 'error'], true))) {
+            return null;
+        }
+
+        $current = $sourceState === 'fresh';
+        $metadata = [
+            'provenance' => 'live',
+            'dataState' => $current ? 'current' : ($sourceState === 'missing' ? 'unknown' : 'degraded'),
+            'sourceState' => $sourceState,
+            'sourceCutoffAt' => $sourceCutoffAt,
+            'sourceLabel' => (string) ($fact['sourceLabel'] ?? 'Laboratory operational feeds'),
+            'workspaceHref' => $this->workspaceHref($key),
+        ];
+        foreach (['statOrders', 'statCompliant', 'pendingCount', 'byDecisionClass', 'atRiskCount', 'oldestOpenAgeMinutes', 'byState', 'coverageState'] as $aggregate) {
+            if (array_key_exists($aggregate, $fact)) {
+                $metadata[$aggregate] = $fact[$aggregate];
+            }
+        }
+
+        return $this->fromKey($ctx, $key, (float) $value, [
+            'display' => $this->display($key, (float) $value),
+            'sub' => $current ? $context : 'Last known · '.str_replace('_', ' ', $sourceState).' · '.$context,
+            'updatedAt' => $sourceCutoffAt ?? $ctx->nowIso,
+            'metadata' => $metadata,
+            ...($current ? [] : ['status' => CockpitStatus::NORMAL]),
+        ]);
+    }
+
+    private function display(string $key, float $value): ?string
+    {
+        if ($key !== 'flow.ancillary_lab_critical_callbacks') {
+            return null;
+        }
+        $count = (int) $value;
+
+        return $count.' '.($count === 1 ? 'callback' : 'callbacks');
+    }
+
+    private function workspaceHref(string $key): string
+    {
+        return match ($key) {
+            'flow.ancillary_lab_stat_compliance' => '/lab?priority=stat&source=cockpit',
+            'flow.ancillary_lab_oldest_decision_pending' => '/lab/pending-decisions?source=cockpit',
+            'flow.ancillary_lab_critical_callbacks' => '/lab?lens=critical_callbacks&source=cockpit',
+            default => '/lab?source=cockpit',
+        };
+    }
+
+    /** @param array<string, mixed> $fact */
+    private function decisionPendingContext(array $fact): string
+    {
+        $classes = collect($fact['byDecisionClass'] ?? [])->map(
+            fn (array $row): string => str_replace('_', ' ', (string) $row['decisionClass']).' '.(int) $row['count'],
+        )->implode(' · ');
+        $context = (int) ($fact['pendingCount'] ?? 0).' decision gates';
+
+        return $classes === '' ? $context : $context.' · '.$classes;
+    }
+
+    /** @param array<string, mixed> $fact */
+    private function criticalCallbackContext(array $fact): string
+    {
+        $context = (int) ($fact['atRiskCount'] ?? 0).' at risk';
+        $oldest = $fact['oldestOpenAgeMinutes'] ?? null;
+
+        return $oldest === null ? $context : $context.' · oldest '.(int) $oldest.' min';
+    }
+}

--- a/app/Domain/Cockpit/Metrics/OkrMetrics.php
+++ b/app/Domain/Cockpit/Metrics/OkrMetrics.php
@@ -8,11 +8,12 @@ use App\Services\Rtdc\DemandForecastService;
 use App\Support\Cockpit\MetricValue;
 
 /**
- * Executive OKR scorecard (spec §2.1) — the 9 registry cards. Runs LAST so
- * it reuses values other providers already computed this snapshot (open
- * shifts, hand hygiene, worked/UOS) instead of re-querying. Live where the
- * house has the source (ED LOS admitted, DBN, readmit, midnight occupancy
- * via the RTDC by_midnight horizon); demo elsewhere.
+ * Executive OKR scorecard (spec §2.1) — 13 registry cards (9 core + 4 service
+ * sectors added 2026-07-19). Runs LAST so it reuses values other providers
+ * already computed this snapshot (open shifts, hand hygiene, worked/UOS, and
+ * the radiology/lab/pharmacy/home headline signals) instead of re-querying.
+ * Live where the house has the source (ED LOS admitted, DBN, readmit, midnight
+ * occupancy via the RTDC by_midnight horizon); demo elsewhere.
  */
 class OkrMetrics extends BaseMetrics
 {
@@ -47,6 +48,13 @@ class OkrMetrics extends BaseMetrics
             $this->reuse($ctx, 'okr.worked_per_uos', 'financial.worked_per_uos') ?? $this->demo($ctx, 'okr.worked_per_uos'),
             $this->demo($ctx, 'okr.hcahps'),
             $this->fromLegacy($ctx, 'okr.readmit_30d', 'readmission'),
+            // Service-sector OKRs (2026-07-19): reuse each sector's live headline
+            // signal, falling back to the seeded constant so the scorecard shows
+            // the sector even in an environment without its ancillary/home feed.
+            $this->reuse($ctx, 'okr.rad_sla_breaches', 'flow.ancillary_rad_open_breaches') ?? $this->demo($ctx, 'okr.rad_sla_breaches'),
+            $this->reuse($ctx, 'okr.lab_stat_tat', 'flow.ancillary_lab_stat_compliance') ?? $this->demo($ctx, 'okr.lab_stat_tat'),
+            $this->reuse($ctx, 'okr.rx_stockouts', 'flow.ancillary_rx_shortage_stockouts') ?? $this->demo($ctx, 'okr.rx_stockouts'),
+            $this->reuse($ctx, 'okr.hah_avoided_bed_days', 'home.avoided_bed_days_mtd') ?? $this->demo($ctx, 'okr.hah_avoided_bed_days'),
         ]);
     }
 

--- a/app/Domain/Cockpit/Metrics/PharmacyMetrics.php
+++ b/app/Domain/Cockpit/Metrics/PharmacyMetrics.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Domain\Cockpit\Metrics;
+
+use App\Domain\Cockpit\SnapshotContext;
+use App\Enums\CockpitStatus;
+use App\Services\Cockpit\StatusEngine;
+use App\Services\Pharmacy\PharmacyCockpitHealthService;
+use App\Support\Cockpit\MetricValue;
+
+/**
+ * Pharmacy domain provider (sector expansion 2026-07-19). The ancillary
+ * medication aggregates — formerly Flow sub-tiles — promoted to a first-class
+ * cockpit sector. Emits the SAME governed `flow.ancillary_rx_*` keys (seeded
+ * catalog, admin-tuned edges, and accrued history preserved); only the domain
+ * section changes from `flow` to `pharmacy`.
+ *
+ * Aggregate-only: composes PharmacyCockpitHealthService verbatim — no
+ * pharmacist/verifier dimension exists anywhere in the contract (§13). The
+ * sepsis-at-risk signal is administration-warehouse qualified: a stale or
+ * absent tail renders it unknown (tile skipped), never a false success or
+ * failure. Freshness discipline: stale/degraded sources demote to last-known
+ * NORMAL; missing/error with no cutoff emits nothing; an all-empty domain is
+ * ABSENT.
+ */
+class PharmacyMetrics extends BaseMetrics
+{
+    public function __construct(
+        StatusEngine $engine,
+        private readonly PharmacyCockpitHealthService $pharmacy,
+    ) {
+        parent::__construct($engine);
+    }
+
+    public function domain(): string
+    {
+        return 'pharmacy';
+    }
+
+    /** @return list<MetricValue> */
+    public function metrics(SnapshotContext $ctx): array
+    {
+        $pharmacy = $this->health();
+
+        if ($pharmacy === null) {
+            return [];
+        }
+
+        return $this->compact([
+            $this->metric(
+                $ctx,
+                'flow.ancillary_rx_verification_queue',
+                $pharmacy['verificationQueue'],
+                $this->verificationQueueContext($pharmacy['verificationQueue']),
+            ),
+            $this->metric(
+                $ctx,
+                'flow.ancillary_rx_oldest_stat',
+                $pharmacy['oldestStat'],
+                'Oldest open STAT medication',
+            ),
+            $this->metric(
+                $ctx,
+                'flow.ancillary_rx_sepsis_at_risk',
+                $pharmacy['sepsisAtRisk'],
+                $this->sepsisAtRiskContext($pharmacy['sepsisAtRisk']),
+            ),
+            $this->metric(
+                $ctx,
+                'flow.ancillary_rx_shortage_stockouts',
+                $pharmacy['shortageStockouts'],
+                $this->shortageStockoutContext($pharmacy['shortageStockouts']),
+            ),
+        ]);
+    }
+
+    /** @return array<string, mixed>|null */
+    private function health(): ?array
+    {
+        try {
+            return $this->pharmacy->build();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /** @param array<string, mixed> $fact */
+    private function metric(SnapshotContext $ctx, string $key, array $fact, string $context): ?MetricValue
+    {
+        $value = $fact['value'] ?? null;
+        $sourceState = (string) ($fact['sourceState'] ?? 'missing');
+        $sourceCutoffAt = $fact['sourceCutoffAt'] ?? null;
+        if (! is_numeric($value) || ($sourceCutoffAt === null && in_array($sourceState, ['missing', 'error'], true))) {
+            return null;
+        }
+
+        $current = $sourceState === 'fresh';
+        $metadata = [
+            'provenance' => 'live',
+            'dataState' => $current ? 'current' : ($sourceState === 'missing' ? 'unknown' : 'degraded'),
+            'sourceState' => $sourceState,
+            'sourceCutoffAt' => $sourceCutoffAt,
+            'sourceLabel' => (string) ($fact['sourceLabel'] ?? 'Pharmacy operational feeds'),
+            'workspaceHref' => $this->workspaceHref($key),
+        ];
+        foreach (['hourNormDepth', 'oldestAgeMinutes', 'openBreaches', 'openWarnings', 'administrationState', 'administrationCutoffAt', 'shortageOrders', 'coverageState'] as $aggregate) {
+            if (array_key_exists($aggregate, $fact)) {
+                $metadata[$aggregate] = $fact[$aggregate];
+            }
+        }
+
+        return $this->fromKey($ctx, $key, (float) $value, [
+            'display' => $this->display($key, (float) $value),
+            'sub' => $current ? $context : 'Last known · '.str_replace('_', ' ', $sourceState).' · '.$context,
+            'updatedAt' => $sourceCutoffAt ?? $ctx->nowIso,
+            'metadata' => $metadata,
+            ...($current ? [] : ['status' => CockpitStatus::NORMAL]),
+        ]);
+    }
+
+    private function display(string $key, float $value): ?string
+    {
+        $count = (int) $value;
+
+        return match ($key) {
+            'flow.ancillary_rx_verification_queue' => $count.' '.($count === 1 ? 'order' : 'orders'),
+            'flow.ancillary_rx_sepsis_at_risk' => $count.' '.($count === 1 ? 'order' : 'orders'),
+            'flow.ancillary_rx_shortage_stockouts' => $count.' '.($count === 1 ? 'station' : 'stations'),
+            default => null,
+        };
+    }
+
+    private function workspaceHref(string $key): string
+    {
+        return match ($key) {
+            'flow.ancillary_rx_oldest_stat' => '/pharmacy?lens=stat&source=cockpit',
+            'flow.ancillary_rx_sepsis_at_risk' => '/pharmacy?lens=sepsis&source=cockpit',
+            'flow.ancillary_rx_shortage_stockouts' => '/pharmacy?lens=shortage&source=cockpit',
+            default => '/pharmacy?source=cockpit',
+        };
+    }
+
+    /** @param array<string, mixed> $fact */
+    private function verificationQueueContext(array $fact): string
+    {
+        $context = (int) ($fact['value'] ?? 0).' awaiting verification';
+        $norm = $fact['hourNormDepth'] ?? null;
+        $oldest = $fact['oldestAgeMinutes'] ?? null;
+        $context .= $norm === null ? '' : ' · hour norm '.(int) $norm;
+
+        return $oldest === null ? $context : $context.' · oldest '.(int) $oldest.' min';
+    }
+
+    /** @param array<string, mixed> $fact */
+    private function sepsisAtRiskContext(array $fact): string
+    {
+        $breaches = (int) ($fact['openBreaches'] ?? 0);
+        $warnings = $fact['openWarnings'] ?? null;
+        $context = $breaches.' breached';
+
+        return $warnings === null ? $context : $context.' · '.(int) $warnings.' warning';
+    }
+
+    /** @param array<string, mixed> $fact */
+    private function shortageStockoutContext(array $fact): string
+    {
+        $shortageOrders = (int) ($fact['shortageOrders'] ?? 0);
+
+        return $shortageOrders.' shortage '.($shortageOrders === 1 ? 'order' : 'orders').' affected';
+    }
+}

--- a/app/Domain/Cockpit/Metrics/RadiologyMetrics.php
+++ b/app/Domain/Cockpit/Metrics/RadiologyMetrics.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Domain\Cockpit\Metrics;
+
+use App\Domain\Cockpit\SnapshotContext;
+use App\Enums\CockpitStatus;
+use App\Services\Cockpit\StatusEngine;
+use App\Services\Radiology\RadiologyCockpitHealthService;
+use App\Support\Cockpit\MetricValue;
+
+/**
+ * Radiology domain provider (sector expansion 2026-07-19). The ancillary
+ * imaging aggregates — formerly Flow sub-tiles — promoted to a first-class
+ * cockpit sector. Emits the SAME governed `flow.ancillary_rad_*` keys (the
+ * seeded catalog, admin-tuned edges, and accrued history are preserved); only
+ * the domain section changes from `flow` to `radiology`.
+ *
+ * Aggregate-only: composes RadiologyCockpitHealthService verbatim, so the wall
+ * and drill can never invent new math or expose a patient/study. Freshness
+ * discipline (unchanged): a stale/degraded source demotes to a last-known
+ * NORMAL tile so unavailable evidence can never earn green or an alert;
+ * missing/error with no cutoff emits nothing, and an all-empty domain is
+ * ABSENT from the snapshot.
+ */
+class RadiologyMetrics extends BaseMetrics
+{
+    public function __construct(
+        StatusEngine $engine,
+        private readonly RadiologyCockpitHealthService $radiology,
+    ) {
+        parent::__construct($engine);
+    }
+
+    public function domain(): string
+    {
+        return 'radiology';
+    }
+
+    /** @return list<MetricValue> */
+    public function metrics(SnapshotContext $ctx): array
+    {
+        $radiology = $this->health();
+
+        if ($radiology === null) {
+            return [];
+        }
+
+        return $this->compact([
+            $this->metric(
+                $ctx,
+                'flow.ancillary_rad_open_breaches',
+                $radiology['openBreaches'],
+                'Open imaging SLA breaches',
+            ),
+            $this->metric(
+                $ctx,
+                'flow.ancillary_rad_oldest_unread',
+                $radiology['oldestUnread'],
+                $this->unreadContext($radiology['oldestUnread']),
+            ),
+            $this->metric(
+                $ctx,
+                'flow.ancillary_rad_scanners_down',
+                $radiology['scannersDown'],
+                $radiology['scannersDown']['scannerTotal'].' active scanners',
+            ),
+        ]);
+    }
+
+    /** @return array<string, mixed>|null */
+    private function health(): ?array
+    {
+        try {
+            return $this->radiology->build();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /** @param array<string, mixed> $fact */
+    private function metric(SnapshotContext $ctx, string $key, array $fact, string $context): ?MetricValue
+    {
+        $value = $fact['value'] ?? null;
+        $sourceState = (string) ($fact['sourceState'] ?? 'missing');
+        $sourceCutoffAt = $fact['sourceCutoffAt'] ?? null;
+
+        if (! is_numeric($value) || ($sourceCutoffAt === null && in_array($sourceState, ['missing', 'error'], true))) {
+            return null;
+        }
+
+        $current = $sourceState === 'fresh';
+        $sub = $current ? $context : 'Last known · '.str_replace('_', ' ', $sourceState).' · '.$context;
+        $metadata = [
+            'provenance' => 'live',
+            'dataState' => $current ? 'current' : ($sourceState === 'missing' ? 'unknown' : 'degraded'),
+            'sourceState' => $sourceState,
+            'sourceCutoffAt' => $sourceCutoffAt,
+            'sourceLabel' => (string) ($fact['sourceLabel'] ?? 'Radiology operational feeds'),
+            'workspaceHref' => '/radiology',
+        ];
+        if (isset($fact['byPriority']) && is_array($fact['byPriority'])) {
+            $metadata['unreadByPriority'] = $fact['byPriority'];
+        }
+
+        return $this->fromKey($ctx, $key, (float) $value, [
+            'display' => $this->display($key, (float) $value),
+            'sub' => $sub,
+            'updatedAt' => $sourceCutoffAt ?? $ctx->nowIso,
+            'metadata' => $metadata,
+            ...($current ? [] : ['status' => CockpitStatus::NORMAL]),
+        ]);
+    }
+
+    private function display(string $key, float $value): ?string
+    {
+        $count = (int) $value;
+
+        return match ($key) {
+            'flow.ancillary_rad_open_breaches' => $count.' '.($count === 1 ? 'order' : 'orders'),
+            'flow.ancillary_rad_scanners_down' => $count.' '.($count === 1 ? 'scanner' : 'scanners'),
+            default => null,
+        };
+    }
+
+    /** @param array<string, mixed> $fact */
+    private function unreadContext(array $fact): string
+    {
+        $byPriority = collect($fact['byPriority'] ?? [])->map(
+            fn (array $row): string => strtoupper((string) $row['priority']).' '.(int) $row['count'],
+        )->implode(' · ');
+        $context = (int) ($fact['unreadCount'] ?? 0).' unread';
+
+        return $byPriority === '' ? $context : $context.' · '.$byPriority;
+    }
+}

--- a/app/Services/Cockpit/DrillBuilder.php
+++ b/app/Services/Cockpit/DrillBuilder.php
@@ -28,7 +28,7 @@ use Illuminate\Support\Facades\Log;
  */
 class DrillBuilder
 {
-    public const DOMAINS = ['rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial', 'home', 'okr'];
+    public const DOMAINS = ['rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial', 'radiology', 'lab', 'pharmacy', 'home', 'okr'];
 
     private const TITLES = [
         'rtdc' => 'Real-Time Demand & Capacity — Unit Capacity Board',
@@ -39,6 +39,12 @@ class DrillBuilder
         'quality' => 'Quality & Safety — HAI / Safety Ledger',
         'service' => 'Service Lines — Throughput',
         'financial' => 'Financial Stewardship',
+        // Service sectors (2026-07-19): aggregate-only operational health — the
+        // department workspace owns per-item detail, so the drill is the same
+        // measure ledger the panel summarizes, never a patient/order board.
+        'radiology' => 'Radiology — Imaging Operational Health',
+        'lab' => 'Laboratory — Result & Callback Health',
+        'pharmacy' => 'Pharmacy — Medication Flow Health',
         'home' => 'Home Hospital — Virtual Ward',
         'okr' => 'Executive OKR Scorecard',
     ];
@@ -113,7 +119,7 @@ class DrillBuilder
                 'ed' => $this->edTables(),
                 'periop' => array_values(array_filter([$this->orRoomBoard(), $this->pacuBayBoard()])),
                 'staffing' => [$this->unitCoverage()],
-                'flow' => $this->flowTables($tiles),
+                'flow' => $this->flowTables(),
                 'home' => $this->homeTables(),
                 'okr' => [$this->okrTable($tiles)],
                 default => [$this->measureLedger($domain, $tiles)],
@@ -455,9 +461,8 @@ class DrillBuilder
         ];
     }
 
-    /** @param list<array<string, mixed>> $tiles
-     * @return list<array<string, mixed>> */
-    private function flowTables(array $tiles): array
+    /** @return list<array<string, mixed>> */
+    private function flowTables(): array
     {
         $measureRows = array_map(fn (array $m): array => [
             'measure' => ['v' => (string) $m['label'], 'strong' => true],
@@ -482,7 +487,6 @@ class DrillBuilder
         }
 
         return [
-            $this->ancillaryHealthTable($tiles),
             [
                 'caption' => 'Transport performance measures',
                 'columns' => [
@@ -503,102 +507,6 @@ class DrillBuilder
                 ],
                 'rows' => $evsRows,
             ],
-        ];
-    }
-
-    /**
-     * Aggregate-only ancillary rows sourced from the exact cached Flow tiles.
-     * Future Lab and Pharmacy providers populate the reserved rows by emitting
-     * their already-seeded keys; no client-side status calculation is needed.
-     *
-     * @param  list<array<string, mixed>>  $tiles
-     * @return array<string, mixed>
-     */
-    private function ancillaryHealthTable(array $tiles): array
-    {
-        $byKey = collect($tiles)->keyBy('key');
-        $departments = [
-            [
-                'label' => 'Radiology',
-                'keys' => [
-                    'flow.ancillary_rad_open_breaches',
-                    'flow.ancillary_rad_oldest_unread',
-                    'flow.ancillary_rad_scanners_down',
-                ],
-            ],
-            [
-                'label' => 'Laboratory',
-                'keys' => [
-                    'flow.ancillary_lab_stat_compliance',
-                    'flow.ancillary_lab_oldest_decision_pending',
-                    'flow.ancillary_lab_critical_callbacks',
-                ],
-            ],
-            [
-                'label' => 'Pharmacy',
-                'keys' => [
-                    'flow.ancillary_rx_verification_queue',
-                    'flow.ancillary_rx_oldest_stat',
-                    'flow.ancillary_rx_shortage_stockouts',
-                ],
-            ],
-        ];
-        $rows = [];
-
-        foreach ($departments as $department) {
-            $metrics = collect($department['keys'])->map(fn (string $key): ?array => $byKey->get($key))->filter()->values();
-            $sourceStates = $metrics->pluck('metadata.sourceState')->filter()->all();
-            $sourceState = collect(['error', 'missing', 'stale', 'degraded', 'fresh'])
-                ->first(fn (string $state): bool => in_array($state, $sourceStates, true)) ?? 'missing';
-            $cutoffs = $metrics->pluck('metadata.sourceCutoffAt')->filter()->sort()->values();
-            $logical = $metrics->pluck('status')->sortBy(fn (string $status): int => [
-                'crit' => 0, 'warn' => 1, 'watch' => 2, 'normal' => 3, 'ok' => 4,
-            ][$status] ?? 5)->first() ?? 'normal';
-            $canon = CockpitStatus::from($logical)->canon();
-
-            $rows[] = [
-                'service' => ['v' => $department['label'], 'strong' => true],
-                'measure1' => $this->ancillaryMetricCell($byKey->get($department['keys'][0])),
-                'measure2' => $this->ancillaryMetricCell($byKey->get($department['keys'][1])),
-                'measure3' => $this->ancillaryMetricCell($byKey->get($department['keys'][2])),
-                'source' => ['tag' => [
-                    'text' => $metrics->isEmpty() ? 'not available' : str_replace('_', ' ', $sourceState),
-                    'status' => $sourceState === 'fresh' ? 'success' : ($sourceState === 'stale' || $sourceState === 'error' ? 'warning' : 'neutral'),
-                ]],
-                'cutoff' => ['v' => $cutoffs->last() ?? '—', 'dim' => true],
-                'status' => ['chip' => $metrics->isEmpty() ? 'neutral' : $canon],
-            ];
-        }
-
-        return [
-            'caption' => 'Ancillary operational health',
-            'columns' => [
-                ['key' => 'service', 'header' => 'Service', 'align' => 'left'],
-                ['key' => 'measure1', 'header' => 'Open / compliance', 'align' => 'right'],
-                ['key' => 'measure2', 'header' => 'Oldest age', 'align' => 'right'],
-                ['key' => 'measure3', 'header' => 'Resource / callback', 'align' => 'right'],
-                ['key' => 'source', 'header' => 'Source', 'align' => 'left'],
-                ['key' => 'cutoff', 'header' => 'Source cutoff', 'align' => 'left'],
-                ['key' => 'status', 'header' => '', 'align' => 'right'],
-            ],
-            'rows' => $rows,
-        ];
-    }
-
-    /** @param array<string, mixed>|null $metric @return array<string, mixed> */
-    private function ancillaryMetricCell(?array $metric): array
-    {
-        if ($metric === null) {
-            return ['v' => '—', 'dim' => true];
-        }
-
-        $href = $metric['metadata']['workspaceHref'] ?? null;
-
-        return [
-            'v' => (string) $metric['display'],
-            'strong' => true,
-            'status' => CockpitStatus::from((string) $metric['status'])->canon(),
-            ...(is_string($href) && str_starts_with($href, '/') ? ['href' => $href] : []),
         ];
     }
 

--- a/app/Services/Cockpit/SnapshotBuilder.php
+++ b/app/Services/Cockpit/SnapshotBuilder.php
@@ -7,9 +7,12 @@ use App\Domain\Cockpit\Metrics\EdMetrics;
 use App\Domain\Cockpit\Metrics\FinancialMetrics;
 use App\Domain\Cockpit\Metrics\FlowMetrics;
 use App\Domain\Cockpit\Metrics\HomeMetrics;
+use App\Domain\Cockpit\Metrics\LabMetrics;
 use App\Domain\Cockpit\Metrics\OkrMetrics;
 use App\Domain\Cockpit\Metrics\PeriopMetrics;
+use App\Domain\Cockpit\Metrics\PharmacyMetrics;
 use App\Domain\Cockpit\Metrics\QualityMetrics;
+use App\Domain\Cockpit\Metrics\RadiologyMetrics;
 use App\Domain\Cockpit\Metrics\RtdcMetrics;
 use App\Domain\Cockpit\Metrics\ServiceLineMetrics;
 use App\Domain\Cockpit\Metrics\StaffingMetrics;
@@ -69,8 +72,27 @@ class SnapshotBuilder
         'rtdc' => 'rtdc.occupancy',
         'ed' => 'ed.nedocs',
         'periop' => 'periop.prime_util',
+        'staffing' => 'staffing.productivity',
+        'flow' => 'flow.transport_wait',
+        'quality' => 'quality.sepsis_3hr',
+        'service' => 'service.oe_los',
+        'financial' => 'financial.worked_per_uos',
+        // Service sectors (2026-07-19): the ancillary aggregates keep their
+        // governed flow.ancillary_* keys; each sector's ring is its headline
+        // operational signal (oldest unread study / STAT SLA compliance /
+        // oldest STAT medication).
+        'radiology' => 'flow.ancillary_rad_oldest_unread',
+        'lab' => 'flow.ancillary_lab_stat_compliance',
+        'pharmacy' => 'flow.ancillary_rx_oldest_stat',
         'home' => 'home.census_occupancy',
     ];
+
+    /**
+     * Sectors that are ABSENT (not an empty panel) when they emit no tiles:
+     * Home Hospital while its flag is off, and the three ancillary sectors
+     * when their feed has no data. Always-on domains are never listed here.
+     */
+    private const OPTIONAL_WHEN_EMPTY = ['radiology', 'lab', 'pharmacy', 'home'];
 
     public function __construct(
         private readonly CommandCenterDataService $commandCenter,
@@ -206,12 +228,12 @@ class SnapshotBuilder
                 continue;
             }
 
-            // A flag-gated module that is OFF emits zero values and must be
-            // ABSENT from the snapshot (not an empty panel) — deployments
-            // without Home Hospital stay byte-identical. Distinct from a
-            // failing provider: safeMetrics logs those, and always-on domains
-            // always emit at least one tile.
-            if ($values === [] && $provider->domain() === 'home') {
+            // A flag-gated or feed-dependent sector that emits zero values must
+            // be ABSENT from the snapshot (not an empty panel) — deployments
+            // without Home Hospital, or an ancillary sector whose feed has no
+            // data, stay clean. Distinct from a failing always-on provider:
+            // safeMetrics logs those, and always-on domains always emit ≥1 tile.
+            if ($values === [] && in_array($provider->domain(), self::OPTIONAL_WHEN_EMPTY, true)) {
                 continue;
             }
 
@@ -279,6 +301,12 @@ class SnapshotBuilder
             app(QualityMetrics::class),
             app(ServiceLineMetrics::class),
             app(FinancialMetrics::class),
+            // Service sectors (2026-07-19): promoted out of Flow. Each emits
+            // nothing when its ancillary feed has no data, so the panel is
+            // ABSENT rather than empty (see OPTIONAL_WHEN_EMPTY).
+            app(RadiologyMetrics::class),
+            app(LabMetrics::class),
+            app(PharmacyMetrics::class),
             // Home Hospital (ACUM-PRD-HAH-001): emits nothing while
             // HOME_HOSPITAL_ENABLED is off — cockpit unchanged without it.
             app(HomeMetrics::class),

--- a/app/Support/Cockpit/MetricValue.php
+++ b/app/Support/Cockpit/MetricValue.php
@@ -71,7 +71,9 @@ final readonly class MetricValue
             trend: $overrides['trend'] ?? [],
             trendLabel: $overrides['trendLabel'] ?? null,
             updatedAt: $overrides['updatedAt'] ?? now()->toIso8601String(),
-            metadata: $overrides['metadata'] ?? [],
+            // Definition metadata (gauge scale, benchmarks) rides on the tile;
+            // override keys win — the client gaugeScale() reads metadata.scale.
+            metadata: ($overrides['metadata'] ?? []) + ($definition->metadata ?? []),
         );
     }
 

--- a/config/cockpit.php
+++ b/config/cockpit.php
@@ -77,5 +77,12 @@ return [
         'okr.sepsis_3hr' => 87.0,
         'okr.hand_hygiene' => 91.0,
         'okr.worked_per_uos' => 1.04,
+        // Service-sector OKRs (2026-07-19): reuse each sector's live headline
+        // signal, falling back to these seeds when the ancillary/home feed is
+        // absent so the 13-card scorecard never shows a hole.
+        'okr.rad_sla_breaches' => 2.0,
+        'okr.lab_stat_tat' => 88.0,
+        'okr.rx_stockouts' => 0.0,
+        'okr.hah_avoided_bed_days' => 64.0,
     ],
 ];

--- a/database/seeders/CockpitKpiDefinitionSeeder.php
+++ b/database/seeders/CockpitKpiDefinitionSeeder.php
@@ -77,6 +77,12 @@ class CockpitKpiDefinitionSeeder extends Seeder
             // Legacy dashboard bands readmission warn≥11/crit≥13 — kept so the
             // OKR card and the outcomes band never disagree on the same value.
             'okr.readmit_30d' => $this->okr('30-day readmission', '30-day all-cause readmission rate.', '%', 'down', 11, null, 11, 13, 'CMO', 'Care Reliability'),
+            // Service-sector OKRs (2026-07-19): each reuses its sector's live
+            // headline signal (OkrMetrics), falling back to the config demo value.
+            'okr.rad_sla_breaches' => $this->okr('Imaging SLA breaches', 'Open imaging work items beyond their governed SLA.', 'orders', 'down', 0, null, 3, 8, 'Radiology', 'Reliable Diagnostics'),
+            'okr.lab_stat_tat' => $this->okr('Lab STAT SLA compliance', 'STAT laboratory orders completed within the governed SLA.', '%', 'up', 90, 90, 89, 79, 'Laboratory', 'Timely Diagnostics'),
+            'okr.rx_stockouts' => $this->okr('Medication stockouts', 'Active unit, station, or central-pharmacy stockouts affecting fulfillment.', 'items', 'down', 0, null, 1, 5, 'Pharmacy', 'Medication Availability'),
+            'okr.hah_avoided_bed_days' => $this->okr('Avoided bed-days MTD', 'Home episode bed-days the house did not spend this month.', 'days', 'up', 90, null, null, null, 'Hospital@Home', 'Capacity Liberation'),
 
             // ---------------- RTDC (spec §2.2) — refresh 60s ----------------
             'rtdc.census' => $this->kpi('House census', 'Occupied staffed beds, house-wide.', 'pts', 'down', null, null, null, 60),

--- a/database/seeders/CockpitKpiDefinitionSeeder.php
+++ b/database/seeders/CockpitKpiDefinitionSeeder.php
@@ -124,14 +124,14 @@ class CockpitKpiDefinitionSeeder extends Seeder
             'staffing.agency' => $this->kpi('Agency RNs', 'Agency and contract RNs active.', '', 'down', null, null, null, 600),
             'staffing.callouts' => $this->kpi('Callouts', 'Callouts today, all roles.', '', 'down', null, 8, 12, 600),
             'staffing.sitters' => $this->kpi('Sitters / 1:1', 'Active sitter and 1:1 observation assignments.', '', 'down', null, null, null, 600),
-            'staffing.productivity' => $this->kpi('Productivity', 'Worked-hours productivity index.', '%', 'up', 100, 95, 90, 600, null, null, 100),
+            'staffing.productivity' => $this->kpi('Productivity', 'Worked-hours productivity index.', '%', 'up', 100, 95, 90, 600, null, ['scale' => 120], 100),
 
             // ---------------- Flow & transport (spec §2.6) — refresh 300s ---
             'flow.dc_before_noon' => $this->kpi('Discharge before noon', 'Percent of today\'s discharges completed before 12:00.', '%', 'up', 40, 40, 30, 300),
             'flow.discharge_lounge' => $this->kpi('Discharge lounge', 'Discharge lounge occupancy.', 'pts', 'up', null, null, null, 300),
             'flow.transport_queue' => $this->kpi('Transport queue', 'Transport requests pending or in progress.', '', 'down', null, 10, 18, 300),
             'flow.transport_wait' => $this->kpi('Transport wait', 'Average request-to-pickup wait.', 'min', 'down', 15, 15, 25, 300,
-                'Transport delays — average wait {display}'),
+                'Transport delays — average wait {display}', ['scale' => 60]),
             'flow.bed_turnaround' => $this->kpi('Bed turnaround', 'Average EVS dirty-to-ready turnaround.', 'min', 'down', 45, 45, 60, 300,
                 'EVS turnaround {display} — beds returning slowly'),
             'flow.dirty_beds' => $this->kpi('Dirty beds', 'Beds awaiting or in EVS cleaning.', 'beds', 'down', null, 12, 20, 300),
@@ -149,13 +149,13 @@ class CockpitKpiDefinitionSeeder extends Seeder
             // department workspaces own per-item status; Cockpit carries only
             // counts, oldest ages, compliance, and resource availability.
             'flow.ancillary_rad_open_breaches' => $this->kpi('Imaging open breaches', 'Open imaging work items beyond their governed SLA definition.', 'orders', 'down', 0, 1, 5, 60),
-            'flow.ancillary_rad_oldest_unread' => $this->kpi('Oldest unread study', 'Age of the oldest acquired imaging study awaiting a final report.', 'min', 'down', 30, 30, 60, 60),
+            'flow.ancillary_rad_oldest_unread' => $this->kpi('Oldest unread study', 'Age of the oldest acquired imaging study awaiting a final report.', 'min', 'down', 30, 30, 60, 60, null, ['scale' => 90]),
             'flow.ancillary_rad_scanners_down' => $this->kpi('Scanners down', 'Imaging scanners currently unavailable for operational use.', 'scanners', 'down', 0, 1, 2, 60),
             'flow.ancillary_lab_stat_compliance' => $this->kpi('Lab STAT compliance', 'Percent of STAT laboratory orders completed within the active governed SLA.', '%', 'up', 90, 89, 79, 60, null, null, 90),
             'flow.ancillary_lab_oldest_decision_pending' => $this->kpi('Oldest decision-pending result', 'Age of the oldest laboratory order explicitly blocking an ED, discharge, or OR decision.', 'min', 'down', 45, 45, 60, 60),
             'flow.ancillary_lab_critical_callbacks' => $this->kpi('Critical callbacks open', 'Critical laboratory results awaiting documented communication acknowledgment.', 'callbacks', 'down', 0, 1, 3, 60),
             'flow.ancillary_rx_verification_queue' => $this->kpi('Pharmacy verification queue', 'Medication orders currently awaiting pharmacist verification.', 'orders', 'down', null, 10, 20, 60),
-            'flow.ancillary_rx_oldest_stat' => $this->kpi('Oldest STAT medication', 'Age of the oldest unverified or undispensed STAT medication order.', 'min', 'down', 10, 10, 15, 60),
+            'flow.ancillary_rx_oldest_stat' => $this->kpi('Oldest STAT medication', 'Age of the oldest unverified or undispensed STAT medication order.', 'min', 'down', 10, 10, 15, 60, null, ['scale' => 30]),
             'flow.ancillary_rx_sepsis_at_risk' => $this->kpi('Sepsis antibiotics at risk', 'Aggregate count of sepsis antibiotic orders approaching their governed operational clock.', 'orders', 'down', 0, 1, 3, 60),
             'flow.ancillary_rx_shortage_stockouts' => $this->kpi('Medication stockouts', 'Active unit, station, or central-pharmacy stockouts affecting fulfillment.', 'items', 'down', 0, 1, 5, 300),
 
@@ -185,7 +185,7 @@ class CockpitKpiDefinitionSeeder extends Seeder
 
             // ---------------- Service lines (spec §2.8) — refresh 3600s -----
             // oe_los / readmit / avoidable_days match the legacy outcomes band.
-            'service.oe_los' => $this->kpi('O:E LOS', 'Observed over expected (GMLOS-based) length of stay.', 'x', 'down', 1.0, 1.0, 1.2, 3600),
+            'service.oe_los' => $this->kpi('O:E LOS', 'Observed over expected (GMLOS-based) length of stay.', 'x', 'down', 1.0, 1.0, 1.2, 3600, null, ['scale' => 2]),
             'service.readmit_30d' => $this->kpi('30-day readmission', '30-day all-cause readmission rate.', '%', 'down', 11, 11, 13, 3600),
             'service.avoidable_days' => $this->kpi('Avoidable days', 'Documented bed-days beyond clinical need, month to date.', 'bed-days', 'down', null, 101, 200, 3600),
             'service.cmi' => $this->kpi('Case mix index', 'Case mix index (acuity context).', 'x', 'up', null, null, null, 3600),
@@ -193,7 +193,7 @@ class CockpitKpiDefinitionSeeder extends Seeder
             'service.discharges_mtd' => $this->kpi('Discharges MTD', 'Discharges month to date vs plan.', '', 'up', null, null, null, 3600),
 
             // ---------------- Financial stewardship (spec §2.9) — 3600s -----
-            'financial.worked_per_uos' => $this->kpi('Worked hrs / UOS', 'Worked-hours-per-unit-of-service index vs target.', 'x', 'down', 1.00, 1.00, 1.08, 3600),
+            'financial.worked_per_uos' => $this->kpi('Worked hrs / UOS', 'Worked-hours-per-unit-of-service index vs target.', 'x', 'down', 1.00, 1.00, 1.08, 3600, null, ['scale' => 2]),
             'financial.premium_pay' => $this->kpi('Premium pay', 'Overtime + agency + incentive dollars today.', '$k', 'down', null, null, null, 3600),
             'financial.productivity' => $this->kpi('Labor productivity', 'Labor productivity index.', '%', 'up', 100, 100, 92, 3600, null, null, 100),
             'financial.cost_per_case' => $this->kpi('Cost / OR case', 'Cost per OR case vs budget.', '$k', 'down', null, null, null, 3600),

--- a/docs/COCKPIT-SECTOR-EXPANSION-PLAN-2026-07-19.md
+++ b/docs/COCKPIT-SECTOR-EXPANSION-PLAN-2026-07-19.md
@@ -1,0 +1,91 @@
+# Cockpit Sector Expansion — 12 Panels, All Gauged, OKR 9→13
+
+**Date:** 2026-07-19 · **Branch:** `feature/cockpit-sector-expansion` · **Status:** EXECUTING
+
+[SU]-approved shape (all four recommendations accepted):
+
+1. **Full domains, 12-panel grid** — Radiology, Laboratory, Pharmacy, Hospital@Home become
+   first-class cockpit domains with the same grammar as the existing 8 (gauge + top-6
+   MetricRows + drill modal). The `flow.ancillary_*` tiles move OUT of Flow into their
+   own panels; Flow refocuses on transport/EVS/lounge/bottlenecks.
+2. **Real headline metric per panel** — every panel's circular indicator is a defensible
+   operational number, not a synthetic composite (earned-urgency principle).
+3. **OKR scorecard 9→13** — one card per new sector, live-with-demo-fallback like the
+   existing registry.
+4. **Live-first + enable H@H** — reuse the existing `*CockpitHealthService` live reads;
+   `HOME_HOSPITAL_ENABLED=true` dev AND prod; extend demo seed; deploy to prod.
+
+## Recon findings (verified on main 2026-07-19)
+
+- `SnapshotBuilder::DOMAIN_GAUGES` (`app/Services/Cockpit/SnapshotBuilder.php:68`) is the
+  ONE gauge registry; the frontend renders `RadialGauge` automatically wherever a domain
+  has a `gaugeKey` whose tile exists. Missing: staffing, flow, quality, service, financial.
+- **Pre-existing bug found:** `MetricValue::fromDefinition` never merges the definition's
+  `metadata` (where `ed.nedocs` seeds `scale: 200`) into the tile, so the live NEDOCS ring
+  renders `value/100` clamped with mis-scaled band arcs. The `CockpitOverview.test.tsx`
+  fixture hand-writes `metadata.scale` and masks it. Fix: merge definition metadata under
+  overrides in `fromDefinition` (overrides win per-key).
+- Radiology/Lab/Pharmacy have full service layers on main; the cockpit-facing aggregate
+  contracts are `RadiologyCockpitHealthService` / `LabCockpitHealthService` /
+  `PharmacyCockpitHealthService` (sourceState freshness demotion pattern — preserve).
+  The tile emitters (`radiologyMetric`/`laboratoryMetric`/`pharmacyMetric` + display/href
+  helpers) currently live in `FlowMetrics` and move wholesale into the new providers.
+- Hospital@Home is COMPLETE on main: `HomeMetrics` (9 KPIs, gauge already registered in
+  DOMAIN_GAUGES), 3 migrations (2026_07_17), `HomeHospitalDemoSeeder` in `DatabaseSeeder`,
+  and `DrillBuilder::homeTables()` (virtual ward board + referral funnel) already built.
+  It has simply never rendered: flag default false + absent from frontend `DOMAIN_ORDER`.
+- `flow.ancillary_*` consumers are CONTAINED: FlowMetrics, DrillBuilder
+  (`ancillaryHealthTable`), 3 cockpit tests, ancillary seeder test, KPI seeder. No
+  mobile/Eddy/scoped-face consumers.
+- `BaseMetrics::fromKey` skips any key without a seeded definition — every new key MUST
+  land in `CockpitKpiDefinitionSeeder` and be re-seeded on dev + prod.
+- OKR grid is count-agnostic (`auto-fit minmax(190px,1fr)`); pins to update:
+  `CockpitDashboardPageTest` `has('data.okrs', 9)`, `CockpitOverview.test.tsx` 9-card
+  fixture.
+- Seeder preserves admin-tuned edges for `flow.ancillary_*` on re-seed ("governed local
+  policy") — the new `rad.*`/`lab.*`/`rx.*` keys keep that behavior (prefix list update).
+
+## Gauge mapping (Phase 1 + new sectors)
+
+| Domain | gaugeKey | Scale (metadata) | Notes |
+|---|---|---|---|
+| staffing | `staffing.productivity` | 120 | up; ok 100 / warn 95 / crit 90 |
+| flow | `flow.transport_wait` | 60 | down; warn 15 / crit 25; alert-templated |
+| quality | `quality.sepsis_3hr` | 100 | up; ok 90 / crit 80 |
+| service | `service.oe_los` | 2 | down; warn 1.0 / crit 1.2, target 1.0 |
+| financial | `financial.worked_per_uos` | 2 | down; warn 1.00 / crit 1.08 |
+| radiology | `rad.stat_read_compliance` (new fact) | 100 | ratio query on projector tables, Lab-statCompliance pattern |
+| lab | `lab.stat_compliance` | 100 | existing fact, renamed key |
+| pharmacy | `rx.stat_verify_compliance` (new fact) | 100 | same pattern |
+| home | `home.census_occupancy` | 100 | already registered |
+
+Band arcs (frontend `GAUGE_BANDS`) added for the five Phase-1 gauges mirroring their
+seeded edges; 'up' metrics paint the danger zone at the low end.
+
+## Phases
+
+- **P1** (commit 1): metadata-merge fix + 5 DOMAIN_GAUGES entries + seeder scale metadata
+  + GAUGE_BANDS + tests (every rendered panel has a gauge).
+- **P2** (commits 2a/2b): `RadiologyMetrics`/`LabMetrics`/`PharmacyMetrics` providers
+  (keys `rad.*`/`lab.*`/`rx.*`, ~6 tiles each, one new compliance fact per health
+  service); register in SnapshotBuilder + DrillBuilder (+TITLES, drill tables from
+  `*FlowBoardService`); strip ancillary from FlowMetrics + flow drill; frontend
+  DOMAIN_ORDER/TITLES/cockpitDrillDomains/GAUGE_BANDS; seeder defs (alert_template only
+  on lab critical callbacks, rx sepsis-at-risk, rad breaches — Earned-Red ration).
+- **P3** (commit 3): DOMAIN_ORDER += home ("Hospital@Home"), `HOME_HOSPITAL_ENABLED=true`
+  dev, seed verify.
+- **P4** (commit 4): OKR 13 — `okr.rad_stat_tat` (reuse rad gauge), `okr.lab_critical_callback`,
+  `okr.rx_stockouts`, `okr.hah_avoided_bed_days` (reuse `home.avoided_bed_days_mtd`);
+  update pins.
+- **P5** (commit 5): demo-seed enrichment; snapshot→real-Zod Vitest (the `direction: null`
+  bug class); full gates (PHPUnit/Vitest/tsc/vite/canon ≤76/Pint). **User check-in pre-PR.**
+- **P6**: PR → CI → merge → deploy.sh → prod flag + `CockpitKpiDefinitionSeeder` +
+  `zephyrus:demo-seed --skip-imports` → php8.5-fpm restart → tinker/curl verify
+  (12 domains all gauged, 13 OKRs, 4 new drills) → devlog + memory.
+
+## Risks
+
+- 12 panels = 3 rows on xl — visual check on dev; tighten if the A0 glance scrolls.
+- Key rename loses `ops.metric_values` sparkline history for ancillary tiles (accrues
+  fresh; acceptable).
+- Enabling home flag activates its 4 alert templates — deliberate, Earned-Red compliant.

--- a/docs/DEVLOG-cockpit-sector-expansion-2026-07-19.md
+++ b/docs/DEVLOG-cockpit-sector-expansion-2026-07-19.md
@@ -1,0 +1,81 @@
+# Devlog — Cockpit Sector Expansion (2026-07-19)
+
+**Branch:** `feature/cockpit-sector-expansion` · **Base:** main (post PR #45)
+
+Two asks, one coherent change: (1) give **every** main cockpit panel a circular
+indicator, and (2) add four service sectors — **Radiology, Laboratory, Pharmacy,
+Hospital@Home** — as first-class gauged panels with KPIs and OKRs.
+
+## What shipped
+
+### Phase 1 — all panels gauged
+- **Bug fixed:** `MetricValue::fromDefinition` never merged the KPI definition's
+  `metadata` onto the tile, so the NEDOCS ring rendered against `/100` instead of
+  its seeded `scale: 200`, with mis-scaled band arcs. Now definition metadata
+  rides on every tile (override keys win). This was latent because the one
+  Vitest fixture hand-wrote `metadata.scale`.
+- Registered gauges for the five bare panels: **Staffing** (productivity %, scale
+  120), **Flow** (transport request-to-pickup min, scale 60), **Quality** (sepsis
+  3-hr bundle %), **Service Lines** (O:E LOS, scale 2), **Financial** (worked/UOS,
+  scale 2). Each gets a `GAUGE_BANDS` arc mirroring its StatusEngine edges.
+
+### Phase 2 — Radiology / Laboratory / Pharmacy promoted out of Flow
+- New `RadiologyMetrics` / `LabMetrics` / `PharmacyMetrics` providers. They emit
+  the **same governed `flow.ancillary_*` keys** (seeded catalog, admin-tuned
+  edges, and accrued sparkline history preserved) — only the domain section moved
+  from `flow` to `radiology` / `lab` / `pharmacy`. `FlowMetrics` lost its
+  ancillary emission and the three health-service deps; Flow refocuses on
+  transport / EVS / lounge / bottlenecks.
+- `SnapshotBuilder`: registers the three providers + `OPTIONAL_WHEN_EMPTY`
+  (`radiology`, `lab`, `pharmacy`, `home`) so a sector with no feed is **ABSENT**,
+  never an empty panel.
+- `DrillBuilder`: `DOMAINS`/`TITLES` gain the three sectors; each drills to its
+  own aggregate measure ledger (the privacy-preserving default — the workspace
+  owns per-item detail). The old cross-service "Ancillary operational health"
+  table was removed from the Flow drill.
+- Frontend: `DOMAIN_ORDER`/`DOMAIN_TITLES`/`cockpitDrillDomains` → **12 panels**;
+  minute-unit gauges render a compact `"75m"` ring center (a formatted duration
+  overflows the 84px ring) while tile/drill keep the full display.
+
+### Phase 3 — Hospital@Home
+- Promoted `home` into `DOMAIN_ORDER` as panel 12 ("Hospital@Home"). The domain
+  was already fully built (`HomeMetrics`, migrations, seeder, drill) and
+  flag-gated; prod already runs `HOME_HOSPITAL_ENABLED=true`.
+
+### Phase 4 — OKR scorecard 9 → 13
+- Four sector OKRs, each reusing its sector's live headline signal with a config
+  demo fallback (same pattern as the existing 9): Imaging SLA breaches ·
+  Lab STAT SLA compliance · Medication stockouts · H@H avoided bed-days MTD.
+
+## Why the keys did not change
+
+The `flow.ancillary_*` keys carry a documented governance/privacy contract with
+heavy freshness/last-known test coverage. Renaming them (to `rad.*/lab.*/rx.*`)
+would have been cosmetic — invisible to the user — while discarding sparkline
+history and generating large test churn. Relocating emission preserves the
+contract and the history; the domain **section** is what moved.
+
+## Prod readiness (verified before writing code)
+
+Prod already has `CLINICAL_PAYLOADS_ENABLED`, `HOME_HOSPITAL_ENABLED`,
+`DEMO_MODE`, `ARENA_ENABLED` all true, with **66 ancillary orders / 328
+milestones / 8 home episodes** live and a 6-hourly rolling demo-refresh. So the
+four new panels populate automatically on deploy — no infra to stand up. (Dev
+lacks the clinical-payload store, so the three ancillary sectors are absent on
+dev; they are proven by PHPUnit, which enables the store in-test, and by the
+12-panel Vitest fixture.)
+
+## Gates
+
+- `tsc` clean · `vite build` clean · `check-ui-canon.sh` pass (raw-palette ≤ 76)
+- Cockpit Vitest 86/86 · Pint clean
+- PHPUnit: Radiology + Sections + DrillApi (9/9, incl. absent-sector→404) +
+  FlowLive + DashboardPage + AncillaryReference all green; Lab/Pharmacy green
+  (slow — 3–6 min/test from the demo-scenario setUp).
+
+## Follow-ups
+
+- Prod visual verification of all 12 panels + 13 OKRs post-deploy.
+- The three ancillary sectors deliberately do **not** page (no `alert_template`)
+  — consistent with the pre-existing aggregate-only ancillary posture; promoting
+  any to Earned-Red alerting is a separate [SU] ruling.

--- a/resources/js/Components/cockpit/DomainGrid.tsx
+++ b/resources/js/Components/cockpit/DomainGrid.tsx
@@ -14,9 +14,15 @@ import { MetricRow } from './Tile';
 import { ProvenanceBadge } from './ProvenanceBadge';
 import { formatMetricTarget } from './metricFormatting';
 
-// Fixed wall order — operational domains first, ledger domains last. Keys are
-// the server domain registry (SnapshotBuilder providers / DrillBuilder).
-const DOMAIN_ORDER = ['rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial'] as const;
+// Fixed wall order — operational domains first, ledger domains, then the
+// service sectors (2026-07-19 expansion: Radiology / Laboratory / Pharmacy
+// promoted out of Flow, plus Hospital@Home). Keys are the server domain
+// registry (SnapshotBuilder providers / DrillBuilder); a feed-dead sector is
+// ABSENT from the snapshot and simply doesn't render.
+const DOMAIN_ORDER = [
+  'rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial',
+  'radiology', 'lab', 'pharmacy', 'home',
+] as const;
 
 const DOMAIN_TITLES: Record<(typeof DOMAIN_ORDER)[number], string> = {
   rtdc: 'Demand & Capacity',
@@ -27,11 +33,18 @@ const DOMAIN_TITLES: Record<(typeof DOMAIN_ORDER)[number], string> = {
   quality: 'Quality & Safety',
   service: 'Service Lines',
   financial: 'Financial',
+  radiology: 'Radiology',
+  lab: 'Laboratory',
+  pharmacy: 'Pharmacy',
+  home: 'Hospital@Home',
 };
 
 // NEDOCS context arc. The reference's five bands included a green "not busy"
 // zone; canon rations green, so the calm end renders neutral and the arc keeps
 // four reconciled bands (≤60 calm, ≤100 watch, ≤140 overcrowded, ≤200 severe+).
+// The other arcs mirror each gauge's seeded StatusEngine edges — same number,
+// same color, just painted as ring context. 'up' metrics (productivity,
+// sepsis bundle) carry their danger zone at the LOW end of the scale.
 const GAUGE_BANDS: Record<string, RadialGaugeBand[]> = {
   'ed.nedocs': [
     { edge: 60, level: 'neutral' },
@@ -39,7 +52,58 @@ const GAUGE_BANDS: Record<string, RadialGaugeBand[]> = {
     { edge: 140, level: 'warning' },
     { edge: 200, level: 'critical' },
   ],
+  'staffing.productivity': [
+    { edge: 90, level: 'critical' },
+    { edge: 95, level: 'warning' },
+    { edge: 120, level: 'neutral' },
+  ],
+  'flow.transport_wait': [
+    { edge: 15, level: 'neutral' },
+    { edge: 25, level: 'warning' },
+    { edge: 60, level: 'critical' },
+  ],
+  'quality.sepsis_3hr': [
+    { edge: 80, level: 'critical' },
+    { edge: 90, level: 'warning' },
+    { edge: 100, level: 'neutral' },
+  ],
+  'service.oe_los': [
+    { edge: 1.0, level: 'neutral' },
+    { edge: 1.2, level: 'warning' },
+    { edge: 2, level: 'critical' },
+  ],
+  'financial.worked_per_uos': [
+    { edge: 1.0, level: 'neutral' },
+    { edge: 1.08, level: 'warning' },
+    { edge: 2, level: 'critical' },
+  ],
+  'flow.ancillary_rad_oldest_unread': [
+    { edge: 30, level: 'neutral' },
+    { edge: 60, level: 'warning' },
+    { edge: 90, level: 'critical' },
+  ],
+  'flow.ancillary_lab_stat_compliance': [
+    { edge: 79, level: 'critical' },
+    { edge: 89, level: 'warning' },
+    { edge: 100, level: 'neutral' },
+  ],
+  'flow.ancillary_rx_oldest_stat': [
+    { edge: 10, level: 'neutral' },
+    { edge: 15, level: 'warning' },
+    { edge: 30, level: 'critical' },
+  ],
 };
+
+// The ring center shows the tile's own display, EXCEPT for duration gauges:
+// a formatted duration ("1 hr 15 min 0 sec") overflows an 84px ring, so a
+// minute-unit gauge renders a compact "75m" center while the tile/drill keep
+// the full display. Everything else (%, counts, scores) uses display verbatim.
+function gaugeCenter(metric: CockpitMetricValue): string | undefined {
+  if (metric.unit && ['min', 'mins', 'minute', 'minutes'].includes(metric.unit)) {
+    return `${Math.round(metric.value)}m`;
+  }
+  return metric.display;
+}
 
 const SEVERITY: Record<CockpitMetricValue['status'], number> = {
   crit: 4, warn: 3, watch: 2, ok: 1, normal: 0,
@@ -74,7 +138,7 @@ function DomainGauge({ metric }: { metric: CockpitMetricValue }) {
         target={metric.target}
         size={84}
         strokeWidth={9}
-        big={metric.display}
+        big={gaugeCenter(metric)}
         bigClass="text-base"
       />
       <div className="flex min-w-0 flex-col gap-0.5">

--- a/resources/js/types/cockpit.ts
+++ b/resources/js/types/cockpit.ts
@@ -222,7 +222,8 @@ export type CockpitSnapshotSections = z.infer<typeof cockpitSnapshotSectionsSche
 // outside this list are ignored on read, so a mangled deep link degrades to the
 // bare cockpit instead of holding junk state.
 export const cockpitDrillDomains = [
-  'rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial', 'home', 'okr',
+  'rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial',
+  'radiology', 'lab', 'pharmacy', 'home', 'okr',
 ] as const;
 export type CockpitDrillDomain = (typeof cockpitDrillDomains)[number];
 

--- a/tests/Feature/Cockpit/CockpitDashboardPageTest.php
+++ b/tests/Feature/Cockpit/CockpitDashboardPageTest.php
@@ -43,7 +43,7 @@ class CockpitDashboardPageTest extends TestCase
                 ->has('data.capacityStatus.code')
                 ->has('data.census')
                 ->has('data.alerts')
-                ->has('data.okrs', 9)
+                ->has('data.okrs', 13)
                 ->has('data.domains.rtdc.tiles')
                 ->has('data.domains.financial.provenance')
             );

--- a/tests/Feature/Cockpit/CockpitDrillApiTest.php
+++ b/tests/Feature/Cockpit/CockpitDrillApiTest.php
@@ -53,7 +53,8 @@ class CockpitDrillApiTest extends TestCase
         $response->assertOk();
 
         $rows = $response->json('tables.0.rows');
-        $this->assertCount(9, $rows);
+        // 9 core + 4 service-sector OKRs (2026-07-19).
+        $this->assertCount(13, $rows);
         $edLos = collect($rows)->firstWhere('keyResult', 'ED LOS (admitted)');
         $this->assertSame('5 hr 0 min 0 sec', $edLos['target']['v']);
 

--- a/tests/Feature/Cockpit/CockpitSnapshotSectionsTest.php
+++ b/tests/Feature/Cockpit/CockpitSnapshotSectionsTest.php
@@ -175,17 +175,23 @@ class CockpitSnapshotSectionsTest extends TestCase
         $this->assertSame(120, $productivity['metadata']['scale'] ?? null);
     }
 
-    public function test_okr_scorecard_has_nine_cards_with_objectives_and_owners(): void
+    public function test_okr_scorecard_has_thirteen_cards_with_objectives_and_owners(): void
     {
         $payload = app(SnapshotBuilder::class)->build();
 
-        $this->assertCount(9, $payload['okrs']);
+        // 9 core + 4 service-sector OKRs (2026-07-19). The sector cards fall
+        // back to their config demo value here (no ancillary/home feed seeded).
+        $this->assertCount(13, $payload['okrs']);
 
         $byKey = collect($payload['okrs'])->keyBy('key');
         $dbn = $byKey->get('okr.dc_before_noon');
         $this->assertSame('Smooth Throughput', $dbn['objective']);
         $this->assertSame('CNO', $dbn['owner']);
         $this->assertSame('Discharge before noon', $dbn['keyResult']);
+
+        $hah = $byKey->get('okr.hah_avoided_bed_days');
+        $this->assertSame('Capacity Liberation', $hah['objective']);
+        $this->assertSame('Hospital@Home', $hah['owner']);
     }
 
     public function test_quality_service_financial_are_live_after_p7(): void

--- a/tests/Feature/Cockpit/CockpitSnapshotSectionsTest.php
+++ b/tests/Feature/Cockpit/CockpitSnapshotSectionsTest.php
@@ -151,8 +151,28 @@ class CockpitSnapshotSectionsTest extends TestCase
             array_keys($payload['domains']),
         );
 
-        $this->assertSame('rtdc.occupancy', $payload['domains']['rtdc']['gaugeKey']);
-        $this->assertSame('ed.nedocs', $payload['domains']['ed']['gaugeKey']);
+        // Sector expansion: EVERY always-on domain carries a circular indicator.
+        $expectedGauges = [
+            'rtdc' => 'rtdc.occupancy',
+            'ed' => 'ed.nedocs',
+            'periop' => 'periop.prime_util',
+            'staffing' => 'staffing.productivity',
+            'flow' => 'flow.transport_wait',
+            'quality' => 'quality.sepsis_3hr',
+            'service' => 'service.oe_los',
+            'financial' => 'financial.worked_per_uos',
+        ];
+        foreach ($expectedGauges as $domain => $gaugeKey) {
+            $this->assertSame($gaugeKey, $payload['domains'][$domain]['gaugeKey'], $domain);
+        }
+
+        // Definition metadata rides on the tile so the client gauge scales
+        // correctly (the pre-expansion bug rendered NEDOCS against /100).
+        $nedocs = collect($payload['domains']['ed']['tiles'])->firstWhere('key', 'ed.nedocs');
+        $this->assertSame(200, $nedocs['metadata']['scale'] ?? null);
+        $productivity = collect($payload['domains']['staffing']['tiles'])->firstWhere('key', 'staffing.productivity');
+        $this->assertNotNull($productivity, 'staffing gauge tile emits from seeded workforce_actuals');
+        $this->assertSame(120, $productivity['metadata']['scale'] ?? null);
     }
 
     public function test_okr_scorecard_has_nine_cards_with_objectives_and_owners(): void

--- a/tests/Feature/Cockpit/LaboratoryCockpitMetricsTest.php
+++ b/tests/Feature/Cockpit/LaboratoryCockpitMetricsTest.php
@@ -79,7 +79,7 @@ final class LaboratoryCockpitMetricsTest extends TestCase
         $this->assertSame($flowHealth['criticalCallbacks']['open'], $laboratory['criticalCallbacks']['value']);
         $this->assertSame($laboratory['criticalCallbacks']['value'], $laboratory['criticalCallbacks']['atRiskCount']);
 
-        $tiles = collect(app(SnapshotBuilder::class)->build()['domains']['flow']['tiles'])->keyBy('key');
+        $tiles = collect(app(SnapshotBuilder::class)->build()['domains']['lab']['tiles'])->keyBy('key');
         $stat = $tiles->get(self::KEYS[0]);
         $pending = $tiles->get(self::KEYS[1]);
         $callbacks = $tiles->get(self::KEYS[2]);
@@ -121,7 +121,7 @@ final class LaboratoryCockpitMetricsTest extends TestCase
     public function test_refresh_persists_aggregate_history_without_alerts_or_individual_result_detail(): void
     {
         $payload = app(SnapshotBuilder::class)->refresh();
-        $tiles = collect($payload['domains']['flow']['tiles'])->whereIn('key', self::KEYS)->values();
+        $tiles = collect($payload['domains']['lab']['tiles'])->whereIn('key', self::KEYS)->values();
         $this->assertCount(3, $tiles);
         $this->assertSame([], collect($payload['alerts'])->whereIn('key', self::KEYS)->values()->all());
 
@@ -140,33 +140,30 @@ final class LaboratoryCockpitMetricsTest extends TestCase
         $this->assertStringContainsString('byState', $serialized);
     }
 
-    public function test_flow_drill_activates_the_reserved_laboratory_row_from_cached_server_metrics(): void
+    public function test_laboratory_sector_drill_renders_the_aggregate_measure_ledger(): void
     {
         $snapshot = app(SnapshotBuilder::class)->refresh();
-        $tiles = collect($snapshot['domains']['flow']['tiles'])->keyBy('key');
-        $table = collect($this->actingAs(User::factory()->create())
-            ->getJson('/api/cockpit/drill/flow')->assertOk()->json('tables'))
-            ->firstWhere('caption', 'Ancillary operational health');
+        $tiles = collect($snapshot['domains']['lab']['tiles'])->keyBy('key');
+        $payload = $this->actingAs(User::factory()->create())
+            ->getJson('/api/cockpit/drill/lab')->assertOk()->json();
 
+        $this->assertSame('lab', $payload['domain']);
+        $this->assertSame('Laboratory — Result & Callback Health', $payload['title']);
+        $table = collect($payload['tables'])->firstWhere('caption', 'Laboratory — Result & Callback Health — measures');
         $this->assertNotNull($table);
-        $this->assertSame(['Radiology', 'Laboratory', 'Pharmacy'], collect($table['rows'])->pluck('service.v')->all());
-        $lab = collect($table['rows'])->firstWhere('service.v', 'Laboratory');
-        $this->assertSame($tiles->get(self::KEYS[0])['display'], $lab['measure1']['v']);
-        $this->assertSame($tiles->get(self::KEYS[1])['display'], $lab['measure2']['v']);
-        $this->assertSame($tiles->get(self::KEYS[2])['display'], $lab['measure3']['v']);
-        $this->assertSame('/lab?priority=stat&source=cockpit', $lab['measure1']['href']);
-        $this->assertSame('/lab/pending-decisions?source=cockpit', $lab['measure2']['href']);
-        $this->assertSame('/lab?lens=critical_callbacks&source=cockpit', $lab['measure3']['href']);
-        $this->assertSame('fresh', $lab['source']['tag']['text']);
-        $this->assertSame('critical', $lab['status']['chip']);
-        $this->assertNotSame('—', $lab['cutoff']['v']);
 
-        // The Pharmacy row is now activated by X-11 against the same demo cohort.
-        $pharmacy = collect($table['rows'])->firstWhere('service.v', 'Pharmacy');
-        $this->assertSame('fresh', $pharmacy['source']['tag']['text']);
-        $this->assertNotSame('—', $pharmacy['cutoff']['v']);
-        $this->assertStringNotContainsString('patient', strtolower(json_encode($lab, JSON_THROW_ON_ERROR)));
-        $this->assertStringNotContainsString('resultuuid', strtolower(json_encode($lab, JSON_THROW_ON_ERROR)));
+        foreach (self::KEYS as $key) {
+            $tile = $tiles->get($key);
+            $row = collect($table['rows'])->firstWhere('measure.v', $tile['label']);
+            $this->assertNotNull($row, $key);
+            $this->assertSame($tile['display'], $row['value']['v']);
+        }
+        $stat = collect($table['rows'])->firstWhere('measure.v', $tiles->get(self::KEYS[0])['label']);
+        $this->assertSame('critical', $stat['status']['chip']);
+        // Aggregate-only: no result identity leaks into the drill.
+        $json = strtolower(json_encode($table, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('patient', $json);
+        $this->assertStringNotContainsString('resultuuid', $json);
     }
 
     public function test_stale_laboratory_evidence_is_last_known_neutral_and_never_successful(): void
@@ -174,7 +171,7 @@ final class LaboratoryCockpitMetricsTest extends TestCase
         DB::table('ops.source_freshness')->where('source_key', 'ancillary_orders')->update(['status' => 'stale']);
         Cache::forget(SnapshotBuilder::CACHE_KEY);
         $payload = app(SnapshotBuilder::class)->build();
-        $tiles = collect($payload['domains']['flow']['tiles'])->whereIn('key', self::KEYS)->values();
+        $tiles = collect($payload['domains']['lab']['tiles'])->whereIn('key', self::KEYS)->values();
 
         $this->assertCount(3, $tiles);
         $this->assertTrue($tiles->every(fn (array $tile): bool => $tile['status'] === 'normal'));
@@ -183,12 +180,13 @@ final class LaboratoryCockpitMetricsTest extends TestCase
         $this->assertTrue($tiles->every(fn (array $tile): bool => str_starts_with($tile['sub'], 'Last known')));
         $this->assertSame([], collect($payload['alerts'])->whereIn('key', self::KEYS)->values()->all());
 
+        // The sector drill still renders; the neutralized status rides on the tiles.
         app(SnapshotBuilder::class)->refresh();
         $table = collect($this->actingAs(User::factory()->create())
-            ->getJson('/api/cockpit/drill/flow')->assertOk()->json('tables'))
-            ->firstWhere('caption', 'Ancillary operational health');
-        $lab = collect($table['rows'])->firstWhere('service.v', 'Laboratory');
-        $this->assertSame('stale', $lab['source']['tag']['text']);
-        $this->assertSame('neutral', $lab['status']['chip']);
+            ->getJson('/api/cockpit/drill/lab')->assertOk()->json('tables'))
+            ->firstWhere('caption', 'Laboratory — Result & Callback Health — measures');
+        $this->assertNotNull($table);
+        $stat = collect($table['rows'])->firstWhere('measure.v', $tiles->firstWhere('key', self::KEYS[0])['label']);
+        $this->assertSame('neutral', $stat['status']['chip']);
     }
 }

--- a/tests/Feature/Cockpit/PharmacyCockpitMetricsTest.php
+++ b/tests/Feature/Cockpit/PharmacyCockpitMetricsTest.php
@@ -83,7 +83,7 @@ final class PharmacyCockpitMetricsTest extends TestCase
         $this->assertSame($flowHealth['shortageStockouts']['stations'], $pharmacy['shortageStockouts']['value']);
 
         $payload = app(SnapshotBuilder::class)->build();
-        $tiles = collect($payload['domains']['flow']['tiles'])->keyBy('key');
+        $tiles = collect($payload['domains']['pharmacy']['tiles'])->keyBy('key');
         $queue = $tiles->get(self::KEYS[0]);
         $stat = $tiles->get(self::KEYS[1]);
         $sepsis = $tiles->get(self::KEYS[2]);
@@ -117,7 +117,7 @@ final class PharmacyCockpitMetricsTest extends TestCase
     public function test_refresh_persists_aggregate_history_without_alerts_or_individual_detail(): void
     {
         $payload = app(SnapshotBuilder::class)->refresh();
-        $tiles = collect($payload['domains']['flow']['tiles'])->whereIn('key', self::KEYS)->values();
+        $tiles = collect($payload['domains']['pharmacy']['tiles'])->whereIn('key', self::KEYS)->values();
         $this->assertCount(4, $tiles);
         $this->assertSame([], collect($payload['alerts'])->whereIn('key', self::KEYS)->values()->all());
 
@@ -134,26 +134,28 @@ final class PharmacyCockpitMetricsTest extends TestCase
         }
     }
 
-    public function test_flow_drill_activates_the_reserved_pharmacy_row_from_cached_server_metrics(): void
+    public function test_pharmacy_sector_drill_renders_the_aggregate_measure_ledger(): void
     {
         $snapshot = app(SnapshotBuilder::class)->refresh();
-        $tiles = collect($snapshot['domains']['flow']['tiles'])->keyBy('key');
-        $table = collect($this->actingAs(User::factory()->create())
-            ->getJson('/api/cockpit/drill/flow')->assertOk()->json('tables'))
-            ->firstWhere('caption', 'Ancillary operational health');
+        $tiles = collect($snapshot['domains']['pharmacy']['tiles'])->keyBy('key');
+        $payload = $this->actingAs(User::factory()->create())
+            ->getJson('/api/cockpit/drill/pharmacy')->assertOk()->json();
 
+        $this->assertSame('pharmacy', $payload['domain']);
+        $this->assertSame('Pharmacy — Medication Flow Health', $payload['title']);
+        $table = collect($payload['tables'])->firstWhere('caption', 'Pharmacy — Medication Flow Health — measures');
         $this->assertNotNull($table);
-        $this->assertSame(['Radiology', 'Laboratory', 'Pharmacy'], collect($table['rows'])->pluck('service.v')->all());
-        $pharmacy = collect($table['rows'])->firstWhere('service.v', 'Pharmacy');
-        $this->assertSame($tiles->get(self::DRILL_KEYS[0])['display'], $pharmacy['measure1']['v']);
-        $this->assertSame($tiles->get(self::DRILL_KEYS[1])['display'], $pharmacy['measure2']['v']);
-        $this->assertSame($tiles->get(self::DRILL_KEYS[2])['display'], $pharmacy['measure3']['v']);
-        $this->assertSame('/pharmacy?source=cockpit', $pharmacy['measure1']['href']);
-        $this->assertSame('/pharmacy?lens=stat&source=cockpit', $pharmacy['measure2']['href']);
-        $this->assertSame('/pharmacy?lens=shortage&source=cockpit', $pharmacy['measure3']['href']);
-        $this->assertSame('fresh', $pharmacy['source']['tag']['text']);
-        $this->assertNotSame('—', $pharmacy['cutoff']['v']);
-        $this->assertStringNotContainsString('patient', strtolower(json_encode($pharmacy, JSON_THROW_ON_ERROR)));
+
+        // Every emitted sector tile is a ledger row reconciled to the cached
+        // snapshot value — the drill never recomputes.
+        foreach (self::DRILL_KEYS as $key) {
+            $tile = $tiles->get($key);
+            $row = collect($table['rows'])->firstWhere('measure.v', $tile['label']);
+            $this->assertNotNull($row, $key);
+            $this->assertSame($tile['display'], $row['value']['v']);
+        }
+        // Aggregate-only: no patient/order identity leaks into the drill.
+        $this->assertStringNotContainsString('patient', strtolower(json_encode($table, JSON_THROW_ON_ERROR)));
     }
 
     public function test_stale_administration_cannot_create_a_false_sepsis_success_or_failure(): void
@@ -172,7 +174,7 @@ final class PharmacyCockpitMetricsTest extends TestCase
         $this->assertGreaterThanOrEqual(0, $pharmacy['sepsisAtRisk']['openBreaches']);
 
         $payload = app(SnapshotBuilder::class)->build();
-        $tiles = collect($payload['domains']['flow']['tiles'])->keyBy('key');
+        $tiles = collect($payload['domains']['pharmacy']['tiles'])->keyBy('key');
         // A null sepsis value is skipped entirely — it can never render green or
         // fire an alert from stale administration evidence.
         $this->assertFalse($tiles->has(self::KEYS[2]));
@@ -189,7 +191,7 @@ final class PharmacyCockpitMetricsTest extends TestCase
         DB::table('ops.source_freshness')->where('source_key', 'ancillary_orders')->update(['status' => 'stale']);
         Cache::forget(SnapshotBuilder::CACHE_KEY);
         $payload = app(SnapshotBuilder::class)->build();
-        $tiles = collect($payload['domains']['flow']['tiles'])->whereIn('key', self::DRILL_KEYS)->values();
+        $tiles = collect($payload['domains']['pharmacy']['tiles'])->whereIn('key', self::DRILL_KEYS)->values();
 
         $this->assertCount(3, $tiles);
         $this->assertTrue($tiles->every(fn (array $tile): bool => $tile['status'] === 'normal'));
@@ -198,12 +200,14 @@ final class PharmacyCockpitMetricsTest extends TestCase
         $this->assertTrue($tiles->every(fn (array $tile): bool => str_starts_with($tile['sub'], 'Last known')));
         $this->assertSame([], collect($payload['alerts'])->whereIn('key', self::DRILL_KEYS)->values()->all());
 
+        // The sector drill still renders the last-known ledger; the neutralized
+        // status rides on the tiles themselves (asserted above).
         app(SnapshotBuilder::class)->refresh();
         $table = collect($this->actingAs(User::factory()->create())
-            ->getJson('/api/cockpit/drill/flow')->assertOk()->json('tables'))
-            ->firstWhere('caption', 'Ancillary operational health');
-        $pharmacy = collect($table['rows'])->firstWhere('service.v', 'Pharmacy');
-        $this->assertSame('stale', $pharmacy['source']['tag']['text']);
-        $this->assertSame('neutral', $pharmacy['status']['chip']);
+            ->getJson('/api/cockpit/drill/pharmacy')->assertOk()->json('tables'))
+            ->firstWhere('caption', 'Pharmacy — Medication Flow Health — measures');
+        $this->assertNotNull($table);
+        $queue = collect($table['rows'])->firstWhere('measure.v', $tiles->firstWhere('key', self::DRILL_KEYS[0])['label']);
+        $this->assertSame('neutral', $queue['status']['chip']);
     }
 }

--- a/tests/Feature/Cockpit/RadiologyCockpitMetricsTest.php
+++ b/tests/Feature/Cockpit/RadiologyCockpitMetricsTest.php
@@ -76,7 +76,7 @@ class RadiologyCockpitMetricsTest extends TestCase
         $this->assertSame(app(RadiologyReadsService::class)->cockpitHealth()['oldestUnreadAgeMinutes'], $workspace['oldestUnread']['value']);
 
         $payload = app(SnapshotBuilder::class)->build();
-        $tiles = collect($payload['domains']['flow']['tiles'])->keyBy('key');
+        $tiles = collect($payload['domains']['radiology']['tiles'])->keyBy('key');
         $breaches = $tiles->get('flow.ancillary_rad_open_breaches');
         $unread = $tiles->get('flow.ancillary_rad_oldest_unread');
         $scanners = $tiles->get('flow.ancillary_rad_scanners_down');
@@ -128,45 +128,31 @@ class RadiologyCockpitMetricsTest extends TestCase
         $this->assertSame('fresh', $metadata['sourceState']);
     }
 
-    public function test_flow_drill_adds_reconciled_ancillary_health_rows_and_reserves_future_services(): void
+    public function test_radiology_sector_drill_renders_the_aggregate_measure_ledger(): void
     {
         $response = $this->actingAs(User::factory()->create())
-            ->getJson('/api/cockpit/drill/flow')
+            ->getJson('/api/cockpit/drill/radiology')
             ->assertOk();
-        $table = collect($response->json('tables'))->firstWhere('caption', 'Ancillary operational health');
+
+        $this->assertSame('radiology', $response->json('domain'));
+        $this->assertSame('Radiology — Imaging Operational Health', $response->json('title'));
+        $table = collect($response->json('tables'))->firstWhere('caption', 'Radiology — Imaging Operational Health — measures');
 
         $this->assertNotNull($table);
-        $this->assertSame(['Radiology', 'Laboratory', 'Pharmacy'], collect($table['rows'])->pluck('service.v')->all());
-        $radiology = collect($table['rows'])->firstWhere('service.v', 'Radiology');
-        $this->assertSame('1 order', $radiology['measure1']['v']);
-        $this->assertSame('1 hr 15 min 0 sec', $radiology['measure2']['v']);
-        $this->assertSame('2 scanners', $radiology['measure3']['v']);
-        $this->assertSame('fresh', $radiology['source']['tag']['text']);
-        $this->assertSame('critical', $radiology['status']['chip']);
-        $this->assertNotSame('—', $radiology['cutoff']['v']);
-
-        foreach (['Laboratory', 'Pharmacy'] as $future) {
-            $row = collect($table['rows'])->firstWhere('service.v', $future);
-            $this->assertSame('not available', $row['source']['tag']['text']);
-            $this->assertSame('neutral', $row['status']['chip']);
-        }
-
-        DB::table('ops.source_freshness')->where('source_key', 'ancillary_milestones')->update(['status' => 'stale']);
-        Cache::forget(SnapshotBuilder::CACHE_KEY);
-        $mixedSourceTable = collect($this->actingAs(User::factory()->create())
-            ->getJson('/api/cockpit/drill/flow')->assertOk()->json('tables'))
-            ->firstWhere('caption', 'Ancillary operational health');
-        $this->assertSame(
-            'stale',
-            collect($mixedSourceTable['rows'])->firstWhere('service.v', 'Radiology')['source']['tag']['text'],
-        );
+        $rowsByMeasure = collect($table['rows'])->keyBy('measure.v');
+        $this->assertSame('1 order', $rowsByMeasure->get('Imaging open breaches')['value']['v']);
+        $this->assertSame('1 hr 15 min 0 sec', $rowsByMeasure->get('Oldest unread study')['value']['v']);
+        $this->assertSame('2 scanners', $rowsByMeasure->get('Scanners down')['value']['v']);
+        $this->assertSame('critical', $rowsByMeasure->get('Oldest unread study')['value']['status']);
+        // Aggregate-only: no study/patient identity leaks into the drill.
+        $this->assertStringNotContainsString('patient', strtolower(json_encode($table, JSON_THROW_ON_ERROR)));
     }
 
     public function test_stale_sources_neutralize_last_known_metrics_and_missing_report_evidence_cannot_render_success(): void
     {
         DB::table('ops.source_freshness')->whereIn('source_key', ['ancillary_orders', 'ancillary_milestones'])->update(['status' => 'stale']);
         $stale = app(SnapshotBuilder::class)->build();
-        $tiles = collect($stale['domains']['flow']['tiles'])->whereIn('key', [
+        $tiles = collect($stale['domains']['radiology']['tiles'])->whereIn('key', [
             'flow.ancillary_rad_open_breaches',
             'flow.ancillary_rad_oldest_unread',
             'flow.ancillary_rad_scanners_down',
@@ -185,7 +171,7 @@ class RadiologyCockpitMetricsTest extends TestCase
         DB::statement('TRUNCATE TABLE prod.ancillary_breaches, prod.ancillary_milestones CASCADE');
         Cache::forget(SnapshotBuilder::CACHE_KEY);
         $missing = app(SnapshotBuilder::class)->build();
-        $missingTiles = collect($missing['domains']['flow']['tiles'])->keyBy('key');
+        $missingTiles = collect($missing['domains']['radiology']['tiles'])->keyBy('key');
         $this->assertFalse($missingTiles->has('flow.ancillary_rad_oldest_unread'));
         $this->assertNotSame('ok', $missingTiles->get('flow.ancillary_rad_open_breaches')['status']);
         $this->assertNotSame('ok', $missingTiles->get('flow.ancillary_rad_scanners_down')['status']);

--- a/tests/e2e/cockpit-ancillary.spec.ts
+++ b/tests/e2e/cockpit-ancillary.spec.ts
@@ -18,12 +18,14 @@ test('Ancillary service sectors render as first-class cockpit panels', async ({ 
 
   const grid = page.getByTestId('cockpit-domain-grid');
   await expect(grid).toBeVisible({ timeout: 10000 });
-  // The three ancillary sectors (promoted out of Flow, 2026-07-19) plus
-  // Hospital@Home now render as their own gauged panels.
+  // The three ancillary sectors, promoted out of Flow (2026-07-19), now render
+  // as their own gauged panels wherever the ancillary feed has data. (The
+  // Hospital@Home panel is a separately flag-gated module, HOME_HOSPITAL_ENABLED,
+  // so it is asserted by the CockpitOverview unit fixture, not this feed-dependent
+  // browser check.)
   await expect(grid.getByText('Radiology', { exact: true })).toBeVisible();
   await expect(grid.getByText('Laboratory', { exact: true })).toBeVisible();
   await expect(grid.getByText('Pharmacy', { exact: true })).toBeVisible();
-  await expect(grid.getByText('Hospital@Home', { exact: true })).toBeVisible();
 
   // The Radiology panel drills to its own aggregate measure ledger.
   await page.goto('/dashboard?drill=radiology', { waitUntil: 'domcontentloaded' });

--- a/tests/e2e/cockpit-ancillary.spec.ts
+++ b/tests/e2e/cockpit-ancillary.spec.ts
@@ -5,7 +5,7 @@ test.beforeEach(async ({ page }) => {
   await loginAsTestUser(page);
 });
 
-test('Flow drill renders the server-computed ancillary health table', async ({ page }) => {
+test('Ancillary service sectors render as first-class cockpit panels', async ({ page }) => {
   const consoleErrors: string[] = [];
   page.on('console', (message) => {
     if (message.type() === 'error') consoleErrors.push(message.text());
@@ -14,18 +14,21 @@ test('Flow drill renders the server-computed ancillary health table', async ({ p
     await route.fulfill({ status: 204, body: '' });
   });
 
-  await page.goto('/dashboard?drill=flow', { waitUntil: 'domcontentloaded' });
+  await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
 
+  const grid = page.getByTestId('cockpit-domain-grid');
+  await expect(grid).toBeVisible({ timeout: 10000 });
+  // The three ancillary sectors (promoted out of Flow, 2026-07-19) plus
+  // Hospital@Home now render as their own gauged panels.
+  await expect(grid.getByText('Radiology', { exact: true })).toBeVisible();
+  await expect(grid.getByText('Laboratory', { exact: true })).toBeVisible();
+  await expect(grid.getByText('Pharmacy', { exact: true })).toBeVisible();
+  await expect(grid.getByText('Hospital@Home', { exact: true })).toBeVisible();
+
+  // The Radiology panel drills to its own aggregate measure ledger.
+  await page.goto('/dashboard?drill=radiology', { waitUntil: 'domcontentloaded' });
   await expect(page.getByTestId('cockpit-drill-modal')).toBeVisible({ timeout: 10000 });
-  await expect(page.getByText('Patient Flow & Transport', { exact: true })).toBeVisible();
-  const table = page.getByRole('table', { name: 'Ancillary operational health' });
-  await expect(table).toBeVisible();
-  await expect(table.getByText('Radiology', { exact: true })).toBeVisible();
-  await expect(table.getByText('Laboratory', { exact: true })).toBeVisible();
-  await expect(table.getByText('Pharmacy', { exact: true })).toBeVisible();
-  await expect(table.getByRole('columnheader', { name: 'Source cutoff' })).toBeVisible();
-  await expect(table.locator('a[href="/lab?priority=stat&source=cockpit"]')).toBeVisible();
-  await expect(table.locator('a[href="/lab/pending-decisions?source=cockpit"]')).toBeVisible();
-  await expect(table.locator('a[href="/lab?lens=critical_callbacks&source=cockpit"]')).toBeVisible();
+  await expect(page.getByText('Radiology — Imaging Operational Health', { exact: true })).toBeVisible();
+
   expect(consoleErrors).toEqual([]);
 });

--- a/tests/e2e/laboratory-phase-gate.spec.ts
+++ b/tests/e2e/laboratory-phase-gate.spec.ts
@@ -246,12 +246,13 @@ test('Perioperative, RTDC, and Cockpit compact joins reconcile to owned Laborato
   const rtdcDrill = page.getByRole('link', { name: /Open Lab Laboratory Flow Board for/i }).first();
   await expect(rtdcDrill).toHaveAttribute('href', /\/lab\?unitId=\d+&source=ancillary_services/);
 
-  await page.goto('/dashboard?drill=flow', { waitUntil: 'domcontentloaded' });
-  const table = page.getByRole('table', { name: 'Ancillary operational health' });
-  await expect(table.getByText('Laboratory', { exact: true })).toBeVisible();
-  await expect(table.locator('a[href="/lab?priority=stat&source=cockpit"]')).toBeVisible();
-  await expect(table.locator('a[href="/lab/pending-decisions?source=cockpit"]')).toBeVisible();
-  await expect(table.locator('a[href="/lab?lens=critical_callbacks&source=cockpit"]')).toBeVisible();
+  // Laboratory is now a first-class cockpit sector (2026-07-19): its panel
+  // drills to its own aggregate measure ledger.
+  await page.goto('/dashboard?drill=lab', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('cockpit-drill-modal')).toBeVisible({ timeout: 10_000 });
+  const table = page.getByRole('table', { name: 'Laboratory — Result & Callback Health — measures' });
+  await expect(table.getByText('Lab STAT compliance', { exact: true })).toBeVisible();
+  await expect(table.getByText('Critical callbacks open', { exact: true })).toBeVisible();
   await expectContainedAndPrivate(page, 'cockpit-compact-join');
 
   expect(errors.consoleErrors).toEqual([]);

--- a/tests/e2e/pharmacy-phase-gate.spec.ts
+++ b/tests/e2e/pharmacy-phase-gate.spec.ts
@@ -236,15 +236,14 @@ test('ED, RTDC full vector, and Cockpit compact joins reconcile to owned Pharmac
   await expect(page.getByRole('link', { name: /Pharmacy Medication Flow Board for/i }).first()).toBeVisible();
   await expectContainedAndPrivate(page, 'rtdc-full-vector');
 
-  // Cockpit Flow drill reconciles Pharmacy to its owned destinations.
-  await page.goto('/dashboard?drill=flow', { waitUntil: 'domcontentloaded' });
-  const table = page.getByRole('table', { name: 'Ancillary operational health' });
-  await expect(table.getByText('Pharmacy', { exact: true })).toBeVisible();
-  // The compact cockpit row is deliberately bounded to queue, STAT age, and
-  // shortage station measures; sepsis detail remains on the owned workspace.
-  await expect(table.locator('a[href="/pharmacy?source=cockpit"]')).toBeVisible();
-  await expect(table.locator('a[href="/pharmacy?lens=stat&source=cockpit"]')).toBeVisible();
-  await expect(table.locator('a[href="/pharmacy?lens=shortage&source=cockpit"]')).toBeVisible();
+  // Pharmacy is now a first-class cockpit sector (2026-07-19): its panel drills
+  // to its own aggregate measure ledger, bounded to queue, STAT age, sepsis,
+  // and shortage measures; per-order detail remains on the owned workspace.
+  await page.goto('/dashboard?drill=pharmacy', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('cockpit-drill-modal')).toBeVisible({ timeout: 10_000 });
+  const table = page.getByRole('table', { name: 'Pharmacy — Medication Flow Health — measures' });
+  await expect(table.getByText('Pharmacy verification queue', { exact: true })).toBeVisible();
+  await expect(table.getByText('Medication stockouts', { exact: true })).toBeVisible();
   await expectContainedAndPrivate(page, 'cockpit-compact-join');
 
   expect(errors.consoleErrors).toEqual([]);

--- a/tests/js/cockpit/CockpitOverview.test.tsx
+++ b/tests/js/cockpit/CockpitOverview.test.tsx
@@ -41,7 +41,7 @@ const sections: CockpitSnapshotSections = {
   capacityStatus: { level: 'Surge Level 2', code: 'yellow', status: 'warn' },
   census: censusKeys.map((key) => mv(key, key.split('.')[1])),
   alerts: [{ key: 'ed.nedocs', status: 'crit', text: 'ED OVERCROWDED — NEDOCS 142', provenance: 'demo' }],
-  okrs: Array.from({ length: 9 }, (_, i) => ({
+  okrs: Array.from({ length: 13 }, (_, i) => ({
     ...mv(`okr.kr_${i}`, `Key result ${i}`),
     objective: 'Smooth Throughput',
     keyResult: `Key result ${i}`,
@@ -86,7 +86,7 @@ const renderOverview = (props: Partial<Parameters<typeof CockpitOverview>[0]> = 
   );
 
 describe('CockpitOverview', () => {
-  it('renders the full grammar: command bar, ticker, 8 census chips, 12 domain panels, 9 OKR cards, legend', () => {
+  it('renders the full grammar: command bar, ticker, 8 census chips, 12 domain panels, 13 OKR cards, legend', () => {
     renderOverview();
 
     expect(screen.getByText('Summit Regional Medical Center')).toBeInTheDocument();
@@ -97,7 +97,7 @@ describe('CockpitOverview', () => {
     expect(screen.getByText('Hospital@Home')).toBeInTheDocument();
     expect(screen.getByText('Radiology')).toBeInTheDocument();
     expect(screen.getByTestId('cockpit-gauge-ed.nedocs')).toBeInTheDocument();
-    expect(screen.getAllByTestId(/^okr-card-/)).toHaveLength(9);
+    expect(screen.getAllByTestId(/^okr-card-/)).toHaveLength(13);
     expect(screen.getByText('seeded demonstration data')).toBeInTheDocument();
   });
 

--- a/tests/js/cockpit/CockpitOverview.test.tsx
+++ b/tests/js/cockpit/CockpitOverview.test.tsx
@@ -30,7 +30,10 @@ const censusKeys = [
   'rtdc.boarders', 'rtdc.icu_occupancy', 'rtdc.blocked_beds', 'rtdc.occupancy',
 ];
 
-const domainKeys = ['rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial'];
+const domainKeys = [
+  'rtdc', 'ed', 'periop', 'staffing', 'flow', 'quality', 'service', 'financial',
+  'radiology', 'lab', 'pharmacy', 'home',
+];
 
 const sections: CockpitSnapshotSections = {
   asOf: '2026-07-04T12:00:00+00:00',
@@ -83,14 +86,16 @@ const renderOverview = (props: Partial<Parameters<typeof CockpitOverview>[0]> = 
   );
 
 describe('CockpitOverview', () => {
-  it('renders the full grammar: command bar, ticker, 8 census chips, 8 domain panels, 9 OKR cards, legend', () => {
+  it('renders the full grammar: command bar, ticker, 8 census chips, 12 domain panels, 9 OKR cards, legend', () => {
     renderOverview();
 
     expect(screen.getByText('Summit Regional Medical Center')).toBeInTheDocument();
     expect(screen.getByTestId('capacity-status-pill')).toHaveTextContent('Surge Level 2');
     expect(screen.getByText('ED OVERCROWDED — NEDOCS 142')).toBeInTheDocument();
     expect(screen.getByTestId('cockpit-census-strip').children).toHaveLength(8);
-    expect(screen.getByTestId('cockpit-domain-grid').children).toHaveLength(8);
+    expect(screen.getByTestId('cockpit-domain-grid').children).toHaveLength(12);
+    expect(screen.getByText('Hospital@Home')).toBeInTheDocument();
+    expect(screen.getByText('Radiology')).toBeInTheDocument();
     expect(screen.getByTestId('cockpit-gauge-ed.nedocs')).toBeInTheDocument();
     expect(screen.getAllByTestId(/^okr-card-/)).toHaveLength(9);
     expect(screen.getByText('seeded demonstration data')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Two asks, one change: give **every** main cockpit panel a circular indicator, and add four service sectors — **Radiology, Laboratory, Pharmacy, Hospital@Home** — as first-class gauged panels with KPIs and OKRs. The house glance goes from 8 panels to **12**, and the executive OKR scorecard from **9 → 13**.

## What changed

**Every panel gauged (Phase 1)**
- Fixed a latent bug: `MetricValue::fromDefinition` never merged the KPI definition's `metadata` onto the tile, so the NEDOCS ring rendered against `/100` instead of its seeded `scale: 200` (a fixture that hand-wrote `metadata.scale` masked it). Definition metadata now rides on every tile.
- Gauges added for the five bare panels: Staffing (productivity %), Flow (transport request-to-pickup), Quality (sepsis 3-hr bundle), Service Lines (O:E LOS), Financial (worked/UOS) — each with a `GAUGE_BANDS` arc mirroring its StatusEngine edges.

**Radiology / Laboratory / Pharmacy promoted out of Flow (Phase 2)**
- New `RadiologyMetrics` / `LabMetrics` / `PharmacyMetrics` providers emit the **same governed `flow.ancillary_*` keys** (catalog, admin-tuned edges, and sparkline history preserved) — only the domain section moved from `flow`. `FlowMetrics` refocuses on transport / EVS / lounge / bottlenecks.
- `SnapshotBuilder` gains `OPTIONAL_WHEN_EMPTY` so a sector with no feed is **absent**, never an empty panel; `DrillBuilder` gives each sector its own aggregate measure-ledger drill (privacy-preserving — the workspace owns per-item detail).
- Frontend registry → 12 panels; minute-unit gauges render a compact `"75m"` ring center (a formatted duration overflows the 84px ring).

**Hospital@Home (Phase 3)** — promoted the already-built, flag-gated `home` domain into `DOMAIN_ORDER` as panel 12.

**OKR scorecard 9 → 13 (Phase 4)** — Imaging SLA breaches · Lab STAT SLA compliance · Medication stockouts · H@H avoided bed-days, each reusing its sector's live signal with a config demo fallback (same pattern as the existing 9).

## Why the keys didn't change
The `flow.ancillary_*` keys carry a documented governance/privacy contract with heavy freshness test coverage. Renaming them would be cosmetic (invisible to users) while discarding sparkline history and churning tests. Relocating emission preserves both.

## Prod readiness
Prod already runs `CLINICAL_PAYLOADS_ENABLED` / `HOME_HOSPITAL_ENABLED` / `DEMO_MODE` / `ARENA_ENABLED` with 66 ancillary orders / 328 milestones / 8 home episodes live and a 6-hourly rolling demo-refresh — so the four panels populate automatically on deploy. (Dev lacks the clinical-payload store, so the three ancillary sectors are absent on dev; proven instead by PHPUnit, which enables the store in-test, and the 12-panel Vitest fixture.)

## Test plan
- [x] `tsc` · `vite build` · `check-ui-canon.sh` (raw-palette ≤76) · cockpit Vitest 86/86 · Pint
- [x] PHPUnit: Radiology, Sections, DrillApi (incl. absent-sector→404), FlowLive, DashboardPage, AncillaryReference — green
- [x] PHPUnit: Laboratory + Pharmacy cockpit metrics — green (slow: demo-scenario setUp)
- [ ] Prod post-deploy: 12 panels each gauged, 13 OKRs, 4 new sector drills 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
