### PR TITLE
Harden local-to-production release workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 # Remote PostgreSQL database connection
+# Non-production processes that target pgsql.acumenus.net (or the production
+# user/schema identity) are forced into PostgreSQL transaction read-only mode.
+# Production migrations are available only through the guarded deploy workflow.
 DB_CONNECTION=pgsql
 DB_HOST=demo.zephyrus.care
 DB_PORT=5432

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,9 @@ jobs:
           bash scripts/check-no-tracking-technologies.sh
 
       - name: Verify immutable release snapshots
-        run: bash tests/Deployment/immutable-release-snapshot.sh
+        run: |
+          bash tests/Deployment/immutable-release-snapshot.sh
+          bash tests/Deployment/github-ci-gate.sh
 
       - name: Copy environment template
         run: cp .env.example .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,17 @@ The backend serves as a thin layer that passes data to React via Inertia.js — 
 
 Production deployment is manual-only. GitHub Actions is for CI and must not deploy to production.
 
-Manual deployment: `./deploy.sh` (builds, rsyncs to `/var/www/Zephyrus/`, clears Laravel caches, restarts Apache, and verifies the Zephyrus vhost).
+Manual deployment from a clean, synchronized local `main` checkout:
+`./deploy.sh --check` followed by `./deploy.sh`. The canonical script verifies
+exact-commit CI, connects to `smudoshi@zephyrus.acumenus.net`, fast-forwards the
+canonical production checkout, builds an immutable release, rsyncs it to
+`/var/www/Zephyrus/`, clears Laravel caches, restarts services, and verifies the
+Zephyrus vhost.
+
+Production migrations are separate and path-scoped:
+`./deploy.sh --migrate --path database/migrations/<file.php>`. The command
+previews only the named paths and creates and verifies a full logical backup
+before migration. Never use blanket `migrate --force` in the deploy path.
 
 Do not use automated GitHub Actions deploy jobs, ad hoc SSH command blocks, direct production `git pull`, or alternate deploy scripts as application deployment mechanisms.
 

--- a/DEPLOYMENT_CHECKLIST.md
+++ b/DEPLOYMENT_CHECKLIST.md
@@ -3,29 +3,51 @@
 Zephyrus has one supported application deployment mechanism:
 
 ```bash
-cd /home/smudoshi/Github/Zephyrus
+cd /Users/sudoshi/Github/Zephyrus
+./deploy.sh --check
 ./deploy.sh
 ```
 
 ## Pre-Deploy
 
-- [ ] Confirm the release commit is already pushed to `origin/main`.
-- [ ] Confirm the local worktree is clean with `git status --short`.
+- [ ] Confirm the release was merged through a protected pull request.
+- [ ] Synchronize local `main` with `git pull --ff-only`.
+- [ ] Confirm `git rev-list --left-right --count HEAD...origin/main` is `0 0`.
+- [ ] Confirm the local worktree is clean with `git status --short --branch`.
+- [ ] Run `php artisan zephyrus:database-safety`; local production access must
+      report read-only and safe.
 - [ ] Run any release-specific tests or migrations checks needed for the change.
-- [ ] Confirm schema-bearing releases have a migration plan; `./deploy.sh` syncs
-      code and assets but does not replace explicit migration review.
+- [ ] Run `./deploy.sh --check`.
 
 ## Deploy
 
-- [ ] Run `./deploy.sh` from `/home/smudoshi/Github/Zephyrus`.
+- [ ] Run `./deploy.sh` from the clean local `main` checkout.
+- [ ] Type the requested exact-commit deployment confirmation.
 - [ ] Confirm the script completes its asset build, rsync, cache-clear, Apache
       restart, and vhost smoke check.
+
+## Schema-Bearing Release
+
+- [ ] Deploy the application commit first.
+- [ ] Review exact migration paths, production-volume behavior, and forward-fix
+      or restore strategy.
+- [ ] Run `./deploy.sh --migrate --path database/migrations/<file.php>`.
+- [ ] Confirm the script previews only those paths.
+- [ ] Retain the verified `/var/backups/zephyrus/pre-migrate-*.dir` path and
+      adjacent migration ledger.
+- [ ] Confirm final migration status.
 
 ## Post-Deploy
 
 - [ ] Verify `https://zephyrus.acumenus.net` or the affected route returns a
       successful response.
+- [ ] Confirm local `git rev-parse HEAD` matches the production
+      `/var/www/Zephyrus/.release-commit`.
 - [ ] Check Laravel and Apache logs if the deploy script reports any failure.
 
 Do not use GitHub Actions, ad hoc SSH command blocks, direct production
 `git pull`, or alternate deploy scripts as application deployment mechanisms.
+
+See
+[Development and Production Release Runbook](docs/operations/DEVELOPMENT-AND-PRODUCTION-RELEASE-RUNBOOK.md)
+for the complete workflow and recovery procedure.

--- a/DEPLOY_NOW.md
+++ b/DEPLOY_NOW.md
@@ -2,10 +2,12 @@
 
 Zephyrus production deployment is intentionally manual.
 
-Run the canonical deploy script from the development checkout:
+Run the canonical deploy script from the clean, synchronized `main` branch on
+the development Mac:
 
 ```bash
-cd /home/smudoshi/Github/Zephyrus
+cd /Users/sudoshi/Github/Zephyrus
+./deploy.sh --check
 ./deploy.sh
 ```
 
@@ -13,6 +15,16 @@ Do not deploy by GitHub Actions, ad hoc SSH command blocks, direct production
 `git pull`, or alternate deploy scripts. The manual script is the only supported
 application release path.
 
-`./deploy.sh` verifies the local tree, builds production assets, syncs the
-application to `/var/www/Zephyrus`, clears Laravel caches, restarts Apache, and
-checks the Zephyrus vhost.
+`./deploy.sh` verifies the local tree and exact-commit GitHub CI, connects to
+`smudoshi@zephyrus.acumenus.net`, fast-forwards the canonical checkout, builds
+an immutable release, syncs it to `/var/www/Zephyrus`, clears Laravel caches,
+restarts services, and checks the Zephyrus vhost.
+
+Migrations are a separate, backed-up, path-scoped operation:
+
+```bash
+./deploy.sh --migrate \
+  --path database/migrations/YYYY_MM_DD_HHMMSS_example.php
+```
+
+See [DEPLOYMENT_CHECKLIST.md](DEPLOYMENT_CHECKLIST.md).

--- a/README.md
+++ b/README.md
@@ -244,14 +244,18 @@ Production is **manual-only**. GitHub Actions runs **CI only** (Pint, PHPUnit, T
 build) and must never deploy.
 
 ```bash
-./deploy.sh              # build + rsync to /var/www/Zephyrus, clear caches, restart Apache, verify vhost
-./deploy.sh --frontend   # frontend rebuild only
-./deploy.sh --db         # run pending migrations (explicit; the default deploy does NOT migrate)
+./deploy.sh --check      # read-only local/GitHub/SSH/production preflight
+./deploy.sh              # sync exact CI-successful main, build, deploy, and verify
+./deploy.sh --frontend   # compatibility label; full app deploy, no migrations
+./deploy.sh --migrate \
+  --path database/migrations/YYYY_MM_DD_HHMMSS_example.php
+                         # backed-up, path-scoped migration after app deployment
 ```
 
 Production runs behind **Apache + php8.5-fpm** at `https://zephyrus.acumenus.net`, with Reverb as a
 systemd WebSocket service. Do **not** deploy via GitHub Actions, ad-hoc SSH, or direct production
-`git pull`. See [DEPLOYMENT_CHECKLIST.md](DEPLOYMENT_CHECKLIST.md).
+`git pull`. See [DEPLOYMENT_CHECKLIST.md](DEPLOYMENT_CHECKLIST.md) and the
+[development/release runbook](docs/operations/DEVELOPMENT-AND-PRODUCTION-RELEASE-RUNBOOK.md).
 
 ---
 

--- a/app/Console/Commands/DatabaseSafetyCommand.php
+++ b/app/Console/Commands/DatabaseSafetyCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Database\ProductionDatabaseReadOnlyGuard;
+use Illuminate\Console\Command;
+use Illuminate\Database\DatabaseManager;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DatabaseSafetyCommand extends Command
+{
+    protected $signature = 'zephyrus:database-safety {--json : Emit a machine-readable safety report}';
+
+    protected $description = 'Verify that non-production access to the production PostgreSQL database is read-only.';
+
+    public function handle(DatabaseManager $databases, ProductionDatabaseReadOnlyGuard $guard): int
+    {
+        $connection = $databases->connection();
+        $driver = $connection->getDriverName();
+        $environment = app()->environment();
+        $protectionRequired = $guard->shouldProtect($connection->getConfig(), $environment);
+
+        $defaultReadOnly = null;
+        $transactionReadOnly = null;
+
+        if ($driver === 'pgsql') {
+            $defaultReadOnly = $connection->scalar("SELECT current_setting('default_transaction_read_only')");
+            $transactionReadOnly = $connection->scalar("SELECT current_setting('transaction_read_only')");
+        }
+
+        $safe = ! $protectionRequired
+            || ($defaultReadOnly === 'on' && $transactionReadOnly === 'on');
+
+        $report = [
+            'environment' => $environment,
+            'driver' => $driver,
+            'productionProtectionRequired' => $protectionRequired,
+            'defaultTransactionReadOnly' => $defaultReadOnly,
+            'transactionReadOnly' => $transactionReadOnly,
+            'safe' => $safe,
+        ];
+
+        if ($this->option('json')) {
+            $this->output->getOutput()->writeln(
+                (string) json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+                OutputInterface::OUTPUT_RAW,
+            );
+        } else {
+            $this->table(
+                ['Environment', 'Driver', 'Production guard', 'Session default', 'Transaction', 'Safe'],
+                [[
+                    $environment,
+                    $driver,
+                    $protectionRequired ? 'required' : 'not required',
+                    $defaultReadOnly ?? 'n/a',
+                    $transactionReadOnly ?? 'n/a',
+                    $safe ? 'yes' : 'no',
+                ]],
+            );
+        }
+
+        if (! $safe) {
+            $this->error('The production database connection is not read-only.');
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Database/ProductionDatabaseReadOnlyGuard.php
+++ b/app/Database/ProductionDatabaseReadOnlyGuard.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Database;
+
+use Illuminate\Database\Connection;
+use RuntimeException;
+
+final class ProductionDatabaseReadOnlyGuard
+{
+    private const PRODUCTION_HOST = 'pgsql.acumenus.net';
+
+    private const PRODUCTION_USERNAME = 'smudoshi';
+
+    public function protect(Connection $connection, string $environment): void
+    {
+        if (! $this->shouldProtect($connection->getConfig(), $environment)) {
+            return;
+        }
+
+        $pdo = $connection->getPdo();
+        $pdo->exec('SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY');
+
+        $readOnly = $pdo->query("SELECT current_setting('default_transaction_read_only')")
+            ?->fetchColumn();
+
+        if ($readOnly !== 'on') {
+            throw new RuntimeException('production_database_read_only_guard_failed');
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $configuration
+     */
+    public function shouldProtect(array $configuration, string $environment): bool
+    {
+        if ($environment === 'production' || ($configuration['driver'] ?? null) !== 'pgsql') {
+            return false;
+        }
+
+        $host = strtolower(trim((string) ($configuration['host'] ?? '')));
+        $username = trim((string) ($configuration['username'] ?? ''));
+        $schemas = $this->schemas($configuration);
+
+        return $host === self::PRODUCTION_HOST
+            || ($username === self::PRODUCTION_USERNAME && in_array('prod', $schemas, true));
+    }
+
+    /**
+     * @param  array<string, mixed>  $configuration
+     * @return list<string>
+     */
+    private function schemas(array $configuration): array
+    {
+        $configured = $configuration['search_path'] ?? $configuration['schema'] ?? '';
+        $schemas = is_array($configured) ? $configured : explode(',', (string) $configured);
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $schema): string => strtolower(trim((string) $schema, " \t\n\r\0\x0B\"'")),
+            $schemas,
+        )));
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Auth\AuthDriverRegistry;
 use App\Auth\Drivers\AuthentikOidcAuthDriver;
+use App\Database\ProductionDatabaseReadOnlyGuard;
 use App\Security\ClinicalPayloads\ClinicalContentGuard;
 use App\Security\ClinicalPayloads\ClinicalPayloadException;
 use App\Security\ClinicalPayloads\ClinicalPayloadSafeQueueJob;
@@ -24,6 +25,7 @@ use App\Services\Auth\Oidc\OidcProviderConfig;
 use App\Services\Auth\Oidc\OidcReconciliationService;
 use App\Services\Auth\Oidc\OidcTokenValidator;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Database\Events\ConnectionEstablished;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Vite;
 use Illuminate\Support\ServiceProvider;
@@ -35,6 +37,15 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        $this->app->singleton(ProductionDatabaseReadOnlyGuard::class);
+        $this->app->make('events')->listen(
+            ConnectionEstablished::class,
+            function (ConnectionEstablished $event): void {
+                $this->app->make(ProductionDatabaseReadOnlyGuard::class)
+                    ->protect($event->connection, $this->app->environment());
+            },
+        );
+
         $this->app->singleton('log', fn ($app) => new ClinicalSafeLogManager($app));
 
         $this->app->singleton(\App\Services\Authorization\RoleCapabilityService::class);

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,40 +1,413 @@
 #!/bin/bash
-# Deploy script for Zephyrus
+# Canonical local-to-production release script for Zephyrus.
 
 set -Eeuo pipefail
 
 EXPECTED_REPOSITORY_ROOT="/home/smudoshi/Github/Zephyrus"
+PRODUCTION_APPLICATION_ROOT="/var/www/Zephyrus"
+PRODUCTION_SSH_TARGET="smudoshi@zephyrus.acumenus.net"
+DEPLOY_LOCK="/tmp/zephyrus-production-release.lock"
+ORIGINAL_ARGS=("$@")
+DEPLOY_ACTION="application"
+FRONTEND_LABEL=0
+CHECK_ONLY=0
+HOST_ONLY=0
+EXPECTED_COMMIT_ARG=""
+CONFIRM_COMMIT=""
+MIGRATION_PATHS=()
+
+usage() {
+    cat <<'USAGE'
+Usage:
+  ./deploy.sh [--frontend] [--confirm <full-commit-sha>]
+  ./deploy.sh --migrate --path database/migrations/<file.php> [--path ...]
+  ./deploy.sh --check
+
+Run from a clean local main branch to synchronize and deploy the exact
+CI-successful origin/main commit through smudoshi@zephyrus.acumenus.net.
+
+Options:
+  --frontend              Compatibility label; still publishes a full immutable
+                          application snapshot and never runs migrations.
+  --migrate, --db         Run only explicitly named migration paths after the
+                          application commit is deployed and a verified logical
+                          backup is captured.
+  --path <path>           Exact database/migrations/*.php path; repeat as needed.
+  --check                 Read-only local, GitHub CI, SSH, and server preflight.
+  --confirm <commit>      Non-interactive confirmation; must equal the full SHA.
+  --help                  Show this help.
+USAGE
+}
+
+fail() {
+    echo "❌ Error: $*" >&2
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --frontend)
+            FRONTEND_LABEL=1
+            shift
+            ;;
+        --migrate|--db)
+            DEPLOY_ACTION="migration"
+            shift
+            ;;
+        --path)
+            [[ $# -ge 2 ]] || fail "--path requires a migration file"
+            MIGRATION_PATHS+=("$2")
+            shift 2
+            ;;
+        --path=*)
+            MIGRATION_PATHS+=("${1#--path=}")
+            shift
+            ;;
+        --check)
+            CHECK_ONLY=1
+            shift
+            ;;
+        --confirm)
+            [[ $# -ge 2 ]] || fail "--confirm requires the full release commit"
+            CONFIRM_COMMIT="$2"
+            shift 2
+            ;;
+        --host-only)
+            HOST_ONLY=1
+            shift
+            ;;
+        --expected-commit)
+            [[ $# -ge 2 ]] || fail "--expected-commit requires a full commit SHA"
+            EXPECTED_COMMIT_ARG="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+if [[ "${DEPLOY_RUN_MIGRATIONS:-0}" != "0" ]]; then
+    fail "DEPLOY_RUN_MIGRATIONS is no longer supported; use --migrate with explicit --path values"
+fi
+
+if [[ "$DEPLOY_ACTION" == "application" && ${#MIGRATION_PATHS[@]} -gt 0 ]]; then
+    fail "--path is valid only with --migrate"
+fi
+if [[ "$DEPLOY_ACTION" == "migration" && ${#MIGRATION_PATHS[@]} -eq 0 ]]; then
+    fail "--migrate requires at least one explicit --path"
+fi
+if [[ "$FRONTEND_LABEL" -eq 1 && "$DEPLOY_ACTION" == "migration" ]]; then
+    fail "--frontend and --migrate cannot be combined"
+fi
+
+assert_main_release_source() {
+    local repository_root="$1"
+    local current_branch
+    local upstream
+
+    current_branch="$(git -C "$repository_root" branch --show-current)"
+    upstream="$(git -C "$repository_root" rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
+    if [[ "$current_branch" != "main" || "$upstream" != "origin/main" ]]; then
+        echo "🌿 Current branch: ${current_branch:-detached HEAD}" >&2
+        echo "📡 Current upstream: ${upstream:-none}" >&2
+        fail "production releases must come from main tracking origin/main"
+    fi
+
+    if [[ -n "$(git -C "$repository_root" status --porcelain=v1 --untracked-files=normal)" ]]; then
+        git -C "$repository_root" status --short --branch >&2
+        fail "the release worktree must be clean"
+    fi
+
+    git -C "$repository_root" fetch --quiet origin main
+}
+
+validate_migration_paths() {
+    local repository_root="$1"
+    local migration_path
+
+    for migration_path in "${MIGRATION_PATHS[@]}"; do
+        if [[ ! "$migration_path" =~ ^database/migrations/[A-Za-z0-9._-]+\.php$ ]]; then
+            fail "migration path is not a direct database/migrations/*.php file: $migration_path"
+        fi
+        if [[ ! -f "$repository_root/$migration_path" ]]; then
+            fail "migration file does not exist: $migration_path"
+        fi
+        if ! git -C "$repository_root" ls-files --error-unmatch "$migration_path" >/dev/null 2>&1; then
+            fail "migration path is not tracked by Git: $migration_path"
+        fi
+    done
+}
+
+verify_release_ci() {
+    local repository_root="$1"
+    local commit="$2"
+    "$repository_root/scripts/deployment/verify-github-ci.sh" "$commit"
+}
+
+confirm_release() {
+    local commit="$1"
+    local verb="DEPLOY"
+    local expected
+    local answer
+
+    if [[ "$DEPLOY_ACTION" == "migration" ]]; then
+        verb="MIGRATE"
+    fi
+
+    if [[ -n "$CONFIRM_COMMIT" ]]; then
+        [[ "$CONFIRM_COMMIT" == "$commit" ]] \
+            || fail "--confirm must exactly match release commit $commit"
+        return
+    fi
+
+    [[ -t 0 ]] || fail "interactive confirmation unavailable; pass --confirm $commit"
+    expected="$verb ${commit:0:12}"
+    read -r -p "Type '$expected' to continue: " answer
+    [[ "$answer" == "$expected" ]] || fail "release confirmation did not match"
+}
+
+run_remote_preflight() {
+    local commit="$1"
+
+    ssh -o BatchMode=yes -o ConnectTimeout=10 "$PRODUCTION_SSH_TARGET" \
+        bash -s -- "$commit" <<'REMOTE_CHECK'
+set -Eeuo pipefail
+EXPECTED_COMMIT="$1"
+REPOSITORY_ROOT="/home/smudoshi/Github/Zephyrus"
+
+[[ "$(id -un)" == "smudoshi" ]] || {
+    echo "Error: production SSH user is not smudoshi" >&2
+    exit 1
+}
+[[ -d "$REPOSITORY_ROOT/.git" ]] || {
+    echo "Error: canonical production checkout is missing" >&2
+    exit 1
+}
+[[ "$(git -C "$REPOSITORY_ROOT" branch --show-current)" == "main" ]] || {
+    echo "Error: production checkout is not on main" >&2
+    exit 1
+}
+[[ "$(git -C "$REPOSITORY_ROOT" rev-parse --abbrev-ref --symbolic-full-name '@{u}')" == "origin/main" ]] || {
+    echo "Error: production checkout does not track origin/main" >&2
+    exit 1
+}
+[[ -z "$(git -C "$REPOSITORY_ROOT" status --porcelain=v1 --untracked-files=normal)" ]] || {
+    echo "Error: production checkout is dirty" >&2
+    exit 1
+}
+REMOTE_COMMIT="$(git -C "$REPOSITORY_ROOT" ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+[[ "$REMOTE_COMMIT" == "$EXPECTED_COMMIT" ]] || {
+    echo "Error: origin/main changed during preflight" >&2
+    exit 1
+}
+sudo -n true
+printf 'Production preflight passed: user=%s branch=main origin/main=%s\n' \
+    "$(id -un)" "$EXPECTED_COMMIT"
+REMOTE_CHECK
+}
+
+run_remote_release() {
+    local commit="$1"
+
+    ssh -o BatchMode=yes "$PRODUCTION_SSH_TARGET" \
+        bash -s -- "$commit" "$DEPLOY_ACTION" "$FRONTEND_LABEL" "${MIGRATION_PATHS[@]}" <<'REMOTE_RELEASE'
+set -Eeuo pipefail
+EXPECTED_COMMIT="$1"
+DEPLOY_ACTION="$2"
+FRONTEND_LABEL="$3"
+shift 3
+MIGRATION_PATHS=("$@")
+REPOSITORY_ROOT="/home/smudoshi/Github/Zephyrus"
+LOCK_FILE="/tmp/zephyrus-production-release.lock"
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    echo "Error: another Zephyrus production release is already running" >&2
+    exit 1
+fi
+
+cd "$REPOSITORY_ROOT"
+[[ "$(id -un)" == "smudoshi" ]] || {
+    echo "Error: production SSH user is not smudoshi" >&2
+    exit 1
+}
+[[ "$(git branch --show-current)" == "main" ]] || {
+    echo "Error: production checkout is not on main" >&2
+    exit 1
+}
+[[ "$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}')" == "origin/main" ]] || {
+    echo "Error: production checkout does not track origin/main" >&2
+    exit 1
+}
+[[ -z "$(git status --porcelain=v1 --untracked-files=normal)" ]] || {
+    echo "Error: production checkout is dirty" >&2
+    exit 1
+}
+
+git fetch --quiet origin main
+[[ "$(git rev-parse origin/main)" == "$EXPECTED_COMMIT" ]] || {
+    echo "Error: origin/main no longer matches the approved commit" >&2
+    exit 1
+}
+git merge --ff-only "$EXPECTED_COMMIT"
+[[ "$(git rev-parse HEAD)" == "$EXPECTED_COMMIT" ]] || {
+    echo "Error: production checkout did not reach the approved commit" >&2
+    exit 1
+}
+
+DEPLOY_ARGS=(--host-only --expected-commit "$EXPECTED_COMMIT")
+if [[ "$DEPLOY_ACTION" == "migration" ]]; then
+    DEPLOY_ARGS+=(--migrate)
+    for migration_path in "${MIGRATION_PATHS[@]}"; do
+        DEPLOY_ARGS+=(--path "$migration_path")
+    done
+elif [[ "$FRONTEND_LABEL" == "1" ]]; then
+    DEPLOY_ARGS+=(--frontend)
+fi
+
+exec env \
+    ZEPHYRUS_DEPLOY_LOCK_HELD=1 \
+    ZEPHYRUS_REMOTE_APPROVED_COMMIT="$EXPECTED_COMMIT" \
+    ./deploy.sh "${DEPLOY_ARGS[@]}"
+REMOTE_RELEASE
+}
+
+run_path_scoped_migrations() {
+    local release_commit="$1"
+    local deployed_commit
+    local metadata
+    local environment
+    local driver
+    local host
+    local database
+    local short_commit="${release_commit:0:12}"
+    local timestamp
+    local backup_path
+    local ledger_path
+    local migration_path
+    local migration_arguments=()
+
+    validate_migration_paths "$REPOSITORY_ROOT"
+
+    [[ -f "$PRODUCTION_APPLICATION_ROOT/.release-commit" ]] \
+        || fail "the production release marker is missing; deploy the application first"
+    deployed_commit="$(sudo cat "$PRODUCTION_APPLICATION_ROOT/.release-commit")"
+    [[ "$deployed_commit" == "$release_commit" ]] \
+        || fail "deployed application commit $deployed_commit does not match $release_commit"
+
+    metadata="$(
+        cd "$PRODUCTION_APPLICATION_ROOT"
+        sudo -u www-data php -r '
+            require "vendor/autoload.php";
+            $app = require "bootstrap/app.php";
+            $app->make("Illuminate\\Contracts\\Console\\Kernel")->bootstrap();
+            $name = (string) config("database.default");
+            $config = (array) config("database.connections.".$name);
+            echo app()->environment(), "\t";
+            echo (string) ($config["driver"] ?? ""), "\t";
+            echo (string) ($config["host"] ?? ""), "\t";
+            echo (string) ($config["database"] ?? "");
+        '
+    )"
+    IFS=$'\t' read -r environment driver host database <<< "$metadata"
+
+    [[ "$environment" == "production" ]] || fail "deployed application is not in production mode"
+    [[ "$driver" == "pgsql" ]] || fail "production database driver is not PostgreSQL"
+    [[ "$host" == "127.0.0.1" || "$host" == "localhost" || "$host" == "::1" ]] \
+        || fail "production database is not the expected host-local PostgreSQL service"
+    [[ "$database" =~ ^[A-Za-z0-9_.-]+$ ]] || fail "production database name is invalid"
+
+    for migration_path in "${MIGRATION_PATHS[@]}"; do
+        migration_arguments+=(--path "$migration_path")
+    done
+
+    echo "🔎 Previewing only the approved migration paths..."
+    (
+        cd "$PRODUCTION_APPLICATION_ROOT"
+        sudo -u www-data php artisan migrate \
+            --pretend --force --no-interaction "${migration_arguments[@]}"
+    )
+
+    timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+    backup_path="/var/backups/zephyrus/pre-migrate-${short_commit}-${timestamp}.dir"
+    ledger_path="${backup_path}.migrate-status.txt"
+
+    sudo install -d -o postgres -g postgres -m 0700 /var/backups/zephyrus
+    if sudo test -e "$backup_path" || sudo test -e "$ledger_path"; then
+        fail "migration backup target already exists"
+    fi
+
+    echo "💾 Capturing full PostgreSQL logical backup..."
+    sudo -u postgres pg_dump \
+        --format=directory \
+        --jobs=2 \
+        --file="$backup_path" \
+        --dbname="$database"
+    sudo -u postgres pg_restore --list "$backup_path" >/dev/null
+    (
+        cd "$PRODUCTION_APPLICATION_ROOT"
+        sudo -u www-data php artisan migrate:status --no-ansi
+    ) | sudo -u postgres tee "$ledger_path" >/dev/null
+
+    echo "✅ Verified backup: $backup_path"
+    echo "🧾 Migration ledger: $ledger_path"
+    echo "🗄️  Running only the approved migration paths..."
+    (
+        cd "$PRODUCTION_APPLICATION_ROOT"
+        sudo -u www-data php artisan migrate \
+            --force --no-interaction "${migration_arguments[@]}"
+    )
+
+    echo "🔍 Verifying migration status..."
+    (
+        cd "$PRODUCTION_APPLICATION_ROOT"
+        sudo -u www-data php artisan migrate:status --no-ansi
+    )
+    echo "✅ Path-scoped migration release completed for $release_commit"
+}
+
 REPOSITORY_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 
-# Production releases must originate from the canonical main checkout. Other
-# worktrees are useful for development, but are not release sources.
+[[ -n "$REPOSITORY_ROOT" ]] || fail "run this script from a Zephyrus Git worktree"
+
 if [[ "$REPOSITORY_ROOT" != "$EXPECTED_REPOSITORY_ROOT" ]]; then
-    echo "❌ Error: This script must be run from the canonical development checkout"
-    echo "📂 Current repository: ${REPOSITORY_ROOT:-not a Git worktree}"
-    echo "📂 Expected repository: $EXPECTED_REPOSITORY_ROOT"
-    exit 1
+    [[ "$HOST_ONLY" -eq 0 ]] || fail "--host-only is valid only in the canonical production checkout"
+    cd "$REPOSITORY_ROOT"
+    assert_main_release_source "$REPOSITORY_ROOT"
+    validate_migration_paths "$REPOSITORY_ROOT"
+
+    RELEASE_COMMIT="$(git rev-parse HEAD)"
+    REMOTE_COMMIT="$(git rev-parse origin/main)"
+    [[ "$RELEASE_COMMIT" == "$REMOTE_COMMIT" ]] \
+        || fail "local main must exactly match origin/main before release"
+    verify_release_ci "$REPOSITORY_ROOT" "$RELEASE_COMMIT"
+    run_remote_preflight "$RELEASE_COMMIT"
+
+    if [[ "$CHECK_ONLY" -eq 1 ]]; then
+        echo "✅ Read-only release preflight passed for $RELEASE_COMMIT"
+        exit 0
+    fi
+
+    confirm_release "$RELEASE_COMMIT"
+    run_remote_release "$RELEASE_COMMIT"
+    exit 0
 fi
+
 cd "$REPOSITORY_ROOT"
 
-CURRENT_BRANCH="$(git branch --show-current)"
-UPSTREAM="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || true)"
-if [[ "$CURRENT_BRANCH" != "main" || "$UPSTREAM" != "origin/main" ]]; then
-    echo "❌ Error: Production deployments must come from main tracking origin/main"
-    echo "🌿 Current branch: ${CURRENT_BRANCH:-detached HEAD}"
-    echo "📡 Current upstream: ${UPSTREAM:-none}"
-    exit 1
-fi
-
-# Check for uncommitted or untracked source before resolving the release.
-if [[ -n "$(git status --porcelain=v1 --untracked-files=normal)" ]]; then
-    echo "❌ Error: You have uncommitted changes"
-    echo "💡 Please commit or stash your changes before deploying"
-    git status
-    exit 1
+if [[ -z "${ZEPHYRUS_DEPLOY_LOCK_HELD:-}" ]]; then
+    exec flock -n "$DEPLOY_LOCK" \
+        env ZEPHYRUS_DEPLOY_LOCK_HELD=1 "$0" "${ORIGINAL_ARGS[@]}"
 fi
 
 echo "📡 Checking remote status..."
-git fetch --quiet origin main
+assert_main_release_source "$REPOSITORY_ROOT"
 RELEASE_COMMIT="$(git rev-parse HEAD)"
 REMOTE_COMMIT="$(git rev-parse origin/main)"
 
@@ -46,10 +419,36 @@ if [[ "$RELEASE_COMMIT" != "$REMOTE_COMMIT" ]]; then
 fi
 echo "✅ main is current at $RELEASE_COMMIT"
 
+if [[ -n "$EXPECTED_COMMIT_ARG" && "$EXPECTED_COMMIT_ARG" != "$RELEASE_COMMIT" ]]; then
+    fail "production checkout does not match expected commit $EXPECTED_COMMIT_ARG"
+fi
+if [[ "$HOST_ONLY" -eq 1 ]]; then
+    [[ -n "$EXPECTED_COMMIT_ARG" ]] || fail "--host-only requires an expected commit"
+    [[ "${ZEPHYRUS_REMOTE_APPROVED_COMMIT:-}" == "$EXPECTED_COMMIT_ARG" ]] \
+        || fail "--host-only requires the local controller's exact-commit approval"
+fi
+
+verify_release_ci "$REPOSITORY_ROOT" "$RELEASE_COMMIT"
+
+if [[ "$CHECK_ONLY" -eq 1 ]]; then
+    echo "✅ Production-host release preflight passed for $RELEASE_COMMIT"
+    exit 0
+fi
+
+if [[ "$HOST_ONLY" -eq 0 ]]; then
+    confirm_release "$RELEASE_COMMIT"
+fi
+
 if [[ ! -f "$REPOSITORY_ROOT/vendor/autoload.php" ]]; then
     echo "❌ Error: Composer dependencies are missing; run composer install"
     exit 1
 fi
+
+if [[ "$DEPLOY_ACTION" == "migration" ]]; then
+    run_path_scoped_migrations "$RELEASE_COMMIT"
+    exit 0
+fi
+
 if [[ ! -d "$REPOSITORY_ROOT/node_modules" ]]; then
     echo "❌ Error: Node dependencies are missing; run npm install"
     exit 1
@@ -156,10 +555,6 @@ fi
 echo "Clearing Laravel caches..."
 # Clear Laravel caches
 cd /var/www/Zephyrus
-if [[ "${DEPLOY_RUN_MIGRATIONS:-0}" == "1" ]]; then
-    echo "Running database migrations..."
-    sudo -u www-data php artisan migrate --force
-fi
 sudo -u www-data php artisan cache:clear
 sudo -u www-data php artisan view:clear
 sudo -u www-data php artisan config:clear

--- a/docs/operations/DEVELOPMENT-AND-PRODUCTION-RELEASE-RUNBOOK.md
+++ b/docs/operations/DEVELOPMENT-AND-PRODUCTION-RELEASE-RUNBOOK.md
@@ -1,0 +1,243 @@
+# Development and Production Release Runbook
+
+## Scope
+
+This is the supported workflow for developing on the macOS checkout, publishing
+through GitHub, and manually releasing to `zephyrus.acumenus.net`.
+
+The two deliberate release stages are:
+
+1. Publish a feature branch and merge it through a CI-successful pull request.
+2. Run the canonical `./deploy.sh` command from a clean, synchronized local
+   `main` branch.
+
+GitHub Actions validates releases but never deploys them. Operators must not use
+ad hoc SSH deployment commands, direct production `git pull`, or another deploy
+script.
+
+## Safety boundaries
+
+- `main` is protected. Changes require a pull request, strict successful CI,
+  linear history, and resolved review conversations. Force-pushes and branch
+  deletion are disabled.
+- The local `.env` intentionally reads the production PostgreSQL database.
+  Laravel forces every matching non-production PostgreSQL connection into
+  transaction read-only mode as it is established.
+- Verify the local database guard whenever environment configuration changes:
+
+    ```bash
+    php artisan zephyrus:database-safety
+    ```
+
+    Both `Session default` and `Transaction` must be `on`, and `Safe` must be
+    `yes`.
+
+- The Laravel guard does not govern arbitrary external database clients. Do not
+  run `psql`, `pg_dump`, data loaders, seeders, migrations, or standalone
+  database scripts from the Mac against production. Production migrations use
+  only the guarded path-scoped release command below.
+- Production application releases and database migrations are separate
+  operations. A normal deployment never migrates.
+- The production checkout is
+  `/home/smudoshi/Github/Zephyrus`, accessed as
+  `smudoshi@zephyrus.acumenus.net`. The script uses the full target rather than
+  an SSH alias.
+
+## Start or resume development
+
+First synchronize the protected base branch:
+
+```bash
+git switch main
+git status --short --branch
+git fetch origin
+git pull --ff-only
+git rev-list --left-right --count HEAD...origin/main
+```
+
+The final command must return `0 0`. Do not discard unrelated local work to
+make synchronization convenient.
+
+Create a branch:
+
+```bash
+git switch -c feature/<short-description>
+```
+
+Develop and run the checks appropriate to the change. Database-mutating local
+test suites must use the isolated test database, never the production
+connection from `.env`.
+
+## Commit and publish
+
+Stage only the intended paths:
+
+```bash
+git status --short --branch
+git add <explicit-path> [<explicit-path> ...]
+git diff --cached --name-status
+git diff --cached --stat
+git diff --cached --check
+git commit -m "<concise change description>"
+git push -u origin HEAD
+gh pr create --fill
+```
+
+Never use `git add -A` in a mixed worktree. Review the pull request, wait for
+every required GitHub check to pass, resolve conversations, and merge it.
+
+## Synchronize the merged release
+
+Return the Mac to the merged `main` commit:
+
+```bash
+git switch main
+git status --short --branch
+git fetch origin
+git pull --ff-only
+git rev-list --left-right --count HEAD...origin/main
+```
+
+The worktree must be clean and ahead/behind must be `0 0`.
+
+## Read-only release preflight
+
+```bash
+./deploy.sh --check
+```
+
+This verifies, without changing the deployed application:
+
+- clean local `main` tracking `origin/main`;
+- exact local/remote commit identity;
+- a successful exact-commit `main` push run of `.github/workflows/ci.yml`;
+- key-based SSH access to `smudoshi@zephyrus.acumenus.net`;
+- the canonical production checkout, branch, upstream, cleanliness, and remote
+  commit;
+- non-interactive `sudo` availability.
+
+If any check fails, stop and fix that specific condition. The preflight does not
+stash, reset, force-update, or deploy.
+
+## Deploy the application
+
+Run:
+
+```bash
+./deploy.sh
+```
+
+The script asks for `DEPLOY <12-character-commit>`. It then:
+
+1. acquires the production release lock;
+2. fetches `origin/main` in the canonical production checkout;
+3. fast-forwards only to the exact locally approved commit;
+4. re-verifies exact-commit GitHub CI;
+5. builds an immutable Git snapshot;
+6. publishes it to `/var/www/Zephyrus`;
+7. preserves the production `.env` and runtime storage;
+8. clears Laravel caches, refreshes the queue worker and sidecar where present,
+   and restarts Apache;
+9. verifies the release marker, vhost, production assets, edge policy, services,
+   and storage permissions.
+
+`./deploy.sh --frontend` remains a compatibility label for older runbooks. It
+still deploys the full immutable application snapshot and never runs database
+migrations.
+
+For a non-interactive operator session, confirmation can be supplied only as
+the exact full commit:
+
+```bash
+./deploy.sh --confirm "$(git rev-parse HEAD)"
+```
+
+Do not put that form into unattended automation.
+
+## Path-scoped production migration
+
+First deploy the application commit normally. Review every migration and its
+rollback/forward-fix plan. Then name only the approved migration file:
+
+```bash
+./deploy.sh --migrate \
+  --path database/migrations/YYYY_MM_DD_HHMMSS_example.php
+```
+
+Repeat `--path` for a reviewed multi-file release. `--db` is an alias for
+`--migrate` but still requires explicit `--path` values.
+
+The script asks for `MIGRATE <12-character-commit>` and then:
+
+1. proves the deployed `.release-commit` equals the approved `main` commit;
+2. rejects paths outside the tracked `database/migrations/*.php` files;
+3. previews only the named migrations with `--pretend`;
+4. creates a full directory-format logical backup under
+   `/var/backups/zephyrus/`;
+5. validates the backup with `pg_restore --list`;
+6. saves the pre-migration Laravel migration ledger beside the backup;
+7. runs only the named paths and prints final migration status.
+
+The legacy `DEPLOY_RUN_MIGRATIONS=1` blanket path is rejected. Never use
+`migrate:rollback` casually in production; prefer a reviewed forward repair or
+an Ops-approved restore from the verified backup.
+
+## Post-deploy verification
+
+The deploy command performs automated checks. Also inspect the affected
+workflow manually:
+
+```bash
+curl --fail --silent --show-error --output /dev/null \
+  https://zephyrus.acumenus.net/login
+ssh smudoshi@zephyrus.acumenus.net \
+  'sudo cat /var/www/Zephyrus/.release-commit'
+git rev-parse HEAD
+```
+
+The two commits must match. If a check fails, retain the complete deploy output
+and inspect:
+
+```bash
+ssh smudoshi@zephyrus.acumenus.net
+sudo systemctl status apache2 zephyrus-queue-worker.service
+sudo journalctl -u apache2.service -n 50
+sudo journalctl -u zephyrus-queue-worker.service -n 50
+```
+
+## Rollback and recovery
+
+Application rollback is a new reviewed Git release:
+
+1. Revert the offending pull request on a branch.
+2. Run CI and merge the revert through the protected `main` branch.
+3. Synchronize local `main`.
+4. Run `./deploy.sh --check`, then `./deploy.sh`.
+
+Do not detach or force-reset production to an unreviewed old commit.
+
+For a migration incident:
+
+1. Disable the affected feature through its approved kill switch where
+   available.
+2. Stop additional writes to the affected workflow.
+3. Preserve logs, the release SHA, backup path, migration ledger, and failure
+   output.
+4. Prefer a reviewed forward repair.
+5. Restore the verified logical backup only through the Ops-approved recovery
+   procedure and only after accounting for post-backup production writes.
+
+## Common failures
+
+- **Local or production tree is dirty:** inspect it; do not auto-stash or reset.
+- **Local `main` differs from `origin/main`:** use `git pull --ff-only`; resolve
+  divergence deliberately.
+- **CI missing, pending, cancelled, or failed:** wait or repair CI; deployment
+  fails closed.
+- **Production `origin/main` changed after local approval:** resynchronize local
+  `main` and repeat preflight.
+- **Production checkout cannot fast-forward:** stop and investigate; never force.
+- **Database safety command reports writable:** stop local Laravel processes and
+  correct the connection guard before continuing development.
+- **Migration backup or verification fails:** no migration runs; fix backup
+  readiness first.

--- a/scripts/deployment/verify-github-ci.php
+++ b/scripts/deployment/verify-github-ci.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+if ($argc !== 3) {
+    fwrite(STDERR, "Usage: verify-github-ci.php <workflow-runs.json> <commit>\n");
+    exit(64);
+}
+
+[$script, $path, $commit] = $argv;
+
+if (! preg_match('/\A[0-9a-f]{40}\z/', $commit)) {
+    fwrite(STDERR, "Error: commit must be a full 40-character SHA.\n");
+    exit(64);
+}
+
+$contents = file_get_contents($path);
+if ($contents === false) {
+    fwrite(STDERR, "Error: unable to read the GitHub workflow response.\n");
+    exit(1);
+}
+
+try {
+    $payload = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+} catch (JsonException $exception) {
+    fwrite(STDERR, "Error: GitHub returned invalid JSON.\n");
+    exit(1);
+}
+
+$runs = is_array($payload['workflow_runs'] ?? null) ? $payload['workflow_runs'] : [];
+$matchingRuns = array_values(array_filter(
+    $runs,
+    static fn (mixed $run): bool => is_array($run)
+        && ($run['head_sha'] ?? null) === $commit
+        && ($run['head_branch'] ?? null) === 'main'
+        && ($run['event'] ?? null) === 'push',
+));
+
+if ($matchingRuns === []) {
+    fwrite(STDERR, "Error: no main-branch push CI run exists for {$commit}.\n");
+    exit(1);
+}
+
+usort(
+    $matchingRuns,
+    static fn (array $left, array $right): int => strcmp(
+        (string) ($right['created_at'] ?? ''),
+        (string) ($left['created_at'] ?? ''),
+    ),
+);
+
+$run = $matchingRuns[0];
+$status = (string) ($run['status'] ?? 'unknown');
+$conclusion = (string) ($run['conclusion'] ?? '');
+$url = (string) ($run['html_url'] ?? '');
+
+if ($status === 'completed' && $conclusion === 'success') {
+    echo "GitHub CI passed for {$commit}";
+    echo $url !== '' ? " ({$url})\n" : "\n";
+    exit(0);
+}
+
+if (in_array($status, ['queued', 'in_progress', 'pending', 'requested', 'waiting'], true)) {
+    fwrite(STDERR, "Error: GitHub CI is {$status} for {$commit}");
+    fwrite(STDERR, $url !== '' ? " ({$url})\n" : "\n");
+    exit(75);
+}
+
+fwrite(
+    STDERR,
+    "Error: GitHub CI did not pass for {$commit}; status={$status}, conclusion="
+        .($conclusion !== '' ? $conclusion : 'none')
+        .($url !== '' ? " ({$url})" : '')
+        ."\n",
+);
+exit(1);

--- a/scripts/deployment/verify-github-ci.sh
+++ b/scripts/deployment/verify-github-ci.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+usage() {
+    echo "Usage: $0 <full-commit-sha>" >&2
+}
+
+if [[ $# -ne 1 || ! "$1" =~ ^[0-9a-f]{40}$ ]]; then
+    usage
+    exit 64
+fi
+
+COMMIT="$1"
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PARSER="$PROJECT_ROOT/scripts/deployment/verify-github-ci.php"
+RESPONSE_FILE="${ZEPHYRUS_GITHUB_RUNS_JSON:-}"
+TEMP_RESPONSE=""
+
+cleanup() {
+    if [[ -n "$TEMP_RESPONSE" ]]; then
+        rm -f "$TEMP_RESPONSE"
+    fi
+}
+trap cleanup EXIT
+
+if [[ -z "$RESPONSE_FILE" ]]; then
+    TEMP_RESPONSE="$(mktemp "${TMPDIR:-/tmp}/zephyrus-github-ci.XXXXXX")"
+    RESPONSE_FILE="$TEMP_RESPONSE"
+    API_URL="https://api.github.com/repos/sudoshi/Zephyrus/actions/workflows/ci.yml/runs?branch=main&event=push&head_sha=${COMMIT}&per_page=10"
+    CURL_ARGS=(
+        --fail
+        --silent
+        --show-error
+        --location
+        --retry 2
+        --header "Accept: application/vnd.github+json"
+        --header "User-Agent: Zephyrus-production-release"
+        --output "$RESPONSE_FILE"
+    )
+
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        CURL_ARGS+=(--header "Authorization: Bearer ${GITHUB_TOKEN}")
+    fi
+
+    curl "${CURL_ARGS[@]}" "$API_URL"
+fi
+
+php "$PARSER" "$RESPONSE_FILE" "$COMMIT"

--- a/tests/Deployment/github-ci-gate.sh
+++ b/tests/Deployment/github-ci-gate.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERIFY="$PROJECT_ROOT/scripts/deployment/verify-github-ci.sh"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/zephyrus-ci-gate-test.XXXXXX")"
+COMMIT="1111111111111111111111111111111111111111"
+
+cleanup() {
+    rm -rf "$TEST_ROOT"
+}
+trap cleanup EXIT
+
+write_fixture() {
+    local status="$1"
+    local conclusion="$2"
+
+    sed \
+        -e "s/STATUS_VALUE/$status/" \
+        -e "s/CONCLUSION_VALUE/$conclusion/" \
+        > "$TEST_ROOT/runs.json" <<JSON
+{
+  "workflow_runs": [
+    {
+      "head_sha": "$COMMIT",
+      "head_branch": "main",
+      "event": "push",
+      "status": "STATUS_VALUE",
+      "conclusion": "CONCLUSION_VALUE",
+      "created_at": "2026-07-23T12:00:00Z",
+      "html_url": "https://github.com/sudoshi/Zephyrus/actions/runs/1"
+    }
+  ]
+}
+JSON
+}
+
+write_fixture completed success
+ZEPHYRUS_GITHUB_RUNS_JSON="$TEST_ROOT/runs.json" "$VERIFY" "$COMMIT" >/dev/null
+
+write_fixture in_progress ""
+if ZEPHYRUS_GITHUB_RUNS_JSON="$TEST_ROOT/runs.json" "$VERIFY" "$COMMIT" >/dev/null 2>&1; then
+    echo "FAIL: an in-progress CI run passed the gate" >&2
+    exit 1
+fi
+
+write_fixture completed failure
+if ZEPHYRUS_GITHUB_RUNS_JSON="$TEST_ROOT/runs.json" "$VERIFY" "$COMMIT" >/dev/null 2>&1; then
+    echo "FAIL: a failed CI run passed the gate" >&2
+    exit 1
+fi
+
+cat > "$TEST_ROOT/runs.json" <<JSON
+{"workflow_runs":[]}
+JSON
+if ZEPHYRUS_GITHUB_RUNS_JSON="$TEST_ROOT/runs.json" "$VERIFY" "$COMMIT" >/dev/null 2>&1; then
+    echo "FAIL: a missing CI run passed the gate" >&2
+    exit 1
+fi
+
+echo "GitHub CI release gate regression test passed."

--- a/tests/Unit/Database/ProductionDatabaseReadOnlyGuardTest.php
+++ b/tests/Unit/Database/ProductionDatabaseReadOnlyGuardTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Database;
+
+use App\Database\ProductionDatabaseReadOnlyGuard;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ProductionDatabaseReadOnlyGuardTest extends TestCase
+{
+    /**
+     * @param  array<string, mixed>  $configuration
+     */
+    #[DataProvider('connectionPolicies')]
+    public function test_it_identifies_connections_that_must_be_read_only(
+        string $environment,
+        array $configuration,
+        bool $expected,
+    ): void {
+        $guard = new ProductionDatabaseReadOnlyGuard;
+
+        $this->assertSame($expected, $guard->shouldProtect($configuration, $environment));
+    }
+
+    /**
+     * @return iterable<string, array{string, array<string, mixed>, bool}>
+     */
+    public static function connectionPolicies(): iterable
+    {
+        $productionConnection = [
+            'driver' => 'pgsql',
+            'host' => 'pgsql.acumenus.net',
+            'username' => 'smudoshi',
+            'search_path' => 'prod,public',
+        ];
+
+        yield 'local app using canonical production host' => [
+            'local',
+            $productionConnection,
+            true,
+        ];
+
+        yield 'staging app using production identity and schema' => [
+            'staging',
+            [
+                'driver' => 'pgsql',
+                'host' => '50.32.48.115',
+                'username' => 'smudoshi',
+                'schema' => 'prod',
+            ],
+            true,
+        ];
+
+        yield 'production app retains its normal write authority' => [
+            'production',
+            $productionConnection,
+            false,
+        ];
+
+        yield 'isolated local test database is not affected' => [
+            'testing',
+            [
+                'driver' => 'pgsql',
+                'host' => '127.0.0.1',
+                'username' => 'zephyrus_test',
+                'search_path' => ['prod', 'public'],
+            ],
+            false,
+        ];
+
+        yield 'non PostgreSQL connection is not affected' => [
+            'local',
+            [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+            ],
+            false,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- make `deploy.sh` the controlled Mac-to-production release entry point using the exact CI-successful `origin/main` commit and `smudoshi@zephyrus.acumenus.net`
- add read-only local/GitHub/SSH/server preflight, exact-commit confirmation, production release locking, and fast-forward-only server synchronization
- separate database migrations from application deployment; require explicit migration paths, SQL preview, a verified directory-format `pg_dump`, and a retained migration ledger
- force non-production Laravel connections to the production PostgreSQL host/user/schema into transaction read-only mode
- add an exact-commit GitHub CI gate with regression coverage
- document daily sync, scoped publishing, deployment, migration, rollback, and troubleshooting procedures

## Why

The Mac could commit and push, but the supported runbook had no governed handoff from GitHub to the canonical production checkout. Local Laravel also used the production database without an enforced read-only session, and legacy deployment documentation advertised broad migration paths that the script did not safely implement.

## Safety and operator impact

- GitHub Actions remains CI-only; it never deploys.
- Normal `./deploy.sh` never migrates.
- `DEPLOY_RUN_MIGRATIONS=1` is rejected.
- `--migrate`/`--db` requires one or more tracked `database/migrations/*.php` paths.
- Production application rollback remains a reviewed revert/forward release; database recovery remains forward-fix or Ops-approved verified-backup restoration.
- No production deployment or migration was performed as part of this PR.

## Validation

- `bash -n` for deployment and CI gate scripts
- PHP syntax checks for the guard, command, provider, and CI parser
- Laravel Pint targeted check: pass
- `ProductionDatabaseReadOnlyGuardTest`: 5 tests, 5 assertions, pass
- GitHub CI gate regression: pass for success; rejects pending, failed, and missing runs
- immutable release snapshot regression: pass
- live GitHub CI lookup for current `main`: pass
- `php artisan zephyrus:database-safety --json`: production protection required, both read-only settings `on`, `safe: true`
- targeted Prettier checks and `git diff --check`: pass

The complete repository test matrix is delegated to protected GitHub CI because this Mac does not currently run the isolated local PostgreSQL test service.