### PR TITLE
fix: 4D navigator drops stale rounds rings when no run is open (HFE audit F-6, part 1)

### DIFF
--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -36,7 +36,7 @@ import { buildOccupancyInsights } from '@/features/patientFlowNavigator/occupanc
 import { useEddyStore } from '@/stores/eddyStore';
 import { fetchRoundRuns, fetchRoundScene } from '@/features/virtualRounds/api';
 import { runsResponseSchema, sceneResponseSchema } from '@/features/virtualRounds/schemas';
-import { buildRoundRoute, buildRoundStopCells } from '@/features/virtualRounds/roundsScene';
+import { buildRoundRoute, buildRoundStopCells, findOpenRun } from '@/features/virtualRounds/roundsScene';
 import type { RoundStop } from '@/features/virtualRounds/roundsScene';
 import type { RunSummary } from '@/features/virtualRounds/types';
 import type {
@@ -943,13 +943,18 @@ export default function PatientFlowNavigator({
         if (!runsPayload.success || cancelled) return;
         roundsFailCountRef.current = 0;
 
-        const openRun = runsPayload.data.data.find((run) =>
-          ['active', 'paused', 'closing', 'draft', 'scheduled'].includes(run.status),
-        );
+        const openRun = findOpenRun(runsPayload.data.data);
         if (!openRun) {
           if (roundsRunUuidRef.current !== null) {
+            // Run just went terminal (completed/cancelled) or was retired by the
+            // demo refresh: announce once AND drop the rings, so a finished run's
+            // itinerary can't linger in the scene as if it were live work
+            // (HFE audit F-6). Mirrors the persistent-failure clear below.
             roundsRunUuidRef.current = null;
+            roundsSceneHashRef.current = '';
+            roundsVersionRef.current += 1;
             setRoundsRun((prev) => (prev ? { ...prev, status: 'completed' } : prev));
+            setRoundStops([]);
             setToastMessage('Rounds run complete');
           }
           return;

--- a/resources/js/features/virtualRounds/roundsScene.ts
+++ b/resources/js/features/virtualRounds/roundsScene.ts
@@ -10,6 +10,19 @@ import { roundStopSchema } from './schemas';
 
 export type RoundStop = z.infer<typeof roundStopSchema>;
 
+/**
+ * Run statuses that keep a rounds overlay LIVE. Anything else — `completed`,
+ * `cancelled`, or the run vanishing entirely (retired by the 6h demo refresh,
+ * HFE audit F-6) — means the scene must drop the stale rings, not keep
+ * rendering a finished run's itinerary as if it were active work.
+ */
+export const OPEN_RUN_STATUSES = ['draft', 'scheduled', 'active', 'paused', 'closing'] as const;
+
+/** The most recent live run, or null when none is open. */
+export function findOpenRun<T extends { status: string }>(runs: readonly T[]): T | null {
+  return runs.find((run) => (OPEN_RUN_STATUSES as readonly string[]).includes(run.status)) ?? null;
+}
+
 export interface RoundStopCell {
   anchor: ProjectionAnchor;
   stop: RoundStop;

--- a/tests/js/virtualRounds/roundsScene.test.ts
+++ b/tests/js/virtualRounds/roundsScene.test.ts
@@ -3,6 +3,8 @@ import type { ProjectionPlacementIndex } from '@/features/patientFlowNavigator/p
 import {
   buildRoundRoute,
   buildRoundStopCells,
+  findOpenRun,
+  OPEN_RUN_STATUSES,
   ROUND_STOP_COLORS,
   type RoundStop,
 } from '@/features/virtualRounds/roundsScene';
@@ -173,3 +175,24 @@ describe('buildRoundRoute (R-4)', () => {
     expect(route.map((segment) => segment.dashed)).toEqual([false, true]);
   });
 });
+
+describe('findOpenRun (HFE audit F-6 — stale-ring guard)', () => {
+  it('returns the live run for every open status', () => {
+    for (const status of OPEN_RUN_STATUSES) {
+      expect(findOpenRun([{ run_uuid: 'r1', status }])).toEqual({ run_uuid: 'r1', status });
+    }
+  });
+
+  it('returns null when only terminal runs exist (completed / cancelled)', () => {
+    expect(findOpenRun([{ status: 'completed' }, { status: 'cancelled' }])).toBeNull();
+  });
+
+  it('returns null for an empty list (run retired by the demo refresh)', () => {
+    expect(findOpenRun([])).toBeNull();
+  });
+
+  it('prefers the first open run when both open and terminal runs are present', () => {
+    const runs = [{ run_uuid: 'done', status: 'completed' }, { run_uuid: 'live', status: 'active' }];
+    expect(findOpenRun(runs)?.run_uuid).toBe('live');
+  });
+})


### PR DESCRIPTION
## Summary
Part 1 of the F-6 disposition from the independent HFE audit (docs/audits/2026-07-19-flow4d-codex-hfe-audit.md).

The rounds overlay marked a run `completed` when no open run was observed but **never cleared `roundStops`** — so a finished or demo-refresh-retired run's rings lingered in the scene indefinitely, as if they were live work. The no-open-run transition now also clears the rings + bumps the scene version, **mirroring the already-shipped persistent-failure clear path** (the 5-consecutive-failure branch already does exactly this). Extracted `OPEN_RUN_STATUSES` + `findOpenRun()` to `roundsScene.ts` (pure, unit-tested) from the inline status list.

## Scope / what's deferred
This is the self-contained, verifiable half of F-6. The **full mixed-epoch fix** — a server refresh-version identifier + atomic client rebootstrap of *all* datasets (summary/locations/events/ambient/occupancy/projections/rounds) when the 6h demo refresh rolls the epoch — is **deferred**: it needs field verification across a real refresh boundary, which can't be done in isolation, and there is no existing refresh-version signal to build on yet.

**Field-verification note:** the ring-clearing behavior itself should be eyeballed against a real run completion / demo-refresh on the prod wall as part of rollout — it's low-risk (mirrors shipped behavior) but changes what the wall shows at the moment a run ends.

## Test plan
- [x] 620/620 vitest (+4 findOpenRun: every open status live, terminal→null, empty→null, first-open-wins)
- [x] tsc --noEmit, vite build, check-ui-canon.sh clean (isolated worktree)
- [ ] CI 15/15
- [ ] Deploy + field verification of a run-completion transition