### PR TITLE
Accelerate backend and iOS ratification

### DIFF
--- a/app/Domain/Cockpit/Metrics/PeriopMetrics.php
+++ b/app/Domain/Cockpit/Metrics/PeriopMetrics.php
@@ -14,8 +14,10 @@ use Illuminate\Support\Facades\Schema;
  * Perioperative / OR (spec §2.4). LIVE.
  *
  * FCOTS / turnover / block util / cancellations come from the legacy payload
- * (same OR-day window as /dashboard). Prime-time utilization wraps
- * PerioperativeMetricsService; cases-today is one count; PACU holds mirrors
+ * (same OR-day window as /dashboard). Prime-time utilization uses the
+ * PerioperativeMetricsService headline-only path, which preserves the same
+ * window and denominator without rebuilding the full OR dashboard;
+ * cases-today is one count; PACU holds mirrors
  * InterventionAttributionService::pacuHoldsAt()'s convention (in PACU ≥75min
  * with no pacu_out_time — that helper is private, the semantics are shared).
  */
@@ -57,7 +59,7 @@ class PeriopMetrics extends BaseMetrics
     private function primeTimeUtilization(): ?float
     {
         try {
-            $staffed = $this->periop->build()['lastMonth']['primetimeUtilization']['staffed'] ?? null;
+            $staffed = $this->periop->headlinePrimeTimeUtilizationPct();
 
             return is_numeric($staffed) ? (float) $staffed : null;
         } catch (\Throwable) {

--- a/app/Domain/Cockpit/Metrics/StaffingMetrics.php
+++ b/app/Domain/Cockpit/Metrics/StaffingMetrics.php
@@ -10,10 +10,12 @@ use App\Support\Cockpit\MetricValue;
 
 /**
  * Staffing & workforce (spec §2.5). LIVE as of P7: open shifts from
- * StaffingOperationsService::overview(); OT% / agency RNs / callouts /
+ * StaffingOperationsService::cockpitSummary(); OT% / agency RNs / callouts /
  * sitters / productivity from today's prod.workforce_actuals rows via
- * WorkforceActualsService. A cost center that reported no hours today yields
- * a null tile (skipped) rather than a fabricated number.
+ * WorkforceActualsService. The cockpit projection intentionally excludes the
+ * workforce directory and request queue because it consumes neither. A cost
+ * center that reported no hours today yields a null tile (skipped) rather than
+ * a fabricated number.
  */
 class StaffingMetrics extends BaseMetrics
 {
@@ -55,7 +57,7 @@ class StaffingMetrics extends BaseMetrics
     private function overview(): array
     {
         try {
-            return $this->staffing->overview();
+            return $this->staffing->cockpitSummary();
         } catch (\Throwable) {
             return [];
         }

--- a/app/Services/Dashboard/PerioperativeMetricsService.php
+++ b/app/Services/Dashboard/PerioperativeMetricsService.php
@@ -60,6 +60,23 @@ class PerioperativeMetricsService
         ];
     }
 
+    /**
+     * Return the cockpit headline without building the full OR dashboard.
+     *
+     * SnapshotBuilder needs only this scalar. Routing that call through
+     * build() also executes the first-case, case-length, turnover, block,
+     * volume, cancellation, trend, and workbench queries even though their
+     * results are discarded. Keep the exact dashboard window and the shared
+     * PrimetimeUtilizationService authority while avoiding that amplification.
+     */
+    public function headlinePrimeTimeUtilizationPct(): float
+    {
+        $window = $this->dataWindow();
+        [$current] = $this->primeTimeUtilizationSplit($window);
+
+        return (float) round($current);
+    }
+
     // -----------------------------------------------------------------------
     // Working window
     //
@@ -165,11 +182,7 @@ class PerioperativeMetricsService
         );
 
         // Primetime utilization (staffed/unstaffed %), recent vs prior.
-        [$staffedNow, $staffedPrev] = $this->splitMetric(
-            $w,
-            fn (?string $from, ?string $to): float => $this->primetimeUtilizationPct($from, $to),
-            84.0
-        );
+        [$staffedNow, $staffedPrev] = $this->primeTimeUtilizationSplit($w);
         $unstaffedNow = $staffedNow > 0 ? max(0, (int) round($staffedNow - 1)) : 0;
 
         return [
@@ -238,6 +251,19 @@ class PerioperativeMetricsService
         }
 
         return [$current, $previous];
+    }
+
+    /**
+     * @param  array{anchor:?string,start:?string,split:?string,prevStart:?string,label:string,prevLabel:string,hasData:bool}  $window
+     * @return array{0:float,1:float}
+     */
+    private function primeTimeUtilizationSplit(array $window): array
+    {
+        return $this->splitMetric(
+            $window,
+            fn (?string $from, ?string $to): float => $this->primetimeUtilizationPct($from, $to),
+            84.0,
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/app/Services/Staffing/StaffingOperationsService.php
+++ b/app/Services/Staffing/StaffingOperationsService.php
@@ -110,6 +110,32 @@ class StaffingOperationsService
         ];
     }
 
+    /**
+     * Return only the values consumed by the cockpit staffing provider.
+     *
+     * The full overview intentionally includes the canonical workforce
+     * directory summary, at-risk unit detail, request queue serialization, and
+     * resource options. SnapshotBuilder consumes none of those structures, so
+     * loading them on every cockpit refresh needlessly scales with the entire
+     * staff-assignment population.
+     *
+     * @return array{metrics:array{unfilled_requests:int},coverage:array<string,mixed>}
+     */
+    public function cockpitSummary(): array
+    {
+        $plans = $this->todaysPlans();
+
+        return [
+            'metrics' => [
+                'unfilled_requests' => StaffingRequest::query()
+                    ->where('is_deleted', false)
+                    ->where('status', 'unfilled')
+                    ->count(),
+            ],
+            'coverage' => $this->coverageSummary($plans),
+        ];
+    }
+
     public function create(array $data, ?int $actorUserId): StaffingRequest
     {
         return DB::transaction(function () use ($data, $actorUserId): StaffingRequest {

--- a/docs/hummingbird/ZEPHYRUS-HUMMINGBIRD-FUNCTIONAL-PARITY-AND-PATIENT-EXPERIENCE-PLAN-2026-07-19.md
+++ b/docs/hummingbird/ZEPHYRUS-HUMMINGBIRD-FUNCTIONAL-PARITY-AND-PATIENT-EXPERIENCE-PLAN-2026-07-19.md
@@ -183,31 +183,61 @@ This checkpoint records repository implementation, not production approval or de
 
 #### 3.2.9 CI feature-shard duration remediation — evidence and implementation gates
 
-The 2026-07-24 release exposed a concentrated backend-test performance defect rather than a broad cost of Hummingbird ratification. The exact-merge run was held by two PostgreSQL feature shards after the other 17 jobs had passed. Release evidence from PR run `30107421291` records `feature-7` at **4,265.32 seconds** for 194 tests / 8,878 assertions. The following five classes consumed approximately **98.2%** of that shard:
+The 2026-07-24 release exposed a concentrated backend-test performance defect rather than a broad cost of Hummingbird ratification. The exact-merge run was held by two PostgreSQL feature shards after the other 17 jobs had passed. Release evidence from PR run `30107421291` records `feature-6` at **4,135.68 seconds** for 224 tests / 2,755 assertions and `feature-7` at **4,265.32 seconds** for 194 tests / 8,878 assertions. The critical classes were highly concentrated:
 
-| Test class                     | Recorded test time | Share of 4,265.32 s |
-| ------------------------------ | -----------------: | ------------------: |
-| `LaboratoryCockpitMetricsTest` |         2,701.30 s |               63.3% |
-| `AncillaryDemoScenarioTest`    |         1,018.88 s |               23.9% |
-| `PharmacyFlowBoardTest`        |           218.46 s |                5.1% |
-| `PharmacyTatAnalyticsTest`     |           135.40 s |                3.2% |
-| `LabFlowBoardTest`             |           116.26 s |                2.7% |
-| **Measured concentration**     |     **4,190.30 s** |           **98.2%** |
+| Baseline shard | Test class                     | Recorded test time | Share of shard |
+| -------------- | ------------------------------ | -----------------: | -------------: |
+| `feature-6`    | `PharmacyCockpitMetricsTest`   |         3,330.40 s |          80.5% |
+| `feature-6`    | `PharmacyDispenseTest`         |           404.27 s |           9.8% |
+| `feature-7`    | `LaboratoryCockpitMetricsTest` |         2,701.30 s |          63.3% |
+| `feature-7`    | `AncillaryDemoScenarioTest`    |         1,018.88 s |          23.9% |
+| `feature-7`    | `PharmacyFlowBoardTest`        |           218.46 s |           5.1% |
+| `feature-7`    | `PharmacyTatAnalyticsTest`     |           135.40 s |           3.2% |
+| `feature-7`    | `LabFlowBoardTest`             |           116.26 s |           2.7% |
 
-The single stale-laboratory-evidence case took **1,276.07 seconds**. The next four laboratory/ancillary refresh cases took **545.68**, **542.48**, **398.18**, and **337.07** seconds. These timings include each test's setup, which repeatedly seeds broad RTDC, case-management, staffing, command-center, cockpit, and ancillary catalogs and executes a complete `AncillaryDemoScenarioService::refresh`. Several test bodies then rebuild the entire Cockpit snapshot—legacy command-center payload, all metric providers, trends, source health, persistence/history, and drill reads—multiple times even when the assertion is scoped to one laboratory sector.
+The single stale-laboratory-evidence case took **1,276.07 seconds**. The next four laboratory/ancillary refresh cases took **545.68**, **542.48**, **398.18**, and **337.07** seconds. These timings include each test's setup, which repeatedly seeds broad RTDC, case-management, staffing, command-center, cockpit, and ancillary catalogs and executes a complete `AncillaryDemoScenarioService::refresh`. Several test bodies then rebuild the entire Cockpit snapshot—legacy command-center payload, all metric providers, trends, source health, persistence/history, and drill reads—multiple times even when the assertion is scoped to one laboratory or pharmacy sector.
+
+Disposable PostgreSQL 16 profiling isolated two production-path amplification defects and one test-boundary defect:
+
+1. `PeriopMetrics` needed one rounded prime-time-utilization headline, but called `PerioperativeMetricsService::build()`. That full build also executed first-case, case-duration, turnover, block, volume, cancellation, trend, and workbench queries whose results the Cockpit discarded. The slow-query log repeatedly recorded **12–27 second** first-case and case-duration aggregates.
+2. `StaffingMetrics` needed only unfilled-request count and coverage, but called `StaffingOperationsService::overview()`. The full overview also materialized the canonical workforce directory, at-risk detail, request queue, and resource options that the Cockpit discarded.
+3. The laboratory and pharmacy Cockpit tests correctly exercised their real seeded ancillary scenarios, but also rebuilt an unrelated legacy `CommandCenterDataService` base payload on every snapshot. That base payload was not part of the ancillary assertions.
+
+The implementation introduces a headline-only perioperative projection and a Cockpit-only staffing projection. Both reuse the existing authoritative calculation/window helpers rather than create alternate formulas. Parity tests require the fast values to equal the full dashboard/overview values. The perioperative guard permits only **2–4 queries** and fails if the fast path touches `prod.or_logs` or `prod.case_metrics`; the ancillary snapshot guards fail if discarded OR-dashboard or workforce-directory aggregates reappear. The focused laboratory and pharmacy tests mock only the unrelated command-center base payload while retaining their real ancillary seed, full `AncillaryDemoScenarioService::refresh`, Cockpit providers, status engine, persistence/history, and drill reconciliation.
+
+The same change stabilizes the Hummingbird staff iOS exact-replay journey without weakening it. The test uses a short unique reply body, waits a bounded two seconds for the editor's exact value after `typeText`, then retains the explicit exact-replay and exactly-one-visible-message assertions. The formerly failing journey passed **four consecutive local executions**, including three iterations with test retries disabled, and the complete staff iOS lane passed in preliminary PR CI.
+
+Preliminary PR `#60` run `30122622952`, pinned to pre-rebase head `a6db752b776a61b1ec33422058d466719aa63e19`, passed **19/19 jobs**. Its new JUnit artifacts prove zero failures/errors/skips and preserve per-suite, per-class, and per-test times. The comparison below uses the immediately preceding PR `#58` run `30118042639` for whole-job wall time and the retained `30107421291` PHPUnit evidence for class-level baselines:
+
+| Evidence scope                           | Baseline    | Optimized   | Reduction |
+| ---------------------------------------- | ----------- | ----------- | --------: |
+| `feature-6` whole CI job                 | 43m32s      | 15m35s      |     64.2% |
+| `feature-7` whole CI job / critical path | 1h12m54s    | 24m57s      |     65.8% |
+| All eight feature-job runner minutes     | 180m21s     | 104m39s     |     42.0% |
+| `feature-6` PHPUnit                      | 4,135.68 s  | 881.96 s    |     78.7% |
+| `feature-7` PHPUnit                      | 4,265.32 s  | 1,448.58 s  |     66.0% |
+| `PharmacyCockpitMetricsTest`             | 3,330.40 s  | 155.64 s    |     95.3% |
+| `LaboratoryCockpitMetricsTest`           | 2,701.30 s  | 174.69 s    |     93.5% |
+| `feature-6` tests / assertions           | 224 / 2,755 | 224 / 2,755 | preserved |
+| `feature-7` tests / assertions           | 194 / 8,878 | 194 / 8,881 | +3 guards |
+
+The first-stage target is observed, not yet ratified: the critical path is down more than 60% and no shard exceeded 30 minutes in **one of the required three** clean exact-head runs. Residual JUnit evidence identifies the next measured work instead of hiding it behind sharding: `AncillaryDemoScenarioTest` is **753.74 seconds / 52.0%** of optimized `feature-7`; `PharmacyDispenseTest` is **365.69 seconds / 41.5%** of optimized `feature-6`; the two flow-board classes and pharmacy TAT analytics are approximately stable. The remaining work must profile those paths and test setup directly before introducing a weighted manifest or any index.
 
 The current sharder adds a second structural problem: it sorts every `tests/Feature/**/*Test.php` path and assigns `index % 8`. Adding or renaming one earlier-sorting file reassigns nearly every later test to another shard, so load distribution is neither historically weighted nor stable across ordinary test-file additions. Scheduling can hide some critical-path cost, but it cannot solve a single 45-minute class; production query/setup cost must also be reduced.
 
 - [x] Establish a content-free timing baseline from retained CI release evidence and identify the critical-path classes and individual cases. Do not attribute the 70-minute tail to all patient/Hummingbird tests or to human approval.
-- [ ] Emit a JUnit or equivalent machine-readable per-test timing artifact from every backend shard, plus setup-versus-test-body and aggregate database query-count/query-time measurements for the five critical classes. Redact bindings and never publish patient/clinical fixture content in timing or SQL evidence.
+- [x] Emit a machine-readable JUnit timing artifact from every backend shard inside the existing release-evidence package. The preliminary run retained suite/class/test durations with zero content or SQL bindings and proved that the artifact survives both success and failure.
+- [x] Remove the measured Cockpit payload amplification. Add authoritative headline-only perioperative and Cockpit-only staffing projections, exact-output parity tests, query-count/source guards, and focused ancillary snapshot boundaries. Do not replace the shared metric authorities or weaken full integration coverage.
+- [x] Stabilize the Hummingbird staff iOS exact-replay input boundary with a bounded value expectation while retaining explicit replay and no-duplicate safety assertions.
+- [ ] Add setup-versus-test-body and aggregate database query-count/query-time measurements for the residual critical classes. Redact bindings and never publish patient/clinical fixture content in timing or SQL evidence.
 - [ ] Replace global filename-position modulo assignment with a checked-in or deterministically generated **stable weighted shard manifest**. The verifier must prove every discovered feature test appears exactly once, no excluded test silently enters a shard, no path is duplicated, and manifest drift fails CI. Use rolling medians from successful exact-SHA runs; keep a deterministic cold-start weight for new files.
-- [ ] Isolate the five measured heavy classes across shards immediately, but report this as scheduling relief only. Do not claim the suite optimized while one class still requires approximately 45 minutes.
+- [ ] Reassess class isolation only after three clean timing runs establish rolling medians. Report any later redistribution as scheduling relief only; do not use it to conceal a slow class or a production query/setup defect.
 - [ ] Profile `AncillaryDemoScenarioService::refresh`, `SnapshotBuilder::buildWithContext`, `LabFlowBoardService`, `LabDecisionPendingService`, and the Cockpit drill/current path on the exact 66-order / 328-milestone reference fixture. Capture `EXPLAIN (ANALYZE, BUFFERS, WAL)` only in a disposable non-production database and inspect repeated cohort scans, correlated subqueries, JSON predicates, trigger/provenance writes, and missing or ineffective composite/expression indexes.
 - [ ] Introduce one request-scoped aggregate snapshot for laboratory cohort/freshness/summary/callback/decision-pending facts so the Cockpit provider, health service, and drill reuse the same governed calculation instead of independently re-reading the cohort. Preserve the existing single-snapshot reconciliation rule, freshness semantics, privacy projection, and status-engine ownership.
 - [ ] Consolidate repeated aggregate queries with bounded CTEs or grouped aggregates where query plans prove improvement. Add indexes only from measured plans and representative cardinalities; do not add speculative indexes or weaken append-only/provenance triggers.
-- [ ] Reduce test setup amplification without sharing mutable state between tests: create the smallest governed ancillary fixture needed by service-level cases; retain at least one full-seeder/full-refresh integration case for each protected end-to-end invariant; combine only assertions that deliberately validate one immutable snapshot; and keep transaction isolation. Do not switch these PostgreSQL contract tests to SQLite, remove release-boundary assertions, suppress migrations/triggers, or reuse a dirty database.
-- [ ] Add performance regression budgets in two stages. First require at least a **60%** reduction from the 4,265.32-second `feature-7` baseline with no shard above **30 minutes** across three clean exact-SHA runs. After query/setup remediation, tighten the backend feature critical path to **15 minutes** across three clean runs. A budget change requires recorded evidence and review; a timeout increase is not optimization.
-- [ ] Re-run every affected class, the complete backend suite, the capability/contract/security verifiers, and all 19 CI jobs with zero skipped tests. Compare test/ assertion coverage, database invariants, output contracts, and query plans before and after. Ship CI scheduling and production-query changes as separately reviewable commits so a faster shard cannot conceal a semantic regression.
+- [ ] Continue reducing test setup amplification without sharing mutable state between tests: create the smallest governed ancillary fixture needed by service-level cases; retain at least one full-seeder/full-refresh integration case for each protected end-to-end invariant; combine only assertions that deliberately validate one immutable snapshot; and keep transaction isolation. Do not switch these PostgreSQL contract tests to SQLite, remove release-boundary assertions, suppress migrations/triggers, or reuse a dirty database.
+- [ ] Ratify performance regression budgets in two stages. The first observation satisfies at least a **60%** reduction from the 4,265.32-second `feature-7` baseline with no shard above **30 minutes**, but the gate remains **1/3 clean exact-head runs**. After query/setup remediation, tighten the backend feature critical path to **15 minutes** across three clean runs. A budget change requires recorded evidence and review; a timeout increase is not optimization.
+- [ ] Complete final publication evidence on the rebased implementation head: re-run every affected class, the complete backend suite, capability/contract/security verifiers, all four native products, and all 19 CI jobs with zero skipped tests. Compare test/assertion coverage, database invariants, output contracts, and query plans before and after. Ship CI scheduling and production-query changes as separately reviewable commits so a faster shard cannot conceal a semantic regression.
 
 ### 3.3 Parity status vocabulary
 

--- a/hummingbird/iosApp/HummingbirdUITests/PatientCommunicationRoutingUITests.swift
+++ b/hummingbird/iosApp/HummingbirdUITests/PatientCommunicationRoutingUITests.swift
@@ -279,7 +279,7 @@ final class PatientCommunicationRoutingUITests: XCTestCase {
     func testLostCommittedReplyRequiresExplicitExactReplayAndDoesNotDuplicateMessage() {
         launchScenario("ambiguous_reply")
         openDetail()
-        let replyBody = "I will review the discharge steps with you this afternoon."
+        let replyBody = "Replay-safe reply 7391."
         enterDraft(replyBody)
 
         let send = app.buttons["patientCommunications.sendButton"]
@@ -360,7 +360,15 @@ final class PatientCommunicationRoutingUITests: XCTestCase {
         XCTAssertTrue(editor.waitForExistence(timeout: 5))
         editor.tap()
         editor.typeText(text)
-        XCTAssertTrue((editor.value as? String)?.contains(text) == true)
+        let typedValue = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value CONTAINS %@", text),
+            object: editor
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [typedValue], timeout: 2),
+            .completed,
+            "Expected the reply editor to contain the exact test body; actual value: \(String(describing: editor.value))"
+        )
     }
 
     private func assertSeededDraft(_ text: String) {

--- a/scripts/ci/run-backend-test-shard.sh
+++ b/scripts/ci/run-backend-test-shard.sh
@@ -5,8 +5,14 @@ set -Eeuo pipefail
 readonly SHARD="${1:-}"
 readonly FEATURE_SHARD_COUNT=8
 
+phpunit_evidence_args=()
+if [[ -n "${RELEASE_EVIDENCE_DIR:-}" ]]; then
+    mkdir -p "$RELEASE_EVIDENCE_DIR"
+    phpunit_evidence_args+=("--log-junit=$RELEASE_EVIDENCE_DIR/phpunit-$SHARD.xml")
+fi
+
 if [[ "$SHARD" == "unit" ]]; then
-    exec php artisan test --testsuite=Unit --no-ansi
+    exec php artisan test --testsuite=Unit --no-ansi "${phpunit_evidence_args[@]}"
 fi
 
 if [[ ! "$SHARD" =~ ^feature-([0-7])$ ]]; then
@@ -44,4 +50,4 @@ fi
 echo "Running ${#feature_tests[@]} feature test files in $SHARD:"
 printf '  %s\n' "${feature_tests[@]}"
 
-exec php artisan test --no-ansi "${feature_tests[@]}"
+exec php artisan test --no-ansi "${phpunit_evidence_args[@]}" "${feature_tests[@]}"

--- a/tests/Feature/Analytics/SuiteMetricReuseTest.php
+++ b/tests/Feature/Analytics/SuiteMetricReuseTest.php
@@ -25,7 +25,23 @@ final class SuiteMetricReuseTest extends TestCase
         $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class]);
         $calculator = app(SuiteMetricCalculator::class);
 
-        $perioperative = app(PerioperativeMetricsService::class)->build();
+        $perioperativeService = app(PerioperativeMetricsService::class);
+        $perioperative = $perioperativeService->build();
+        $headlineQueries = [];
+        DB::listen(static function ($query) use (&$headlineQueries): void {
+            $headlineQueries[] = strtolower($query->sql);
+        });
+        $headlinePrimeTime = $perioperativeService->headlinePrimeTimeUtilizationPct();
+        $this->assertSame(
+            (float) $perioperative['lastMonth']['primetimeUtilization']['staffed'],
+            $headlinePrimeTime,
+        );
+        $this->assertGreaterThanOrEqual(2, count($headlineQueries));
+        $this->assertLessThanOrEqual(4, count($headlineQueries));
+        $this->assertFalse(collect($headlineQueries)->contains(
+            fn (string $sql): bool => str_contains($sql, 'prod.or_logs')
+                || str_contains($sql, 'prod.case_metrics'),
+        ));
         $firstCases = DB::select(<<<'SQL'
             SELECT first_start, sched
             FROM (

--- a/tests/Feature/Cockpit/LaboratoryCockpitMetricsTest.php
+++ b/tests/Feature/Cockpit/LaboratoryCockpitMetricsTest.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use App\Services\Cockpit\MetricValueWriter;
 use App\Services\Cockpit\SnapshotBuilder;
 use App\Services\Cockpit\StatusEngine;
+use App\Services\CommandCenterDataService;
 use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
 use App\Services\Demo\DemoClock;
 use App\Services\Lab\LabCockpitHealthService;
@@ -22,6 +23,7 @@ use Database\Seeders\StaffingReferenceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Mockery\MockInterface;
 use Tests\TestCase;
 
 final class LaboratoryCockpitMetricsTest extends TestCase
@@ -51,6 +53,12 @@ final class LaboratoryCockpitMetricsTest extends TestCase
             AncillaryReferenceSeeder::class,
         ]);
         app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
+        $this->mock(CommandCenterDataService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('build')->andReturn([
+                'generatedAtIso' => $this->anchor->toIso8601String(),
+                'strain' => [],
+            ]);
+        });
     }
 
     protected function tearDown(): void
@@ -79,7 +87,16 @@ final class LaboratoryCockpitMetricsTest extends TestCase
         $this->assertSame($flowHealth['criticalCallbacks']['open'], $laboratory['criticalCallbacks']['value']);
         $this->assertSame($laboratory['criticalCallbacks']['value'], $laboratory['criticalCallbacks']['atRiskCount']);
 
+        $snapshotQueries = [];
+        DB::listen(static function ($query) use (&$snapshotQueries): void {
+            $snapshotQueries[] = strtolower($query->sql);
+        });
         $tiles = collect(app(SnapshotBuilder::class)->build()['domains']['lab']['tiles'])->keyBy('key');
+        $this->assertFalse(collect($snapshotQueries)->contains(
+            fn (string $sql): bool => str_contains($sql, 'distinct on (oc.room_id, oc.surgery_date)')
+                || str_contains($sql, 'extract(epoch from (l.procedure_end_time - l.procedure_start_time))')
+                || str_contains($sql, 'hosp_org.staff_assignments'),
+        ), 'Cockpit scalar paths must not execute discarded OR dashboard or workforce-directory aggregates.');
         $stat = $tiles->get(self::KEYS[0]);
         $pending = $tiles->get(self::KEYS[1]);
         $callbacks = $tiles->get(self::KEYS[2]);

--- a/tests/Feature/Cockpit/PharmacyCockpitMetricsTest.php
+++ b/tests/Feature/Cockpit/PharmacyCockpitMetricsTest.php
@@ -7,6 +7,7 @@ use App\Models\User;
 use App\Services\Cockpit\MetricValueWriter;
 use App\Services\Cockpit\SnapshotBuilder;
 use App\Services\Cockpit\StatusEngine;
+use App\Services\CommandCenterDataService;
 use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
 use App\Services\Demo\DemoClock;
 use App\Services\Pharmacy\PharmacyCockpitHealthService;
@@ -21,6 +22,7 @@ use Database\Seeders\StaffingReferenceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Mockery\MockInterface;
 use Tests\TestCase;
 
 final class PharmacyCockpitMetricsTest extends TestCase
@@ -57,6 +59,12 @@ final class PharmacyCockpitMetricsTest extends TestCase
             AncillaryReferenceSeeder::class,
         ]);
         app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
+        $this->mock(CommandCenterDataService::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('build')->andReturn([
+                'generatedAtIso' => $this->anchor->toIso8601String(),
+                'strain' => [],
+            ]);
+        });
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Staffing/StaffingApiTest.php
+++ b/tests/Feature/Staffing/StaffingApiTest.php
@@ -6,6 +6,7 @@ use App\Models\Staffing\StaffingPlan;
 use App\Models\Staffing\StaffingRequest;
 use App\Models\User;
 use App\Services\Demo\OperationalDemoDataService;
+use App\Services\Staffing\StaffingOperationsService;
 use Database\Seeders\RtdcSeeder;
 use Database\Seeders\StaffingReferenceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -88,6 +89,12 @@ class StaffingApiTest extends TestCase
             ->assertJsonPath('data.metrics.at_risk_units', 2)
             ->assertJsonPath('data.metrics.total_gap_headcount', 3)
             ->assertJsonPath('data.coverage.coverage_pct', 77); // 10 available / 13 required
+
+        $staffing = app(StaffingOperationsService::class);
+        $overview = $staffing->overview();
+        $cockpit = $staffing->cockpitSummary();
+        $this->assertSame($overview['metrics']['unfilled_requests'], $cockpit['metrics']['unfilled_requests']);
+        $this->assertSame($overview['coverage'], $cockpit['coverage']);
     }
 
     public function test_sla_preserves_whole_second_precision(): void


### PR DESCRIPTION
## Summary

- add headline-only perioperative and cockpit-only staffing projections so `SnapshotBuilder` no longer builds discarded full-domain payloads
- preserve the exact prime-time window, fallback, rounding, and shared `PrimetimeUtilizationService` authority
- keep laboratory and pharmacy cockpit tests fully integrated with their ancillary scenario while stubbing the unrelated legacy command-center base payload
- add parity and query-regression guards against reintroducing full OR dashboard or workforce-directory work
- stabilize the iOS exact-replay UI journey with a shorter unique body and a bounded field-value expectation while preserving the exact-replay and no-duplicate assertions
- retain deterministic per-suite and per-test JUnit timings in every backend shard artifact so future balancing decisions use exact evidence
- update the canonical Hummingbird checklist with exact baseline/optimized timings, completed controls, residual bottlenecks, and the still-open three-run budget gate

## Root cause and measured effect

Retained CI evidence from run `30107421291` showed the critical path in `feature-6` and `feature-7`:

- `PharmacyCockpitMetricsTest`: 3,330.40 seconds
- `LaboratoryCockpitMetricsTest`: 2,701.30 seconds

A single lab/pharmacy snapshot test reproduced locally at about 132 seconds. PostgreSQL slow-query evidence showed that a one-scalar perioperative request repeatedly executed 12-27 second first-case and case-duration aggregates, while staffing requested two cockpit values through the full canonical workforce summary.

On the same disposable PostgreSQL 16 harness after this change:

- laboratory scalar test: 132.4s -> 20.9s
- pharmacy scalar test: 132.1s -> 20.6s
- full laboratory class: 4 tests / 68 assertions in 66.9s
- full pharmacy class: 5 tests / 66 assertions in 96.9s
- formerly worst stale-evidence methods: 269-514s -> about 21s each in isolation

## Local validation

- Laravel Pint: 8 changed PHP files pass
- `git diff --check`: pass
- `SuiteMetricReuseTest`: 1 test / 12 assertions
- `LaboratoryCockpitMetricsTest`: 4 tests / 68 assertions
- `PharmacyCockpitMetricsTest`: 5 tests / 66 assertions
- `StaffingApiTest`: 9 tests / 54 assertions
- `StaffingLiveSourcesTest`: 3 tests / 16 assertions
- `CockpitSnapshotSectionsTest`: 8 tests / 67 assertions
- Hummingbird staff Xcode project verification: pass
- exact iOS replay-loss UI journey: 4 consecutive local passes, including 3 repeated iterations with retries disabled
- shard runner syntax: pass; JUnit evidence emitted with suite, class, and test timings
- canonical plan target-file Prettier check and `git diff --check`: pass
- preliminary CI run `30122622952`: 19/19, with feature-6 reduced 64.2% and feature-7 reduced 65.8%
- rebased exact-head CI run `30124481668`: 19/19 with no retry; every backend, browser, security, and native-product lane passed

All database validation used isolated disposable test databases. This change adds no migration, activation, approval, release, patient session, token, or production-data mutation.
