### PR TITLE
fix(demo): give urgent transport band headroom above its design target

### DIFF
--- a/config/hospital.php
+++ b/config/hospital.php
@@ -61,9 +61,14 @@ return [
         // Discharge-before-noon is a metric hospitals fight to hit; >45% is fantasy. (min, max).
         'discharge_before_noon' => [0.18, 0.42],
         // Transport priority mix — routine dominates, stat is a thin slice.
+        // Each ceiling sits a realistic margin ABOVE its seeded design target so
+        // the demo's own intended mix never flags itself: routine target ~60%
+        // (ceiling 85), stat target ~10% (ceiling 15), urgent target ~30%
+        // (ceiling 35 — the seeded 3-per-10 urgent pattern lands at ~30%, so a
+        // 0.30 ceiling left zero headroom and history accumulation tipped it over).
         'transport_priority_share' => [
             'routine' => [0.55, 0.85],
-            'urgent' => [0.10, 0.30],
+            'urgent' => [0.10, 0.35],
             'stat' => [0.02, 0.15],
         ],
         // Share of the ACTIVE transport queue allowed to be past its needed_by (SLA breach).

--- a/tests/Unit/Demo/DistributionProfileTest.php
+++ b/tests/Unit/Demo/DistributionProfileTest.php
@@ -48,6 +48,9 @@ class DistributionProfileTest extends TestCase
         $this->assertCount(2, $p->dischargeBeforeNoonBand());
         $this->assertArrayHasKey('routine', $p->transportPriorityBands());
         $this->assertLessThan(0.5, $p->transportOverdueShareMax());
+        // The urgent ceiling must clear the seeded ~30% design target (3-per-10
+        // urgent pattern) with headroom — a 0.30 knife-edge self-flagged.
+        $this->assertGreaterThan(0.30, $p->transportPriorityBands()['urgent'][1]);
     }
 
     public function test_throws_a_clear_error_for_an_unregistered_facility(): void


### PR DESCRIPTION
## Problem

After #49 fixed the transport overdue drift, one `warning` invariant remained on the prod demo-refresh: `plausibility.transport_priority_mix`. Exact prod distribution (202 rows):

| priority | share | band | verdict |
|---|---|---|---|
| routine | 59.90% | [55, 85] | ✅ |
| **urgent** | **30.20%** | **[10, 30]** | ❌ (0.20pp over) |
| stat | 9.90% | [2, 15] | ✅ |

## Root cause — a threshold/design mismatch, not bad data

The seeded design deliberately targets **~30% urgent** (`OperationalDemoDataService`'s 3-per-10 pattern). But the urgent band `[0.10, 0.30]` gave that target **zero headroom**, while the other two bands clear their design targets comfortably:

- routine: target ~60%, ceiling 85 → +25pp headroom
- stat: target ~10%, ceiling 15 → +5pp headroom
- **urgent: target ~30%, ceiling 30 → 0pp headroom** ← knife-edge

So urgent sat exactly on its ceiling and normal transport-history accumulation tipped it fractionally over — the demo flagged its **own intended mix**.

## Fix

Raise the urgent ceiling to **0.35**, restoring the symmetric target+headroom pattern (35% urgent transport is plausible; STAT stays the capped thin slice at 15%). One-line config change in `config/hospital.php`, plus a `DistributionProfileTest` assertion locking the ceiling above 0.30 so it can't be re-tightened to the self-flagging edge.

## Verification

- Arithmetic: urgent 30.20% now clears the 0.35 ceiling.
- `DistributionProfileTest` green (4 passed, 18 assertions). Pint clean.
- After merge + deploy this clears the **last** transport plausibility warning; the prod demo-refresh gate was already green (`criticalFailed=0`, published).

Follow-up to #49 (transport SLA drift). No schema/migration change, no app code.