### PR TITLE
Align OWASP CRS with REST methods

### DIFF
--- a/deploy/apache/zephyrus-edge-security.conf
+++ b/deploy/apache/zephyrus-edge-security.conf
@@ -23,8 +23,9 @@ SecAuditEngine RelevantOnly
 SecAuditLogRelevantStatus "^(?:5|4(?!04))"
 
 # OWASP CRS variables are scoped per transaction. The Debian security2 module
-# configuration loads the CRS ruleset; these actions tighten its block level.
-SecAction "id:1000001,phase:1,pass,nolog,setvar:tx.inbound_anomaly_score_threshold=5,setvar:tx.outbound_anomaly_score_threshold=4"
+# configuration loads the CRS ruleset; these actions tighten its block level
+# and align CRS method enforcement with Zephyrus's explicit REST method policy.
+SecAction "id:1000001,phase:1,pass,nolog,setvar:'tx.allowed_methods=GET HEAD POST PUT PATCH DELETE OPTIONS',setvar:tx.inbound_anomaly_score_threshold=5,setvar:tx.outbound_anomaly_score_threshold=4"
 
 SecRule REQUEST_METHOD "!@within GET HEAD POST PUT PATCH DELETE OPTIONS" \
     "id:1000002,phase:1,deny,status:405,log,msg:'Zephyrus rejected unsupported HTTP method'"

--- a/deploy/security/edge-policy.json
+++ b/deploy/security/edge-policy.json
@@ -1,55 +1,64 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "policy_version": "1.0.0",
-  "application": "zephyrus",
-  "production_origin": "https://zephyrus.acumenus.net",
-  "apache_include": "/etc/apache2/zephyrus/edge-security.conf",
-  "apache_tls_vhost": "/etc/apache2/sites-enabled/zephyrus.acumenus.net-le-ssl.conf",
-  "required_modules": [
-    "headers_module",
-    "rewrite_module",
-    "security2_module",
-    "ssl_module"
-  ],
-  "waf": {
-    "engine": "ModSecurity",
-    "ruleset": "OWASP Core Rule Set",
-    "mode": "blocking",
-    "inbound_anomaly_threshold": 5,
-    "request_body_limit_bytes": 10485760,
-    "default_api_body_limit_bytes": 1048576
-  },
-  "required_response_headers": [
-    "Content-Security-Policy",
-    "Cross-Origin-Opener-Policy",
-    "Cross-Origin-Resource-Policy",
-    "Permissions-Policy",
-    "Referrer-Policy",
-    "Strict-Transport-Security",
-    "X-Content-Type-Options",
-    "X-Frame-Options"
-  ],
-  "blocked_path_patterns": [
-    "^/(?:\\.env|\\.git|storage|vendor)(?:/|$)",
-    "^/(?:artisan|composer\\.(?:json|lock)|package(?:-lock)?\\.json|phpunit\\.xml)(?:$|/)"
-  ],
-  "machine_ingress": [
-    {
-      "path": "/api/integrations/v1/patient-flow/hl7v2",
-      "application_authentication": "scoped rotating bearer token",
-      "edge_transport_requirement": "mTLS or explicit partner CIDR allowlist before production enablement",
-      "maximum_body_bytes": 1048576
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "policy_version": "1.0.0",
+    "application": "zephyrus",
+    "production_origin": "https://zephyrus.acumenus.net",
+    "apache_include": "/etc/apache2/zephyrus/edge-security.conf",
+    "apache_tls_vhost": "/etc/apache2/sites-enabled/zephyrus.acumenus.net-le-ssl.conf",
+    "required_modules": [
+        "headers_module",
+        "rewrite_module",
+        "security2_module",
+        "ssl_module"
+    ],
+    "waf": {
+        "engine": "ModSecurity",
+        "ruleset": "OWASP Core Rule Set",
+        "mode": "blocking",
+        "allowed_methods": [
+            "GET",
+            "HEAD",
+            "POST",
+            "PUT",
+            "PATCH",
+            "DELETE",
+            "OPTIONS"
+        ],
+        "inbound_anomaly_threshold": 5,
+        "request_body_limit_bytes": 10485760,
+        "default_api_body_limit_bytes": 1048576
     },
-    {
-      "path_prefix": "/api/eddy/agent",
-      "application_authentication": "scoped rotating machine token",
-      "edge_transport_requirement": "loopback/private network or explicit partner CIDR allowlist",
-      "maximum_body_bytes": 1048576
+    "required_response_headers": [
+        "Content-Security-Policy",
+        "Cross-Origin-Opener-Policy",
+        "Cross-Origin-Resource-Policy",
+        "Permissions-Policy",
+        "Referrer-Policy",
+        "Strict-Transport-Security",
+        "X-Content-Type-Options",
+        "X-Frame-Options"
+    ],
+    "blocked_path_patterns": [
+        "^/(?:\\.env|\\.git|storage|vendor)(?:/|$)",
+        "^/(?:artisan|composer\\.(?:json|lock)|package(?:-lock)?\\.json|phpunit\\.xml)(?:$|/)"
+    ],
+    "machine_ingress": [
+        {
+            "path": "/api/integrations/v1/patient-flow/hl7v2",
+            "application_authentication": "scoped rotating bearer token",
+            "edge_transport_requirement": "mTLS or explicit partner CIDR allowlist before production enablement",
+            "maximum_body_bytes": 1048576
+        },
+        {
+            "path_prefix": "/api/eddy/agent",
+            "application_authentication": "scoped rotating machine token",
+            "edge_transport_requirement": "loopback/private network or explicit partner CIDR allowlist",
+            "maximum_body_bytes": 1048576
+        }
+    ],
+    "release_rules": {
+        "critical_or_high_findings_allowed": false,
+        "production_phi_allowed_without_live_edge_verification": false,
+        "waiver_requires_expiry_owner_and_compensating_control": true
     }
-  ],
-  "release_rules": {
-    "critical_or_high_findings_allowed": false,
-    "production_phi_allowed_without_live_edge_verification": false,
-    "waiver_requires_expiry_owner_and_compensating_control": true
-  }
 }

--- a/scripts/security/verify-edge-security.php
+++ b/scripts/security/verify-edge-security.php
@@ -26,10 +26,16 @@ $assert(is_string($policyJson), 'The edge policy is missing or unreadable.');
 $policy = is_string($policyJson) ? json_decode($policyJson, true) : null;
 $assert(is_array($policy), 'The edge policy is not valid JSON.');
 
+$expectedAllowedMethods = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
+
 if (is_array($policy)) {
     $assert(($policy['policy_version'] ?? null) === '1.0.0', 'The edge policy version is not recognized.');
     $assert(($policy['waf']['mode'] ?? null) === 'blocking', 'The WAF policy must operate in blocking mode.');
     $assert(($policy['waf']['ruleset'] ?? null) === 'OWASP Core Rule Set', 'OWASP CRS must be the declared WAF ruleset.');
+    $assert(
+        ($policy['waf']['allowed_methods'] ?? null) === $expectedAllowedMethods,
+        'The WAF method policy must exactly match the Zephyrus REST method contract.',
+    );
     $assert(($policy['release_rules']['critical_or_high_findings_allowed'] ?? true) === false, 'Critical/high findings must block release.');
     $assert(($policy['release_rules']['production_phi_allowed_without_live_edge_verification'] ?? true) === false, 'PHI must require live edge verification.');
     $assert(count($policy['machine_ingress'] ?? []) >= 2, 'Every machine-ingress class must have an edge trust contract.');
@@ -41,6 +47,10 @@ if (is_string($apache)) {
     foreach (['SecRuleEngine On', 'SecRequestBodyAccess On', 'SecRequestBodyLimitAction Reject', 'TraceEnable Off', 'OWASP CRS'] as $directive) {
         $assert(str_contains($apache, $directive), "Apache edge policy is missing: {$directive}");
     }
+    $assert(
+        str_contains($apache, 'tx.allowed_methods='.implode(' ', $expectedAllowedMethods)),
+        'Apache does not align OWASP CRS with the Zephyrus REST method contract.',
+    );
     $assert(! str_contains($apache, '<IfModule'), 'The WAF policy must fail closed, not disappear behind IfModule.');
 }
 
@@ -83,10 +93,15 @@ foreach ($arguments as $argument) {
         continue;
     }
 
-    $request = static function (string $url, string $method = 'GET'): array {
+    $request = static function (string $url, string $method = 'GET', array $headers = []): array {
+        $headerArguments = implode(' ', array_map(
+            static fn (string $header): string => '--header '.escapeshellarg($header),
+            $headers,
+        ));
         $command = sprintf(
-            'curl --silent --show-error --output /dev/null --dump-header - --request %s --max-time 20 %s',
+            'curl --silent --show-error --output /dev/null --dump-header - --request %s --max-time 20 %s %s',
             escapeshellarg($method),
+            $headerArguments,
             escapeshellarg($url),
         );
         exec($command, $lines, $status);
@@ -109,6 +124,21 @@ foreach ($arguments as $argument) {
     [$traceStatus, $traceHeaders] = $request($origin.'/', 'TRACE');
     $assert($traceStatus === 0, 'TRACE probe failed.');
     $assert(preg_match('/^HTTP\/\S+ (?:403|405|501)\b/m', $traceHeaders) === 1, 'TRACE was not rejected.');
+
+    [$deleteStatus, $deleteHeaders] = $request(
+        $origin.'/api/mobile/v1/me/sessions/00000000-0000-4000-8000-000000000000',
+        'DELETE',
+        ['Accept: application/json'],
+    );
+    $assert($deleteStatus === 0, 'Mobile session DELETE boundary was unreachable.');
+    $assert(
+        preg_match('/^HTTP\/\S+ 401\b/m', $deleteHeaders) === 1,
+        'Mobile session DELETE did not reach Laravel authentication.',
+    );
+    $assert(
+        preg_match('/^Cache-Control:.*\bno-store\b/im', $deleteHeaders) === 1,
+        'Mobile session DELETE did not retain the no-store boundary.',
+    );
 }
 
 if ($failures !== []) {

--- a/tests/Feature/Security/EdgeSecurityContractTest.php
+++ b/tests/Feature/Security/EdgeSecurityContractTest.php
@@ -16,6 +16,10 @@ final class EdgeSecurityContractTest extends TestCase
 
         $this->assertSame('blocking', $policy['waf']['mode']);
         $this->assertSame('OWASP Core Rule Set', $policy['waf']['ruleset']);
+        $this->assertSame(
+            ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+            $policy['waf']['allowed_methods'],
+        );
         $this->assertContains('security2_module', $policy['required_modules']);
         $this->assertFalse($policy['release_rules']['critical_or_high_findings_allowed']);
         $this->assertFalse($policy['release_rules']['production_phi_allowed_without_live_edge_verification']);
@@ -30,6 +34,10 @@ final class EdgeSecurityContractTest extends TestCase
         $this->assertStringContainsString('SecRequestBodyLimitAction Reject', $policy);
         $this->assertStringContainsString('TraceEnable Off', $policy);
         $this->assertStringContainsString('OWASP CRS', $policy);
+        $this->assertStringContainsString(
+            'tx.allowed_methods=GET HEAD POST PUT PATCH DELETE OPTIONS',
+            $policy,
+        );
         $this->assertStringContainsString('@gt 1048576', $policy);
         $this->assertStringNotContainsString('<IfModule', $policy);
     }


### PR DESCRIPTION
## Summary

- align OWASP CRS method enforcement with Zephyrus's explicit REST method contract
- make the allowed method set machine-readable and contract-tested
- add a live release probe proving mobile session `DELETE` reaches Laravel authentication and retains `Cache-Control: no-store`

## Production evidence

The deployed staff session-management route was registered in Laravel (`OPTIONS` advertised `DELETE`), but an unauthenticated production `DELETE /api/mobile/v1/me/sessions/{uuid}` returned Apache HTML `403`. The ModSecurity audit log identified OWASP CRS rule `911100`: CRS's default `tx.allowed_methods` omitted `DELETE`, despite Zephyrus's own edge rule allowing it.

The exact new `SecAction` passes `apache2ctl -t` on the production host without changing host state.

## Validation

- `php -l` for verifier and feature contract test
- `jq empty deploy/security/edge-policy.json`
- `php scripts/security/verify-edge-security.php --contract`
- Laravel Pint
- Prettier
- `git diff --check`
- production Apache parser: `Syntax OK`

The focused PHPUnit command could not start locally because the required loopback PostgreSQL test service is unavailable; the failure occurred in isolated database provisioning before PHPUnit loaded any tests. CI owns the fully provisioned database lanes.

## Safety boundaries

- no application route or authorization change
- no patient feature-flag activation
- no production mutation in the diagnostic phase
- exact method allowlist remains bounded to `GET HEAD POST PUT PATCH DELETE OPTIONS`