### PR TITLE
fix(demo): reset transport SLA deadlines on rolling refresh

### DIFF
--- a/database/seeders/DemoTuningSeeder.php
+++ b/database/seeders/DemoTuningSeeder.php
@@ -202,16 +202,40 @@ class DemoTuningSeeder extends Seeder
         }
     }
 
-    /** 4. Refresh active EVS SLAs to a near-now spread (UTC-aligned wall clock). */
+    /** 4. Refresh active EVS + transport SLAs to a near-now spread (UTC-aligned wall clock). */
     private function refreshSlas(): void
     {
-        // OperationalDemoDataService exclusively owns its transport scenario,
-        // including the deterministic four-of-twenty overdue cohort. Rewriting
-        // those deadlines here made strict demo validation nondeterministic.
         DB::update("
             UPDATE prod.evs_requests
             SET needed_at = (now() AT TIME ZONE 'UTC') + ((floor(random()*110) - 30)||' minutes')::interval
             WHERE status NOT IN ('completed', 'canceled', 'failed')
+        ");
+
+        // Transport deadlines otherwise drift to 100%-overdue: the rolling
+        // refresh re-seeds via CommandCenterDemoSeeder — never
+        // OperationalDemoDataService::rollForward — so nothing resets these
+        // against the moving anchor and every active request eventually breaches
+        // SLA. Reset DETERMINISTICALLY (no random()) so strict demo validation
+        // stays reproducible: every fifth active request, ordered by id, is left
+        // overdue → ~20% breaching, matching the seed-time cohort and the
+        // plausibility_targets.transport_overdue_share_max ceiling. The request
+        // table carries no append-only trigger (only transport_events/commands/
+        // handoff_evidence do), so this UPDATE is sanctioned.
+        DB::update("
+            WITH ranked AS (
+                SELECT transport_request_id,
+                       row_number() OVER (ORDER BY transport_request_id) AS rn
+                FROM prod.transport_requests
+                WHERE completed_at IS NULL
+            )
+            UPDATE prod.transport_requests tr
+            SET needed_at = CASE
+                    WHEN ranked.rn % 5 = 0
+                        THEN (now() AT TIME ZONE 'UTC') - ((5 + (ranked.rn % 3) * 5)||' minutes')::interval
+                        ELSE (now() AT TIME ZONE 'UTC') + ((15 + (ranked.rn % 4) * 10)||' minutes')::interval
+                END
+            FROM ranked
+            WHERE tr.transport_request_id = ranked.transport_request_id
         ");
     }
 

--- a/tests/Feature/Demo/TransportSlaRefreshTest.php
+++ b/tests/Feature/Demo/TransportSlaRefreshTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature\Demo;
+
+use App\Services\Demo\DemoClock;
+use App\Services\Demo\DemoInvariantService;
+use Carbon\CarbonImmutable;
+use Database\Seeders\DemoTuningSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * Rolling demo-refresh transport SLA drift (2026-07-20). The refresh re-seeds
+ * via CommandCenterDemoSeeder, never OperationalDemoDataService::rollForward,
+ * so transport `needed_at` values were frozen at their seed time and every
+ * active request eventually drifted past SLA — prod showed 100% overdue. The
+ * DemoTuningSeeder SLA refresh now resets them deterministically to a ~20%
+ * overdue cohort, matching plausibility_targets.transport_overdue_share_max.
+ */
+class TransportSlaRefreshTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedActiveTransport(int $count, CarbonImmutable $anchor): void
+    {
+        // Routine-dominant mix (7 routine / 2 urgent / 1 stat per 10) so the
+        // priority-mix invariant is not the thing under test; every row is
+        // ACTIVE (completed_at null) and starts OVERDUE (needed_at in the past),
+        // reproducing the drift.
+        $priorities = ['routine', 'routine', 'urgent', 'routine', 'stat', 'routine', 'urgent', 'routine', 'routine', 'routine'];
+
+        for ($i = 0; $i < $count; $i++) {
+            DB::table('prod.transport_requests')->insert([
+                'request_uuid' => (string) Str::uuid(),
+                'request_type' => 'inpatient',
+                'priority' => $priorities[$i % count($priorities)],
+                'status' => 'requested',
+                'patient_ref' => 'sla-drift-'.$i,
+                'origin' => 'Unit A',
+                'destination' => 'CT Scanner 2',
+                'transport_mode' => 'stretcher',
+                'clinical_service' => 'Medicine',
+                'requested_by' => 'demo-seeder',
+                'requested_at' => $anchor->subHours(2),
+                'needed_at' => $anchor->subMinutes(30 + $i), // all overdue
+                'completed_at' => null,
+                'is_deleted' => false,
+                'created_at' => $anchor->subHours(2),
+                'updated_at' => $anchor->subHours(2),
+            ]);
+        }
+    }
+
+    private function overdueFinding(CarbonImmutable $anchor): array
+    {
+        return collect(app(DemoInvariantService::class)->run(new DemoClock($anchor)))
+            ->firstWhere('key', 'plausibility.transport_overdue_share');
+    }
+
+    public function test_tuning_refresh_recovers_a_fully_overdue_transport_queue(): void
+    {
+        $anchor = CarbonImmutable::now();
+        $this->seedActiveTransport(20, $anchor);
+
+        // Drifted state: the whole active queue has breached SLA.
+        $before = $this->overdueFinding($anchor);
+        $this->assertNotNull($before);
+        $this->assertFalse($before['passed'], 'a fully overdue queue must fail the invariant');
+        $this->assertStringContainsString('100%', $before['observed']);
+
+        // The rolling refresh's SLA reset runs here.
+        $this->seed(DemoTuningSeeder::class);
+
+        $after = $this->overdueFinding(CarbonImmutable::now());
+        $this->assertTrue($after['passed'], "overdue share must fall back within SLA — got {$after['observed']}");
+        // Deterministic every-fifth cohort → 4 of 20.
+        $this->assertStringContainsString('4/20 active overdue', $after['observed']);
+    }
+}


### PR DESCRIPTION
## Problem

Prod's scheduled `zephyrus:demo-refresh --validate` reported `plausibility.transport_overdue_share` at **100% overdue** (e.g. `22/22 active overdue`). This is a `warning`-severity invariant, so it did **not** block the gate (`criticalFailed=0`, cockpit kept publishing) — but it made the transport queue read as an implausible all-breached backlog on the investor demo.

## Root cause

The rolling refresh coordinator's `operational` step re-seeds via `CommandCenterDemoSeeder`, **never** `OperationalDemoDataService::rollForward`. `DemoTuningSeeder::refreshSlas()` reset EVS and staffing `needed_at` near the moving anchor every cycle, but transport was dropped (a past `random()` nondeterminism concern) and never re-homed. So transport `needed_at` stayed **frozen at seed time**; as the anchor rolls forward for hours, every active request drifts past SLA → ~100% overdue. Reproduced on dev: `20/20 active overdue (100%)`.

## Fix

`refreshSlas()` now also resets active transport `needed_at` **deterministically** — every fifth active request (ordered by id) is left overdue → ~20% breaching, matching both the seed-time `[4,9,14,19]` cohort and `config('hospital.plausibility_targets.transport_overdue_share_max')` (0.20). Deterministic (no `random()`) so strict demo validation stays reproducible. `prod.transport_requests` carries **no** append-only trigger (only `transport_events`/`transport_commands`/`transport_handoff_evidence` do), so the `UPDATE` is sanctioned.

## Verification

- Dev before: `transport_overdue_share` = `20/20 (100%)` FAIL.
- Dev after `DemoTuningSeeder`: `4/20 (20%)` PASS; `transport_priority_mix` (60/30/10) PASS.
- New regression test `TransportSlaRefreshTest` seeds a fully-overdue queue, asserts the invariant fails, runs the tuning refresh, asserts recovery to `4/20 (20%)`. Passing (5 assertions, ~3s). Pint clean.

## Scope

Cosmetic/data-realism only — non-gating warning, pre-existing, no schema/migration change, no user-facing app code. Surfaced during the cockpit sector-expansion (#46) prod verification.