### PR TITLE
feat: 4D navigator non-pointer action list (HFE audit F-8)

### DIFF
--- a/resources/js/Components/PatientFlowNavigator/NavigatorActionList.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorActionList.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import type { NavigatorBarrier, OccupancyInsight } from '@/features/patientFlowNavigator/types';
+
+interface NavigatorActionListProps {
+  /** Non-ok occupancy insights (delayed/watch) — the coral/amber disks. */
+  delayed: OccupancyInsight[];
+  /** Open operational barriers (aggregate, patient-free). */
+  barriers: NavigatorBarrier[];
+  onSelectLocation: (location: string) => void;
+  onSelectBarrier: (barrierId: number) => void;
+}
+
+const STATUS_WORD: Record<string, string> = {
+  delayed: 'Delayed',
+  watch: 'Watch',
+  ok: 'On track',
+};
+
+/**
+ * Non-pointer parity for the scene's aggregate signals (HFE audit F-8): the
+ * canvas raycast can select delayed disks and barrier diamonds, but a keyboard
+ * or AT user had no equivalent path — H1.2 closed patient selection only.
+ * These are REAL buttons routed through the same `selectEntity` API the pointer
+ * uses. Labels are location/barrier-level (never patient identity), so the list
+ * is safe on a shared wall under any lens.
+ */
+export default function NavigatorActionList({
+  delayed,
+  barriers,
+  onSelectLocation,
+  onSelectBarrier,
+}: NavigatorActionListProps) {
+  if (delayed.length === 0 && barriers.length === 0) return null;
+
+  return (
+    <nav className="patient-flow-action-list" aria-label="Delayed locations and barriers">
+      {delayed.length > 0 && (
+        <section aria-label="Delayed and watched locations">
+          <h3 className="patient-flow-action-list-heading">Delayed &amp; watch ({delayed.length})</h3>
+          <ul>
+            {delayed.map((insight) => (
+              <li key={`loc-${insight.location}`}>
+                <button
+                  type="button"
+                  className={`patient-flow-action-row status-${insight.primaryStatus}`}
+                  onClick={() => onSelectLocation(insight.location)}
+                >
+                  <span className="patient-flow-action-row-label">
+                    {insight.locationName ?? insight.location}
+                  </span>
+                  <span className="patient-flow-action-row-meta">
+                    {STATUS_WORD[insight.primaryStatus] ?? insight.primaryStatus}
+                    {insight.serviceLine ? ` · ${insight.serviceLine}` : ''}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {barriers.length > 0 && (
+        <section aria-label="Open barriers">
+          <h3 className="patient-flow-action-list-heading">Barriers ({barriers.length})</h3>
+          <ul>
+            {barriers.map((barrier) => (
+              <li key={`bar-${barrier.barrier_id}`}>
+                <button
+                  type="button"
+                  className={`patient-flow-action-row category-${barrier.category}`}
+                  onClick={() => onSelectBarrier(barrier.barrier_id)}
+                >
+                  <span className="patient-flow-action-row-label">
+                    {barrier.unit_label ?? `Unit ${barrier.unit_id ?? '—'}`}
+                  </span>
+                  <span className="patient-flow-action-row-meta">
+                    {barrier.category}
+                    {barrier.reason_code ? ` · ${barrier.reason_code}` : ''}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </nav>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -1132,6 +1132,82 @@
   outline-offset: -2px;
 }
 
+/* --- Action list (F-8): non-pointer selection of delayed locations + barriers,
+   below the feed. Same scoped overlay treatment as the other panels. --------- */
+
+.patient-flow-action-list {
+  position: absolute;
+  z-index: 3;
+  top: 214px;
+  right: 16px;
+  width: min(390px, calc(100vw - 32px));
+  max-height: 32%;
+  overflow: auto;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  background: rgba(27, 31, 29, 0.92);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.3);
+  padding: 10px 12px;
+}
+
+.patient-flow-action-list section + section {
+  margin-top: 10px;
+}
+
+.patient-flow-action-list-heading {
+  margin: 0 0 6px;
+  color: #b9b2a6;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.patient-flow-action-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.patient-flow-action-row {
+  width: 100%;
+  min-height: 24px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: baseline;
+  border: 1px solid rgba(239, 234, 220, 0.14);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #ddd6c7;
+  font-size: 11px;
+  text-align: left;
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.patient-flow-action-row-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.patient-flow-action-row-meta {
+  color: #b9b2a6;
+  white-space: nowrap;
+}
+
+.patient-flow-action-row:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #f3efe5;
+}
+
+.patient-flow-action-row:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: -2px;
+}
+
 /* --- Saved views (N-7) ---------------------------------------------------- */
 
 .patient-flow-views {

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -74,6 +74,7 @@ import {
 } from '@/features/patientFlowNavigator/introTour';
 import type { PageProps } from '@/types';
 import type { CameraView, NavigatorScene } from './NavigatorScene';
+import NavigatorActionList from './NavigatorActionList';
 import NavigatorChronobar from './NavigatorChronobar';
 import NavigatorFeed from './NavigatorFeed';
 import NavigatorFloorRail from './NavigatorFloorRail';
@@ -339,6 +340,9 @@ export default function PatientFlowNavigator({
   // camera emit never re-renders the tree when the place label is unchanged.
   const cameraSpanRef = useRef<HTMLSpanElement | null>(null);
   const [metrics, setMetrics] = useState<NavigatorMetrics>({ active: 0, events: 0, occupiedLocations: 0 });
+  // F-8 non-pointer parity: the delayed/watch locations currently drawn in the
+  // scene, exposed as a keyboard-selectable list (NavigatorActionList).
+  const [actionableInsights, setActionableInsights] = useState<OccupancyInsight[]>([]);
   const [occupancy, setOccupancy] = useState<OccupancySummary>(EMPTY_OCCUPANCY_SUMMARY);
   const [forecast, setForecast] = useState<ForecastAggregates | null>(null);
   const [inspectorTitle, setInspectorTitle] = useState('Select a patient or location');
@@ -537,6 +541,8 @@ export default function PatientFlowNavigator({
       : occupancyInsights;
     lastVisibleStatesRef.current = states;
     lastOccupancyInsightsRef.current = occupancyInsights;
+    // Only the visible disks are selectable in the scene; the list mirrors them.
+    setActionableInsights(visibleOccupancyInsights.filter((insight) => insight.primaryStatus !== 'ok'));
     scene.updateTokens(
       states,
       layersRef.current.tokens && dotsPolicy !== 'none',
@@ -1222,6 +1228,40 @@ export default function PatientFlowNavigator({
     sceneRef.current?.selectEntity({ kind: 'patient', id: patientId });
   }, [dotsPolicy]);
 
+  // F-8: keyboard/AT selection of a delayed location — the same code path a
+  // canvas raycast on the disk takes (shared occupancyInspectorData builder,
+  // shared selectEntity API). Labels are location-level, identity-safe.
+  const selectLocationFromList = useCallback((location: string): void => {
+    const insight = lastOccupancyInsightsRef.current.find((candidate) => candidate.location === location);
+    if (!insight) return;
+    const data = occupancyInspectorData(insight);
+    const redacted = redactSelection(data, dotsPolicy);
+    const element = elementLabelFor(data);
+    const name = String(redacted.location_name ?? redacted.location ?? 'Location');
+    setInspectorTitle(element && element !== name ? `${element} · ${name}` : name);
+    setInspectorRows(flattenInspector(redacted));
+    setInspectorAction(null);
+    sceneRef.current?.selectEntity({ kind: 'occupancy', id: location });
+  }, [dotsPolicy]);
+
+  // F-8: keyboard/AT selection of an open barrier (aggregate, patient-free).
+  const selectBarrierFromList = useCallback((barrierId: number): void => {
+    const barrier = barriersRef.current.find((candidate) => candidate.barrier_id === barrierId);
+    if (!barrier) return;
+    const rows: Array<[string, string]> = [
+      ['Category', barrier.category],
+      ['Unit', barrier.unit_label ?? (barrier.unit_id !== null ? `Unit ${barrier.unit_id}` : '—')],
+      ['Reason', barrier.reason_code ?? '—'],
+      ['Owner', barrier.owner ?? '—'],
+      ['Opened', barrier.opened_at ?? '—'],
+    ];
+    if (barrier.description) rows.push(['Detail', barrier.description]);
+    setInspectorTitle(`Barrier · ${barrier.category}`);
+    setInspectorRows(rows);
+    setInspectorAction(null);
+    sceneRef.current?.selectEntity({ kind: 'barrier', id: String(barrier.barrier_id) });
+  }, []);
+
   // N-7: three persona-keyed camera/floor/layers bookmarks. The updater
   // stays pure — persistence happens outside setState.
   const saveView = useCallback((slot: number): void => {
@@ -1539,6 +1579,13 @@ export default function PatientFlowNavigator({
         feed={feed}
         redactIdentity={dotsPolicy !== null && dotsPolicy !== 'full'}
         onSelectPatient={patientDotsVisible ? selectPatientFromList : undefined}
+      />
+
+      <NavigatorActionList
+        delayed={actionableInsights}
+        barriers={layers.barriers ? barriers : []}
+        onSelectLocation={selectLocationFromList}
+        onSelectBarrier={selectBarrierFromList}
       />
 
       <NavigatorInspector title={inspectorTitle} rows={inspectorRows} action={inspectorAction} />

--- a/tests/js/patientFlow/NavigatorActionList.test.tsx
+++ b/tests/js/patientFlow/NavigatorActionList.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import NavigatorActionList from '@/Components/PatientFlowNavigator/NavigatorActionList';
+import type { NavigatorBarrier, OccupancyInsight } from '@/features/patientFlowNavigator/types';
+
+/**
+ * F-8 non-pointer parity: the canvas raycast can select delayed disks and
+ * barrier diamonds; this list gives keyboard/AT users the same reach through
+ * the same selectEntity path. Labels stay location/barrier-level — never
+ * patient identity — so the list is safe on a shared wall under any lens.
+ */
+
+function insight(location: string, status: OccupancyInsight['primaryStatus']): OccupancyInsight {
+  return {
+    key: `k-${location}`,
+    location,
+    locationName: `${location} · MedSurg`,
+    serviceLine: 'medicine',
+    position: { x: 0, y: 0, z: 0 },
+    stayMinutes: 600,
+    primaryStatus: status,
+    timers: [],
+    blockers: [],
+    // Identity fields deliberately present to prove the list never surfaces them.
+    patientDisplayId: 'PT-SECRET',
+    patientId: 'pat-secret',
+    encounterId: 'enc-secret',
+  } as OccupancyInsight;
+}
+
+const barrier: NavigatorBarrier = {
+  barrier_id: 42,
+  unit_id: 7,
+  unit_label: 'MICU',
+  category: 'placement',
+  reason_code: 'awaiting_bed',
+  description: 'Receiving bed pending',
+  owner: 'Bed Manager',
+  status: 'open',
+  opened_at: '2026-07-19T10:00:00Z',
+  encounter_ref: null,
+};
+
+describe('NavigatorActionList', () => {
+  it('renders nothing when there is nothing to act on', () => {
+    const { container } = render(
+      <NavigatorActionList delayed={[]} barriers={[]} onSelectLocation={vi.fn()} onSelectBarrier={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('lists delayed locations as buttons and selects by location code', () => {
+    const onSelectLocation = vi.fn();
+    render(
+      <NavigatorActionList
+        delayed={[insight('MICU3-B012', 'delayed'), insight('5W-014', 'watch')]}
+        barriers={[]}
+        onSelectLocation={onSelectLocation}
+        onSelectBarrier={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Delayed & watch (2)')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /MICU3-B012 · MedSurg/ }));
+    expect(onSelectLocation).toHaveBeenCalledWith('MICU3-B012');
+  });
+
+  it('never surfaces patient identity in a location row', () => {
+    render(
+      <NavigatorActionList
+        delayed={[insight('MICU3-B012', 'delayed')]}
+        barriers={[]}
+        onSelectLocation={vi.fn()}
+        onSelectBarrier={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText(/PT-SECRET|pat-secret|enc-secret/)).toBeNull();
+  });
+
+  it('lists open barriers as buttons and selects by barrier id', () => {
+    const onSelectBarrier = vi.fn();
+    render(
+      <NavigatorActionList
+        delayed={[]}
+        barriers={[barrier]}
+        onSelectLocation={vi.fn()}
+        onSelectBarrier={onSelectBarrier}
+      />,
+    );
+    expect(screen.getByText('Barriers (1)')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /MICU.*placement/ }));
+    expect(onSelectBarrier).toHaveBeenCalledWith(42);
+  });
+
+  it('exposes both sections as labelled regions for AT navigation', () => {
+    render(
+      <NavigatorActionList
+        delayed={[insight('MICU3-B012', 'delayed')]}
+        barriers={[barrier]}
+        onSelectLocation={vi.fn()}
+        onSelectBarrier={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('navigation', { name: 'Delayed locations and barriers' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Delayed and watched locations' })).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: 'Open barriers' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
Closes the F-8 accessibility gap from the independent HFE audit (docs/audits/2026-07-19-flow4d-codex-hfe-audit.md): the canvas raycast can select delayed disks and barrier diamonds, but keyboard/AT users had no equivalent — H1.2 delivered patient selection only.

`NavigatorActionList` renders the **visible delayed/watch locations** and **open barriers** as real `<button>`s in labelled `<nav>`/`<section>` regions, each routed through the **same `selectEntity` API and `occupancyInspectorData` builder** the pointer path already uses. Labels are location/barrier-level (never patient identity), so the list is safe on a shared wall under any lens. The delayed slice is set in `refreshScene` alongside the existing occupancy ref (bucket-gated, consistent with the neighbouring `setMetrics`/`setOccupancy`); barriers were already reactive and are gated on the Barriers layer being on.

Purely additive — no existing behavior changes. Round-stops already have non-pointer paths (board "Locate in 4D" + HUD Prev/Next), so they're intentionally out of scope here.

## Test plan
- [x] 616/616 vitest (+5 NavigatorActionList: empty→null, location select by code, identity never surfaced, barrier select by id, labelled AT regions)
- [x] tsc --noEmit, vite build, check-ui-canon.sh all clean (isolated worktree)
- [ ] CI 15/15
- [ ] Deploy + live verification

Note: scoped overlay CSS deliberately mirrors the existing feed/search-results panels (sanctioned dark-only wall treatment, F-9 ruling) — the design hook flags those raw values but the scripted canon floor passes.