### PR TITLE
Fix macOS deployment preflight compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
       - name: Verify immutable release snapshots
         run: |
           bash tests/Deployment/immutable-release-snapshot.sh
+          bash tests/Deployment/deploy-bash32-compat.sh
           bash tests/Deployment/github-ci-gate.sh
 
       - name: Copy environment template

--- a/deploy.sh
+++ b/deploy.sh
@@ -131,7 +131,9 @@ validate_migration_paths() {
     local repository_root="$1"
     local migration_path
 
-    for migration_path in "${MIGRATION_PATHS[@]}"; do
+    # The ${array[@]+...} form is required for macOS Bash 3.2 with set -u:
+    # expanding an initialized-but-empty array directly is treated as unbound.
+    for migration_path in "${MIGRATION_PATHS[@]+"${MIGRATION_PATHS[@]}"}"; do
         if [[ ! "$migration_path" =~ ^database/migrations/[A-Za-z0-9._-]+\.php$ ]]; then
             fail "migration path is not a direct database/migrations/*.php file: $migration_path"
         fi
@@ -216,7 +218,8 @@ run_remote_release() {
     local commit="$1"
 
     ssh -o BatchMode=yes "$PRODUCTION_SSH_TARGET" \
-        bash -s -- "$commit" "$DEPLOY_ACTION" "$FRONTEND_LABEL" "${MIGRATION_PATHS[@]}" <<'REMOTE_RELEASE'
+        bash -s -- "$commit" "$DEPLOY_ACTION" "$FRONTEND_LABEL" \
+        "${MIGRATION_PATHS[@]+"${MIGRATION_PATHS[@]}"}" <<'REMOTE_RELEASE'
 set -Eeuo pipefail
 EXPECTED_COMMIT="$1"
 DEPLOY_ACTION="$2"
@@ -264,7 +267,7 @@ git merge --ff-only "$EXPECTED_COMMIT"
 DEPLOY_ARGS=(--host-only --expected-commit "$EXPECTED_COMMIT")
 if [[ "$DEPLOY_ACTION" == "migration" ]]; then
     DEPLOY_ARGS+=(--migrate)
-    for migration_path in "${MIGRATION_PATHS[@]}"; do
+    for migration_path in "${MIGRATION_PATHS[@]+"${MIGRATION_PATHS[@]}"}"; do
         DEPLOY_ARGS+=(--path "$migration_path")
     done
 elif [[ "$FRONTEND_LABEL" == "1" ]]; then
@@ -323,7 +326,7 @@ run_path_scoped_migrations() {
         || fail "production database is not the expected host-local PostgreSQL service"
     [[ "$database" =~ ^[A-Za-z0-9_.-]+$ ]] || fail "production database name is invalid"
 
-    for migration_path in "${MIGRATION_PATHS[@]}"; do
+    for migration_path in "${MIGRATION_PATHS[@]+"${MIGRATION_PATHS[@]}"}"; do
         migration_arguments+=(--path "$migration_path")
     done
 

--- a/tests/Deployment/deploy-bash32-compat.sh
+++ b/tests/Deployment/deploy-bash32-compat.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEPLOY_SCRIPT="$PROJECT_ROOT/deploy.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+unsafe_loop='for migration_path in "${MIGRATION_PATHS[@]}"; do'
+unsafe_argument='"${MIGRATION_PATHS[@]}" <<'
+safe_expansion='${MIGRATION_PATHS[@]+"${MIGRATION_PATHS[@]}"}'
+
+if grep -Fq "$unsafe_loop" "$DEPLOY_SCRIPT"; then
+    fail "deploy.sh contains a Bash 3.2-unsafe empty-array loop"
+fi
+if grep -Fq "$unsafe_argument" "$DEPLOY_SCRIPT"; then
+    fail "deploy.sh contains a Bash 3.2-unsafe empty-array argument expansion"
+fi
+
+safe_count="$(grep -Fo "$safe_expansion" "$DEPLOY_SCRIPT" | wc -l | tr -d ' ')"
+[[ "$safe_count" -ge 4 ]] \
+    || fail "deploy.sh does not consistently use the nounset-safe migration array expansion"
+
+# This expression must expand to zero words for an empty array and preserve all
+# words for a populated array. It runs under macOS Bash 3.2 on developer Macs
+# and remains a portable behavior check in Linux CI.
+bash -uc '
+    paths=()
+    set -- base "${paths[@]+"${paths[@]}"}"
+    [[ "$#" -eq 1 ]]
+
+    paths=("database/migrations/one.php" "database/migrations/two.php")
+    set -- base "${paths[@]+"${paths[@]}"}"
+    [[ "$#" -eq 3 ]]
+    [[ "$2" == "database/migrations/one.php" ]]
+    [[ "$3" == "database/migrations/two.php" ]]
+'
+
+echo "Deployment Bash 3.2 empty-array compatibility test passed."


### PR DESCRIPTION
Fixes the Bash 3.2 nounset failure found by the non-mutating production preflight. Empty migration arrays now expand to zero arguments, and CI includes a regression that rejects the unsafe form. No migrations or production changes are included.\n\nLocal verification:\n- bash -n deploy.sh tests/Deployment/deploy-bash32-compat.sh\n- bash tests/Deployment/deploy-bash32-compat.sh\n- bash tests/Deployment/immutable-release-snapshot.sh\n- bash tests/Deployment/github-ci-gate.sh\n- ./deploy.sh --check advances to the expected feature-branch guard