### PR TITLE
Add governed DRG Care Pathways Catalog Explorer

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -54,3 +54,18 @@ condition = "AND"
 paths = ['''^tests/Feature/Rounds/PatientRoundQuestionPromotionTest\.php$''']
 # See the preceding allowlist: match the captured deterministic fixture value.
 regexes = ['''test-rounds-question-key-v1''']
+
+[[allowlists]]
+# Care-pathway governance fixtures: captured real API envelopes whose
+# `"key"` field is the public stable pathway identifier (drgcp-<slug>-<hex12>
+# from care_pathways.definitions.pathway_key), not credential material. The
+# generic API-key rule fires on the field name. Scoped to the two committed
+# fixture files and to values with the drgcp- prefix only; digests, tokens,
+# and every other file remain subject to scanning.
+description = "Care-pathway fixture public pathway_key identifiers"
+condition = "AND"
+paths = [
+  '''^tests/js/carePathways/__fixtures__/pathways-page1\.json$''',
+  '''^tests/js/carePathways/__fixtures__/version-detail\.json$''',
+]
+regexes = ['''^drgcp-[a-z0-9-]+$''']

--- a/app/Http/Controllers/CarePathwayCatalogPageController.php
+++ b/app/Http/Controllers/CarePathwayCatalogPageController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\CarePathways\CatalogGovernanceReadService;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class CarePathwayCatalogPageController extends Controller
+{
+    public function __construct(
+        private readonly CatalogGovernanceReadService $catalog,
+    ) {}
+
+    public function index(): Response
+    {
+        $summary = $this->catalog->summary();
+        if ($summary === null) {
+            throw new NotFoundHttpException;
+        }
+
+        return Inertia::render('CarePathways/Catalog/Index', [
+            'initialSummary' => $summary,
+            'initialPathways' => $this->catalog->pathways(['page' => 1, 'per_page' => 25]),
+        ]);
+    }
+
+    public function show(string $versionUuid): Response
+    {
+        $version = $this->catalog->version($versionUuid);
+        if ($version === null) {
+            throw new NotFoundHttpException;
+        }
+
+        return Inertia::render('CarePathways/Catalog/Show', [
+            'initialVersion' => $version,
+        ]);
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -77,6 +77,7 @@ class HandleInertiaRequests extends Middleware
                     'manage_data_stewardship' => $allows(Capability::ManageDataStewardship),
                     'view_patient_communications' => $allows(Capability::ViewPatientCommunications),
                     'respond_patient_communications' => $allows(Capability::RespondPatientCommunications),
+                    'view_care_pathway_catalog' => $allows(Capability::ViewCarePathwayCatalog),
                 ],
             ],
             'adminScope' => $usesAdminScope
@@ -99,6 +100,10 @@ class HandleInertiaRequests extends Middleware
                 // A read-only synthetic journey; independent from every real
                 // catalog, assignment, patient, Hummingbird, and Eddy gate.
                 'care_pathways_demo' => (bool) config('care-pathways.demo.enabled'),
+                // Read-only governance examination surface for the inactive
+                // catalog; gated identically to the governance JSON API so nav
+                // and route never disagree. Never a clinical-serving gate.
+                'care_pathways_catalog' => (bool) config('care-pathways.governance_enabled'),
                 'virtual_rounds' => (bool) config('rounds.enabled'),
                 // Home Hospital ships disabled; nav stays hidden (never a dead
                 // link) until HOME_HOSPITAL_ENABLED is on — matching the server

--- a/docs/DEVLOG-care-pathways-catalog-explorer-2026-07-24.md
+++ b/docs/DEVLOG-care-pathways-catalog-explorer-2026-07-24.md
@@ -1,0 +1,121 @@
+# DEVLOG — Care Pathways Catalog Explorer (2026-07-24)
+
+Plan: `docs/superpowers/plans/2026-07-24-drg-care-pathways-catalog-explorer.md`
+Branch: `main` (direct, per [SU] instruction). Commits `67cb7512..cbed94f9`.
+
+## What shipped
+
+A comprehensive **Catalog Explorer** that elucidates all 250 governed DRG care
+pathways — the first UI consumer of the (previously orphaned) governance read
+API — plus a design-canon rebuild of the Heart-Failure journey demo.
+
+### 1. `/care-pathways/catalog` — Overview + Index (`Pages/CarePathways/Catalog/Index.tsx`)
+- **GovernanceBanner** (on every catalog surface): "Reference catalog — not
+  clinically approved", the envelope's `clinical_approval_warning`, release
+  state `inactive`, clinical sign-offs `0`, patient/Eddy serving `Off`.
+- **CatalogOverview**: release header (grouper v43.1, window 2026-04-01 →
+  2026-09-30, dataset key, source cutoff), metric wall via the system
+  `MetricGrid`/`metric()` (250 pathways · 770 MS-DRG codes · 802 associations ·
+  10,123 claims · 811 sources · 0 sign-offs), evidence partition (96 verified /
+  154 limitations), disposition partition (96 sign-off queue / 148 specialist /
+  6 redesign), release controls with reconciliation state.
+- **ActivationReadiness**: the six activation gates as an explicit icon+label
+  checklist derived from `release_readiness` — the honest "why this stays
+  inactive" narrative.
+- **PathwayFilters + PathwayTable**: debounced search, DRG-code / evidence /
+  disposition / approval filters (mirroring the API's validation exactly),
+  paginated 250-row table (rank, pathway link, MDC, service line, DRG chips,
+  evidence badge, governance chips).
+
+### 2. `/care-pathways/catalog/{versionUuid}` — Detail (`Pages/CarePathways/Catalog/Show.tsx`)
+Per-DRG elucidation: all **28 clinical prose sections** in canonical clinical
+reading order (admission criteria → data quality notes; immutable source text
+with digest provenance, approved-text slot for the editorial pipeline), DRG
+candidates with grouper metadata + the clinician-confirmation framing,
+paginated **evidence claims with PubMed-linked graded sources**, structured
+authoring state (empty in release 2 — stated, not hidden), and the append-only
+governance ledger (reviews, approvals, source changes, digests, unresolved
+flags).
+
+### 3. Data layer (`lib/carePathways/`, `hooks/carePathways/`)
+Zod schemas mirror `CatalogGovernanceReadService` envelopes exactly and were
+**validated against real captured envelopes** (fixtures committed at
+`tests/js/carePathways/__fixtures__/`, parsed in `catalogSchemas.test.ts`).
+Typed axios client + TanStack Query hooks; server-rendered Inertia props pass
+through the same Zod gate as live fetches. No `any` anywhere.
+
+### 4. Backend (`CarePathwayCatalogPageController`, routes, share, nav)
+Two thin Inertia routes gated **identically to the governance JSON API**
+(`EnsureCarePathwayGovernanceEnabled` + `can:viewCarePathwayCatalog`), a
+`care_pathways_catalog` feature share, `view_care_pathway_catalog` in the
+`can` share, and a "Catalog Explorer" nav leaf gated on **both** the feature
+and the capability. TDD: `CarePathwayCatalogPageTest` (5 tests — fail-closed
+404, capability 403, Inertia render assertions, unknown-version 404).
+
+### 5. Demo rebuild (`Pages/CarePathways/Demo.tsx`)
+Same six-step journey and six surface projections, now on canon:
+healthcare-* tokens (in-file raw palette 104 → 0), `Surface` primitive,
+`tabular-nums` (no `font-mono`), fully typed projections, icon+label status
+pills, `DashboardLayout`+`PageContentLayout` (double gutter removed), and a
+feature-gated "Browse the 250-pathway catalog" cross-link.
+**Raw-palette ratchet baseline lowered 180 → 76** in `check-ui-canon.sh`.
+
+## Dev provisioning (Phase 0 — dev-only, additive, reversible)
+
+`zephyrus_dev` had **no `care_pathways` schema**. Provisioned via the canonical
+pipeline:
+1. Ran the 8 catalog migrations individually with `--path=` (the 9th,
+   `2026_07_22_001400`, was intentionally skipped: it needs
+   `patient_experience.encounter_access_grants` which dev lacks, and its
+   catalog-side `stage_definitions` table has 0 rows even in the fully adopted
+   `zephyrus` DB and is untouched by import and read services).
+2. Copied `raw.drg_cp_*` + manifest + `raw.drg_care_pathway_imports` from the
+   `zephyrus` DB via pg_dump (11 tables + 2 views), restored the manifest FK.
+3. `php artisan care-pathways:adopt-raw-release 1 --actor="dev-bootstrap-2026-07-24"`
+   — dry-run controls passed, then adopted **inactive**. Counts identical to
+   prod: 250/250/7000/770/10123, 0 sign-offs.
+4. Dev `.env`: `CARE_PATHWAYS_GOVERNANCE_ENABLED=true` and
+   `CARE_PATHWAYS_DEMO_ENABLED=true` (verification). **Prod untouched.**
+
+Rollback: `DROP SCHEMA care_pathways CASCADE` on `zephyrus_dev` + remove the
+two env lines.
+
+## Verification evidence
+
+- PHPUnit: full CarePathway lane **53 passed (428 assertions)** including the
+  new page test; isolated `zephyrus_test_*` DB.
+- vitest: **39 passed** (envelope schemas vs real fixtures, demo envelope
+  guard, navigation config).
+- `npx tsc --noEmit` clean; `npx vite build` clean (twice, incl. final state).
+- `check-ui-canon.sh` green at the NEW lower baseline (76).
+- Browser (dev, `superadmin` session via curl): catalog Index 200 with real
+  250-pathway payload; filters verified through the live API (`q=sepsis`→1,
+  `drg=870`→Sepsis, `evidence_state=limitations`→154, `disposition=redesign`→6
+  — all matching release controls); Sepsis detail 200 (28 sections, DRGs
+  870/871/872, 57 claims, PMID links incl. Sepsis-3); demo 200 with step-3
+  release boundaries correct (rounds visible, patient locked).
+
+## Gotchas recorded
+
+- **`.env.local` trap**: a stale 2-line `.env.local` (session-cookie overrides,
+  Feb 27) shadows `.env` whenever `APP_ENV=local` is in the actual process
+  environment — `php artisan serve` passes it through, so serve dies with
+  MissingAppKey. Workaround: `php -S 127.0.0.1:8084` from `public/` with the
+  framework router (no APP_ENV passthrough). Left `.env.local` untouched.
+- Dev login is `superadmin` / admin@acumenus.net (the `admin` username belongs
+  to an inactive seed user).
+- Nav: the CARE_PATHWAYS domain stays gated on `care_pathways_demo`; the
+  Catalog leaf self-gates on `care_pathways_catalog` + capability. The
+  theoretical demo-off+catalog-on combo would hide the domain (acceptable —
+  no such environment exists; revisit if that combination ever ships).
+
+## Deferred / [SU] decisions
+
+- **Prod exposure**: setting `CARE_PATHWAYS_GOVERNANCE_ENABLED=true` on prod is
+  an explicit [SU] decision (GET-only and fail-closed by design, but it exposes
+  the governed catalog to capability-holding prod staff). Prod's `zephyrus` DB
+  already holds the adopted release; no migration or adoption is needed there —
+  only the env flag + `php8.5-fpm` reload.
+- Everything clinical-serving (catalog/assignment/rounds/patient/Eddy/writeback
+  flags, approvals, activation) remains **off / deferred on institutional and
+  clinical authority** — unchanged by this work.

--- a/docs/hummingbird/capability-ledger.v1.yaml
+++ b/docs/hummingbird/capability-ledger.v1.yaml
@@ -1207,6 +1207,31 @@ capabilities:
     offline_class: NO_CACHE
     data_classification: internal
 
+  - id: care_pathways.catalog_explorer
+    domain: care_pathways
+    title: Governed DRG catalog explorer (read-only governance examination)
+    implementation_status: complete
+    target_disposition: DESKTOP_ONLY
+    phase: care_pathways_p0
+    owners: { product: Care Pathways Product, engineering: Web Platform }
+    user_roles: ["@web_authorized"]
+    authorization_capabilities:
+      ViewCarePathwayCatalog:
+        - GET /care-pathways/catalog
+        - "GET /care-pathways/catalog/{versionUuid}"
+    verification_evidence:
+      - tests/Feature/CarePathways/CarePathwayCatalogPageTest.php
+      - tests/js/carePathways/catalogSchemas.test.ts
+      - tests/js/config/navigationConfig.test.ts
+    web_routes: [/care-pathways/catalog]
+    staff_bff_operations: []
+    patient_api_operations: []
+    ios_routes: []
+    android_routes: []
+    notification_events: []
+    offline_class: NO_CACHE
+    data_classification: internal
+
   - id: patient_communications.staff_response
     domain: patient_experience
     title: Accountable staff inbox and response lifecycle for inpatient communications

--- a/docs/hummingbird/capability-registry.lock
+++ b/docs/hummingbird/capability-registry.lock
@@ -59,3 +59,4 @@ staffing.operations
 transport.analytics
 transport.operations
 transport.resources
+care_pathways.catalog_explorer

--- a/docs/hummingbird/generated/capability-coverage.md
+++ b/docs/hummingbird/generated/capability-coverage.md
@@ -8,12 +8,12 @@
 
 ## Inventory summary
 
-- Capabilities: 51
-- Navigation routes with a single ledger owner: 100
+- Capabilities: 52
+- Navigation routes with a single ledger owner: 101
 - Staff mobile/auth operations with a single ledger owner: 60
 - Patient API operations with a single ledger owner: 25
-- Implementation states: `not_applicable` 11, `partial` 22, `planned` 18
-- Target dispositions: `DEEPLINK` 8, `DESKTOP_ONLY` 9, `GLANCE` 10, `NATIVE` 20, `NOTIFY` 3, `PATIENT` 1
+- Implementation states: `complete` 1, `not_applicable` 11, `partial` 22, `planned` 18
+- Target dispositions: `DEEPLINK` 8, `DESKTOP_ONLY` 10, `GLANCE` 10, `NATIVE` 20, `NOTIFY` 3, `PATIENT` 1
 
 ## Capability ledger
 
@@ -30,6 +30,7 @@
 | `analytics` | `analytics.predictive_workbench` — Predictive planning and scenario workbench | `not_applicable` | `DESKTOP_ONLY` | `governance_p0` | Operations Intelligence Product | Web Platform | `/analytics/predictive`<br>`/analytics/workbench` | — | — | — | — |
 | `analytics` | `analytics.process_intelligence` — Process intelligence | `not_applicable` | `DEEPLINK` | `staff_p3` | Process Intelligence Product | Web Platform | `/analytics/process-intelligence` | — | — | — | — |
 | `analytics` | `analytics.retrospective` — Retrospective review | `not_applicable` | `DEEPLINK` | `staff_p3` | Operations Intelligence Product | Web Platform | `/analytics/retrospective` | — | — | — | — |
+| `care_pathways` | `care_pathways.catalog_explorer` — Governed DRG catalog explorer (read-only governance examination) | `complete` | `DESKTOP_ONLY` | `care_pathways_p0` | Care Pathways Product | Web Platform | `/care-pathways/catalog` | — | — | — | — |
 | `care_pathways` | `care_pathways.synthetic_journey_demo` — Synthetic care-pathway journey demo | `partial` | `DESKTOP_ONLY` | `care_pathways_p0` | Care Pathways Product | Web Platform | `/care-pathways/demo` | — | — | — | — |
 | `cockpit` | `cockpit.agent_inbox` — Agent inbox and governed operational approvals | `partial` | `NATIVE` | `staff_p1` | Operations Intelligence Product | Hummingbird Platform | `/ops/agent-inbox` | `GET /api/mobile/v1/ops/inbox`<br>`POST /api/mobile/v1/ops/approvals/{uuid}/decision` | — | `hummingbird/iosApp/Hummingbird/Features/Capacity/CapacityDemandView.swift` | `hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/capacity/CapacityDemandScreens.kt` |
 | `cockpit` | `cockpit.executive_brief` — Executive brief | `partial` | `NATIVE` | `staff_p1` | Executive Operations Product | Hummingbird Platform | `/ops/executive-brief` | `GET /api/mobile/v1/command/house` | — | `hummingbird/iosApp/Hummingbird/Features/Executive/ExecutiveHomeView.swift` | `hummingbird/androidApp/app/src/main/java/net/acumenus/hummingbird/ui/executive/ExecutiveScreens.kt` |

--- a/docs/superpowers/plans/2026-07-24-drg-care-pathways-catalog-explorer.md
+++ b/docs/superpowers/plans/2026-07-24-drg-care-pathways-catalog-explorer.md
@@ -1,0 +1,1054 @@
+# DRG Care Pathways Catalog Explorer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a comprehensive, on-canon "Catalog Explorer" surface that lets authorized staff examine all 250 governed DRG care pathways — an Overview dashboard, a searchable/filterable 250-pathway index, and a full per-pathway detail view — reading exclusively from the existing (already-complete) governance read API, and rebuild the off-canon Heart-Failure Demo onto the design system.
+
+**Architecture:** The Laravel `CatalogGovernanceReadService` already returns every shape we need (`summary()`, `pathways()`, `version()`, `claims()`), fail-closed on `governance_enabled`, with the "not clinically approved / inactive" framing baked into every envelope. We add (1) two thin Inertia page routes/controllers that server-render initial data and delegate live filtering/pagination to the JSON API, (2) a Zod-validated typed API client + TanStack Query hooks, (3) three React pages built on the `Surface`/`Panel`/`MetricCard` canon primitives and `healthcare-*` tokens, and (4) a canon rebuild of `Demo.tsx`. No new backend business logic — the catalog is the single source of truth.
+
+**Tech Stack:** Laravel 11 / PHP 8.4 (Inertia render + existing governance services), React 19 + TypeScript + Vite, TanStack Query v5, Zod v4, TailwindCSS v4 (`healthcare-*` tokens), lucide-react icons, PHPUnit (isolated `zephyrus_test_*` on host PG17).
+
+---
+
+## Non-Negotiable Constraints (read before any task)
+
+- **Governance framing is mandatory.** This is a *reference/examination* surface, never a clinical-serving one. Every page must surface: `state = inactive`, `clinical_signoff_count = 0`, the envelope's `clinical_approval_warning` ("Automated evidence verification is not institutional clinical approval."), and `patient_serving:false / eddy_serving:false`. Never imply a pathway is clinically approved or active.
+- **No serving flags are touched.** Only `CARE_PATHWAYS_GOVERNANCE_ENABLED` (a read gate) changes, and only on **dev** in this plan. Prod stays off until [SU] explicitly approves.
+- **Token canon (CLAUDE.md).** `healthcare-*` tokens with `dark:` pairs only; **no raw Tailwind palette** (`slate/gray/cyan/emerald/rose/amber/white-*`); surfaces via `Surface`/`Panel`/`Card`/`MetricCard` only (never `bg-white`/hand-rolled); weights 400/500/600 only (**no `font-bold`**); Tailwind size scale only (**no `text-[Npx]`**); metrics/IDs `tabular-nums` (**never `font-mono`**); status by icon+label, never color alone; earned-urgency color rationing (`healthcare-critical/warning/success/info`); gold `:focus-visible`. `scripts/check-ui-canon.sh` must stay green and the raw-palette ratchet must **go down** (fixing Demo.tsx).
+- **DB safety.** Host PG17 via `~/.pgpass`, TCP (`-h localhost -U claude_dev`), never Docker PG, never peer socket. All Phase 0 ops are additive to `zephyrus_dev` only and reversible via `DROP SCHEMA care_pathways CASCADE` on dev.
+- **Named exports only** (except Inertia page default exports, which the framework requires). **No `any`** — every API boundary is Zod-validated.
+
+## File Structure
+
+**Backend (new):**
+- `app/Http/Controllers/CarePathwayCatalogPageController.php` — `index()` (Overview+Index shell, server-renders `summary()` + page-1 `pathways()`) and `show($versionUuid)` (Detail shell, server-renders `version()`).
+- `tests/Feature/CarePathways/CarePathwayCatalogPageTest.php` — gating + render assertions.
+
+**Backend (modify):**
+- `routes/web.php` — register the two Inertia routes (after the demo route, ~line 94).
+- `app/Http/Middleware/HandleInertiaRequests.php` — add `care_pathways_catalog` to the `features` share (~line 98).
+- `resources/js/config/navigationConfig.ts` — add `care_pathways_catalog` to `NavigationFeatures` (~line 82) and a "Catalog" group to the `CARE_PATHWAYS` nav domain (~line 193).
+
+**Frontend data layer (new):**
+- `resources/js/lib/carePathways/catalogSchemas.ts` — Zod schemas mirroring the PHP envelopes.
+- `resources/js/lib/carePathways/catalogApi.ts` — typed axios client returning parsed data.
+- `resources/js/hooks/carePathways/useCatalog.ts` — TanStack Query hooks.
+
+**Frontend pages (new):**
+- `resources/js/Pages/CarePathways/Catalog/Index.tsx` — Overview + Pathway Index.
+- `resources/js/Pages/CarePathways/Catalog/Show.tsx` — Pathway Detail.
+
+**Frontend components (new, under `resources/js/Components/CarePathways/`):**
+- `GovernanceBanner.tsx` — the mandatory inactive/not-approved framing (reused on every page).
+- `CatalogOverview.tsx` — release header + metric tiles + evidence/disposition partitions + distributions.
+- `ActivationReadiness.tsx` — activation blockers list from `release_readiness` + counts.
+- `PathwayFilters.tsx` — search + faceted filter controls.
+- `PathwayTable.tsx` — virtualized/paginated 250-row table.
+- `EvidenceBadge.tsx`, `GovernanceStatus.tsx`, `DrgChips.tsx` — small shared display atoms (icon+label, never color alone).
+- `PathwaySections.tsx` — the 28 clinical prose sections (accordion, source vs approved).
+- `PathwayAuthoring.tsx` — milestones / goals / activities / education.
+- `EvidenceClaims.tsx` — paginated claims → sources.
+- `GovernanceLedger.tsx` — reviews / approvals / change log / provenance digests.
+
+**Frontend (modify):**
+- `resources/js/Pages/CarePathways/Demo.tsx` — canon rebuild + "Back to Catalog" cross-link.
+
+---
+
+## Phase 0 — Provision dev data + enable read gate (dev only, additive, reversible)
+
+> Ops, not TDD. The governance API and every page below return empty/404 until `zephyrus_dev` holds the adopted catalog. `zephyrus_dev` currently has **no `care_pathways` schema**; the fully-adopted release lives in the separate `zephyrus` DB, and the raw source tables (`raw.drg_cp_*`) live there too. We reproduce the canonical migrate → load raw → adopt pipeline on `zephyrus_dev`.
+
+### Task 0.1: Run the care_pathways migrations on zephyrus_dev
+
+**Files:** none (DB migration).
+
+- [ ] **Step 1: Confirm starting state (schema absent)**
+
+Run:
+```bash
+export PGPASSFILE=~/.pgpass
+psql -h localhost -U claude_dev -d zephyrus_dev -tAc "SELECT to_regclass('care_pathways.catalog_releases');"
+```
+Expected: empty line (schema absent).
+
+- [ ] **Step 2: Run ONLY the 8 catalog migrations (skip the patient-instance one)**
+
+The 9th migration (`2026_07_22_001400_create_patient_pathway_instance_history`) builds `patient_experience.*` tables that depend on `encounter_access_grants` and are **out of scope** for a read-only catalog explorer. Run the 8 catalog migrations by path:
+
+```bash
+cd /home/smudoshi/Github/Zephyrus
+for m in 2026_07_21_000900_create_care_pathway_catalog \
+         2026_07_21_001000_extend_care_pathway_provenance \
+         2026_07_21_001100_create_care_pathway_current_provenance_views \
+         2026_07_21_001200_create_care_pathway_source_status_ledger \
+         2026_07_21_001300_repair_care_pathway_source_retraction_negation \
+         2026_07_21_001400_create_care_pathway_release_source_membership \
+         2026_07_21_001500_protect_care_pathway_section_sources \
+         2026_07_21_001600_enforce_care_pathway_source_membership; do
+  php artisan migrate --path="database/migrations/${m}.php" --database=pgsql
+done
+```
+Expected: each prints `DONE`. (These target `DB_DATABASE=zephyrus_dev` per `.env`.)
+
+- [ ] **Step 3: Verify schema + triggers exist**
+
+Run:
+```bash
+psql -h localhost -U claude_dev -d zephyrus_dev -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='care_pathways' AND table_type='BASE TABLE';"
+```
+Expected: `25`.
+
+### Task 0.2: Copy the raw verification tables from zephyrus → zephyrus_dev
+
+**Files:** none (DB data copy).
+
+- [ ] **Step 1: Dump the raw drg_cp_* tables + manifest from zephyrus**
+
+```bash
+export PGPASSFILE=~/.pgpass
+pg_dump -h localhost -U claude_dev -d zephyrus \
+  --table='raw.drg_care_pathway_verification_imports' \
+  --table='raw.drg_cp_*' \
+  --no-owner --no-privileges -f /tmp/drg_cp_raw.sql
+```
+Expected: file written, no error.
+
+- [ ] **Step 2: Load into zephyrus_dev (raw schema already exists there)**
+
+```bash
+psql -h localhost -U claude_dev -d zephyrus_dev -v ON_ERROR_STOP=1 -f /tmp/drg_cp_raw.sql
+```
+Expected: `COPY` lines, no error. If `raw` schema is missing, precede with `psql -h localhost -U claude_dev -d zephyrus_dev -c "CREATE SCHEMA IF NOT EXISTS raw;"`.
+
+- [ ] **Step 3: Verify raw manifest row id=1 exists**
+
+```bash
+psql -h localhost -U claude_dev -d zephyrus_dev -tAc "SELECT count(*) FROM raw.drg_cp_verified_pathways_v43_1_20260721;"
+```
+Expected: `250`.
+
+### Task 0.3: Adopt the release inactive via the canonical pipeline
+
+**Files:** none (artisan command).
+
+- [ ] **Step 1: Dry-run to validate all controls before writing**
+
+```bash
+cd /home/smudoshi/Github/Zephyrus
+php artisan care-pathways:adopt-raw-release 1 --actor="dev-bootstrap-2026-07-24" --dry-run
+```
+Expected: `Care-pathway release controls passed (dry run).` with `Pathways: 250`, `MS-DRG codebook entries: 770`, `Pathway-to-DRG associations: 802`, `Evidence claims: 10123`. If any control fails, STOP — the raw copy is incomplete; re-run Task 0.2.
+
+- [ ] **Step 2: Adopt for real (writes the inactive catalog)**
+
+```bash
+php artisan care-pathways:adopt-raw-release 1 --actor="dev-bootstrap-2026-07-24"
+```
+Expected: `Care-pathway release adopted inactive.` `State: inactive` `Pathways: 250`.
+
+- [ ] **Step 3: Verify population matches zephyrus**
+
+```bash
+psql -h localhost -U claude_dev -d zephyrus_dev -tAc "SELECT (SELECT count(*) FROM care_pathways.definitions) defs, (SELECT count(*) FROM care_pathways.versions) versions, (SELECT count(*) FROM care_pathways.sections) sections, (SELECT count(*) FROM care_pathways.drg_codebook_entries) drgs, (SELECT count(*) FROM care_pathways.evidence_claims) claims, (SELECT clinical_signoff_count FROM care_pathways.catalog_releases) signoffs;"
+```
+Expected: `250|250|7000|770|10123|0`.
+
+### Task 0.4: Enable the governance read gate on dev + verify end-to-end
+
+**Files:** Modify `.env` (dev only — not committed).
+
+- [ ] **Step 1: Add the dev read flag**
+
+Append to `/home/smudoshi/Github/Zephyrus/.env`:
+```
+CARE_PATHWAYS_GOVERNANCE_ENABLED=true
+```
+
+- [ ] **Step 2: Clear config cache**
+
+```bash
+php artisan config:clear
+```
+Expected: `Configuration cache cleared successfully.`
+
+- [ ] **Step 3: Confirm the admin user holds `viewCarePathwayCatalog`**
+
+```bash
+php artisan tinker --execute="\$u = App\Models\User::where('email','admin@acumenus.net')->first(); dump(app(App\Services\Authorization\RoleCapabilityService::class)->allows(\$u, App\Authorization\Capability::ViewCarePathwayCatalog));"
+```
+Expected: `true`. If `false`, note in the devlog — the page will 403 for that user and a capability grant is a separate [SU] decision (do NOT self-grant).
+
+- [ ] **Step 4: Smoke the JSON API returns the 250 catalog (authenticated)**
+
+Start the dev server if not running, then confirm the summary endpoint returns data (not 404). Document the exact curl (with session cookie) in the devlog. Expected `meta.dataset_key = "drg-care-pathways-verification-package-v43.1-20260721"`, `data.release.state = "inactive"`, `data.release.clinical_signoff_count = 0`.
+
+---
+
+## Phase 1 — Inertia page routes, controllers, share, nav (backend, TDD)
+
+### Task 1.1: CarePathwayCatalogPageController + routes (test-first)
+
+**Files:**
+- Create: `app/Http/Controllers/CarePathwayCatalogPageController.php`
+- Create: `tests/Feature/CarePathways/CarePathwayCatalogPageTest.php`
+- Modify: `routes/web.php` (after the `/care-pathways/demo` route, ~line 94)
+
+- [ ] **Step 1: Write the failing feature test**
+
+```php
+<?php
+
+namespace Tests\Feature\CarePathways;
+
+use App\Authorization\Capability;
+use App\Models\User;
+use Tests\Support\CarePathwayRawFixture;
+use Tests\TestCase;
+
+final class CarePathwayCatalogPageTest extends TestCase
+{
+    use CarePathwayRawFixture;
+
+    public function test_catalog_index_returns_404_when_governance_disabled(): void
+    {
+        config(['care-pathways.governance_enabled' => false]);
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->get('/care-pathways/catalog')->assertNotFound();
+    }
+
+    public function test_catalog_index_renders_inertia_page_with_summary_for_authorized_user(): void
+    {
+        $this->seedAdoptedCarePathwayRelease(); // fixture trait: migrates + adopts release into the test DB
+        config(['care-pathways.governance_enabled' => true]);
+        $user = $this->userWithCapability(Capability::ViewCarePathwayCatalog);
+
+        $this->actingAs($user)
+            ->get('/care-pathways/catalog')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('CarePathways/Catalog/Index')
+                ->where('initialSummary.data.release.state', 'inactive')
+                ->where('initialSummary.data.release.clinical_signoff_count', 0)
+                ->has('initialPathways.data'));
+    }
+
+    public function test_catalog_show_404s_for_unknown_version(): void
+    {
+        $this->seedAdoptedCarePathwayRelease();
+        config(['care-pathways.governance_enabled' => true]);
+        $user = $this->userWithCapability(Capability::ViewCarePathwayCatalog);
+
+        $this->actingAs($user)
+            ->get('/care-pathways/catalog/00000000-0000-0000-0000-000000000000')
+            ->assertNotFound();
+    }
+}
+```
+
+Note: reuse/extend `Tests\Support\CarePathwayRawFixture`. If it lacks `seedAdoptedCarePathwayRelease()` / `userWithCapability()` helpers, add them mirroring `CarePathwayGovernanceApiTest` (which already boots an adopted release + authorized user). Read that test first and copy its exact bootstrapping.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./scripts/test-suite.sh contract` filtered to the new test, or:
+`php artisan test --filter=CarePathwayCatalogPageTest`
+Expected: FAIL — route `/care-pathways/catalog` not defined (404 on the render test / route-not-found).
+
+- [ ] **Step 3: Create the controller**
+
+```php
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\CarePathways\CatalogGovernanceReadService;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class CarePathwayCatalogPageController extends Controller
+{
+    public function __construct(
+        private readonly CatalogGovernanceReadService $catalog,
+    ) {}
+
+    public function index(Request $request): Response
+    {
+        $summary = $this->catalog->summary();
+        if ($summary === null) {
+            throw new NotFoundHttpException();
+        }
+
+        $pathways = $this->catalog->pathways(['page' => 1, 'per_page' => 25]);
+
+        return Inertia::render('CarePathways/Catalog/Index', [
+            'initialSummary' => $summary,
+            'initialPathways' => $pathways,
+        ]);
+    }
+
+    public function show(Request $request, string $versionUuid): Response
+    {
+        $version = $this->catalog->version($versionUuid);
+        if ($version === null) {
+            throw new NotFoundHttpException();
+        }
+
+        return Inertia::render('CarePathways/Catalog/Show', [
+            'initialVersion' => $version,
+        ]);
+    }
+}
+```
+
+- [ ] **Step 4: Register the routes** in `routes/web.php` immediately after the `/care-pathways/demo` route (~line 94), inside the same authenticated group:
+
+```php
+        Route::middleware([
+            \App\Http\Middleware\EnsureCarePathwayGovernanceEnabled::class,
+            'can:viewCarePathwayCatalog',
+        ])->group(function (): void {
+            Route::get('/care-pathways/catalog', [\App\Http\Controllers\CarePathwayCatalogPageController::class, 'index'])
+                ->name('care-pathways.catalog');
+            Route::get('/care-pathways/catalog/{versionUuid}', [\App\Http\Controllers\CarePathwayCatalogPageController::class, 'show'])
+                ->whereUuid('versionUuid')
+                ->name('care-pathways.catalog.show');
+        });
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `php artisan test --filter=CarePathwayCatalogPageTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Run Pint**
+
+Run: `docker compose exec -T php sh -c "cd /var/www/html && vendor/bin/pint"` (or the host Pint if Docker isn't up: `vendor/bin/pint app/Http/Controllers/CarePathwayCatalogPageController.php`).
+Expected: no style errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/Http/Controllers/CarePathwayCatalogPageController.php tests/Feature/CarePathways/CarePathwayCatalogPageTest.php routes/web.php
+git commit -m "feat: add care pathways catalog explorer page routes (gated, read-only)"
+```
+
+### Task 1.2: Share the `care_pathways_catalog` feature flag
+
+**Files:** Modify `app/Http/Middleware/HandleInertiaRequests.php` (features block, ~line 98).
+
+- [ ] **Step 1: Add the flag** inside the `'features' => [ ... ]` array, next to `care_pathways_demo`:
+
+```php
+                // Read-only governance examination surface for the inactive
+                // catalog; gated identically to the governance JSON API so nav
+                // and route never disagree. Never a clinical-serving gate.
+                'care_pathways_catalog' => (bool) config('care-pathways.governance_enabled'),
+```
+
+- [ ] **Step 2: Verify it serializes** — start dev server, load any authenticated page, confirm `features.care_pathways_catalog === true` in the Inertia `page.props` (browser devtools or `window`). Expected: `true` on dev.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Http/Middleware/HandleInertiaRequests.php
+git commit -m "feat: share care_pathways_catalog feature flag to frontend nav"
+```
+
+### Task 1.3: Add the Catalog nav entry
+
+**Files:** Modify `resources/js/config/navigationConfig.ts` (type ~line 82; `CARE_PATHWAYS` domain ~line 193).
+
+- [ ] **Step 1: Extend `NavigationFeatures`** — add after `care_pathways_demo`:
+
+```ts
+  readonly care_pathways_catalog?: boolean;
+```
+
+- [ ] **Step 2: Add a "Catalog" group** to the `CARE_PATHWAYS` domain's `groups` array (before or after the existing "Simulation" group):
+
+```ts
+    {
+      title: 'Catalog',
+      items: [
+        {
+          label: 'Catalog Explorer',
+          href: '/care-pathways/catalog',
+          icon: BookOpen, // import from lucide-react at top of file
+          requiredFeature: 'care_pathways_catalog',
+        },
+      ],
+    },
+```
+
+Ensure `BookOpen` is added to the existing `lucide-react` import. Do NOT change `dashboardHref`/`requiredFeature` of the domain (it stays `care_pathways_demo`), so the domain shows whenever *either* the demo or the catalog is enabled and each leaf self-gates.
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/config/navigationConfig.ts
+git commit -m "feat: add Catalog Explorer to Care Pathways nav (feature-gated)"
+```
+
+---
+
+## Phase 2 — Frontend data layer: Zod schemas, API client, hooks
+
+### Task 2.1: Zod schemas mirroring the governance envelopes
+
+**Files:** Create `resources/js/lib/carePathways/catalogSchemas.ts`.
+
+These MUST match `CatalogGovernanceReadService` exactly. Nullable fields use `.nullable()`; unknown-but-present JSON uses `z.unknown()`.
+
+- [ ] **Step 1: Write the schemas**
+
+```ts
+import { z } from "zod";
+
+const metaSchema = z.object({
+  schema: z.string(),
+  catalog_release_uuid: z.string(),
+  dataset_key: z.string(),
+  grouper_version: z.string(),
+  source_cutoff_date: z.string().nullable(),
+  as_of: z.string(),
+  clinical_approval_warning: z.string(),
+  patient_serving: z.boolean(),
+  hummingbird_serving: z.boolean(),
+  eddy_serving: z.boolean(),
+  pagination: z
+    .object({ page: z.number(), per_page: z.number(), total: z.number(), last_page: z.number() })
+    .optional(),
+});
+
+const releaseSchema = z.object({
+  catalog_release_uuid: z.string(),
+  dataset_key: z.string(),
+  grouper_version: z.string(),
+  grouper_effective_period: z.object({ start: z.string().nullable(), end: z.string().nullable() }),
+  state: z.string(),
+  clinical_signoff_complete: z.boolean(),
+  clinical_signoff_count: z.number(),
+  pathway_count: z.number(),
+  adopted_at: z.string().nullable(),
+  activated_at: z.string().nullable(),
+  withdrawn_at: z.string().nullable(),
+});
+
+export const summaryEnvelopeSchema = z.object({
+  data: z.object({
+    release: releaseSchema,
+    catalog: z.object({
+      definitions: z.number(),
+      versions: z.number(),
+      institutionally_approved_versions: z.number(),
+      active_versions: z.number(),
+      sections: z.number(),
+      approved_sections: z.number(),
+      patient_or_caregiver_sections: z.number(),
+      drg_codebook_entries: z.number(),
+      drg_mappings: z.number(),
+      evidence_claims: z.number(),
+      sources: z.number(),
+      current_sources: z.number(),
+      noncurrent_sources: z.number(),
+      changes: z.number(),
+    }),
+    review_queues: z.object({
+      evidence_verified: z.number(),
+      evidence_limitations: z.number(),
+      institutional_signoff: z.number(),
+      specialist_review: z.number(),
+      redesign: z.number(),
+      recorded_reviews: z.number(),
+      recorded_approvals: z.number(),
+    }),
+    controls: z.object({
+      by_status: z.record(z.string(), z.number()),
+      failed: z.number(),
+      residual_unknowns: z.number(),
+      service_line_mappings: z.record(z.string(), z.number()),
+    }),
+    serving_flags: z.record(z.string(), z.boolean()),
+    release_readiness: z.object({
+      clinical_signoff_complete: z.boolean(),
+      may_serve_approved_catalog: z.boolean(),
+      patient_projection_released: z.boolean(),
+      eddy_retrieval_released: z.boolean(),
+    }),
+    authorization: z.record(z.string(), z.boolean()).optional(),
+  }),
+  meta: metaSchema,
+});
+
+const drgCandidateSchema = z.object({
+  ms_drg: z.string(),
+  title: z.string(),
+  mdc: z.string().nullable(),
+  type_code: z.string().nullable(),
+  type_label: z.string().nullable(),
+  mapping_role: z.string(),
+  ambiguity_note: z.string().nullable(),
+  requires_clinician_confirmation: z.boolean(),
+});
+
+const pathwayIdentitySchema = z.object({
+  uuid: z.string(),
+  key: z.string(),
+  name: z.string(),
+  mdc: z.string().nullable(),
+  care_type: z.string().nullable(),
+  source_service_line: z.string().nullable(),
+  service_line_code: z.string().nullable(),
+  lifecycle_state: z.string(),
+});
+
+const versionIdentitySchema = z.object({
+  version_uuid: z.string(),
+  semantic_version: z.string(),
+  source_rank: z.number().nullable(),
+  content_digest: z.string(),
+  effective_period: z.object({ start: z.string().nullable(), end: z.string().nullable() }),
+  source_cutoff_date: z.string().nullable(),
+  exact_version: z.boolean(),
+});
+
+const evidenceSchema = z.object({
+  status: z.string(),
+  confidence: z.string().nullable(),
+  source_specificity: z.string().nullable(),
+  release_disposition: z.string(),
+  claim_count: z.number(),
+  source_currency: z.string(),
+});
+
+const pathwayRowGovernanceSchema = z.object({
+  clinical_signoff_status: z.string(),
+  institutional_approval_status: z.string(),
+  activation_status: z.string(),
+  section_count: z.number(),
+  approved_section_count: z.number(),
+  review_count: z.number(),
+  approval_count: z.number(),
+});
+
+export const pathwayRowSchema = z.object({
+  pathway: pathwayIdentitySchema,
+  version: versionIdentitySchema,
+  drg_candidates: z.array(drgCandidateSchema),
+  evidence: evidenceSchema,
+  governance: pathwayRowGovernanceSchema,
+});
+
+export const pathwaysEnvelopeSchema = z.object({
+  data: z.array(pathwayRowSchema),
+  meta: metaSchema,
+});
+
+const reviewSchema = z.object({
+  review_uuid: z.string(),
+  reviewer_role: z.string(),
+  review_scope: z.string(),
+  decision: z.string(),
+  reason: z.string(),
+  issues: z.unknown(),
+  reviewed_at: z.string().nullable(),
+});
+
+const approvalSchema = z.object({
+  approval_uuid: z.string(),
+  approval_type: z.string(),
+  decision: z.string(),
+  conditions: z.string().nullable(),
+  effective_period: z.object({ start: z.string().nullable(), end: z.string().nullable() }),
+  decided_at: z.string().nullable(),
+});
+
+const sectionSchema = z.object({
+  section_uuid: z.string(),
+  section_code: z.string(),
+  audience: z.string(),
+  language_code: z.string(),
+  source_text: z.string(),
+  approved_text: z.string().nullable(),
+  content_mode: z.string(),
+  review_state: z.string(),
+  source_digest: z.string(),
+  approved_digest: z.string().nullable(),
+});
+
+const milestoneSchema = z.object({
+  milestone_uuid: z.string(),
+  stable_key: z.string(),
+  title: z.string(),
+  phase: z.string().nullable(),
+  sequence: z.number().nullable(),
+  predecessor_keys: z.unknown(),
+  expected_range: z.unknown(),
+  applicability_ref: z.string().nullable(),
+  completion_evidence_ref: z.string().nullable(),
+  review_state: z.string(),
+});
+
+const goalSchema = z.object({
+  goal_uuid: z.string(),
+  stable_key: z.string(),
+  goal_code: z.string().nullable(),
+  goal_text: z.string(),
+  author_type: z.string(),
+  target: z.unknown(),
+  patient_visible_explanation: z.string().nullable(),
+  review_state: z.string(),
+});
+
+const activitySchema = z.object({
+  activity_uuid: z.string(),
+  stable_key: z.string(),
+  activity_type: z.string(),
+  title: z.string(),
+  performer_role: z.string().nullable(),
+  timing: z.unknown(),
+  preconditions: z.unknown(),
+  executable: z.boolean(),
+  fhir_canonical_ref: z.string().nullable(),
+  review_state: z.string(),
+});
+
+const educationSchema = z.object({
+  education_uuid: z.string(),
+  stable_key: z.string(),
+  audience: z.string(),
+  language_code: z.string(),
+  reading_level: z.string().nullable(),
+  title: z.string(),
+  approved_content: z.string().nullable(),
+  teach_back_prompt: z.string().nullable(),
+  required_reviewer_role: z.string().nullable(),
+  content_digest: z.string().nullable(),
+  review_state: z.string(),
+});
+
+export const versionEnvelopeSchema = z.object({
+  data: z.object({
+    pathway: pathwayIdentitySchema,
+    version: versionIdentitySchema.extend({
+      source_digest: z.string(),
+      unresolved_flags: z.unknown(),
+    }),
+    drg_candidates: z.array(drgCandidateSchema),
+    evidence: evidenceSchema,
+    governance: z.object({
+      clinical_signoff_status: z.string(),
+      institutional_approval_status: z.string(),
+      activation_status: z.string(),
+      reviews: z.array(reviewSchema),
+      approvals: z.array(approvalSchema),
+    }),
+    sections: z.array(sectionSchema),
+    authoring: z.object({
+      milestones: z.array(milestoneSchema),
+      activities: z.array(activitySchema),
+      goals: z.array(goalSchema),
+      education: z.array(educationSchema),
+    }),
+    changes: z.array(z.record(z.string(), z.unknown())),
+  }),
+  meta: metaSchema,
+});
+
+const claimSchema = z.object({
+  claim_uuid: z.string(),
+  source_rank: z.number(),
+  source_field: z.string(),
+  claim_type: z.string().nullable(),
+  claim_excerpt: z.string(),
+  automated_review: z.object({ pass_1: z.unknown(), pass_2: z.unknown() }),
+  clinical_adjudication: z.unknown(),
+  verification_date: z.string().nullable(),
+  claim_digest: z.string(),
+  sources: z.array(
+    z.object({
+      source_uuid: z.string(),
+      pmid: z.string().nullable(),
+      title: z.string().nullable(),
+      current_status: z.string(),
+      content_digest: z.string(),
+      evidence_grade: z.string().nullable(),
+      applicability_note: z.string().nullable(),
+    }),
+  ),
+});
+
+export const claimsEnvelopeSchema = z.object({
+  data: z.array(claimSchema),
+  meta: metaSchema,
+});
+
+export type SummaryEnvelope = z.infer<typeof summaryEnvelopeSchema>;
+export type PathwaysEnvelope = z.infer<typeof pathwaysEnvelopeSchema>;
+export type PathwayRow = z.infer<typeof pathwayRowSchema>;
+export type VersionEnvelope = z.infer<typeof versionEnvelopeSchema>;
+export type ClaimsEnvelope = z.infer<typeof claimsEnvelopeSchema>;
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add resources/js/lib/carePathways/catalogSchemas.ts
+git commit -m "feat: add Zod schemas for care pathways governance envelopes"
+```
+
+### Task 2.2: Typed API client + query filter type
+
+**Files:** Create `resources/js/lib/carePathways/catalogApi.ts`.
+
+- [ ] **Step 1: Write the client**
+
+```ts
+import axios from "axios";
+import {
+  claimsEnvelopeSchema,
+  pathwaysEnvelopeSchema,
+  summaryEnvelopeSchema,
+  versionEnvelopeSchema,
+  type ClaimsEnvelope,
+  type PathwaysEnvelope,
+  type SummaryEnvelope,
+  type VersionEnvelope,
+} from "./catalogSchemas";
+
+const BASE = "/api/care-pathways/v1";
+
+export interface PathwayQuery {
+  q?: string;
+  drg?: string;
+  mdc?: string;
+  service_line?: string;
+  evidence_state?: "verified" | "limitations";
+  disposition?: "signoff" | "specialist_review" | "redesign";
+  institutional_approval_status?: "not_reviewed" | "in_review" | "approved" | "rejected" | "withdrawn";
+  activation_status?: "inactive" | "active" | "withdrawn";
+  page?: number;
+  per_page?: number;
+}
+
+export async function fetchSummary(): Promise<SummaryEnvelope> {
+  const { data } = await axios.get<unknown>(`${BASE}/summary`);
+  return summaryEnvelopeSchema.parse(data);
+}
+
+export async function fetchPathways(query: PathwayQuery): Promise<PathwaysEnvelope> {
+  const params = Object.fromEntries(
+    Object.entries(query).filter(([, v]) => v !== undefined && v !== ""),
+  );
+  const { data } = await axios.get<unknown>(`${BASE}/pathways`, { params });
+  return pathwaysEnvelopeSchema.parse(data);
+}
+
+export async function fetchVersion(versionUuid: string): Promise<VersionEnvelope> {
+  const { data } = await axios.get<unknown>(`${BASE}/versions/${versionUuid}`);
+  return versionEnvelopeSchema.parse(data);
+}
+
+export async function fetchClaims(versionUuid: string, page = 1, perPage = 50): Promise<ClaimsEnvelope> {
+  const { data } = await axios.get<unknown>(`${BASE}/versions/${versionUuid}/claims`, {
+    params: { page, per_page: perPage },
+  });
+  return claimsEnvelopeSchema.parse(data);
+}
+```
+
+- [ ] **Step 2: Type-check + commit**
+
+Run: `npx tsc --noEmit` (Expected: no errors), then:
+```bash
+git add resources/js/lib/carePathways/catalogApi.ts
+git commit -m "feat: add typed care pathways catalog API client"
+```
+
+### Task 2.3: TanStack Query hooks
+
+**Files:** Create `resources/js/hooks/carePathways/useCatalog.ts`.
+
+- [ ] **Step 1: Write the hooks** (TanStack Query is already provided app-wide via `Providers/HeroUIProvider`):
+
+```ts
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+  fetchClaims,
+  fetchPathways,
+  fetchSummary,
+  fetchVersion,
+  type PathwayQuery,
+} from "@/lib/carePathways/catalogApi";
+import type {
+  ClaimsEnvelope,
+  PathwaysEnvelope,
+  SummaryEnvelope,
+  VersionEnvelope,
+} from "@/lib/carePathways/catalogSchemas";
+
+export function useCatalogSummary(initialData?: SummaryEnvelope) {
+  return useQuery({
+    queryKey: ["care-pathways", "summary"],
+    queryFn: fetchSummary,
+    initialData,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useCatalogPathways(query: PathwayQuery, initialData?: PathwaysEnvelope) {
+  return useQuery({
+    queryKey: ["care-pathways", "pathways", query],
+    queryFn: () => fetchPathways(query),
+    initialData:
+      initialData && query.page === 1 && Object.keys(query).length <= 2 ? initialData : undefined,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useCatalogVersion(versionUuid: string, initialData?: VersionEnvelope) {
+  return useQuery({
+    queryKey: ["care-pathways", "version", versionUuid],
+    queryFn: () => fetchVersion(versionUuid),
+    initialData,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useCatalogClaims(versionUuid: string, page: number) {
+  return useQuery<ClaimsEnvelope>({
+    queryKey: ["care-pathways", "claims", versionUuid, page],
+    queryFn: () => fetchClaims(versionUuid, page),
+    placeholderData: keepPreviousData,
+  });
+}
+```
+
+- [ ] **Step 2: Type-check + commit**
+
+Run: `npx tsc --noEmit` (Expected: no errors), then:
+```bash
+git add resources/js/hooks/carePathways/useCatalog.ts
+git commit -m "feat: add TanStack Query hooks for care pathways catalog"
+```
+
+---
+
+## Phase 3 — Overview + Pathway Index page
+
+> Visual polish for Phases 3–4 goes through `/impeccable craft` (reads PRODUCT.md + DESIGN.md). All components below use ONLY `healthcare-*` tokens + `Surface`/`Panel`/`MetricCard`. Status atoms pair an icon + label (never color alone). Reserve `healthcare-critical` (coral) strictly for real breaches — here, the only "critical" framing allowed is the inactive/blocked governance state, shown as `healthcare-warning` (amber), not coral.
+
+### Task 3.1: GovernanceBanner (mandatory framing, reused everywhere)
+
+**Files:** Create `resources/js/Components/CarePathways/GovernanceBanner.tsx`.
+
+- [ ] **Step 1: Implement** — a `Panel`-based banner. Props: `{ warning: string; state: string; signoffCount: number }`. Renders a `ShieldAlert` (lucide) icon + heading "Reference catalog — not clinically approved", the `warning` text, and three inline facts (`tabular-nums`): `State: {state}`, `Clinical sign-offs: {signoffCount}`, `Patient/Eddy serving: Off`. Tokens: `bg-healthcare-warning/10` equivalent via `healthcare-*` (use `text-healthcare-warning dark:text-healthcare-warning-dark` for the icon; body text `text-healthcare-text-primary`). Named export `GovernanceBanner`.
+
+- [ ] **Step 2: Type-check.** Run `npx tsc --noEmit`. Expected: no errors.
+
+### Task 3.2: Overview + partition + distribution components
+
+**Files:** Create `resources/js/Components/CarePathways/CatalogOverview.tsx`, `resources/js/Components/CarePathways/ActivationReadiness.tsx`.
+
+- [ ] **Step 1: `CatalogOverview`** — prop `{ summary: SummaryEnvelope["data"]; meta: SummaryEnvelope["meta"] }`. Layout:
+  - Release header (`Panel`): grouper version, effective period, dataset key (`tabular-nums`), `as_of`.
+  - Metric tiles row (`MetricCard`): Pathways (`catalog.definitions`), DRG codes (`catalog.drg_codebook_entries`), DRG associations (`catalog.drg_mappings`), Evidence claims (`catalog.evidence_claims`), Sources (`catalog.sources`), Clinical sign-offs (`release.clinical_signoff_count`, always 0 → render with `healthcare-warning` label + `AlertTriangle` icon, NOT success).
+  - Evidence partition (`Panel`): a labelled bar — `review_queues.evidence_verified` (96) vs `evidence_limitations` (154) of `pathway_count` (250). Use `healthcare-success` for verified, `healthcare-warning` for limitations, each with an icon + numeric label.
+  - Disposition partition (`Panel`): `institutional_signoff` (96) / `specialist_review` (148) / `redesign` (6), same treatment (`info` / `warning` / `warning`).
+  - Controls (`Panel`): `controls.by_status` as labelled counts; `controls.failed` (expect 0) and `controls.residual_unknowns` (expect 0) shown with `CheckCircle` when 0.
+
+- [ ] **Step 2: `ActivationReadiness`** — prop `{ readiness: SummaryEnvelope["data"]["release_readiness"]; release: SummaryEnvelope["data"]["release"]; catalog: SummaryEnvelope["data"]["catalog"] }`. Derives and lists the activation blockers as an explicit checklist (icon + label), e.g.:
+  - `Clinical sign-off complete` → `readiness.clinical_signoff_complete` (false → `XCircle` amber "Not complete — 0/250 institutional sign-offs")
+  - `All versions institutionally approved` → `catalog.institutionally_approved_versions === release.pathway_count`
+  - `All versions active` → `catalog.active_versions === release.pathway_count`
+  - `May serve approved catalog` → `readiness.may_serve_approved_catalog` (false)
+  Each false item uses `healthcare-warning` + an icon; the panel title is "Why this catalog stays inactive". This is the honest "defensible" framing [SU] expects.
+
+- [ ] **Step 3: Type-check.** Run `npx tsc --noEmit`. Expected: no errors.
+
+### Task 3.3: Filters + table + display atoms
+
+**Files:** Create `EvidenceBadge.tsx`, `GovernanceStatus.tsx`, `DrgChips.tsx`, `PathwayFilters.tsx`, `PathwayTable.tsx` under `resources/js/Components/CarePathways/`.
+
+- [ ] **Step 1: Display atoms**
+  - `EvidenceBadge` — prop `{ status: string }`. Maps the long status label to a short chip with icon: contains "verified" → `ShieldCheck` + `healthcare-success` "Verified"; contains "limitations" → `AlertTriangle` + `healthcare-warning` "Limitations". Icon + text, never color-only.
+  - `GovernanceStatus` — prop `{ approval: string; activation: string }`. Renders two chips: institutional approval (`not_reviewed`→`Circle` neutral; `approved`→`CheckCircle` success; `rejected`→`XCircle` warning) and activation (`inactive`→`PauseCircle` neutral). Always icon + label.
+  - `DrgChips` — prop `{ drgs: DrgCandidate[]; max?: number }`. Renders up to `max` (default 6) MS-DRG codes as monospaced-look chips using `tabular-nums` (NOT `font-mono`), each `role`-tinted via `healthcare-*`; overflow "+N more". Tooltip/title = DRG `title`.
+
+- [ ] **Step 2: `PathwayFilters`** — prop `{ value: PathwayQuery; onChange: (next: PathwayQuery) => void }`. Controls: debounced search input (`q`), DRG code input (`drg`, 3-digit), MDC text (`mdc`), service line text (`service_line`), and selects for `evidence_state` / `disposition` / `institutional_approval_status` / `activation_status`. All inputs use canon form styling (`bg-healthcare-surface`, `border-healthcare-border`, gold `:focus-visible`). A "Clear" button resets to `{ page: 1, per_page: 25 }`.
+
+- [ ] **Step 3: `PathwayTable`** — prop `{ rows: PathwayRow[]; pagination: {...}; onPage: (p: number) => void; isLoading: boolean }`. A `Panel`-wrapped table. Columns: Rank (`version.source_rank`, `tabular-nums`), Pathway (`pathway.name` → link to `/care-pathways/catalog/{version.version_uuid}` via Inertia `Link`), MDC (`pathway.mdc`), Service line (`pathway.source_service_line`), DRGs (`<DrgChips>`), Evidence (`<EvidenceBadge>`), Status (`<GovernanceStatus>`), Sections (`governance.approved_section_count`/`section_count`, `tabular-nums`). Footer: pagination (`page`/`last_page`/`total`) with prev/next; disable while `isLoading`. Header row uses `text-healthcare-text-secondary`, `text-xs` uppercase. Zebra/hover via `healthcare-surface`/`healthcare-hover` tokens. 250 rows are paginated (25/pg), so no virtualization library needed; keep DOM light.
+
+- [ ] **Step 4: Type-check.** Run `npx tsc --noEmit`. Expected: no errors.
+
+### Task 3.4: Compose the Index page
+
+**Files:** Create `resources/js/Pages/CarePathways/Catalog/Index.tsx`.
+
+- [ ] **Step 1: Implement** the page (default export required by Inertia):
+
+Props: `{ initialSummary: SummaryEnvelope; initialPathways: PathwaysEnvelope }`. Behavior:
+- Wrap in `AuthenticatedLayout` + `<Head title="Care Pathways Catalog" />`.
+- `const [query, setQuery] = useState<PathwayQuery>({ page: 1, per_page: 25 })`.
+- `const summary = useCatalogSummary(initialSummary)`.
+- `const pathways = useCatalogPathways(query, initialPathways)`.
+- Render order: `<GovernanceBanner>` (from `summary.data.meta.clinical_approval_warning` + `release.state` + `clinical_signoff_count`) → `<CatalogOverview>` → `<ActivationReadiness>` → `<PathwayFilters value={query} onChange={setQuery}>` → `<PathwayTable rows={pathways.data.data} pagination={pathways.data.meta.pagination} onPage={(p)=>setQuery(q=>({...q,page:p}))} isLoading={pathways.isFetching}>`.
+- Gutter owned by `PageContentLayout` (`p-4`) — do NOT add an outer padded wrapper (avoid double gutter). Content max-width comes from the layout.
+- Include a header link to the Journey Demo (`/care-pathways/demo`) only when that route exists; render as a secondary action.
+
+- [ ] **Step 2: Type-check + build (build is stricter).**
+
+Run: `npx tsc --noEmit && npx vite build`
+Expected: both succeed, no `UNRESOLVED_IMPORT`.
+
+- [ ] **Step 3: Browser verification** — load `/care-pathways/catalog` on dev as `admin@acumenus.net`. Confirm: banner shows inactive + 0 sign-offs; overview tiles show 250/770/802/10123; table lists rank-ordered pathways; a search for "sepsis" filters; a DRG filter `870` narrows; clicking a row navigates to detail. Screenshot for the devlog.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/Components/CarePathways/ resources/js/Pages/CarePathways/Catalog/Index.tsx
+git commit -m "feat: care pathways catalog overview + 250-pathway index"
+```
+
+---
+
+## Phase 4 — Pathway Detail page
+
+### Task 4.1: Detail sections, authoring, evidence, ledger components
+
+**Files:** Create `PathwaySections.tsx`, `PathwayAuthoring.tsx`, `EvidenceClaims.tsx`, `GovernanceLedger.tsx` under `resources/js/Components/CarePathways/`.
+
+- [ ] **Step 1: `PathwaySections`** — prop `{ sections: Section[] }`. Groups sections by `audience` (`staff_reference` / `staff_workflow` / `patient` / `caregiver`). Renders each as a collapsible `Panel` row keyed by `section_code` (humanize: `admission_criteria` → "Admission Criteria"). Shows `source_text`; if `approved_text` present, show it under an "Approved" sub-label with a `content_mode`/`review_state` chip. A small `Fingerprint` icon reveals the `source_digest` (truncated, `tabular-nums`) on hover/title for provenance. Long text wraps with readable line length.
+
+- [ ] **Step 2: `PathwayAuthoring`** — prop `{ authoring: VersionEnvelope["data"]["authoring"] }`. Four `Panel`s:
+  - Milestones: ordered by `sequence`; each shows `title`, `phase` chip, `expected_range` (render `.display` if present), `review_state` chip.
+  - Goals: `goal_text`, `author_type` chip, `target` summary, `patient_visible_explanation` if present.
+  - Activities: `title`, `activity_type` chip, `performer_role`, `executable` flag (icon), `fhir_canonical_ref` if present.
+  - Education: `title`, `audience` chip, `reading_level`, `teach_back_prompt` if present.
+  Empty arrays render a quiet "None defined in this version" (`text-healthcare-text-secondary`) — do not hide silently.
+
+- [ ] **Step 3: `EvidenceClaims`** — prop `{ versionUuid: string; claimCount: number }`. Uses `useCatalogClaims(versionUuid, page)` with local `page` state. Renders a `Panel` titled "Evidence claims ({claimCount})". Each claim: `source_field` chip, `claim_type`, `claim_excerpt`, and its `sources[]` as a list (PMID link when present → `https://pubmed.ncbi.nlm.nih.gov/{pmid}/`, `evidence_grade` chip, `current_status` chip with `AlertTriangle` if not `current`). Paginate via `meta.pagination`.
+
+- [ ] **Step 4: `GovernanceLedger`** — prop `{ governance: VersionEnvelope["data"]["governance"]; version: ...; changes: unknown[] }`. Three `Panel`s: Reviews (`reviewer_role`, `decision` chip, `reason`, `reviewed_at`), Approvals (`approval_type`, `decision`, `effective_period`, `decided_at`), and Provenance (`content_digest`, `source_digest`, `effective_period`, `source_cutoff_date`, `unresolved_flags` count). Include the change log (`changes[]`: `source_field`, `old_value`→`new_value`, `reason`, `changed_on`) as a compact table. All digests `tabular-nums`, truncated with full value in `title`.
+
+- [ ] **Step 5: Type-check.** Run `npx tsc --noEmit`. Expected: no errors.
+
+### Task 4.2: Compose the Detail page
+
+**Files:** Create `resources/js/Pages/CarePathways/Catalog/Show.tsx`.
+
+- [ ] **Step 1: Implement** (default export). Props: `{ initialVersion: VersionEnvelope }`. Behavior:
+- `AuthenticatedLayout` + `<Head title={`${pathway.name} — Care Pathway`} />`.
+- `const version = useCatalogVersion(initialVersion.data.version.version_uuid, initialVersion)`.
+- Header `Panel`: back link (`Link` to `/care-pathways/catalog`, `ArrowLeft`), `pathway.name`, `pathway.mdc` + `care_type` + `source_service_line` chips, `semantic_version` + `source_rank` (`tabular-nums`), `<GovernanceStatus>`.
+- `<GovernanceBanner>` (from `version.data.meta`) — reused, so the not-approved framing is present on detail too.
+- `<DrgChips drgs={data.drg_candidates} max={99}>` in a "DRG candidates" `Panel`, each row showing `ms_drg`, `title`, `mdc`, `type_label`, `mapping_role`, and the `requires_clinician_confirmation` note.
+- `<PathwaySections sections={data.sections}>`.
+- `<PathwayAuthoring authoring={data.authoring}>`.
+- `<EvidenceClaims versionUuid={...} claimCount={data.evidence.claim_count}>`.
+- `<GovernanceLedger governance={data.governance} version={data.version} changes={data.changes}>`.
+- Respect single-gutter rule (layout owns `p-4`).
+
+- [ ] **Step 2: Type-check + build.**
+
+Run: `npx tsc --noEmit && npx vite build`
+Expected: both succeed.
+
+- [ ] **Step 3: Browser verification** — open a detail page (e.g. click "Sepsis" from the index). Confirm all 28 section fields render, milestones/goals show, DRG candidates list with clinician-confirmation note, evidence claims paginate and link to PubMed, provenance digests visible, banner present. Screenshot for devlog.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add resources/js/Components/CarePathways/ resources/js/Pages/CarePathways/Catalog/Show.tsx
+git commit -m "feat: care pathways per-DRG detail view (sections, evidence, provenance)"
+```
+
+---
+
+## Phase 5 — Demo.tsx canon rebuild + cross-link
+
+> `Demo.tsx` currently violates canon heavily (raw `slate/cyan/emerald/amber/rose` palette, `font-mono`, hand-rolled `bg-white` surfaces, cyan gradient, `tracking-[0.18em]`, `any` props). Rebuild onto canon WITHOUT changing behavior (the 6-step journey + 6 surface projections stay identical). This LOWERS the `check-ui-canon.sh` raw-palette ratchet.
+
+### Task 5.1: Migrate Demo.tsx to the design system
+
+**Files:** Modify `resources/js/Pages/CarePathways/Demo.tsx`.
+
+- [ ] **Step 1: Replace surfaces** — swap every hand-rolled `rounded-2xl border border-slate-200 bg-white shadow-sm dark:...` and the local `Panel` function for the canon `Panel`/`Surface` primitives (`@/Components/ui/Panel`). Remove the local `Panel` definition.
+
+- [ ] **Step 2: Replace palette** — map raw colors to tokens: `slate-*` surfaces/text → `healthcare-surface`/`healthcare-text-*`; `cyan-*` accents → `healthcare-primary` (NOT cyan — cyan is banned); `emerald-*` → `healthcare-success`; `amber-*` → `healthcare-warning`; `rose-*` → `healthcare-critical`. Replace the cyan header gradient with a canon `Surface` header (no gradient, or a subtle `healthcare-primary` accent border). Remove `tracking-[0.18em]` (use default tracking or `tracking-wide`).
+
+- [ ] **Step 3: Replace `font-mono`** on the timeline `<time>` (line ~963) with `tabular-nums`.
+
+- [ ] **Step 4: Type the props** — replace every `any` (`care_team: any`, `virtual_rounds: any`, etc.) with explicit interfaces (or reuse the existing `scenarioFromApiEnvelope` typing). At minimum, define narrow interfaces for each surface's shape so `tsc` passes without `any`.
+
+- [ ] **Step 5: Add the cross-link** — in the header, add a secondary `Link` (Inertia) to `/care-pathways/catalog` labelled "Browse the 250-pathway catalog", shown only if `care_pathways_catalog` feature is on (read from `usePage().props.features`).
+
+- [ ] **Step 6: Verify canon + behavior.**
+
+Run: `bash scripts/check-ui-canon.sh` (Expected: green; raw-palette ratchet count DECREASED), then `npx tsc --noEmit && npx vite build` (Expected: pass).
+Browser: re-walk all 6 steps + all 6 surfaces on dev; confirm identical behavior, now on canon (dark + light). Screenshot.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add resources/js/Pages/CarePathways/Demo.tsx scripts/check-ui-canon.sh
+git commit -m "refactor: migrate Care Pathways Demo onto design canon + link to catalog"
+```
+
+---
+
+## Phase 6 — Full verification + devlog
+
+### Task 6.1: Backend test lane
+
+- [ ] **Step 1: Run the care-pathway suite** on beastmode (isolated `zephyrus_test_*`):
+
+Run: `./scripts/test-suite.sh contract` (or `php artisan test --testsuite=Feature --filter=CarePathway`)
+Expected: new `CarePathwayCatalogPageTest` green; no regressions in existing `CarePathway*` tests.
+
+### Task 6.2: Frontend gates
+
+- [ ] **Step 1:** `npx tsc --noEmit` — Expected: clean.
+- [ ] **Step 2:** `npx vite build` — Expected: clean (stricter; catches unresolved imports).
+- [ ] **Step 3:** `bash scripts/check-ui-canon.sh` — Expected: green; confirm raw-palette baseline went DOWN vs pre-change (Demo fix). Record the delta.
+
+### Task 6.3: Devlog + memory
+
+- [ ] **Step 1: Write** `docs/DEVLOG-care-pathways-catalog-explorer-2026-07-24.md` summarizing: what shipped (3 views + Demo rebuild), the dev-only governance-enable (prod still off), the migrate+adopt provisioning done on `zephyrus_dev`, test/build/canon evidence, screenshots, and the explicit deferred items (prod governance flag = [SU] decision; capability grants unchanged).
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/DEVLOG-care-pathways-catalog-explorer-2026-07-24.md
+git commit -m "docs: devlog for care pathways catalog explorer"
+```
+
+- [ ] **Step 3:** Update the `project_zephyrus_care_pathways` memory with: the new Catalog Explorer surface (routes `care-pathways.catalog[.show]`), the `CARE_PATHWAYS_GOVERNANCE_ENABLED` dev-on/prod-off state, and the `zephyrus_dev` adoption. (Memory update happens outside the repo.)
+
+---
+
+## Deployment note (NOT in this plan's scope)
+
+`deploy.sh` is an immutable-commit snapshot that **skips migrations** and does not touch prod `.env`. Shipping this to prod later requires, as separate explicit [SU]-approved steps: (1) run the 8 care_pathways migrations + adopt on the prod DB (if not already — the prod `zephyrus` DB already has the adopted release), and (2) set `CARE_PATHWAYS_GOVERNANCE_ENABLED=true` in the prod `.env` and confirm the intended staff hold `viewCarePathwayCatalog`. This plan does none of that — it stops at a fully-working, verified dev surface.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Overview ✔ (Phase 3), 250 Index ✔ (Phase 3), per-DRG Detail elucidating all 49 fields ✔ (Phase 4: sections=28 prose fields, authoring=milestones/goals/activities/education, drg_candidates, evidence, provenance). Governance-API-as-SSOT ✔ (Phase 2, no CSV). Demo rebuild ✔ (Phase 5). Dev data prerequisite ✔ (Phase 0).
+- **Governance framing:** `GovernanceBanner` + `ActivationReadiness` enforce the inactive/not-approved narrative on every page; no serving flag touched; prod deferred.
+- **Canon:** every component specifies `healthcare-*` tokens + `Surface`/`Panel`/`MetricCard`, `tabular-nums`, icon+label status, and Phase 5 lowers the ratchet. `check-ui-canon.sh` gate in Phase 6.
+- **Type consistency:** Zod-inferred types (`SummaryEnvelope`, `PathwaysEnvelope`, `PathwayRow`, `VersionEnvelope`, `ClaimsEnvelope`) flow from `catalogSchemas.ts` → `catalogApi.ts` → `useCatalog.ts` → pages/components unchanged. `PathwayQuery` shape matches the controller's validation rules exactly (`evidence_state`, `disposition`, `institutional_approval_status`, `activation_status`, `q`, `drg`, `mdc`, `service_line`, `page`, `per_page`).
+- **Placeholder scan:** data-layer, controllers, routes, shares, nav, Phase 0 commands are fully coded; presentational components carry exact prop contracts + token rules (visual polish via `/impeccable craft`) — acceptable for a skilled dev per the writing-plans skill.

--- a/resources/js/Components/CarePathways/ActivationReadiness.tsx
+++ b/resources/js/Components/CarePathways/ActivationReadiness.tsx
@@ -1,0 +1,102 @@
+import { CheckCircle2, XCircle } from "lucide-react";
+import { Surface } from "@/Components/ui/Surface";
+import { Section } from "@/Components/system";
+import type { SummaryEnvelope } from "@/lib/carePathways/catalogSchemas";
+
+interface ActivationReadinessProps {
+    readiness: SummaryEnvelope["data"]["release_readiness"];
+    release: SummaryEnvelope["data"]["release"];
+    catalog: SummaryEnvelope["data"]["catalog"];
+}
+
+interface ReadinessItem {
+    label: string;
+    met: boolean;
+    detail: string;
+}
+
+function ReadinessRow({ item }: { item: ReadinessItem }) {
+    const Icon = item.met ? CheckCircle2 : XCircle;
+
+    return (
+        <li className="flex items-start gap-2.5">
+            <Icon
+                className={`mt-0.5 h-4 w-4 shrink-0 ${
+                    item.met
+                        ? "text-healthcare-success dark:text-healthcare-success-dark"
+                        : "text-healthcare-warning dark:text-healthcare-warning-dark"
+                }`}
+                aria-hidden="true"
+            />
+            <div className="min-w-0">
+                <p className="text-sm font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                    {item.label}
+                    <span className="sr-only">
+                        {item.met ? " — met" : " — not met"}
+                    </span>
+                </p>
+                <p className="text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    {item.detail}
+                </p>
+            </div>
+        </li>
+    );
+}
+
+// The honest answer to "why can't this serve patients yet". Derived entirely
+// from the release_readiness envelope — the server, not the UI, owns truth.
+export function ActivationReadiness({
+    readiness,
+    release,
+    catalog,
+}: ActivationReadinessProps) {
+    const items: readonly ReadinessItem[] = [
+        {
+            label: "Institutional clinical sign-off",
+            met: readiness.clinical_signoff_complete,
+            detail: `${release.clinical_signoff_count} of ${release.pathway_count} pathways carry institutional SME sign-off.`,
+        },
+        {
+            label: "All versions institutionally approved",
+            met: catalog.institutionally_approved_versions === release.pathway_count,
+            detail: `${catalog.institutionally_approved_versions} of ${release.pathway_count} versions approved by institutional review.`,
+        },
+        {
+            label: "All versions activated",
+            met: catalog.active_versions === release.pathway_count,
+            detail: `${catalog.active_versions} of ${release.pathway_count} versions active; activation requires prior approval.`,
+        },
+        {
+            label: "Release may serve the approved catalog",
+            met: readiness.may_serve_approved_catalog,
+            detail: readiness.may_serve_approved_catalog
+                ? "The release satisfies every activation gate."
+                : "Blocked until every gate above passes and the release state is set to active.",
+        },
+        {
+            label: "Patient projection released",
+            met: readiness.patient_projection_released,
+            detail: "Patient- and caregiver-facing projections require separate editorial approval.",
+        },
+        {
+            label: "Eddy retrieval released",
+            met: readiness.eddy_retrieval_released,
+            detail: "Eddy may not cite the catalog until reference serving is separately approved.",
+        },
+    ];
+
+    return (
+        <Section
+            title="Why this catalog stays inactive"
+            icon="heroicons:lock-closed"
+        >
+            <Surface className="p-4">
+                <ul className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                    {items.map((item) => (
+                        <ReadinessRow key={item.label} item={item} />
+                    ))}
+                </ul>
+            </Surface>
+        </Section>
+    );
+}

--- a/resources/js/Components/CarePathways/CatalogOverview.tsx
+++ b/resources/js/Components/CarePathways/CatalogOverview.tsx
@@ -1,0 +1,263 @@
+import { AlertTriangle, CheckCircle2 } from "lucide-react";
+import { Surface } from "@/Components/ui/Surface";
+import { MetricGrid, Section } from "@/Components/system";
+import { metric } from "@/Components/system/metric";
+import type { SummaryEnvelope } from "@/lib/carePathways/catalogSchemas";
+
+interface CatalogOverviewProps {
+    summary: SummaryEnvelope["data"];
+    meta: SummaryEnvelope["meta"];
+}
+
+interface PartitionSegment {
+    label: string;
+    value: number;
+    barClass: string;
+    textClass: string;
+}
+
+function PartitionBar({
+    segments,
+    total,
+}: {
+    segments: readonly PartitionSegment[];
+    total: number;
+}) {
+    return (
+        <div>
+            <div
+                className="flex h-2 w-full overflow-hidden rounded-full bg-healthcare-background dark:bg-healthcare-background-dark"
+                role="presentation"
+            >
+                {segments.map((segment) => (
+                    <div
+                        key={segment.label}
+                        className={segment.barClass}
+                        style={{
+                            width: `${total > 0 ? (segment.value / total) * 100 : 0}%`,
+                        }}
+                    />
+                ))}
+            </div>
+            <dl className="mt-3 flex flex-wrap gap-x-6 gap-y-2">
+                {segments.map((segment) => (
+                    <div
+                        key={segment.label}
+                        className="flex items-baseline gap-1.5"
+                    >
+                        <dd
+                            className={`text-lg font-semibold tabular-nums ${segment.textClass}`}
+                        >
+                            {segment.value}
+                        </dd>
+                        <dt className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            {segment.label}
+                        </dt>
+                    </div>
+                ))}
+                <div className="ml-auto flex items-baseline gap-1.5">
+                    <dd className="text-lg font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                        {total}
+                    </dd>
+                    <dt className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        total
+                    </dt>
+                </div>
+            </dl>
+        </div>
+    );
+}
+
+export function CatalogOverview({ summary, meta }: CatalogOverviewProps) {
+    const { release, catalog, review_queues: queues, controls } = summary;
+
+    const controlsClean =
+        controls.failed === 0 && controls.residual_unknowns === 0;
+    const ControlsIcon = controlsClean ? CheckCircle2 : AlertTriangle;
+
+    const metrics = [
+        metric({
+            key: "pathways",
+            label: "Pathways",
+            value: catalog.definitions,
+            definition:
+                "Distinct governed pathway definitions adopted in this release.",
+        }),
+        metric({
+            key: "drg-codes",
+            label: "MS-DRG codes",
+            value: catalog.drg_codebook_entries,
+            definition:
+                "Unique MS-DRG codebook entries pinned to this grouper version.",
+        }),
+        metric({
+            key: "drg-associations",
+            label: "DRG associations",
+            value: catalog.drg_mappings,
+            definition:
+                "Pathway-to-DRG candidate mappings; several pathways share DRGs.",
+        }),
+        metric({
+            key: "claims",
+            label: "Evidence claims",
+            value: catalog.evidence_claims,
+            definition:
+                "Clinical claims extracted from source text and independently reviewed.",
+        }),
+        metric({
+            key: "sources",
+            label: "Sources",
+            value: catalog.sources,
+            caption: `${catalog.noncurrent_sources} non-current`,
+            definition:
+                "Bibliographic sources in the release index; currency tracked per source.",
+        }),
+        metric({
+            key: "signoffs",
+            label: "Clinical sign-offs",
+            value: release.clinical_signoff_count,
+            status: "warning",
+            caption: `of ${release.pathway_count} pathways`,
+            definition:
+                "Institutional SME sign-offs recorded. Zero — the release stays inactive.",
+        }),
+    ];
+
+    return (
+        <div className="space-y-4">
+            <Section
+                title={`MS-DRG v${release.grouper_version} verification package`}
+                summary={`Grouper window ${release.grouper_effective_period.start ?? "—"} → ${release.grouper_effective_period.end ?? "—"} · source cutoff ${meta.source_cutoff_date ?? "—"}`}
+                icon="heroicons:archive-box"
+            >
+                <p className="text-xs tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    {release.dataset_key}
+                </p>
+                <MetricGrid metrics={metrics} detailed={false} />
+            </Section>
+
+            <div className="grid gap-4 lg:grid-cols-2">
+                <Section
+                    title="Evidence verification"
+                    icon="heroicons:document-magnifying-glass"
+                >
+                    <Surface className="p-4">
+                        <PartitionBar
+                            total={release.pathway_count}
+                            segments={[
+                                {
+                                    label: "verified",
+                                    value: queues.evidence_verified,
+                                    barClass:
+                                        "bg-healthcare-success dark:bg-healthcare-success-dark",
+                                    textClass:
+                                        "text-healthcare-success dark:text-healthcare-success-dark",
+                                },
+                                {
+                                    label: "with limitations",
+                                    value: queues.evidence_limitations,
+                                    barClass:
+                                        "bg-healthcare-warning dark:bg-healthcare-warning-dark",
+                                    textClass:
+                                        "text-healthcare-warning dark:text-healthcare-warning-dark",
+                                },
+                            ]}
+                        />
+                        <p className="mt-3 text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            Automated independent review only — verification is
+                            not institutional clinical approval.
+                        </p>
+                    </Surface>
+                </Section>
+
+                <Section
+                    title="Release disposition"
+                    icon="heroicons:clipboard-document-check"
+                >
+                    <Surface className="p-4">
+                        <PartitionBar
+                            total={release.pathway_count}
+                            segments={[
+                                {
+                                    label: "sign-off queue",
+                                    value: queues.institutional_signoff,
+                                    barClass:
+                                        "bg-healthcare-info dark:bg-healthcare-info-dark",
+                                    textClass:
+                                        "text-healthcare-info dark:text-healthcare-info-dark",
+                                },
+                                {
+                                    label: "specialist review",
+                                    value: queues.specialist_review,
+                                    barClass:
+                                        "bg-healthcare-warning dark:bg-healthcare-warning-dark",
+                                    textClass:
+                                        "text-healthcare-warning dark:text-healthcare-warning-dark",
+                                },
+                                {
+                                    label: "redesign",
+                                    value: queues.redesign,
+                                    barClass:
+                                        "bg-healthcare-text-secondary dark:bg-healthcare-text-secondary-dark",
+                                    textClass:
+                                        "text-healthcare-text-primary dark:text-healthcare-text-primary-dark",
+                                },
+                            ]}
+                        />
+                        <p className="mt-3 text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            Every pathway carries exactly one disposition; none
+                            is clinically signed off in this release.
+                        </p>
+                    </Surface>
+                </Section>
+            </div>
+
+            <Section
+                title="Release controls"
+                icon="heroicons:shield-check"
+                actions={
+                    <span
+                        className={`inline-flex items-center gap-1.5 text-xs font-medium ${
+                            controlsClean
+                                ? "text-healthcare-success dark:text-healthcare-success-dark"
+                                : "text-healthcare-warning dark:text-healthcare-warning-dark"
+                        }`}
+                    >
+                        <ControlsIcon className="h-4 w-4" aria-hidden="true" />
+                        {controlsClean
+                            ? "All controls reconciled"
+                            : "Controls need attention"}
+                    </span>
+                }
+            >
+                <Surface className="p-4">
+                    <dl className="flex flex-wrap gap-x-8 gap-y-2">
+                        {Object.entries(controls.by_status).map(
+                            ([status, count]) => (
+                                <div
+                                    key={status}
+                                    className="flex items-baseline gap-1.5"
+                                >
+                                    <dd className="text-lg font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                        {count}
+                                    </dd>
+                                    <dt className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                        {status.replaceAll("_", " ")}
+                                    </dt>
+                                </div>
+                            ),
+                        )}
+                        <div className="flex items-baseline gap-1.5">
+                            <dd className="text-lg font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                {controls.residual_unknowns}
+                            </dd>
+                            <dt className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                residual unknowns
+                            </dt>
+                        </div>
+                    </dl>
+                </Surface>
+            </Section>
+        </div>
+    );
+}

--- a/resources/js/Components/CarePathways/EvidenceClaims.tsx
+++ b/resources/js/Components/CarePathways/EvidenceClaims.tsx
@@ -1,0 +1,146 @@
+import { AlertTriangle, ChevronLeft, ChevronRight, ExternalLink } from "lucide-react";
+import { useState } from "react";
+import { Surface } from "@/Components/ui/Surface";
+import { Section } from "@/Components/system";
+import { useCatalogClaims } from "@/hooks/carePathways/useCatalog";
+import type { EvidenceClaim } from "@/lib/carePathways/catalogSchemas";
+
+function ClaimSources({ claim }: { claim: EvidenceClaim }) {
+    if (claim.sources.length === 0) {
+        return null;
+    }
+
+    return (
+        <ul className="mt-2 space-y-1">
+            {claim.sources.map((source) => (
+                <li
+                    key={source.source_uuid}
+                    className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark"
+                >
+                    {source.pmid ? (
+                        <a
+                            href={`https://pubmed.ncbi.nlm.nih.gov/${source.pmid}/`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center gap-1 font-medium text-healthcare-primary hover:underline dark:text-healthcare-primary-dark"
+                        >
+                            PMID <span className="tabular-nums">{source.pmid}</span>
+                            <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                        </a>
+                    ) : (
+                        <span className="font-medium">Source</span>
+                    )}
+                    <span className="min-w-0 flex-1 truncate" title={source.title ?? undefined}>
+                        {source.title ?? "Untitled source"}
+                    </span>
+                    {source.evidence_grade && (
+                        <span className="rounded-full border border-healthcare-border px-1.5 dark:border-healthcare-border-dark">
+                            Grade {source.evidence_grade}
+                        </span>
+                    )}
+                    {source.current_status !== "current" && (
+                        <span className="inline-flex items-center gap-1 text-healthcare-warning dark:text-healthcare-warning-dark">
+                            <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                            {source.current_status}
+                        </span>
+                    )}
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+export function EvidenceClaims({
+    versionUuid,
+    claimCount,
+}: {
+    versionUuid: string;
+    claimCount: number;
+}) {
+    const [page, setPage] = useState(1);
+    const claims = useCatalogClaims(versionUuid, page);
+    const pagination = claims.data?.meta.pagination;
+
+    return (
+        <Section
+            title="Evidence claims"
+            summary={`${claimCount} claims extracted from source text, independently reviewed`}
+            icon="heroicons:document-magnifying-glass"
+        >
+            <Surface className="p-4" aria-busy={claims.isFetching}>
+                {claims.isError ? (
+                    <p
+                        className="text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark"
+                        role="alert"
+                    >
+                        Evidence claims could not be loaded. Try again — no
+                        catalog state was changed.
+                    </p>
+                ) : (
+                    <div
+                        className={`space-y-4 transition-opacity ${claims.isFetching ? "opacity-60" : ""}`}
+                    >
+                        {(claims.data?.data ?? []).map((claim) => (
+                            <div
+                                key={claim.claim_uuid}
+                                className="border-b border-healthcare-border pb-3 last:border-b-0 last:pb-0 dark:border-healthcare-border-dark"
+                            >
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <span className="rounded-full border border-healthcare-border px-2 py-0.5 text-xs font-medium text-healthcare-text-secondary dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark">
+                                        {claim.source_field.replaceAll("_", " ")}
+                                    </span>
+                                    {claim.claim_type && (
+                                        <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                            {claim.claim_type.replaceAll("_", " ")}
+                                        </span>
+                                    )}
+                                    {claim.verification_date && (
+                                        <span className="ml-auto text-xs tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                            verified {claim.verification_date}
+                                        </span>
+                                    )}
+                                </div>
+                                <p className="mt-1.5 max-w-prose text-sm leading-6 text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                    {claim.claim_excerpt}
+                                </p>
+                                <ClaimSources claim={claim} />
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {pagination && pagination.last_page > 1 && (
+                    <div className="mt-4 flex items-center justify-between border-t border-healthcare-border pt-4 dark:border-healthcare-border-dark">
+                        <p className="text-xs tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            Page {pagination.page} of {pagination.last_page} ·{" "}
+                            {pagination.total} claims
+                        </p>
+                        <div className="flex gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setPage(page - 1)}
+                                disabled={claims.isFetching || page <= 1}
+                                className="inline-flex items-center gap-1 rounded-md border border-healthcare-border px-2.5 py-1.5 text-sm font-medium text-healthcare-text-primary disabled:opacity-40 dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark"
+                            >
+                                <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                                Previous
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => setPage(page + 1)}
+                                disabled={
+                                    claims.isFetching ||
+                                    page >= pagination.last_page
+                                }
+                                className="inline-flex items-center gap-1 rounded-md border border-healthcare-border px-2.5 py-1.5 text-sm font-medium text-healthcare-text-primary disabled:opacity-40 dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark"
+                            >
+                                Next
+                                <ChevronRight className="h-4 w-4" aria-hidden="true" />
+                            </button>
+                        </div>
+                    </div>
+                )}
+            </Surface>
+        </Section>
+    );
+}

--- a/resources/js/Components/CarePathways/GovernanceBanner.tsx
+++ b/resources/js/Components/CarePathways/GovernanceBanner.tsx
@@ -1,0 +1,55 @@
+import { ShieldAlert } from "lucide-react";
+import { Surface } from "@/Components/ui/Surface";
+
+interface GovernanceBannerProps {
+    warning: string;
+    state: string;
+    signoffCount: number;
+}
+
+// Mandatory framing for every catalog surface: the release is inactive and
+// nothing here is clinically approved. Never soften or hide this banner.
+export function GovernanceBanner({
+    warning,
+    state,
+    signoffCount,
+}: GovernanceBannerProps) {
+    return (
+        <Surface className="p-4">
+            <div className="flex items-start gap-3">
+                <ShieldAlert
+                    className="mt-0.5 h-5 w-5 shrink-0 text-healthcare-warning dark:text-healthcare-warning-dark"
+                    aria-hidden="true"
+                />
+                <div className="min-w-0">
+                    <p className="text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                        Reference catalog — not clinically approved
+                    </p>
+                    <p className="mt-1 text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        {warning}
+                    </p>
+                    <dl className="mt-2 flex flex-wrap gap-x-6 gap-y-1 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        <div className="flex gap-1.5">
+                            <dt className="font-medium">Release state:</dt>
+                            <dd className="font-semibold uppercase tracking-wide text-healthcare-warning dark:text-healthcare-warning-dark">
+                                {state}
+                            </dd>
+                        </div>
+                        <div className="flex gap-1.5">
+                            <dt className="font-medium">Clinical sign-offs:</dt>
+                            <dd className="font-semibold tabular-nums">
+                                {signoffCount}
+                            </dd>
+                        </div>
+                        <div className="flex gap-1.5">
+                            <dt className="font-medium">
+                                Patient / Eddy serving:
+                            </dt>
+                            <dd className="font-semibold">Off</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </Surface>
+    );
+}

--- a/resources/js/Components/CarePathways/GovernanceLedger.tsx
+++ b/resources/js/Components/CarePathways/GovernanceLedger.tsx
@@ -1,0 +1,159 @@
+import { Fingerprint } from "lucide-react";
+import { Surface } from "@/Components/ui/Surface";
+import { Section } from "@/Components/system";
+import type { VersionEnvelope } from "@/lib/carePathways/catalogSchemas";
+
+type VersionData = VersionEnvelope["data"];
+
+function Digest({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="flex items-center gap-2 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+            <Fingerprint className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            <span className="font-medium">{label}</span>
+            <span className="truncate tabular-nums" title={value}>
+                {value}
+            </span>
+        </div>
+    );
+}
+
+const changeText = (value: unknown): string => {
+    if (value === null || value === undefined || value === "") return "—";
+    return typeof value === "string" ? value : JSON.stringify(value);
+};
+
+export function GovernanceLedger({
+    governance,
+    version,
+    changes,
+}: {
+    governance: VersionData["governance"];
+    version: VersionData["version"];
+    changes: VersionData["changes"];
+}) {
+    const flags = Array.isArray(version.unresolved_flags)
+        ? version.unresolved_flags
+        : [];
+
+    return (
+        <Section
+            title="Governance ledger"
+            summary="Append-only reviews, approvals, and source-change history"
+            icon="heroicons:scale"
+        >
+            <div className="grid gap-4 lg:grid-cols-2">
+                <Surface className="p-4">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        Reviews ({governance.reviews.length}) · Approvals (
+                        {governance.approvals.length})
+                    </p>
+                    {governance.reviews.length === 0 &&
+                    governance.approvals.length === 0 ? (
+                        <p className="mt-2 text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            No reviews or approvals recorded — this version has
+                            not entered institutional review.
+                        </p>
+                    ) : (
+                        <div className="mt-2 space-y-3">
+                            {governance.reviews.map((review) => (
+                                <div key={review.review_uuid} className="text-sm">
+                                    <p className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                        {review.reviewer_role} —{" "}
+                                        {review.decision.replaceAll("_", " ")}
+                                    </p>
+                                    <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                        {review.review_scope} ·{" "}
+                                        {review.reviewed_at ?? "—"}
+                                    </p>
+                                    <p className="mt-0.5 max-w-prose text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                        {review.reason}
+                                    </p>
+                                </div>
+                            ))}
+                            {governance.approvals.map((approval) => (
+                                <div
+                                    key={approval.approval_uuid}
+                                    className="text-sm"
+                                >
+                                    <p className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                        {approval.approval_type.replaceAll(
+                                            "_",
+                                            " ",
+                                        )}{" "}
+                                        — {approval.decision}
+                                    </p>
+                                    <p className="text-xs tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                        {approval.decided_at ?? "—"}
+                                    </p>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </Surface>
+
+                <Surface className="p-4">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        Provenance
+                    </p>
+                    <div className="mt-2 space-y-1.5">
+                        <Digest label="Content" value={version.content_digest} />
+                        <Digest label="Source" value={version.source_digest} />
+                        <div className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            Effective{" "}
+                            <span className="tabular-nums">
+                                {version.effective_period.start ?? "—"}
+                            </span>{" "}
+                            →{" "}
+                            <span className="tabular-nums">
+                                {version.effective_period.end ?? "open"}
+                            </span>
+                            {" · "}source cutoff{" "}
+                            <span className="tabular-nums">
+                                {version.source_cutoff_date ?? "—"}
+                            </span>
+                        </div>
+                        <div className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            Unresolved flags:{" "}
+                            <span className="tabular-nums">{flags.length}</span>
+                            {flags.length > 0 && (
+                                <span> — {flags.map(changeText).join(", ")}</span>
+                            )}
+                        </div>
+                    </div>
+
+                    <p className="mt-4 text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        Source changes ({changes.length})
+                    </p>
+                    {changes.length === 0 ? (
+                        <p className="mt-1 text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            No source-change entries for this pathway.
+                        </p>
+                    ) : (
+                        <div className="mt-2 space-y-2">
+                            {changes.map((change, index) => (
+                                <div
+                                    key={changeText(change.change_uuid) + index}
+                                    className="text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark"
+                                >
+                                    <p className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                        {changeText(change.source_field).replaceAll(
+                                            "_",
+                                            " ",
+                                        )}
+                                        {" · "}
+                                        <span className="tabular-nums">
+                                            {changeText(change.changed_on)}
+                                        </span>
+                                    </p>
+                                    <p className="max-w-prose">
+                                        {changeText(change.reason)}
+                                    </p>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </Surface>
+            </div>
+        </Section>
+    );
+}

--- a/resources/js/Components/CarePathways/PathwayAuthoring.tsx
+++ b/resources/js/Components/CarePathways/PathwayAuthoring.tsx
@@ -1,0 +1,180 @@
+import { CheckCircle2, Circle } from "lucide-react";
+import { Surface } from "@/Components/ui/Surface";
+import { Section } from "@/Components/system";
+import type { VersionEnvelope } from "@/lib/carePathways/catalogSchemas";
+
+type Authoring = VersionEnvelope["data"]["authoring"];
+
+const asDisplayRange = (value: unknown): string | null => {
+    if (
+        typeof value === "object" &&
+        value !== null &&
+        "display" in value &&
+        typeof (value as { display: unknown }).display === "string"
+    ) {
+        return (value as { display: string }).display;
+    }
+    return null;
+};
+
+function AuthoringGroup({
+    title,
+    children,
+}: {
+    title: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <Surface className="p-4">
+            <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                {title}
+            </p>
+            <div className="mt-2 space-y-2">{children}</div>
+        </Surface>
+    );
+}
+
+// Structured authoring artifacts (milestones / goals / activities / education)
+// are authored AFTER adoption, during clinical review. Release 2 ships with
+// none — that absence is stated, not hidden.
+export function PathwayAuthoring({ authoring }: { authoring: Authoring }) {
+    const counts =
+        authoring.milestones.length +
+        authoring.activities.length +
+        authoring.goals.length +
+        authoring.education.length;
+
+    if (counts === 0) {
+        return (
+            <Section
+                title="Structured authoring"
+                icon="heroicons:pencil-square"
+            >
+                <Surface className="p-4">
+                    <p className="text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        No milestones, goals, activities, or education have been
+                        authored for this version. Structured artifacts are
+                        created during clinical review — after institutional
+                        sign-off begins, not at adoption.
+                    </p>
+                </Surface>
+            </Section>
+        );
+    }
+
+    return (
+        <Section
+            title="Structured authoring"
+            summary={`${counts} artifacts`}
+            icon="heroicons:pencil-square"
+        >
+            <div className="grid gap-4 lg:grid-cols-2">
+                {authoring.milestones.length > 0 && (
+                    <AuthoringGroup title={`Milestones (${authoring.milestones.length})`}>
+                        {[...authoring.milestones]
+                            .sort(
+                                (a, b) =>
+                                    (a.sequence ?? Number.MAX_SAFE_INTEGER) -
+                                    (b.sequence ?? Number.MAX_SAFE_INTEGER),
+                            )
+                            .map((milestone) => (
+                                <div
+                                    key={milestone.milestone_uuid}
+                                    className="flex items-start justify-between gap-3 text-sm"
+                                >
+                                    <div>
+                                        <p className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                            {milestone.title}
+                                        </p>
+                                        <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                            {milestone.phase ?? "—"}
+                                            {asDisplayRange(
+                                                milestone.expected_range,
+                                            ) &&
+                                                ` · ${asDisplayRange(milestone.expected_range)}`}
+                                        </p>
+                                    </div>
+                                    <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                        {milestone.review_state}
+                                    </span>
+                                </div>
+                            ))}
+                    </AuthoringGroup>
+                )}
+                {authoring.goals.length > 0 && (
+                    <AuthoringGroup title={`Goals (${authoring.goals.length})`}>
+                        {authoring.goals.map((goal) => (
+                            <div key={goal.goal_uuid} className="text-sm">
+                                <p className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                    {goal.goal_text}
+                                </p>
+                                <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                    {goal.author_type} · {goal.review_state}
+                                </p>
+                            </div>
+                        ))}
+                    </AuthoringGroup>
+                )}
+                {authoring.activities.length > 0 && (
+                    <AuthoringGroup title={`Activities (${authoring.activities.length})`}>
+                        {authoring.activities.map((activity) => {
+                            const ExecIcon = activity.executable
+                                ? CheckCircle2
+                                : Circle;
+                            return (
+                                <div
+                                    key={activity.activity_uuid}
+                                    className="flex items-start justify-between gap-3 text-sm"
+                                >
+                                    <div>
+                                        <p className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                            {activity.title}
+                                        </p>
+                                        <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                            {activity.activity_type}
+                                            {activity.performer_role &&
+                                                ` · ${activity.performer_role}`}
+                                        </p>
+                                    </div>
+                                    <span
+                                        className="inline-flex items-center gap-1 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark"
+                                        title={
+                                            activity.executable
+                                                ? "Executable (FHIR-aligned)"
+                                                : "Narrative only"
+                                        }
+                                    >
+                                        <ExecIcon
+                                            className="h-3.5 w-3.5"
+                                            aria-hidden="true"
+                                        />
+                                        {activity.executable
+                                            ? "Executable"
+                                            : "Narrative"}
+                                    </span>
+                                </div>
+                            );
+                        })}
+                    </AuthoringGroup>
+                )}
+                {authoring.education.length > 0 && (
+                    <AuthoringGroup title={`Education (${authoring.education.length})`}>
+                        {authoring.education.map((item) => (
+                            <div key={item.education_uuid} className="text-sm">
+                                <p className="font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                    {item.title}
+                                </p>
+                                <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                    {item.audience}
+                                    {item.reading_level &&
+                                        ` · reading level ${item.reading_level}`}
+                                    {` · ${item.review_state}`}
+                                </p>
+                            </div>
+                        ))}
+                    </AuthoringGroup>
+                )}
+            </div>
+        </Section>
+    );
+}

--- a/resources/js/Components/CarePathways/PathwayFilters.tsx
+++ b/resources/js/Components/CarePathways/PathwayFilters.tsx
@@ -1,0 +1,152 @@
+import { Search, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { PathwayQuery } from "@/lib/carePathways/catalogApi";
+
+interface PathwayFiltersProps {
+    value: PathwayQuery;
+    onChange: (next: PathwayQuery) => void;
+}
+
+const inputClass =
+    "w-full rounded-md border border-healthcare-border bg-healthcare-surface px-3 py-1.5 text-sm text-healthcare-text-primary placeholder:text-healthcare-text-secondary dark:border-healthcare-border-dark dark:bg-healthcare-surface-dark dark:text-healthcare-text-primary-dark dark:placeholder:text-healthcare-text-secondary-dark";
+
+const DEFAULT_QUERY: PathwayQuery = { page: 1, per_page: 25 };
+
+export function PathwayFilters({ value, onChange }: PathwayFiltersProps) {
+    const [search, setSearch] = useState(value.q ?? "");
+    const [drg, setDrg] = useState(value.drg ?? "");
+
+    // Debounce free-text inputs; selects apply immediately.
+    useEffect(() => {
+        const handle = setTimeout(() => {
+            if ((value.q ?? "") !== search || (value.drg ?? "") !== drg) {
+                onChange({
+                    ...value,
+                    q: search || undefined,
+                    drg: drg || undefined,
+                    page: 1,
+                });
+            }
+        }, 300);
+        return () => clearTimeout(handle);
+    }, [search, drg, value, onChange]);
+
+    const setSelect = (key: keyof PathwayQuery) => (selected: string) => {
+        onChange({
+            ...value,
+            [key]: selected === "" ? undefined : selected,
+            page: 1,
+        });
+    };
+
+    const hasFilters =
+        Boolean(search || drg) ||
+        Boolean(
+            value.mdc ||
+            value.service_line ||
+            value.evidence_state ||
+            value.disposition ||
+            value.institutional_approval_status ||
+            value.activation_status,
+        );
+
+    return (
+        <div className="flex flex-wrap items-center gap-2">
+            <label className="relative min-w-56 flex-1">
+                <span className="sr-only">Search pathways</span>
+                <Search
+                    className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark"
+                    aria-hidden="true"
+                />
+                <input
+                    type="search"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Search condition or pathway key…"
+                    className={`${inputClass} pl-8`}
+                />
+            </label>
+
+            <label className="w-24">
+                <span className="sr-only">MS-DRG code</span>
+                <input
+                    type="text"
+                    inputMode="numeric"
+                    maxLength={3}
+                    value={drg}
+                    onChange={(event) =>
+                        setDrg(event.target.value.replace(/[^0-9]/g, ""))
+                    }
+                    placeholder="DRG"
+                    className={`${inputClass} tabular-nums`}
+                />
+            </label>
+
+            <label>
+                <span className="sr-only">Evidence state</span>
+                <select
+                    value={value.evidence_state ?? ""}
+                    onChange={(event) =>
+                        setSelect("evidence_state")(event.target.value)
+                    }
+                    className={inputClass}
+                >
+                    <option value="">Evidence: all</option>
+                    <option value="verified">Verified</option>
+                    <option value="limitations">With limitations</option>
+                </select>
+            </label>
+
+            <label>
+                <span className="sr-only">Disposition</span>
+                <select
+                    value={value.disposition ?? ""}
+                    onChange={(event) =>
+                        setSelect("disposition")(event.target.value)
+                    }
+                    className={inputClass}
+                >
+                    <option value="">Disposition: all</option>
+                    <option value="signoff">Sign-off queue</option>
+                    <option value="specialist_review">Specialist review</option>
+                    <option value="redesign">Redesign</option>
+                </select>
+            </label>
+
+            <label>
+                <span className="sr-only">Institutional approval</span>
+                <select
+                    value={value.institutional_approval_status ?? ""}
+                    onChange={(event) =>
+                        setSelect("institutional_approval_status")(
+                            event.target.value,
+                        )
+                    }
+                    className={inputClass}
+                >
+                    <option value="">Approval: all</option>
+                    <option value="not_reviewed">Not reviewed</option>
+                    <option value="in_review">In review</option>
+                    <option value="approved">Approved</option>
+                    <option value="rejected">Rejected</option>
+                    <option value="withdrawn">Withdrawn</option>
+                </select>
+            </label>
+
+            {hasFilters && (
+                <button
+                    type="button"
+                    onClick={() => {
+                        setSearch("");
+                        setDrg("");
+                        onChange({ ...DEFAULT_QUERY });
+                    }}
+                    className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm font-medium text-healthcare-text-secondary hover:bg-healthcare-surface-hover dark:text-healthcare-text-secondary-dark dark:hover:bg-healthcare-surface-hover-dark"
+                >
+                    <X className="h-4 w-4" aria-hidden="true" />
+                    Clear
+                </button>
+            )}
+        </div>
+    );
+}

--- a/resources/js/Components/CarePathways/PathwaySections.tsx
+++ b/resources/js/Components/CarePathways/PathwaySections.tsx
@@ -1,0 +1,171 @@
+import { Fingerprint } from "lucide-react";
+import { Surface } from "@/Components/ui/Surface";
+import { Section } from "@/Components/system";
+import type { PathwaySection } from "@/lib/carePathways/catalogSchemas";
+
+// Canonical clinical reading order — mirrors config/care-pathways.php
+// source_section_fields. Unknown codes sort after these, alphabetically.
+const SECTION_ORDER: readonly string[] = [
+    "admission_criteria",
+    "risk_stratification",
+    "initial_workup_labs",
+    "initial_imaging_dx",
+    "time_critical_interventions",
+    "initial_management",
+    "day1_milestones",
+    "day2_milestones",
+    "day3plus_milestones",
+    "consults_multidisciplinary",
+    "monitoring_level",
+    "nutrition_mobility_vte",
+    "discharge_criteria",
+    "discharge_planning",
+    "expected_los",
+    "target_los",
+    "quality_metrics",
+    "common_complications",
+    "readmission_drivers",
+    "guideline_source",
+    "key_citations",
+    "evidence_grade",
+    "severity_cc_mcc_notes",
+    "pathway_pearls",
+    "verification_notes",
+    "scope_and_volume_notes",
+    "clinical_verification_basis",
+    "data_quality_notes",
+];
+
+const SECTION_LABELS: Record<string, string> = {
+    admission_criteria: "Admission Criteria",
+    risk_stratification: "Risk Stratification",
+    initial_workup_labs: "Initial Workup — Labs",
+    initial_imaging_dx: "Initial Imaging & Diagnostics",
+    time_critical_interventions: "Time-Critical Interventions",
+    initial_management: "Initial Management",
+    day1_milestones: "Day 1 Milestones",
+    day2_milestones: "Day 2 Milestones",
+    day3plus_milestones: "Day 3+ Milestones",
+    consults_multidisciplinary: "Consults & Multidisciplinary Care",
+    monitoring_level: "Monitoring Level",
+    nutrition_mobility_vte: "Nutrition, Mobility & VTE Prophylaxis",
+    discharge_criteria: "Discharge Criteria",
+    discharge_planning: "Discharge Planning",
+    expected_los: "Expected Length of Stay",
+    target_los: "Target Length of Stay",
+    quality_metrics: "Quality Metrics",
+    common_complications: "Common Complications",
+    readmission_drivers: "Readmission Drivers",
+    guideline_source: "Guideline Source",
+    key_citations: "Key Citations",
+    evidence_grade: "Evidence Grade",
+    severity_cc_mcc_notes: "Severity CC/MCC Notes",
+    pathway_pearls: "Pathway Pearls",
+    verification_notes: "Verification Notes",
+    scope_and_volume_notes: "Scope & Volume Notes",
+    clinical_verification_basis: "Clinical Verification Basis",
+    data_quality_notes: "Data Quality Notes",
+};
+
+const sectionLabel = (code: string): string =>
+    SECTION_LABELS[code] ??
+    code
+        .replaceAll("_", " ")
+        .replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+const orderIndex = (code: string): number => {
+    const index = SECTION_ORDER.indexOf(code);
+    return index === -1 ? SECTION_ORDER.length : index;
+};
+
+function SectionRow({ section }: { section: PathwaySection }) {
+    return (
+        <details className="group border-b border-healthcare-border last:border-b-0 dark:border-healthcare-border-dark">
+            <summary className="flex cursor-pointer items-center justify-between gap-3 px-4 py-2.5 hover:bg-healthcare-surface-hover dark:hover:bg-healthcare-surface-hover-dark">
+                <span className="text-sm font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                    {sectionLabel(section.section_code)}
+                </span>
+                <span className="flex shrink-0 items-center gap-2 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    {section.content_mode !== "source" && (
+                        <span className="rounded-full border border-healthcare-border px-2 py-0.5 dark:border-healthcare-border-dark">
+                            {section.content_mode}
+                        </span>
+                    )}
+                    <span
+                        className="inline-flex items-center gap-1"
+                        title={`Source digest ${section.source_digest}`}
+                    >
+                        <Fingerprint className="h-3.5 w-3.5" aria-hidden="true" />
+                        <span className="tabular-nums">
+                            {section.source_digest.slice(0, 8)}
+                        </span>
+                    </span>
+                </span>
+            </summary>
+            <div className="space-y-3 px-4 pb-4 pt-1">
+                <p className="max-w-prose whitespace-pre-line text-sm leading-6 text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                    {section.source_text}
+                </p>
+                {section.approved_text !== null && (
+                    <div className="border-t border-healthcare-border pt-3 dark:border-healthcare-border-dark">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-success dark:text-healthcare-success-dark">
+                            Approved text ({section.review_state})
+                        </p>
+                        <p className="mt-1 max-w-prose whitespace-pre-line text-sm leading-6 text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                            {section.approved_text}
+                        </p>
+                    </div>
+                )}
+            </div>
+        </details>
+    );
+}
+
+const AUDIENCE_LABELS: Record<string, string> = {
+    staff_reference: "Staff reference",
+    staff_workflow: "Staff workflow",
+    patient: "Patient",
+    caregiver: "Caregiver",
+};
+
+export function PathwaySections({
+    sections,
+}: {
+    sections: readonly PathwaySection[];
+}) {
+    const byAudience = new Map<string, PathwaySection[]>();
+    for (const section of sections) {
+        const group = byAudience.get(section.audience) ?? [];
+        byAudience.set(section.audience, [...group, section]);
+    }
+
+    return (
+        <Section
+            title="Clinical content"
+            summary={`${sections.length} immutable source sections — editorial approval required before any serving`}
+            icon="heroicons:document-text"
+        >
+            <div className="space-y-4">
+                {[...byAudience.entries()].map(([audience, group]) => (
+                    <Surface key={audience} className="overflow-hidden">
+                        <p className="border-b border-healthcare-border px-4 py-2 text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark">
+                            {AUDIENCE_LABELS[audience] ?? audience}
+                        </p>
+                        {[...group]
+                            .sort(
+                                (a, b) =>
+                                    orderIndex(a.section_code) -
+                                    orderIndex(b.section_code),
+                            )
+                            .map((section) => (
+                                <SectionRow
+                                    key={section.section_uuid}
+                                    section={section}
+                                />
+                            ))}
+                    </Surface>
+                ))}
+            </div>
+        </Section>
+    );
+}

--- a/resources/js/Components/CarePathways/PathwayTable.tsx
+++ b/resources/js/Components/CarePathways/PathwayTable.tsx
@@ -1,0 +1,200 @@
+import { Link } from "@inertiajs/react";
+import { ChevronLeft, ChevronRight, SearchX } from "lucide-react";
+import { Surface } from "@/Components/ui/Surface";
+import { Section } from "@/Components/system";
+import type { PathwayRow } from "@/lib/carePathways/catalogSchemas";
+import {
+    DrgChips,
+    EvidenceBadge,
+    GovernanceStatus,
+} from "@/Components/CarePathways/StatusAtoms";
+
+interface Pagination {
+    page: number;
+    per_page: number;
+    total: number;
+    last_page: number;
+}
+
+interface PathwayTableProps {
+    rows: readonly PathwayRow[];
+    pagination?: Pagination;
+    onPage: (page: number) => void;
+    isLoading: boolean;
+}
+
+const headerCell =
+    "px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark";
+
+const bodyCell = "px-3 py-2.5 align-top text-sm";
+
+export function PathwayTable({
+    rows,
+    pagination,
+    onPage,
+    isLoading,
+}: PathwayTableProps) {
+    return (
+        <Section
+            title="Pathways"
+            icon="heroicons:map"
+            actions={
+                pagination && (
+                    <span className="text-xs tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        {pagination.total} pathway
+                        {pagination.total === 1 ? "" : "s"}
+                    </span>
+                )
+            }
+        >
+            <Surface className="p-4">
+            <div
+                className={`overflow-x-auto transition-opacity ${isLoading ? "opacity-60" : ""}`}
+                aria-busy={isLoading}
+            >
+                <table className="w-full min-w-[900px] border-collapse">
+                    <thead>
+                        <tr className="border-b border-healthcare-border dark:border-healthcare-border-dark">
+                            <th scope="col" className={headerCell}>
+                                Rank
+                            </th>
+                            <th scope="col" className={headerCell}>
+                                Pathway
+                            </th>
+                            <th scope="col" className={headerCell}>
+                                MDC
+                            </th>
+                            <th scope="col" className={headerCell}>
+                                Service line
+                            </th>
+                            <th scope="col" className={headerCell}>
+                                DRGs
+                            </th>
+                            <th scope="col" className={headerCell}>
+                                Evidence
+                            </th>
+                            <th scope="col" className={headerCell}>
+                                Governance
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.map((row) => (
+                            <tr
+                                key={row.version.version_uuid}
+                                className="border-b border-healthcare-border last:border-b-0 hover:bg-healthcare-surface-hover dark:border-healthcare-border-dark dark:hover:bg-healthcare-surface-hover-dark"
+                            >
+                                <td
+                                    className={`${bodyCell} tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark`}
+                                >
+                                    {row.version.source_rank ?? "—"}
+                                </td>
+                                <td className={bodyCell}>
+                                    <Link
+                                        href={`/care-pathways/catalog/${row.version.version_uuid}`}
+                                        className="font-medium text-healthcare-primary hover:underline dark:text-healthcare-primary-dark"
+                                    >
+                                        {row.pathway.name}
+                                    </Link>
+                                    <p className="mt-0.5 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                        {row.pathway.care_type ?? "—"}
+                                        {" · "}
+                                        <span className="tabular-nums">
+                                            {row.evidence.claim_count}
+                                        </span>{" "}
+                                        claims
+                                        {" · "}
+                                        <span className="tabular-nums">
+                                            {row.governance.section_count}
+                                        </span>{" "}
+                                        sections
+                                    </p>
+                                </td>
+                                <td
+                                    className={`${bodyCell} max-w-52 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark`}
+                                >
+                                    {row.pathway.mdc ?? "—"}
+                                </td>
+                                <td
+                                    className={`${bodyCell} text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark`}
+                                >
+                                    {row.pathway.source_service_line ?? "—"}
+                                </td>
+                                <td className={bodyCell}>
+                                    <DrgChips drgs={row.drg_candidates} />
+                                </td>
+                                <td className={bodyCell}>
+                                    <EvidenceBadge
+                                        status={row.evidence.status}
+                                    />
+                                </td>
+                                <td className={bodyCell}>
+                                    <GovernanceStatus
+                                        approval={
+                                            row.governance
+                                                .institutional_approval_status
+                                        }
+                                        activation={
+                                            row.governance.activation_status
+                                        }
+                                    />
+                                </td>
+                            </tr>
+                        ))}
+                        {rows.length === 0 && !isLoading && (
+                            <tr>
+                                <td colSpan={7} className="px-3 py-10">
+                                    <div className="flex flex-col items-center gap-2 text-center">
+                                        <SearchX
+                                            className="h-6 w-6 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark"
+                                            aria-hidden="true"
+                                        />
+                                        <p className="text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                            No pathways match the current
+                                            filters.
+                                        </p>
+                                    </div>
+                                </td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
+            </div>
+
+            {pagination && pagination.last_page > 1 && (
+                <div className="mt-4 flex items-center justify-between border-t border-healthcare-border pt-4 dark:border-healthcare-border-dark">
+                    <p className="text-xs tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                        Page {pagination.page} of {pagination.last_page}
+                    </p>
+                    <div className="flex gap-2">
+                        <button
+                            type="button"
+                            onClick={() => onPage(pagination.page - 1)}
+                            disabled={isLoading || pagination.page <= 1}
+                            className="inline-flex items-center gap-1 rounded-md border border-healthcare-border px-2.5 py-1.5 text-sm font-medium text-healthcare-text-primary disabled:opacity-40 dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark"
+                        >
+                            <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+                            Previous
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => onPage(pagination.page + 1)}
+                            disabled={
+                                isLoading ||
+                                pagination.page >= pagination.last_page
+                            }
+                            className="inline-flex items-center gap-1 rounded-md border border-healthcare-border px-2.5 py-1.5 text-sm font-medium text-healthcare-text-primary disabled:opacity-40 dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark"
+                        >
+                            Next
+                            <ChevronRight
+                                className="h-4 w-4"
+                                aria-hidden="true"
+                            />
+                        </button>
+                    </div>
+                </div>
+            )}
+            </Surface>
+        </Section>
+    );
+}

--- a/resources/js/Components/CarePathways/StatusAtoms.tsx
+++ b/resources/js/Components/CarePathways/StatusAtoms.tsx
@@ -1,0 +1,140 @@
+import {
+    AlertTriangle,
+    CheckCircle2,
+    Circle,
+    Clock3,
+    PauseCircle,
+    ShieldCheck,
+    XCircle,
+} from "lucide-react";
+import type { DrgCandidate } from "@/lib/carePathways/catalogSchemas";
+
+// Small shared display atoms for the Catalog Explorer. Status is always
+// icon + label — never color alone (canon).
+
+const chipBase =
+    "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium";
+
+export function EvidenceBadge({ status }: { status: string }) {
+    const limitations = status.toLowerCase().includes("limitations");
+
+    return limitations ? (
+        <span
+            className={`${chipBase} border-healthcare-warning/40 text-healthcare-warning dark:border-healthcare-warning-dark/40 dark:text-healthcare-warning-dark`}
+            title={status}
+        >
+            <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+            Limitations
+        </span>
+    ) : (
+        <span
+            className={`${chipBase} border-healthcare-success/40 text-healthcare-success dark:border-healthcare-success-dark/40 dark:text-healthcare-success-dark`}
+            title={status}
+        >
+            <ShieldCheck className="h-3.5 w-3.5" aria-hidden="true" />
+            Verified
+        </span>
+    );
+}
+
+const approvalDisplay: Record<
+    string,
+    { label: string; icon: typeof Circle; tone: string }
+> = {
+    not_reviewed: {
+        label: "Not reviewed",
+        icon: Circle,
+        tone: "border-healthcare-border text-healthcare-text-secondary dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark",
+    },
+    in_review: {
+        label: "In review",
+        icon: Clock3,
+        tone: "border-healthcare-info/40 text-healthcare-info dark:border-healthcare-info-dark/40 dark:text-healthcare-info-dark",
+    },
+    approved: {
+        label: "Approved",
+        icon: CheckCircle2,
+        tone: "border-healthcare-success/40 text-healthcare-success dark:border-healthcare-success-dark/40 dark:text-healthcare-success-dark",
+    },
+    rejected: {
+        label: "Rejected",
+        icon: XCircle,
+        tone: "border-healthcare-warning/40 text-healthcare-warning dark:border-healthcare-warning-dark/40 dark:text-healthcare-warning-dark",
+    },
+    withdrawn: {
+        label: "Withdrawn",
+        icon: XCircle,
+        tone: "border-healthcare-border text-healthcare-text-secondary dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark",
+    },
+};
+
+export function GovernanceStatus({
+    approval,
+    activation,
+}: {
+    approval: string;
+    activation: string;
+}) {
+    const display = approvalDisplay[approval] ?? approvalDisplay.not_reviewed;
+    const ApprovalIcon = display.icon;
+
+    return (
+        <span className="inline-flex flex-wrap items-center gap-1.5">
+            <span className={`${chipBase} ${display.tone}`}>
+                <ApprovalIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                {display.label}
+            </span>
+            <span
+                className={`${chipBase} border-healthcare-border text-healthcare-text-secondary dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark`}
+            >
+                <PauseCircle className="h-3.5 w-3.5" aria-hidden="true" />
+                {activation === "inactive"
+                    ? "Inactive"
+                    : activation === "active"
+                      ? "Active"
+                      : "Withdrawn"}
+            </span>
+        </span>
+    );
+}
+
+const roleTone: Record<string, string> = {
+    candidate:
+        "border-healthcare-primary/40 text-healthcare-primary dark:border-healthcare-primary-dark/40 dark:text-healthcare-primary-dark",
+    supporting:
+        "border-healthcare-info/40 text-healthcare-info dark:border-healthcare-info-dark/40 dark:text-healthcare-info-dark",
+    retrospective_reconciliation:
+        "border-healthcare-border text-healthcare-text-secondary dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark",
+    excluded:
+        "border-healthcare-warning/40 text-healthcare-warning dark:border-healthcare-warning-dark/40 dark:text-healthcare-warning-dark",
+};
+
+export function DrgChips({
+    drgs,
+    max = 6,
+}: {
+    drgs: readonly DrgCandidate[];
+    max?: number;
+}) {
+    const shown = drgs.slice(0, max);
+    const overflow = drgs.length - shown.length;
+
+    return (
+        <span className="inline-flex flex-wrap items-center gap-1">
+            {shown.map((drg) => (
+                <span
+                    key={drg.ms_drg}
+                    className={`${chipBase} tabular-nums ${roleTone[drg.mapping_role] ?? roleTone.candidate}`}
+                    title={`${drg.ms_drg} — ${drg.title} (${drg.mapping_role.replaceAll("_", " ")})`}
+                >
+                    {drg.ms_drg}
+                </span>
+            ))}
+            {overflow > 0 && (
+                <span className="text-xs tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                    +{overflow} more
+                </span>
+            )}
+        </span>
+    );
+}

--- a/resources/js/Pages/CarePathways/Catalog/Index.tsx
+++ b/resources/js/Pages/CarePathways/Catalog/Index.tsx
@@ -1,0 +1,13 @@
+import { Head } from "@inertiajs/react";
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
+
+// Placeholder shell — replaced by the full Catalog Explorer (overview +
+// 250-pathway index) in the catalog-explorer plan Phase 3.
+export default function Index() {
+    return (
+        <AuthenticatedLayout>
+            <Head title="Care Pathways Catalog" />
+            <div className="p-4" />
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/CarePathways/Catalog/Index.tsx
+++ b/resources/js/Pages/CarePathways/Catalog/Index.tsx
@@ -1,13 +1,113 @@
-import { Head } from "@inertiajs/react";
-import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
+import { Head, Link, usePage } from "@inertiajs/react";
+import { HeartPulse } from "lucide-react";
+import { useCallback, useState } from "react";
+import DashboardLayout from "@/Components/Dashboard/DashboardLayout";
+import PageContentLayout from "@/Components/Common/PageContentLayout";
+import { ActivationReadiness } from "@/Components/CarePathways/ActivationReadiness";
+import { CatalogOverview } from "@/Components/CarePathways/CatalogOverview";
+import { GovernanceBanner } from "@/Components/CarePathways/GovernanceBanner";
+import { PathwayFilters } from "@/Components/CarePathways/PathwayFilters";
+import { PathwayTable } from "@/Components/CarePathways/PathwayTable";
+import {
+    useCatalogPathways,
+    useCatalogSummary,
+} from "@/hooks/carePathways/useCatalog";
+import type { PathwayQuery } from "@/lib/carePathways/catalogApi";
+import type { PageProps } from "@/types";
+import {
+    pathwaysEnvelopeSchema,
+    summaryEnvelopeSchema,
+    type PathwaysEnvelope,
+    type SummaryEnvelope,
+} from "@/lib/carePathways/catalogSchemas";
 
-// Placeholder shell — replaced by the full Catalog Explorer (overview +
-// 250-pathway index) in the catalog-explorer plan Phase 3.
-export default function Index() {
+interface IndexProps {
+    initialSummary: unknown;
+    initialPathways: unknown;
+}
+
+export default function Index({ initialSummary, initialPathways }: IndexProps) {
+    // Server-rendered props pass through the same Zod gate as live fetches.
+    const [seedSummary] = useState<SummaryEnvelope>(() =>
+        summaryEnvelopeSchema.parse(initialSummary),
+    );
+    const [seedPathways] = useState<PathwaysEnvelope>(() =>
+        pathwaysEnvelopeSchema.parse(initialPathways),
+    );
+
+    const [query, setQuery] = useState<PathwayQuery>({ page: 1, per_page: 25 });
+    const summary = useCatalogSummary(seedSummary);
+    const pathways = useCatalogPathways(query, seedPathways);
+
+    const onPage = useCallback(
+        (page: number) => setQuery((current) => ({ ...current, page })),
+        [],
+    );
+
+    const demoEnabled =
+        usePage<PageProps>().props.features?.care_pathways_demo === true;
+
+    const summaryData = summary.data ?? seedSummary;
+
     return (
-        <AuthenticatedLayout>
+        <DashboardLayout>
             <Head title="Care Pathways Catalog" />
-            <div className="p-4" />
-        </AuthenticatedLayout>
+            <PageContentLayout
+                title="Care Pathways Catalog"
+                subtitle="Governed DRG catalog — 250 pathways under evidence verification and institutional review"
+                headerContent={
+                    demoEnabled ? (
+                        <Link
+                            href="/care-pathways/demo"
+                            className="inline-flex items-center gap-2 rounded-md border border-healthcare-border px-3 py-1.5 text-sm font-medium text-healthcare-text-primary hover:bg-healthcare-surface-hover dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark dark:hover:bg-healthcare-surface-hover-dark"
+                        >
+                            <HeartPulse className="h-4 w-4" aria-hidden="true" />
+                            Pathway Journey Demo
+                        </Link>
+                    ) : undefined
+                }
+            >
+                <div className="space-y-4">
+                    <GovernanceBanner
+                        warning={summaryData.meta.clinical_approval_warning}
+                        state={summaryData.data.release.state}
+                        signoffCount={
+                            summaryData.data.release.clinical_signoff_count
+                        }
+                    />
+
+                    <CatalogOverview
+                        summary={summaryData.data}
+                        meta={summaryData.meta}
+                    />
+
+                    <ActivationReadiness
+                        readiness={summaryData.data.release_readiness}
+                        release={summaryData.data.release}
+                        catalog={summaryData.data.catalog}
+                    />
+
+                    <PathwayFilters value={query} onChange={setQuery} />
+
+                    {pathways.isError ? (
+                        <p
+                            className="rounded-md border border-healthcare-border p-4 text-sm text-healthcare-text-secondary dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark"
+                            role="alert"
+                        >
+                            The pathway list could not be loaded. Adjust the
+                            filters or try again — no catalog state was
+                            changed.
+                        </p>
+                    ) : (
+                        <PathwayTable
+                            rows={pathways.data?.data ?? []}
+                            pagination={pathways.data?.meta.pagination}
+                            onPage={onPage}
+                            isLoading={pathways.isFetching}
+                        />
+                    )}
+                </div>
+            </PageContentLayout>
+        </DashboardLayout>
     );
 }

--- a/resources/js/Pages/CarePathways/Catalog/Show.tsx
+++ b/resources/js/Pages/CarePathways/Catalog/Show.tsx
@@ -1,13 +1,154 @@
-import { Head } from "@inertiajs/react";
-import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
+import { Head, Link } from "@inertiajs/react";
+import { ArrowLeft } from "lucide-react";
+import { useState } from "react";
+import DashboardLayout from "@/Components/Dashboard/DashboardLayout";
+import PageContentLayout from "@/Components/Common/PageContentLayout";
+import { EvidenceClaims } from "@/Components/CarePathways/EvidenceClaims";
+import { GovernanceBanner } from "@/Components/CarePathways/GovernanceBanner";
+import { GovernanceLedger } from "@/Components/CarePathways/GovernanceLedger";
+import { PathwayAuthoring } from "@/Components/CarePathways/PathwayAuthoring";
+import { PathwaySections } from "@/Components/CarePathways/PathwaySections";
+import {
+    DrgChips,
+    EvidenceBadge,
+    GovernanceStatus,
+} from "@/Components/CarePathways/StatusAtoms";
+import { Section } from "@/Components/system";
+import { Surface } from "@/Components/ui/Surface";
+import { useCatalogVersion } from "@/hooks/carePathways/useCatalog";
+import {
+    versionEnvelopeSchema,
+    type VersionEnvelope,
+} from "@/lib/carePathways/catalogSchemas";
 
-// Placeholder shell — replaced by the full per-pathway detail view in the
-// catalog-explorer plan Phase 4.
-export default function Show() {
+interface ShowProps {
+    initialVersion: unknown;
+}
+
+export default function Show({ initialVersion }: ShowProps) {
+    // Server-rendered props pass through the same Zod gate as live fetches.
+    const [seed] = useState<VersionEnvelope>(() =>
+        versionEnvelopeSchema.parse(initialVersion),
+    );
+    const query = useCatalogVersion(seed.data.version.version_uuid, seed);
+    const envelope = query.data ?? seed;
+    const { pathway, version, drg_candidates, evidence, governance, sections, authoring, changes } =
+        envelope.data;
+
     return (
-        <AuthenticatedLayout>
-            <Head title="Care Pathway Detail" />
-            <div className="p-4" />
-        </AuthenticatedLayout>
+        <DashboardLayout>
+            <Head title={`${pathway.name} — Care Pathway`} />
+            <PageContentLayout
+                title={pathway.name}
+                subtitle={`${pathway.mdc ?? "MDC —"} · ${pathway.care_type ?? "—"} · ${pathway.source_service_line ?? "—"}`}
+                headerContent={
+                    <Link
+                        href="/care-pathways/catalog"
+                        className="inline-flex items-center gap-2 rounded-md border border-healthcare-border px-3 py-1.5 text-sm font-medium text-healthcare-text-primary hover:bg-healthcare-surface-hover dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark dark:hover:bg-healthcare-surface-hover-dark"
+                    >
+                        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+                        Catalog
+                    </Link>
+                }
+            >
+                <div className="space-y-4">
+                    <GovernanceBanner
+                        warning={envelope.meta.clinical_approval_warning}
+                        state="inactive"
+                        signoffCount={
+                            governance.approvals.filter(
+                                (approval) => approval.decision === "approved",
+                            ).length
+                        }
+                    />
+
+                    <Surface className="p-4">
+                        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+                            <div className="flex items-baseline gap-1.5">
+                                <span className="text-lg font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                    {version.source_rank ?? "—"}
+                                </span>
+                                <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                    volume rank
+                                </span>
+                            </div>
+                            <div className="flex items-baseline gap-1.5">
+                                <span className="text-lg font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                    {version.semantic_version}
+                                </span>
+                                <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                    version
+                                </span>
+                            </div>
+                            <div className="flex items-baseline gap-1.5">
+                                <span className="text-lg font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                    {evidence.claim_count}
+                                </span>
+                                <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                    evidence claims
+                                </span>
+                            </div>
+                            <EvidenceBadge status={evidence.status} />
+                            <GovernanceStatus
+                                approval={governance.institutional_approval_status}
+                                activation={governance.activation_status}
+                            />
+                        </div>
+                        <p className="mt-3 text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            {evidence.release_disposition}
+                            {evidence.confidence &&
+                                ` · verification confidence: ${evidence.confidence}`}
+                            {evidence.source_currency !== "current" &&
+                                " · linked to at least one non-current source"}
+                        </p>
+                    </Surface>
+
+                    <Section
+                        title="DRG candidates"
+                        summary="Grouper output is a candidate signal — clinician confirmation is always required"
+                        icon="heroicons:hashtag"
+                    >
+                        <Surface className="overflow-hidden">
+                            {drg_candidates.map((drg) => (
+                                <div
+                                    key={drg.ms_drg}
+                                    className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-healthcare-border px-4 py-2.5 last:border-b-0 dark:border-healthcare-border-dark"
+                                >
+                                    <DrgChips drgs={[drg]} max={1} />
+                                    <span className="min-w-0 flex-1 text-sm text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                        {drg.title}
+                                    </span>
+                                    <span className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                        {drg.mdc && `MDC ${drg.mdc}`}
+                                        {drg.type_label && ` · ${drg.type_label}`}
+                                        {` · ${drg.mapping_role.replaceAll("_", " ")}`}
+                                    </span>
+                                    {drg.ambiguity_note && (
+                                        <p className="w-full text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                            {drg.ambiguity_note}
+                                        </p>
+                                    )}
+                                </div>
+                            ))}
+                        </Surface>
+                    </Section>
+
+                    <PathwaySections sections={sections} />
+
+                    <PathwayAuthoring authoring={authoring} />
+
+                    <EvidenceClaims
+                        versionUuid={version.version_uuid}
+                        claimCount={evidence.claim_count}
+                    />
+
+                    <GovernanceLedger
+                        governance={governance}
+                        version={version}
+                        changes={changes}
+                    />
+                </div>
+            </PageContentLayout>
+        </DashboardLayout>
     );
 }

--- a/resources/js/Pages/CarePathways/Catalog/Show.tsx
+++ b/resources/js/Pages/CarePathways/Catalog/Show.tsx
@@ -1,0 +1,13 @@
+import { Head } from "@inertiajs/react";
+import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
+
+// Placeholder shell — replaced by the full per-pathway detail view in the
+// catalog-explorer plan Phase 4.
+export default function Show() {
+    return (
+        <AuthenticatedLayout>
+            <Head title="Care Pathway Detail" />
+            <div className="p-4" />
+        </AuthenticatedLayout>
+    );
+}

--- a/resources/js/Pages/CarePathways/Demo.tsx
+++ b/resources/js/Pages/CarePathways/Demo.tsx
@@ -1,8 +1,9 @@
-import { Head } from "@inertiajs/react";
+import { Head, Link, usePage } from "@inertiajs/react";
 import axios from "axios";
 import {
     ArrowLeft,
     ArrowRight,
+    BookOpen,
     Bot,
     Check,
     CircleAlert,
@@ -11,6 +12,7 @@ import {
     History,
     LockKeyhole,
     MessageCircle,
+    Minus,
     RefreshCcw,
     ShieldCheck,
     Smartphone,
@@ -18,7 +20,10 @@ import {
     Users,
 } from "lucide-react";
 import { useMemo, useState, type ReactNode } from "react";
-import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
+import DashboardLayout from "@/Components/Dashboard/DashboardLayout";
+import PageContentLayout from "@/Components/Common/PageContentLayout";
+import { Surface } from "@/Components/ui/Surface";
+import type { PageProps } from "@/types";
 
 type StepState = "complete" | "current" | "upcoming";
 
@@ -28,6 +33,68 @@ interface ScenarioStep {
     summary: string;
     index: number;
     state: StepState;
+}
+
+interface CareTeamProjection {
+    visible: boolean;
+    assignment: {
+        status: string;
+        pathway: string;
+        version: string;
+        current_stage: string;
+        confidence: string;
+        requires_confirmation: boolean;
+        matched: string[];
+        conflicts: string[];
+        decision_record: string;
+    };
+    milestones: Array<{ label: string; owner: string; state: string }>;
+    next_decisions: string[];
+}
+
+interface RoundsProjection {
+    visible: boolean;
+    queue_status: string;
+    pathway_badge: {
+        stage: string;
+        variance: string | null;
+        patient_question_count: number;
+    };
+    role_inputs: Array<{ role: string; state: string; summary: string }>;
+    open_question: string | null;
+}
+
+interface StaffProjection {
+    visible: boolean;
+    for_you: { priority: string; title: string; detail: string };
+    patient_context: Record<string, string | number | boolean>;
+    notification: { message: string };
+}
+
+interface PatientProjection {
+    visible: boolean;
+    headline: string;
+    why_here: string;
+    today: Array<{ label: string; state: string }>;
+    goals: Array<{ author: string; text: string }>;
+    question: { text: string; status: string };
+    urgent_help: string;
+}
+
+interface EddyProjection {
+    visible: boolean;
+    mode: string;
+    prompt: string;
+    answer: string;
+    citations: Array<{ label: string; reference: string; scope: string }>;
+    guardrails: Record<string, boolean>;
+}
+
+interface GovernanceProjection {
+    release_state: string;
+    controls: { failed: number; residual_unknowns: number };
+    activation_blockers: string[];
+    separation: Record<string, string>;
 }
 
 interface DemoScenario {
@@ -52,12 +119,12 @@ interface DemoScenario {
         service: string;
         privacy: string;
     };
-    care_team: any;
-    virtual_rounds: any;
-    hummingbird_staff: any;
-    hummingbird_patient: any;
-    eddy: any;
-    governance: any;
+    care_team: CareTeamProjection;
+    virtual_rounds: RoundsProjection;
+    hummingbird_staff: StaffProjection;
+    hummingbird_patient: PatientProjection;
+    eddy: EddyProjection;
+    governance: GovernanceProjection;
     timeline: Array<{
         step: number;
         time: string;
@@ -136,31 +203,35 @@ function StatusPill({ value }: { value: string }) {
         "resolved",
         "done",
         "active",
+        "answered_in_person",
     ].includes(value);
     const attention = [
         "due",
+        "today",
         "needs_action",
         "needs_help",
         "action_due",
         "ready_with_barrier",
+        "sent_to_care_team",
     ].includes(value);
+    const Icon = positive ? Check : attention ? CircleAlert : Minus;
+    const tone = positive
+        ? "border-healthcare-success/40 text-healthcare-success dark:border-healthcare-success-dark/40 dark:text-healthcare-success-dark"
+        : attention
+          ? "border-healthcare-warning/40 text-healthcare-warning dark:border-healthcare-warning-dark/40 dark:text-healthcare-warning-dark"
+          : "border-healthcare-border text-healthcare-text-secondary dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark";
 
     return (
         <span
-            className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-wide ${
-                positive
-                    ? "border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-200"
-                    : attention
-                      ? "border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-100"
-                      : "border-slate-300 bg-slate-50 text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
-            }`}
+            className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium uppercase tracking-wide ${tone}`}
         >
+            <Icon className="h-3 w-3" aria-hidden="true" />
             {titleCase(value)}
         </span>
     );
 }
 
-function Panel({
+function DemoPanel({
     title,
     icon,
     children,
@@ -170,17 +241,17 @@ function Panel({
     children: ReactNode;
 }) {
     return (
-        <section className="rounded-2xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-950">
-            <header className="flex items-center gap-3 border-b border-slate-200 px-5 py-4 dark:border-slate-800">
-                <span className="grid h-9 w-9 place-items-center rounded-xl bg-cyan-50 text-cyan-700 dark:bg-cyan-950 dark:text-cyan-200">
+        <Surface>
+            <header className="flex items-center gap-3 border-b border-healthcare-border px-5 py-3.5 dark:border-healthcare-border-dark">
+                <span className="grid h-8 w-8 place-items-center rounded-lg bg-healthcare-background text-healthcare-primary dark:bg-healthcare-background-dark dark:text-healthcare-primary-dark">
                     {icon}
                 </span>
-                <h2 className="text-base font-semibold text-slate-950 dark:text-white">
+                <h2 className="text-base font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                     {title}
                 </h2>
             </header>
             <div className="p-5">{children}</div>
-        </section>
+        </Surface>
     );
 }
 
@@ -194,11 +265,14 @@ function LockedSurface({
     return (
         <div className="grid min-h-72 place-items-center text-center">
             <div className="max-w-md">
-                <LockKeyhole className="mx-auto mb-4 h-10 w-10 text-slate-400" />
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">
+                <LockKeyhole
+                    className="mx-auto mb-4 h-10 w-10 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark"
+                    aria-hidden="true"
+                />
+                <h3 className="text-lg font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                     {label} is not released yet
                 </h3>
-                <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+                <p className="mt-2 text-sm leading-6 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                     Advance to {unlockStep}. The simulation reveals each
                     projection only after its release boundary is reached.
                 </p>
@@ -207,46 +281,46 @@ function LockedSurface({
     );
 }
 
-function CareTeamPanel({ data }: { data: DemoScenario["care_team"] }) {
+function CareTeamPanel({ data }: { data: CareTeamProjection }) {
     return (
         <div className="grid gap-5 xl:grid-cols-[1.25fr_1fr]">
             <div className="space-y-5">
-                <div className="rounded-xl bg-slate-950 p-5 text-white dark:bg-slate-900">
+                <Surface className="p-5">
                     <div className="flex flex-wrap items-start justify-between gap-3">
                         <div>
-                            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-primary dark:text-healthcare-primary-dark">
                                 Current pathway stage
                             </p>
-                            <h3 className="mt-2 text-2xl font-semibold">
+                            <h3 className="mt-2 text-2xl font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                 {data.assignment.current_stage}
                             </h3>
-                            <p className="mt-2 text-sm text-slate-300">
+                            <p className="mt-2 text-sm text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                 {data.assignment.pathway} ·{" "}
                                 {data.assignment.version}
                             </p>
                         </div>
                         <StatusPill value={data.assignment.status} />
                     </div>
-                    <p className="mt-5 border-t border-slate-700 pt-4 text-sm leading-6 text-slate-200">
+                    <p className="mt-5 border-t border-healthcare-border pt-4 text-sm leading-6 text-healthcare-text-secondary dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark">
                         {data.assignment.decision_record}
                     </p>
-                </div>
+                </Surface>
 
                 <div>
-                    <h3 className="mb-3 text-sm font-semibold text-slate-900 dark:text-white">
+                    <h3 className="mb-3 text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                         Milestone ownership
                     </h3>
                     <div className="space-y-2">
-                        {data.milestones.map((milestone: any) => (
+                        {data.milestones.map((milestone) => (
                             <div
                                 key={milestone.label}
-                                className="flex items-center justify-between gap-4 rounded-xl border border-slate-200 px-4 py-3 dark:border-slate-800"
+                                className="flex items-center justify-between gap-4 rounded-lg border border-healthcare-border px-4 py-3 dark:border-healthcare-border-dark"
                             >
                                 <div>
-                                    <p className="text-sm font-medium text-slate-900 dark:text-white">
+                                    <p className="text-sm font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                         {milestone.label}
                                     </p>
-                                    <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                                    <p className="mt-1 text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                         Owner: {milestone.owner}
                                     </p>
                                 </div>
@@ -258,56 +332,60 @@ function CareTeamPanel({ data }: { data: DemoScenario["care_team"] }) {
             </div>
 
             <div className="space-y-5">
-                <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
-                    <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+                <div className="rounded-lg border border-healthcare-border p-4 dark:border-healthcare-border-dark">
+                    <h3 className="text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                         Next decisions
                     </h3>
                     <ul className="mt-3 space-y-3">
-                        {data.next_decisions.map((decision: string) => (
+                        {data.next_decisions.map((decision) => (
                             <li
                                 key={decision}
-                                className="flex gap-3 text-sm leading-6 text-slate-700 dark:text-slate-200"
+                                className="flex gap-3 text-sm leading-6 text-healthcare-text-primary dark:text-healthcare-text-primary-dark"
                             >
-                                <CircleAlert className="mt-1 h-4 w-4 shrink-0 text-amber-500" />
+                                <CircleAlert
+                                    className="mt-1 h-4 w-4 shrink-0 text-healthcare-warning dark:text-healthcare-warning-dark"
+                                    aria-hidden="true"
+                                />
                                 {decision}
                             </li>
                         ))}
                     </ul>
                 </div>
 
-                <div className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
-                    <h3 className="text-sm font-semibold text-slate-900 dark:text-white">
+                <div className="rounded-lg border border-healthcare-border p-4 dark:border-healthcare-border-dark">
+                    <h3 className="text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                         Assignment evidence
                     </h3>
                     <dl className="mt-3 space-y-3 text-sm">
                         <div className="flex justify-between gap-4">
-                            <dt className="text-slate-500">Confidence</dt>
-                            <dd className="text-right font-medium text-slate-900 dark:text-white">
+                            <dt className="text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                Confidence
+                            </dt>
+                            <dd className="text-right font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                 {titleCase(data.assignment.confidence)}
                             </dd>
                         </div>
                         <div className="flex justify-between gap-4">
-                            <dt className="text-slate-500">Confirmation</dt>
-                            <dd className="text-right font-medium text-slate-900 dark:text-white">
+                            <dt className="text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                Confirmation
+                            </dt>
+                            <dd className="text-right font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                 {data.assignment.requires_confirmation
                                     ? "Required"
                                     : "Recorded in demo"}
                             </dd>
                         </div>
                         <div>
-                            <dt className="text-slate-500">Matched signals</dt>
+                            <dt className="text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                Matched signals
+                            </dt>
                             <dd className="mt-2 flex flex-wrap gap-2">
                                 {data.assignment.matched.length ? (
-                                    data.assignment.matched.map(
-                                        (item: string) => (
-                                            <StatusPill
-                                                key={item}
-                                                value={item}
-                                            />
-                                        ),
-                                    )
+                                    data.assignment.matched.map((item) => (
+                                        <StatusPill key={item} value={item} />
+                                    ))
                                 ) : (
-                                    <span className="text-slate-500">
+                                    <span className="text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                         Not evaluated
                                     </span>
                                 )}
@@ -320,7 +398,7 @@ function CareTeamPanel({ data }: { data: DemoScenario["care_team"] }) {
     );
 }
 
-function RoundsPanel({ data }: { data: DemoScenario["virtual_rounds"] }) {
+function RoundsPanel({ data }: { data: RoundsProjection }) {
     if (!data.visible)
         return (
             <LockedSurface
@@ -331,51 +409,55 @@ function RoundsPanel({ data }: { data: DemoScenario["virtual_rounds"] }) {
 
     return (
         <div className="grid gap-5 lg:grid-cols-2">
-            <div className="rounded-xl border border-slate-200 p-5 dark:border-slate-800">
+            <div className="rounded-lg border border-healthcare-border p-5 dark:border-healthcare-border-dark">
                 <div className="flex items-start justify-between gap-3">
                     <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                             4D pathway badge
                         </p>
-                        <h3 className="mt-2 text-xl font-semibold text-slate-900 dark:text-white">
+                        <h3 className="mt-2 text-xl font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                             {data.pathway_badge.stage}
                         </h3>
                     </div>
                     <StatusPill value={data.queue_status} />
                 </div>
                 <div className="mt-5 grid grid-cols-2 gap-3">
-                    <div className="rounded-lg bg-slate-50 p-3 dark:bg-slate-900">
-                        <p className="text-xs text-slate-500">Variance</p>
-                        <p className="mt-1 text-sm font-medium text-slate-900 dark:text-white">
+                    <div className="rounded-lg bg-healthcare-background p-3 dark:bg-healthcare-background-dark">
+                        <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            Variance
+                        </p>
+                        <p className="mt-1 text-sm font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                             {data.pathway_badge.variance ?? "None"}
                         </p>
                     </div>
-                    <div className="rounded-lg bg-slate-50 p-3 dark:bg-slate-900">
-                        <p className="text-xs text-slate-500">Questions</p>
-                        <p className="mt-1 text-sm font-medium text-slate-900 dark:text-white">
+                    <div className="rounded-lg bg-healthcare-background p-3 dark:bg-healthcare-background-dark">
+                        <p className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                            Questions
+                        </p>
+                        <p className="mt-1 text-sm font-medium tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                             {data.pathway_badge.patient_question_count}
                         </p>
                     </div>
                 </div>
                 {data.open_question && (
-                    <blockquote className="mt-4 rounded-lg border-l-4 border-cyan-500 bg-cyan-50 p-4 text-sm text-cyan-950 dark:bg-cyan-950/40 dark:text-cyan-100">
+                    <blockquote className="mt-4 rounded-lg bg-healthcare-background p-4 text-sm italic text-healthcare-text-primary dark:bg-healthcare-background-dark dark:text-healthcare-text-primary-dark">
                         “{data.open_question}”
                     </blockquote>
                 )}
             </div>
             <div className="space-y-3">
-                {data.role_inputs.map((input: any) => (
+                {data.role_inputs.map((input) => (
                     <div
                         key={input.role}
-                        className="rounded-xl border border-slate-200 p-4 dark:border-slate-800"
+                        className="rounded-lg border border-healthcare-border p-4 dark:border-healthcare-border-dark"
                     >
                         <div className="flex items-center justify-between gap-3">
-                            <h3 className="font-semibold text-slate-900 dark:text-white">
+                            <h3 className="font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                 {input.role}
                             </h3>
                             <StatusPill value={input.state} />
                         </div>
-                        <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+                        <p className="mt-2 text-sm leading-6 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                             {input.summary}
                         </p>
                     </div>
@@ -385,7 +467,16 @@ function RoundsPanel({ data }: { data: DemoScenario["virtual_rounds"] }) {
     );
 }
 
-function StaffPanel({ data }: { data: DemoScenario["hummingbird_staff"] }) {
+function PhoneFrame({ children }: { children: ReactNode }) {
+    return (
+        <div className="rounded-[2rem] border-8 border-healthcare-border bg-healthcare-surface p-4 shadow-md dark:border-healthcare-border-dark dark:bg-healthcare-surface-dark">
+            <div className="mx-auto mb-5 h-1.5 w-20 rounded-full bg-healthcare-border dark:bg-healthcare-border-dark" />
+            {children}
+        </div>
+    );
+}
+
+function StaffPanel({ data }: { data: StaffProjection }) {
     if (!data.visible)
         return (
             <LockedSurface
@@ -396,25 +487,29 @@ function StaffPanel({ data }: { data: DemoScenario["hummingbird_staff"] }) {
 
     return (
         <div className="mx-auto grid max-w-4xl gap-5 lg:grid-cols-[320px_1fr]">
-            <div className="rounded-[2rem] border-8 border-slate-900 bg-slate-950 p-4 text-white shadow-xl">
-                <div className="mx-auto mb-5 h-1.5 w-20 rounded-full bg-slate-700" />
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300">
+            <PhoneFrame>
+                <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-primary dark:text-healthcare-primary-dark">
                     For You
                 </p>
-                <div className="mt-4 rounded-2xl bg-slate-900 p-4">
+                <div className="mt-4 rounded-xl bg-healthcare-background p-4 dark:bg-healthcare-background-dark">
                     <div className="flex items-center justify-between gap-2">
-                        <MessageCircle className="h-5 w-5 text-amber-300" />
+                        <MessageCircle
+                            className="h-5 w-5 text-healthcare-warning dark:text-healthcare-warning-dark"
+                            aria-hidden="true"
+                        />
                         <StatusPill value={data.for_you.priority} />
                     </div>
-                    <h3 className="mt-4 font-semibold">{data.for_you.title}</h3>
-                    <p className="mt-2 text-sm leading-6 text-slate-300">
+                    <h3 className="mt-4 font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                        {data.for_you.title}
+                    </h3>
+                    <p className="mt-2 text-sm leading-6 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                         {data.for_you.detail}
                     </p>
                 </div>
-            </div>
+            </PhoneFrame>
             <div className="space-y-4">
-                <div className="rounded-xl border border-slate-200 p-5 dark:border-slate-800">
-                    <h3 className="font-semibold text-slate-900 dark:text-white">
+                <div className="rounded-lg border border-healthcare-border p-5 dark:border-healthcare-border-dark">
+                    <h3 className="font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                         Role-shaped patient context
                     </h3>
                     <dl className="mt-4 grid gap-4 sm:grid-cols-2">
@@ -422,12 +517,12 @@ function StaffPanel({ data }: { data: DemoScenario["hummingbird_staff"] }) {
                             ([key, value]) => (
                                 <div
                                     key={key}
-                                    className="rounded-lg bg-slate-50 p-3 dark:bg-slate-900"
+                                    className="rounded-lg bg-healthcare-background p-3 dark:bg-healthcare-background-dark"
                                 >
-                                    <dt className="text-xs text-slate-500">
+                                    <dt className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                         {titleCase(key)}
                                     </dt>
-                                    <dd className="mt-1 text-sm font-semibold text-slate-900 dark:text-white">
+                                    <dd className="mt-1 text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                         {String(value)}
                                     </dd>
                                 </div>
@@ -435,16 +530,22 @@ function StaffPanel({ data }: { data: DemoScenario["hummingbird_staff"] }) {
                         )}
                     </dl>
                 </div>
-                <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-950 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-100">
-                    Push is a generic doorbell only: “
-                    {data.notification.message}” No PHI is included.
+                <div className="flex items-start gap-2 rounded-lg border border-healthcare-border p-4 text-sm text-healthcare-text-primary dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark">
+                    <ShieldCheck
+                        className="mt-0.5 h-4 w-4 shrink-0 text-healthcare-success dark:text-healthcare-success-dark"
+                        aria-hidden="true"
+                    />
+                    <span>
+                        Push is a generic doorbell only: “
+                        {data.notification.message}” No PHI is included.
+                    </span>
                 </div>
             </div>
         </div>
     );
 }
 
-function PatientPanel({ data }: { data: DemoScenario["hummingbird_patient"] }) {
+function PatientPanel({ data }: { data: PatientProjection }) {
     if (!data.visible)
         return (
             <LockedSurface
@@ -455,21 +556,20 @@ function PatientPanel({ data }: { data: DemoScenario["hummingbird_patient"] }) {
 
     return (
         <div className="mx-auto grid max-w-5xl gap-6 lg:grid-cols-[360px_1fr]">
-            <div className="rounded-[2rem] border-8 border-slate-900 bg-white p-5 shadow-xl dark:bg-slate-950">
-                <div className="mx-auto mb-5 h-1.5 w-20 rounded-full bg-slate-300 dark:bg-slate-700" />
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-700 dark:text-cyan-300">
+            <PhoneFrame>
+                <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-primary dark:text-healthcare-primary-dark">
                     {data.headline}
                 </p>
-                <p className="mt-3 text-lg font-semibold leading-7 text-slate-950 dark:text-white">
+                <p className="mt-3 text-lg font-semibold leading-7 text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                     {data.why_here}
                 </p>
                 <div className="mt-5 space-y-3">
-                    {data.today.map((item: any) => (
+                    {data.today.map((item) => (
                         <div
                             key={item.label}
-                            className="rounded-xl border border-slate-200 p-3 dark:border-slate-800"
+                            className="rounded-xl border border-healthcare-border p-3 dark:border-healthcare-border-dark"
                         >
-                            <p className="text-sm text-slate-900 dark:text-white">
+                            <p className="text-sm text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                 {item.label}
                             </p>
                             <div className="mt-2">
@@ -478,40 +578,44 @@ function PatientPanel({ data }: { data: DemoScenario["hummingbird_patient"] }) {
                         </div>
                     ))}
                 </div>
-            </div>
+            </PhoneFrame>
             <div className="space-y-4">
-                <div className="rounded-xl border border-slate-200 p-5 dark:border-slate-800">
-                    <h3 className="font-semibold text-slate-900 dark:text-white">
+                <div className="rounded-lg border border-healthcare-border p-5 dark:border-healthcare-border-dark">
+                    <h3 className="font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                         Goals remain attributable
                     </h3>
                     <div className="mt-4 space-y-3">
-                        {data.goals.map((goal: any) => (
+                        {data.goals.map((goal) => (
                             <div
                                 key={goal.text}
-                                className="rounded-lg bg-slate-50 p-4 dark:bg-slate-900"
+                                className="rounded-lg bg-healthcare-background p-4 dark:bg-healthcare-background-dark"
                             >
-                                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                     {titleCase(goal.author)}
                                 </p>
-                                <p className="mt-2 text-sm leading-6 text-slate-800 dark:text-slate-100">
+                                <p className="mt-2 text-sm leading-6 text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                     {goal.text}
                                 </p>
                             </div>
                         ))}
                     </div>
                 </div>
-                <div className="rounded-xl border border-cyan-200 bg-cyan-50 p-5 dark:border-cyan-900 dark:bg-cyan-950/40">
-                    <p className="text-xs font-semibold uppercase tracking-wide text-cyan-800 dark:text-cyan-200">
+                <div className="rounded-lg border border-healthcare-border p-5 dark:border-healthcare-border-dark">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-primary dark:text-healthcare-primary-dark">
                         Question to the care team
                     </p>
-                    <p className="mt-2 text-sm font-medium text-cyan-950 dark:text-cyan-50">
+                    <p className="mt-2 text-sm font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                         {data.question.text}
                     </p>
                     <div className="mt-3">
                         <StatusPill value={data.question.status} />
                     </div>
                 </div>
-                <p className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-xs leading-5 text-amber-950 dark:border-amber-900 dark:bg-amber-950/40 dark:text-amber-100">
+                <p className="flex items-start gap-2 rounded-lg border border-healthcare-border p-4 text-xs leading-5 text-healthcare-text-secondary dark:border-healthcare-border-dark dark:text-healthcare-text-secondary-dark">
+                    <CircleAlert
+                        className="mt-0.5 h-4 w-4 shrink-0 text-healthcare-warning dark:text-healthcare-warning-dark"
+                        aria-hidden="true"
+                    />
                     {data.urgent_help}
                 </p>
             </div>
@@ -519,70 +623,80 @@ function PatientPanel({ data }: { data: DemoScenario["hummingbird_patient"] }) {
     );
 }
 
-function EddyPanel({ data }: { data: DemoScenario["eddy"] }) {
+function EddyPanel({ data }: { data: EddyProjection }) {
     if (!data.visible)
         return <LockedSurface label="Eddy" unlockStep="Coordinate rounds" />;
 
     return (
         <div className="grid gap-5 lg:grid-cols-[1.2fr_1fr]">
-            <div className="rounded-xl bg-slate-950 p-5 text-white dark:bg-black">
+            <Surface className="p-5">
                 <div className="flex items-center gap-3">
-                    <Bot className="h-6 w-6 text-cyan-300" />
+                    <Bot
+                        className="h-6 w-6 text-healthcare-primary dark:text-healthcare-primary-dark"
+                        aria-hidden="true"
+                    />
                     <div>
-                        <p className="text-xs uppercase tracking-wide text-slate-400">
+                        <p className="text-xs uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                             {titleCase(data.mode)}
                         </p>
-                        <h3 className="font-semibold">
+                        <h3 className="font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                             Local-only pathway draft
                         </h3>
                     </div>
                 </div>
-                <p className="mt-5 rounded-lg bg-slate-900 p-4 text-sm leading-6 text-slate-300">
+                <p className="mt-5 rounded-lg bg-healthcare-background p-4 text-sm leading-6 text-healthcare-text-secondary dark:bg-healthcare-background-dark dark:text-healthcare-text-secondary-dark">
                     {data.prompt}
                 </p>
-                <p className="mt-4 text-sm leading-7 text-white">
+                <p className="mt-4 text-sm leading-7 text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                     {data.answer}
                 </p>
                 <div className="mt-5 space-y-3">
-                    {data.citations.map((citation: any) => (
+                    {data.citations.map((citation) => (
                         <div
                             key={citation.reference}
-                            className="rounded-lg border border-slate-700 p-3"
+                            className="rounded-lg border border-healthcare-border p-3 dark:border-healthcare-border-dark"
                         >
-                            <p className="text-sm font-semibold">
+                            <p className="text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                 {citation.label}
                             </p>
-                            <p className="mt-1 text-xs text-cyan-300">
+                            <p className="mt-1 text-xs tabular-nums text-healthcare-primary dark:text-healthcare-primary-dark">
                                 {citation.reference}
                             </p>
-                            <p className="mt-2 text-xs leading-5 text-slate-400">
+                            <p className="mt-2 text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                 {citation.scope}
                             </p>
                         </div>
                     ))}
                 </div>
-            </div>
-            <div className="rounded-xl border border-slate-200 p-5 dark:border-slate-800">
-                <h3 className="font-semibold text-slate-900 dark:text-white">
+            </Surface>
+            <div className="rounded-lg border border-healthcare-border p-5 dark:border-healthcare-border-dark">
+                <h3 className="font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                     Enforced guardrails
                 </h3>
                 <div className="mt-4 space-y-3">
                     {Object.entries(data.guardrails).map(([key, enabled]) => (
                         <div
                             key={key}
-                            className="flex items-center justify-between gap-4 rounded-lg bg-slate-50 px-3 py-2.5 dark:bg-slate-900"
+                            className="flex items-center justify-between gap-4 rounded-lg bg-healthcare-background px-3 py-2.5 dark:bg-healthcare-background-dark"
                         >
-                            <span className="text-sm text-slate-700 dark:text-slate-200">
+                            <span className="text-sm text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                 {titleCase(key)}
                             </span>
                             <span
                                 className={
                                     enabled
-                                        ? "text-emerald-600"
-                                        : "text-slate-500"
+                                        ? "text-healthcare-success dark:text-healthcare-success-dark"
+                                        : "text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark"
                                 }
                             >
-                                {enabled ? <Check className="h-5 w-5" /> : "No"}
+                                {enabled ? (
+                                    <Check
+                                        className="h-5 w-5"
+                                        aria-label="Enabled"
+                                    />
+                                ) : (
+                                    "No"
+                                )}
                             </span>
                         </div>
                     ))}
@@ -596,73 +710,88 @@ function GovernancePanel({
     data,
     catalog,
 }: {
-    data: DemoScenario["governance"];
+    data: GovernanceProjection;
     catalog: DemoScenario["catalog"];
 }) {
     return (
         <div className="grid gap-5 lg:grid-cols-2">
-            <div className="rounded-xl border border-slate-200 p-5 dark:border-slate-800">
+            <div className="rounded-lg border border-healthcare-border p-5 dark:border-healthcare-border-dark">
                 <div className="flex items-start justify-between gap-3">
                     <div>
-                        <p className="text-xs uppercase tracking-wide text-slate-500">
+                        <p className="text-xs uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                             Real catalog release
                         </p>
-                        <h3 className="mt-2 text-xl font-semibold text-slate-950 dark:text-white">
+                        <h3 className="mt-2 text-xl font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                             MS-DRG v{String(catalog.grouper_version)}
                         </h3>
                     </div>
                     <StatusPill value={data.release_state} />
                 </div>
                 <dl className="mt-5 grid grid-cols-2 gap-3">
-                    {[
-                        ["Pathways", catalog.pathways],
-                        ["Evidence verified", catalog.evidence_verified],
-                        ["Limitations", catalog.evidence_limitations],
-                        ["Clinical signoffs", catalog.clinical_signoff_count],
-                        ["Failed controls", data.controls.failed],
-                        ["Residual unknowns", data.controls.residual_unknowns],
-                    ].map(([label, value]) => (
+                    {(
+                        [
+                            ["Pathways", catalog.pathways],
+                            ["Evidence verified", catalog.evidence_verified],
+                            ["Limitations", catalog.evidence_limitations],
+                            [
+                                "Clinical signoffs",
+                                catalog.clinical_signoff_count,
+                            ],
+                            ["Failed controls", data.controls.failed],
+                            [
+                                "Residual unknowns",
+                                data.controls.residual_unknowns,
+                            ],
+                        ] as Array<[string, string | number | boolean]>
+                    ).map(([label, value]) => (
                         <div
-                            key={String(label)}
-                            className="rounded-lg bg-slate-50 p-3 dark:bg-slate-900"
+                            key={label}
+                            className="rounded-lg bg-healthcare-background p-3 dark:bg-healthcare-background-dark"
                         >
-                            <dt className="text-xs text-slate-500">
-                                {String(label)}
+                            <dt className="text-xs text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                {label}
                             </dt>
-                            <dd className="mt-1 text-xl font-semibold text-slate-950 dark:text-white">
+                            <dd className="mt-1 text-xl font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                 {String(value)}
                             </dd>
                         </div>
                     ))}
                 </dl>
             </div>
-            <div className="rounded-xl border border-amber-200 bg-amber-50 p-5 dark:border-amber-900 dark:bg-amber-950/30">
-                <h3 className="font-semibold text-amber-950 dark:text-amber-100">
+            <div className="rounded-lg border border-healthcare-border p-5 dark:border-healthcare-border-dark">
+                <h3 className="flex items-center gap-2 font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                    <CircleAlert
+                        className="h-4 w-4 text-healthcare-warning dark:text-healthcare-warning-dark"
+                        aria-hidden="true"
+                    />
                     Why production is still inactive
                 </h3>
                 <ul className="mt-4 space-y-3">
-                    {data.activation_blockers.map((blocker: string) => (
+                    {data.activation_blockers.map((blocker) => (
                         <li
                             key={blocker}
-                            className="flex gap-3 text-sm leading-6 text-amber-950 dark:text-amber-100"
+                            className="flex gap-3 text-sm leading-6 text-healthcare-text-primary dark:text-healthcare-text-primary-dark"
                         >
-                            <CircleAlert className="mt-1 h-4 w-4 shrink-0" />
+                            <CircleAlert
+                                className="mt-1 h-4 w-4 shrink-0 text-healthcare-warning dark:text-healthcare-warning-dark"
+                                aria-hidden="true"
+                            />
                             {blocker}
                         </li>
                     ))}
                 </ul>
             </div>
-            <div className="lg:col-span-2 grid gap-3 md:grid-cols-3">
+            <div className="grid gap-3 md:grid-cols-3 lg:col-span-2">
                 {Object.entries(data.separation).map(([key, value]) => (
                     <div
                         key={key}
-                        className="rounded-xl border border-slate-200 p-4 dark:border-slate-800"
+                        className="rounded-lg border border-healthcare-border p-4 dark:border-healthcare-border-dark"
                     >
-                        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                             {titleCase(key)}
                         </p>
-                        <p className="mt-2 text-sm leading-6 text-slate-700 dark:text-slate-200">
-                            {String(value)}
+                        <p className="mt-2 text-sm leading-6 text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                            {value}
                         </p>
                     </div>
                 ))}
@@ -676,6 +805,9 @@ export default function Demo({ initialScenario }: DemoProps) {
     const [surface, setSurface] = useState<SurfaceKey>(initialSurface);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    const catalogEnabled =
+        usePage<PageProps>().props.features?.care_pathways_catalog === true;
 
     const currentStep = scenario.meta.current_step;
     const activeStep = scenario.steps[currentStep];
@@ -727,66 +859,67 @@ export default function Demo({ initialScenario }: DemoProps) {
     };
 
     return (
-        <AuthenticatedLayout>
+        <DashboardLayout>
             <Head title="Care Pathway Journey Demo" />
-            <div className="min-h-full bg-slate-50 px-4 py-6 dark:bg-slate-900/40 sm:px-6 lg:px-8">
-                <div className="mx-auto max-w-[1500px] space-y-6">
-                    <div
-                        className="flex items-start gap-3 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-amber-950 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100"
-                        role="status"
-                    >
-                        <CircleAlert className="mt-0.5 h-5 w-5 shrink-0" />
-                        <div>
-                            <p className="text-sm font-semibold">
-                                Synthetic simulation — not clinical care
-                            </p>
-                            <p className="mt-1 text-xs leading-5">
-                                {scenario.meta.warning}
-                            </p>
-                        </div>
-                    </div>
-
-                    <header className="rounded-2xl bg-gradient-to-br from-slate-950 via-slate-900 to-cyan-950 p-6 text-white shadow-xl sm:p-8">
-                        <div className="flex flex-col justify-between gap-6 xl:flex-row xl:items-end">
+            <PageContentLayout
+                title={scenario.meta.title}
+                subtitle="One fictional patient, six governed steps, and every intended audience projection — without activating the clinical catalog"
+                headerContent={
+                    catalogEnabled ? (
+                        <Link
+                            href="/care-pathways/catalog"
+                            className="inline-flex items-center gap-2 rounded-md border border-healthcare-border px-3 py-1.5 text-sm font-medium text-healthcare-text-primary hover:bg-healthcare-surface-hover dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark dark:hover:bg-healthcare-surface-hover-dark"
+                        >
+                            <BookOpen className="h-4 w-4" aria-hidden="true" />
+                            Browse the 250-pathway catalog
+                        </Link>
+                    ) : undefined
+                }
+            >
+                <div className="space-y-4">
+                    <Surface className="p-4" role="status">
+                        <div className="flex items-start gap-3">
+                            <CircleAlert
+                                className="mt-0.5 h-5 w-5 shrink-0 text-healthcare-warning dark:text-healthcare-warning-dark"
+                                aria-hidden="true"
+                            />
                             <div>
-                                <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300">
-                                    <HeartPulse className="h-4 w-4" /> Care
-                                    Pathway Journey Demo
-                                </div>
-                                <h1 className="mt-4 max-w-4xl text-3xl font-semibold tracking-tight sm:text-4xl">
-                                    {scenario.meta.title}
-                                </h1>
-                                <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-300">
-                                    One fictional patient, six governed steps,
-                                    and every intended audience
-                                    projection—without activating the clinical
-                                    catalog.
+                                <p className="text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                    Synthetic simulation — not clinical care
+                                </p>
+                                <p className="mt-1 text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                    {scenario.meta.warning}
                                 </p>
                             </div>
-                            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 xl:min-w-[620px]">
-                                {[
+                        </div>
+                    </Surface>
+
+                    <Surface className="p-4">
+                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+                            {(
+                                [
                                     ["Patient", scenario.subject.display_name],
                                     ["Location", scenario.subject.location],
-                                    ["Journey", scenario.subject.encounter_day],
+                                    [
+                                        "Journey",
+                                        scenario.subject.encounter_day,
+                                    ],
                                     ["Progress", `${progress}%`],
-                                ].map(([label, value]) => (
-                                    <div
-                                        key={label}
-                                        className="rounded-xl border border-white/10 bg-white/5 p-3"
-                                    >
-                                        <p className="text-xs uppercase tracking-wide text-slate-400">
-                                            {label}
-                                        </p>
-                                        <p className="mt-1 text-sm font-semibold text-white">
-                                            {value}
-                                        </p>
-                                    </div>
-                                ))}
-                            </div>
+                                ] as Array<[string, string]>
+                            ).map(([label, value]) => (
+                                <div key={label}>
+                                    <p className="text-xs uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                        {label}
+                                    </p>
+                                    <p className="mt-1 text-sm font-semibold tabular-nums text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
+                                        {value}
+                                    </p>
+                                </div>
+                            ))}
                         </div>
-                    </header>
+                    </Surface>
 
-                    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+                    <Surface className="p-5">
                         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
                             {scenario.steps.map((step) => (
                                 <button
@@ -794,7 +927,13 @@ export default function Demo({ initialScenario }: DemoProps) {
                                     type="button"
                                     onClick={() => loadStep(step.index)}
                                     disabled={loading}
-                                    className={`rounded-xl border p-4 text-left transition ${step.state === "current" ? "border-cyan-500 bg-cyan-50 ring-2 ring-cyan-100 dark:bg-cyan-950/40 dark:ring-cyan-950" : step.state === "complete" ? "border-emerald-200 bg-emerald-50 dark:border-emerald-900 dark:bg-emerald-950/30" : "border-slate-200 hover:border-slate-400 dark:border-slate-800 dark:hover:border-slate-600"}`}
+                                    className={`rounded-lg border p-4 text-left transition ${
+                                        step.state === "current"
+                                            ? "border-healthcare-primary bg-healthcare-background dark:border-healthcare-primary-dark dark:bg-healthcare-background-dark"
+                                            : step.state === "complete"
+                                              ? "border-healthcare-success/40 dark:border-healthcare-success-dark/40"
+                                              : "border-healthcare-border hover:border-healthcare-text-secondary dark:border-healthcare-border-dark dark:hover:border-healthcare-text-secondary-dark"
+                                    }`}
                                     aria-current={
                                         step.state === "current"
                                             ? "step"
@@ -802,32 +941,38 @@ export default function Demo({ initialScenario }: DemoProps) {
                                     }
                                 >
                                     <div className="flex items-center justify-between">
-                                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-                                            Step {step.index + 1}
+                                        <span className="text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
+                                            Step{" "}
+                                            <span className="tabular-nums">
+                                                {step.index + 1}
+                                            </span>
                                         </span>
                                         {step.state === "complete" ? (
-                                            <Check className="h-4 w-4 text-emerald-600" />
+                                            <Check
+                                                className="h-4 w-4 text-healthcare-success dark:text-healthcare-success-dark"
+                                                aria-label="Complete"
+                                            />
                                         ) : (
-                                            <span className="grid h-5 w-5 place-items-center rounded-full border border-current text-xs">
+                                            <span className="grid h-5 w-5 place-items-center rounded-full border border-current text-xs tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                                 {step.index + 1}
                                             </span>
                                         )}
                                     </div>
-                                    <p className="mt-3 text-sm font-semibold text-slate-950 dark:text-white">
+                                    <p className="mt-3 text-sm font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                         {step.label}
                                     </p>
-                                    <p className="mt-2 text-xs leading-5 text-slate-500 dark:text-slate-400">
+                                    <p className="mt-2 text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                         {step.summary}
                                     </p>
                                 </button>
                             ))}
                         </div>
-                        <div className="mt-5 flex flex-col gap-3 border-t border-slate-200 pt-5 dark:border-slate-800 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="mt-5 flex flex-col gap-3 border-t border-healthcare-border pt-5 dark:border-healthcare-border-dark sm:flex-row sm:items-center sm:justify-between">
                             <div>
-                                <p className="text-xs font-semibold uppercase tracking-wide text-cyan-700 dark:text-cyan-300">
+                                <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-primary dark:text-healthcare-primary-dark">
                                     Now demonstrating
                                 </p>
-                                <p className="mt-1 text-sm font-medium text-slate-950 dark:text-white">
+                                <p className="mt-1 text-sm font-medium text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                     {activeStep.label}: {activeStep.summary}
                                 </p>
                             </div>
@@ -836,17 +981,25 @@ export default function Demo({ initialScenario }: DemoProps) {
                                     type="button"
                                     onClick={() => loadStep(0)}
                                     disabled={loading || currentStep === 0}
-                                    className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 disabled:opacity-40 dark:border-slate-700 dark:text-slate-200"
+                                    className="inline-flex items-center gap-2 rounded-lg border border-healthcare-border px-3 py-2 text-sm font-medium text-healthcare-text-primary disabled:opacity-40 dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark"
                                 >
-                                    <RefreshCcw className="h-4 w-4" /> Reset
+                                    <RefreshCcw
+                                        className="h-4 w-4"
+                                        aria-hidden="true"
+                                    />
+                                    Reset
                                 </button>
                                 <button
                                     type="button"
                                     onClick={() => loadStep(currentStep - 1)}
                                     disabled={loading || currentStep === 0}
-                                    className="inline-flex items-center gap-2 rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 disabled:opacity-40 dark:border-slate-700 dark:text-slate-200"
+                                    className="inline-flex items-center gap-2 rounded-lg border border-healthcare-border px-3 py-2 text-sm font-medium text-healthcare-text-primary disabled:opacity-40 dark:border-healthcare-border-dark dark:text-healthcare-text-primary-dark"
                                 >
-                                    <ArrowLeft className="h-4 w-4" /> Back
+                                    <ArrowLeft
+                                        className="h-4 w-4"
+                                        aria-hidden="true"
+                                    />
+                                    Back
                                 </button>
                                 <button
                                     type="button"
@@ -855,62 +1008,72 @@ export default function Demo({ initialScenario }: DemoProps) {
                                         loading ||
                                         currentStep === scenario.meta.max_step
                                     }
-                                    className="inline-flex items-center gap-2 rounded-lg bg-cyan-700 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-cyan-800 disabled:opacity-40"
+                                    className="inline-flex items-center gap-2 rounded-lg bg-healthcare-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-healthcare-primary-hover disabled:opacity-40 dark:bg-healthcare-primary-dark dark:hover:bg-healthcare-primary-hover-dark"
                                 >
-                                    Advance <ArrowRight className="h-4 w-4" />
+                                    Advance
+                                    <ArrowRight
+                                        className="h-4 w-4"
+                                        aria-hidden="true"
+                                    />
                                 </button>
                             </div>
                         </div>
                         {error && (
-                            <p className="mt-4 rounded-lg bg-rose-50 p-3 text-sm text-rose-800 dark:bg-rose-950/40 dark:text-rose-200">
+                            <p
+                                className="mt-4 flex items-start gap-2 rounded-lg border border-healthcare-critical/40 p-3 text-sm text-healthcare-critical dark:border-healthcare-critical-dark/40 dark:text-healthcare-critical-dark"
+                                role="alert"
+                            >
+                                <CircleAlert
+                                    className="mt-0.5 h-4 w-4 shrink-0"
+                                    aria-hidden="true"
+                                />
                                 {error}
                             </p>
                         )}
-                    </section>
+                    </Surface>
 
                     <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-                        {[
+                        {(
                             [
-                                "Real catalog",
-                                String(scenario.catalog.state),
-                                "250 research pathways remain governed",
-                            ],
-                            [
-                                "Demo overlay",
-                                "Simulation only",
-                                "No database writes or clinical activation",
-                            ],
-                            [
-                                "Selected pilot",
-                                "Heart Failure",
-                                "Rank 6 · evidence-verified cohort",
-                            ],
-                            [
-                                "Safety boundary",
-                                "Fail closed",
-                                "Patient and Eddy production flags stay off",
-                            ],
-                        ].map(([label, value, note]) => (
-                            <div
-                                key={label}
-                                className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-950"
-                            >
-                                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                                [
+                                    "Real catalog",
+                                    String(scenario.catalog.state),
+                                    "250 research pathways remain governed",
+                                ],
+                                [
+                                    "Demo overlay",
+                                    "Simulation only",
+                                    "No database writes or clinical activation",
+                                ],
+                                [
+                                    "Selected pilot",
+                                    "Heart Failure",
+                                    "Rank 6 · evidence-verified cohort",
+                                ],
+                                [
+                                    "Safety boundary",
+                                    "Fail closed",
+                                    "Patient and Eddy production flags stay off",
+                                ],
+                            ] as Array<[string, string, string]>
+                        ).map(([label, value, note]) => (
+                            <Surface key={label} className="p-4">
+                                <p className="text-xs font-semibold uppercase tracking-wide text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                     {label}
                                 </p>
-                                <p className="mt-2 text-lg font-semibold text-slate-950 dark:text-white">
+                                <p className="mt-2 text-lg font-semibold text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                     {titleCase(value)}
                                 </p>
-                                <p className="mt-2 text-xs leading-5 text-slate-500 dark:text-slate-400">
+                                <p className="mt-2 text-xs leading-5 text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                     {note}
                                 </p>
-                            </div>
+                            </Surface>
                         ))}
                     </div>
 
-                    <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white p-2 shadow-sm dark:border-slate-800 dark:bg-slate-950">
+                    <Surface className="p-2">
                         <div
-                            className="flex min-w-max gap-1"
+                            className="flex min-w-max gap-1 overflow-x-auto"
                             role="tablist"
                             aria-label="Demo surfaces"
                         >
@@ -921,16 +1084,23 @@ export default function Demo({ initialScenario }: DemoProps) {
                                     role="tab"
                                     aria-selected={surface === key}
                                     onClick={() => setSurface(key)}
-                                    className={`inline-flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium ${surface === key ? "bg-slate-950 text-white dark:bg-cyan-700" : "text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-900"}`}
+                                    className={`inline-flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium ${
+                                        surface === key
+                                            ? "bg-healthcare-primary text-white dark:bg-healthcare-primary-dark"
+                                            : "text-healthcare-text-secondary hover:bg-healthcare-surface-hover dark:text-healthcare-text-secondary-dark dark:hover:bg-healthcare-surface-hover-dark"
+                                    }`}
                                 >
-                                    <Icon className="h-4 w-4" />
+                                    <Icon
+                                        className="h-4 w-4"
+                                        aria-hidden="true"
+                                    />
                                     {label}
                                 </button>
                             ))}
                         </div>
-                    </div>
+                    </Surface>
 
-                    <Panel
+                    <DemoPanel
                         title={
                             surfaces.find((item) => item.key === surface)
                                 ?.label ?? "Demo surface"
@@ -944,9 +1114,9 @@ export default function Demo({ initialScenario }: DemoProps) {
                         }
                     >
                         {renderSurface()}
-                    </Panel>
+                    </DemoPanel>
 
-                    <Panel
+                    <DemoPanel
                         title="Synthetic audit timeline"
                         icon={<History className="h-5 w-5" />}
                     >
@@ -954,25 +1124,25 @@ export default function Demo({ initialScenario }: DemoProps) {
                             {scenario.timeline.map((event) => (
                                 <li
                                     key={`${event.step}-${event.time}`}
-                                    className="rounded-xl border border-slate-200 p-4 dark:border-slate-800"
+                                    className="rounded-lg border border-healthcare-border p-4 dark:border-healthcare-border-dark"
                                 >
                                     <div className="flex items-center justify-between gap-3">
-                                        <span className="text-xs font-semibold uppercase tracking-wide text-cyan-700 dark:text-cyan-300">
+                                        <span className="text-xs font-semibold uppercase tracking-wide text-healthcare-primary dark:text-healthcare-primary-dark">
                                             {event.actor}
                                         </span>
-                                        <time className="font-mono text-xs text-slate-500">
+                                        <time className="text-xs tabular-nums text-healthcare-text-secondary dark:text-healthcare-text-secondary-dark">
                                             {event.time}
                                         </time>
                                     </div>
-                                    <p className="mt-3 text-sm leading-6 text-slate-700 dark:text-slate-200">
+                                    <p className="mt-3 text-sm leading-6 text-healthcare-text-primary dark:text-healthcare-text-primary-dark">
                                         {event.event}
                                     </p>
                                 </li>
                             ))}
                         </ol>
-                    </Panel>
+                    </DemoPanel>
                 </div>
-            </div>
-        </AuthenticatedLayout>
+            </PageContentLayout>
+        </DashboardLayout>
     );
 }

--- a/resources/js/config/navigationConfig.ts
+++ b/resources/js/config/navigationConfig.ts
@@ -74,12 +74,14 @@ export interface NavigationCapabilities {
   readonly run_diagnostics?: boolean;
   readonly view_patient_communications?: boolean;
   readonly respond_patient_communications?: boolean;
+  readonly view_care_pathway_catalog?: boolean;
 }
 
 /** Server-shared feature flags (Inertia `features` prop). A leaf gated on a
  *  disabled feature is hidden — never rendered as a dead link that 404s. */
 export interface NavigationFeatures {
   readonly care_pathways_demo?: boolean;
+  readonly care_pathways_catalog?: boolean;
   readonly virtual_rounds?: boolean;
   readonly home_hospital?: boolean;
   readonly patient_communications?: boolean;
@@ -192,6 +194,18 @@ const CARE_PATHWAYS: NavDomain = {
   matchPrefixes: ['/care-pathways'],
   requiredFeature: 'care_pathways_demo',
   groups: [
+    {
+      title: 'Catalog',
+      items: [
+        {
+          label: 'Catalog Explorer',
+          href: '/care-pathways/catalog',
+          icon: BookOpen,
+          requiredFeature: 'care_pathways_catalog',
+          requiredCapability: 'view_care_pathway_catalog',
+        },
+      ],
+    },
     {
       title: 'Simulation',
       items: [

--- a/resources/js/hooks/carePathways/useCatalog.ts
+++ b/resources/js/hooks/carePathways/useCatalog.ts
@@ -1,0 +1,67 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+    fetchClaims,
+    fetchPathways,
+    fetchSummary,
+    fetchVersion,
+    type PathwayQuery,
+} from "@/lib/carePathways/catalogApi";
+import type {
+    ClaimsEnvelope,
+    PathwaysEnvelope,
+    SummaryEnvelope,
+    VersionEnvelope,
+} from "@/lib/carePathways/catalogSchemas";
+
+const STALE_MS = 5 * 60 * 1000;
+
+const isDefaultQuery = (query: PathwayQuery): boolean =>
+    (query.page ?? 1) === 1 &&
+    Object.entries(query).every(
+        ([key, value]) =>
+            key === "page" || key === "per_page" || value === undefined || value === "",
+    );
+
+export function useCatalogSummary(initialData?: SummaryEnvelope) {
+    return useQuery({
+        queryKey: ["care-pathways", "summary"],
+        queryFn: fetchSummary,
+        initialData,
+        staleTime: STALE_MS,
+    });
+}
+
+export function useCatalogPathways(
+    query: PathwayQuery,
+    initialData?: PathwaysEnvelope,
+) {
+    return useQuery({
+        queryKey: ["care-pathways", "pathways", query],
+        queryFn: () => fetchPathways(query),
+        initialData:
+            initialData && isDefaultQuery(query) ? initialData : undefined,
+        staleTime: STALE_MS,
+        placeholderData: keepPreviousData,
+    });
+}
+
+export function useCatalogVersion(
+    versionUuid: string,
+    initialData?: VersionEnvelope,
+) {
+    return useQuery({
+        queryKey: ["care-pathways", "version", versionUuid],
+        queryFn: () => fetchVersion(versionUuid),
+        initialData,
+        staleTime: STALE_MS,
+    });
+}
+
+export function useCatalogClaims(versionUuid: string, page: number) {
+    return useQuery<ClaimsEnvelope>({
+        queryKey: ["care-pathways", "claims", versionUuid, page],
+        queryFn: () => fetchClaims(versionUuid, page),
+        staleTime: STALE_MS,
+        placeholderData: keepPreviousData,
+    });
+}

--- a/resources/js/iconify-bundle.ts
+++ b/resources/js/iconify-bundle.ts
@@ -115,6 +115,9 @@ const collections: IconifyJSON[] = [
   {
     "prefix": "heroicons",
     "icons": {
+      "archive-box": {
+        "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"m20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125\"/>"
+      },
       "arrow-down": {
         "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"M19.5 13.5L12 21m0 0l-7.5-7.5M12 21V3\"/>"
       },
@@ -300,6 +303,9 @@ const collections: IconifyJSON[] = [
       },
       "hand-raised": {
         "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"M10.05 4.575a1.575 1.575 0 1 0-3.15 0v3m3.15-3v-1.5a1.575 1.575 0 0 1 3.15 0v1.5m-3.15 0l.075 5.925m3.075.75V4.575m0 0a1.575 1.575 0 0 1 3.15 0V15M6.9 7.575a1.575 1.575 0 1 0-3.15 0v8.175a6.75 6.75 0 0 0 6.75 6.75h2.018a5.25 5.25 0 0 0 3.712-1.538l1.732-1.732a5.25 5.25 0 0 0 1.538-3.712l.003-2.024a.67.67 0 0 1 .198-.471a1.575 1.575 0 1 0-2.228-2.228a3.82 3.82 0 0 0-1.12 2.687M6.9 7.575V12m6.27 4.318A4.5 4.5 0 0 1 16.35 15m.002 0h-.002\"/>"
+      },
+      "hashtag": {
+        "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"M5.25 8.25h15m-16.5 7.5h15m-1.8-13.5l-3.9 19.5m-2.1-19.5l-3.9 19.5\"/>"
       },
       "heart": {
         "body": "<path fill=\"none\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"1.5\" d=\"M21 8.25c0-2.485-2.099-4.5-4.687-4.5c-1.936 0-3.598 1.126-4.313 2.733c-.715-1.607-2.377-2.733-4.312-2.733C5.098 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12\"/>"
@@ -690,6 +696,7 @@ export const localIconifyNames = [
   "healthicons:nurse",
   "healthicons:regular-patient",
   "healthicons:ui-menu",
+  "heroicons:archive-box",
   "heroicons:arrow-down",
   "heroicons:arrow-down-circle",
   "heroicons:arrow-down-tray",
@@ -752,6 +759,7 @@ export const localIconifyNames = [
   "heroicons:flag",
   "heroicons:funnel",
   "heroicons:hand-raised",
+  "heroicons:hashtag",
   "heroicons:heart",
   "heroicons:home",
   "heroicons:home-modern",

--- a/resources/js/lib/carePathways/catalogApi.ts
+++ b/resources/js/lib/carePathways/catalogApi.ts
@@ -1,0 +1,67 @@
+import axios from "axios";
+import {
+    claimsEnvelopeSchema,
+    pathwaysEnvelopeSchema,
+    summaryEnvelopeSchema,
+    versionEnvelopeSchema,
+    type ClaimsEnvelope,
+    type PathwaysEnvelope,
+    type SummaryEnvelope,
+    type VersionEnvelope,
+} from "./catalogSchemas";
+
+const BASE = "/api/care-pathways/v1";
+
+export interface PathwayQuery {
+    q?: string;
+    drg?: string;
+    mdc?: string;
+    service_line?: string;
+    evidence_state?: "verified" | "limitations";
+    disposition?: "signoff" | "specialist_review" | "redesign";
+    institutional_approval_status?:
+        | "not_reviewed"
+        | "in_review"
+        | "approved"
+        | "rejected"
+        | "withdrawn";
+    activation_status?: "inactive" | "active" | "withdrawn";
+    page?: number;
+    per_page?: number;
+}
+
+export async function fetchSummary(): Promise<SummaryEnvelope> {
+    const { data } = await axios.get<unknown>(`${BASE}/summary`);
+    return summaryEnvelopeSchema.parse(data);
+}
+
+export async function fetchPathways(
+    query: PathwayQuery,
+): Promise<PathwaysEnvelope> {
+    const params = Object.fromEntries(
+        Object.entries(query).filter(
+            ([, value]) => value !== undefined && value !== "",
+        ),
+    );
+    const { data } = await axios.get<unknown>(`${BASE}/pathways`, { params });
+    return pathwaysEnvelopeSchema.parse(data);
+}
+
+export async function fetchVersion(
+    versionUuid: string,
+): Promise<VersionEnvelope> {
+    const { data } = await axios.get<unknown>(`${BASE}/versions/${versionUuid}`);
+    return versionEnvelopeSchema.parse(data);
+}
+
+export async function fetchClaims(
+    versionUuid: string,
+    page = 1,
+    perPage = 50,
+): Promise<ClaimsEnvelope> {
+    const { data } = await axios.get<unknown>(
+        `${BASE}/versions/${versionUuid}/claims`,
+        { params: { page, per_page: perPage } },
+    );
+    return claimsEnvelopeSchema.parse(data);
+}

--- a/resources/js/lib/carePathways/catalogSchemas.ts
+++ b/resources/js/lib/carePathways/catalogSchemas.ts
@@ -1,0 +1,310 @@
+import { z } from "zod";
+
+// Zod mirrors of the care-pathway governance envelopes produced by
+// App\Services\CarePathways\CatalogGovernanceReadService. Every API boundary
+// in the Catalog Explorer parses through these — no unvalidated shapes.
+
+const metaSchema = z.object({
+    schema: z.string(),
+    catalog_release_uuid: z.string(),
+    dataset_key: z.string(),
+    grouper_version: z.string(),
+    source_cutoff_date: z.string().nullable(),
+    as_of: z.string(),
+    clinical_approval_warning: z.string(),
+    patient_serving: z.boolean(),
+    hummingbird_serving: z.boolean(),
+    eddy_serving: z.boolean(),
+    pagination: z
+        .object({
+            page: z.number(),
+            per_page: z.number(),
+            total: z.number(),
+            last_page: z.number(),
+        })
+        .optional(),
+});
+
+const releaseSchema = z.object({
+    catalog_release_uuid: z.string(),
+    dataset_key: z.string(),
+    grouper_version: z.string(),
+    grouper_effective_period: z.object({
+        start: z.string().nullable(),
+        end: z.string().nullable(),
+    }),
+    state: z.string(),
+    clinical_signoff_complete: z.boolean(),
+    clinical_signoff_count: z.number(),
+    pathway_count: z.number(),
+    adopted_at: z.string().nullable(),
+    activated_at: z.string().nullable(),
+    withdrawn_at: z.string().nullable(),
+});
+
+export const summaryEnvelopeSchema = z.object({
+    data: z.object({
+        release: releaseSchema,
+        catalog: z.object({
+            definitions: z.number(),
+            versions: z.number(),
+            institutionally_approved_versions: z.number(),
+            active_versions: z.number(),
+            sections: z.number(),
+            approved_sections: z.number(),
+            patient_or_caregiver_sections: z.number(),
+            drg_codebook_entries: z.number(),
+            drg_mappings: z.number(),
+            evidence_claims: z.number(),
+            sources: z.number(),
+            current_sources: z.number(),
+            noncurrent_sources: z.number(),
+            changes: z.number(),
+        }),
+        review_queues: z.object({
+            evidence_verified: z.number(),
+            evidence_limitations: z.number(),
+            institutional_signoff: z.number(),
+            specialist_review: z.number(),
+            redesign: z.number(),
+            recorded_reviews: z.number(),
+            recorded_approvals: z.number(),
+        }),
+        controls: z.object({
+            by_status: z.record(z.string(), z.number()),
+            failed: z.number(),
+            residual_unknowns: z.number(),
+            service_line_mappings: z.record(z.string(), z.number()),
+        }),
+        serving_flags: z.record(z.string(), z.boolean()),
+        release_readiness: z.object({
+            clinical_signoff_complete: z.boolean(),
+            may_serve_approved_catalog: z.boolean(),
+            patient_projection_released: z.boolean(),
+            eddy_retrieval_released: z.boolean(),
+        }),
+        authorization: z.record(z.string(), z.boolean()).optional(),
+    }),
+    meta: metaSchema,
+});
+
+const drgCandidateSchema = z.object({
+    ms_drg: z.string(),
+    title: z.string(),
+    mdc: z.string().nullable(),
+    type_code: z.string().nullable(),
+    type_label: z.string().nullable(),
+    mapping_role: z.string(),
+    ambiguity_note: z.string().nullable(),
+    requires_clinician_confirmation: z.boolean(),
+});
+
+const pathwayIdentitySchema = z.object({
+    uuid: z.string(),
+    key: z.string(),
+    name: z.string(),
+    mdc: z.string().nullable(),
+    care_type: z.string().nullable(),
+    source_service_line: z.string().nullable(),
+    service_line_code: z.string().nullable(),
+    lifecycle_state: z.string(),
+});
+
+const versionIdentitySchema = z.object({
+    version_uuid: z.string(),
+    semantic_version: z.string(),
+    source_rank: z.number().nullable(),
+    content_digest: z.string(),
+    effective_period: z.object({
+        start: z.string().nullable(),
+        end: z.string().nullable(),
+    }),
+    source_cutoff_date: z.string().nullable(),
+    exact_version: z.boolean(),
+});
+
+const evidenceSchema = z.object({
+    status: z.string(),
+    confidence: z.string().nullable(),
+    source_specificity: z.string().nullable(),
+    release_disposition: z.string(),
+    claim_count: z.number(),
+    source_currency: z.string(),
+});
+
+const pathwayRowGovernanceSchema = z.object({
+    clinical_signoff_status: z.string(),
+    institutional_approval_status: z.string(),
+    activation_status: z.string(),
+    section_count: z.number(),
+    approved_section_count: z.number(),
+    review_count: z.number(),
+    approval_count: z.number(),
+});
+
+export const pathwayRowSchema = z.object({
+    pathway: pathwayIdentitySchema,
+    version: versionIdentitySchema,
+    drg_candidates: z.array(drgCandidateSchema),
+    evidence: evidenceSchema,
+    governance: pathwayRowGovernanceSchema,
+});
+
+export const pathwaysEnvelopeSchema = z.object({
+    data: z.array(pathwayRowSchema),
+    meta: metaSchema,
+});
+
+const reviewSchema = z.object({
+    review_uuid: z.string(),
+    reviewer_role: z.string(),
+    review_scope: z.string(),
+    decision: z.string(),
+    reason: z.string(),
+    issues: z.unknown(),
+    reviewed_at: z.string().nullable(),
+});
+
+const approvalSchema = z.object({
+    approval_uuid: z.string(),
+    approval_type: z.string(),
+    decision: z.string(),
+    conditions: z.string().nullable(),
+    effective_period: z.object({
+        start: z.string().nullable(),
+        end: z.string().nullable(),
+    }),
+    decided_at: z.string().nullable(),
+});
+
+const sectionSchema = z.object({
+    section_uuid: z.string(),
+    section_code: z.string(),
+    audience: z.string(),
+    language_code: z.string(),
+    source_text: z.string(),
+    approved_text: z.string().nullable(),
+    content_mode: z.string(),
+    review_state: z.string(),
+    source_digest: z.string(),
+    approved_digest: z.string().nullable(),
+});
+
+const milestoneSchema = z.object({
+    milestone_uuid: z.string(),
+    stable_key: z.string(),
+    title: z.string(),
+    phase: z.string().nullable(),
+    sequence: z.number().nullable(),
+    predecessor_keys: z.unknown(),
+    expected_range: z.unknown(),
+    applicability_ref: z.string().nullable(),
+    completion_evidence_ref: z.string().nullable(),
+    review_state: z.string(),
+});
+
+const goalSchema = z.object({
+    goal_uuid: z.string(),
+    stable_key: z.string(),
+    goal_code: z.string().nullable(),
+    goal_text: z.string(),
+    author_type: z.string(),
+    target: z.unknown(),
+    patient_visible_explanation: z.string().nullable(),
+    review_state: z.string(),
+});
+
+const activitySchema = z.object({
+    activity_uuid: z.string(),
+    stable_key: z.string(),
+    activity_type: z.string(),
+    title: z.string(),
+    performer_role: z.string().nullable(),
+    timing: z.unknown(),
+    preconditions: z.unknown(),
+    executable: z.boolean(),
+    fhir_canonical_ref: z.string().nullable(),
+    review_state: z.string(),
+});
+
+const educationSchema = z.object({
+    education_uuid: z.string(),
+    stable_key: z.string(),
+    audience: z.string(),
+    language_code: z.string(),
+    reading_level: z.string().nullable(),
+    title: z.string(),
+    approved_content: z.string().nullable(),
+    teach_back_prompt: z.string().nullable(),
+    required_reviewer_role: z.string().nullable(),
+    content_digest: z.string().nullable(),
+    review_state: z.string(),
+});
+
+export const versionEnvelopeSchema = z.object({
+    data: z.object({
+        pathway: pathwayIdentitySchema,
+        version: versionIdentitySchema.extend({
+            source_digest: z.string(),
+            unresolved_flags: z.unknown(),
+        }),
+        drg_candidates: z.array(drgCandidateSchema),
+        evidence: evidenceSchema,
+        governance: z.object({
+            clinical_signoff_status: z.string(),
+            institutional_approval_status: z.string(),
+            activation_status: z.string(),
+            reviews: z.array(reviewSchema),
+            approvals: z.array(approvalSchema),
+        }),
+        sections: z.array(sectionSchema),
+        authoring: z.object({
+            milestones: z.array(milestoneSchema),
+            activities: z.array(activitySchema),
+            goals: z.array(goalSchema),
+            education: z.array(educationSchema),
+        }),
+        changes: z.array(z.record(z.string(), z.unknown())),
+    }),
+    meta: metaSchema,
+});
+
+const claimSchema = z.object({
+    claim_uuid: z.string(),
+    source_rank: z.number(),
+    source_field: z.string(),
+    claim_type: z.string().nullable(),
+    claim_excerpt: z.string(),
+    automated_review: z.object({
+        pass_1: z.unknown(),
+        pass_2: z.unknown(),
+    }),
+    clinical_adjudication: z.unknown(),
+    verification_date: z.string().nullable(),
+    claim_digest: z.string(),
+    sources: z.array(
+        z.object({
+            source_uuid: z.string(),
+            pmid: z.string().nullable(),
+            title: z.string().nullable(),
+            current_status: z.string(),
+            content_digest: z.string(),
+            evidence_grade: z.string().nullable(),
+            applicability_note: z.string().nullable(),
+        }),
+    ),
+});
+
+export const claimsEnvelopeSchema = z.object({
+    data: z.array(claimSchema),
+    meta: metaSchema,
+});
+
+export type SummaryEnvelope = z.infer<typeof summaryEnvelopeSchema>;
+export type PathwaysEnvelope = z.infer<typeof pathwaysEnvelopeSchema>;
+export type PathwayRow = z.infer<typeof pathwayRowSchema>;
+export type DrgCandidate = z.infer<typeof drgCandidateSchema>;
+export type PathwaySection = z.infer<typeof sectionSchema>;
+export type VersionEnvelope = z.infer<typeof versionEnvelopeSchema>;
+export type ClaimsEnvelope = z.infer<typeof claimsEnvelopeSchema>;
+export type EvidenceClaim = z.infer<typeof claimSchema>;

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -39,6 +39,7 @@ export interface PageProps {
       manage_data_stewardship?: boolean;
       view_patient_communications?: boolean;
       respond_patient_communications?: boolean;
+      view_care_pathway_catalog?: boolean;
     };
   };
   eddy?: {
@@ -49,6 +50,7 @@ export interface PageProps {
   };
   features?: {
     care_pathways_demo?: boolean;
+    care_pathways_catalog?: boolean;
     virtual_rounds?: boolean;
     home_hospital?: boolean;
     patient_communications?: boolean;

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,6 +93,19 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
             ->middleware(\App\Http\Middleware\EnsureCarePathwayDemoEnabled::class)
             ->name('care-pathways.demo');
 
+        // Read-only examination surface for the governed (inactive) DRG catalog.
+        // Gated identically to the governance JSON API: feature flag + capability.
+        Route::middleware([
+            \App\Http\Middleware\EnsureCarePathwayGovernanceEnabled::class,
+            'can:viewCarePathwayCatalog',
+        ])->group(function (): void {
+            Route::get('/care-pathways/catalog', [\App\Http\Controllers\CarePathwayCatalogPageController::class, 'index'])
+                ->name('care-pathways.catalog');
+            Route::get('/care-pathways/catalog/{versionUuid}', [\App\Http\Controllers\CarePathwayCatalogPageController::class, 'show'])
+                ->whereUuid('versionUuid')
+                ->name('care-pathways.catalog.show');
+        });
+
         // Radiology Workspace — keep this group ahead of RTDC so existing RTDC
         // bookmark ordering and the standalone /radiology URLs remain stable.
         Route::prefix('radiology')->name('radiology.')->group(function () {

--- a/scripts/check-ui-canon.sh
+++ b/scripts/check-ui-canon.sh
@@ -87,11 +87,11 @@ if [ -n "$blur" ]; then
 fi
 
 # 6) Raw Tailwind palette RATCHET: bg/text/border-(gray|red|blue|green|amber|
-#    indigo|slate)-N outside Design/Auth. The verified 2026-07-22 mainline
-#    inventory is 180 (including the independently introduced Care Pathways
-#    demo); the count may only go DOWN from that checked-in baseline. Lower the
-#    baseline as violations are fixed; a rising count fails the gate.
-RAW_PALETTE_BASELINE=180
+#    indigo|slate)-N outside Design/Auth. 2026-07-24: the Care Pathways demo
+#    was rebuilt onto healthcare-* tokens, lowering the verified inventory from
+#    180 to 76; the count may only go DOWN from that checked-in baseline. Lower
+#    the baseline as violations are fixed; a rising count fails the gate.
+RAW_PALETTE_BASELINE=76
 raw_count=$(grep -rnE '\b(bg|text|border)-(gray|red|blue|green|amber|indigo|slate)-[0-9]' resources/js --include=*.jsx --include=*.tsx 2>/dev/null \
   | grep -v "/Design/" \
   | grep -v "/Auth/" \

--- a/tests/Feature/CarePathways/CarePathwayCatalogPageTest.php
+++ b/tests/Feature/CarePathways/CarePathwayCatalogPageTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\CarePathways;
+
+use App\Models\User;
+use App\Services\CarePathways\CatalogImportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\CarePathwayRawFixture;
+use Tests\TestCase;
+
+class CarePathwayCatalogPageTest extends TestCase
+{
+    use CarePathwayRawFixture;
+    use RefreshDatabase;
+
+    private User $dataSteward;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configureCarePathwayFixture();
+        $this->seedCarePathwayRawFixture();
+        app(CatalogImportService::class)->adopt(1, 'test-data-steward');
+        config(['care-pathways.governance_enabled' => true]);
+
+        $this->dataSteward = User::factory()->create(['role' => 'data_steward']);
+    }
+
+    public function test_catalog_index_returns_404_when_governance_disabled(): void
+    {
+        config(['care-pathways.governance_enabled' => false]);
+
+        $this->actingAs($this->dataSteward)
+            ->get('/care-pathways/catalog')
+            ->assertNotFound();
+    }
+
+    public function test_catalog_index_forbidden_without_catalog_capability(): void
+    {
+        $frontline = User::factory()->create(['role' => 'user']);
+
+        $this->actingAs($frontline)
+            ->get('/care-pathways/catalog')
+            ->assertForbidden();
+    }
+
+    public function test_catalog_index_renders_inertia_page_with_summary_for_authorized_user(): void
+    {
+        $this->actingAs($this->dataSteward)
+            ->get('/care-pathways/catalog')
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('CarePathways/Catalog/Index')
+                ->where('initialSummary.data.release.state', 'inactive')
+                ->where('initialSummary.data.release.clinical_signoff_count', 0)
+                ->where('initialSummary.meta.patient_serving', false)
+                ->has('initialPathways.data')
+                ->has('initialPathways.meta.pagination'));
+    }
+
+    public function test_catalog_show_renders_version_detail(): void
+    {
+        $versionUuid = (string) DB::table('care_pathways.versions')
+            ->orderBy('pathway_version_id')
+            ->value('pathway_version_uuid');
+
+        $this->actingAs($this->dataSteward)
+            ->get('/care-pathways/catalog/'.$versionUuid)
+            ->assertOk()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('CarePathways/Catalog/Show')
+                ->where('initialVersion.data.version.version_uuid', $versionUuid)
+                ->has('initialVersion.data.sections')
+                ->has('initialVersion.data.drg_candidates'));
+    }
+
+    public function test_catalog_show_404s_for_unknown_version(): void
+    {
+        $this->actingAs($this->dataSteward)
+            ->get('/care-pathways/catalog/00000000-0000-0000-0000-000000000000')
+            ->assertNotFound();
+    }
+}

--- a/tests/js/carePathways/__fixtures__/claims-page1.json
+++ b/tests/js/carePathways/__fixtures__/claims-page1.json
@@ -1,0 +1,3084 @@
+{
+    "data": [
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d1f1bd011",
+            "source_rank": 1,
+            "source_field": "admission_criteria",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "Liveborn infant delivered in-hospital, gestational age >=35 0\/7 wks, birth weight typically >=2000-2500g, physiologically stable transitioning newborn assigned to well-newborn\/mother-baby couplet (rooming-in) care",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "1d8eea7c78b2bdd5c68e94ef0bff57db67e383ab7b68de512884711a5989b5c0",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d1f5d7d40",
+            "source_rank": 1,
+            "source_field": "admission_criteria",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "APGAR >=7 at 5 min and no supplemental O2 requirement",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "148d8b75d7be96666598771106c05c7aec740bb0641f1b2744753230415a11e6",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d1f881784",
+            "source_rank": 1,
+            "source_field": "admission_criteria",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "NOT DRG 795 (route to NICU\/special care): persistent respiratory distress, GA <35 wks, major congenital anomaly, sustained hypoglycemia\/hypothermia, or clinical sepsis",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "b3ed77c7f398cb4823d4b555c87648a86d65817067797be5734ed680ee1f682b",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2042ea34",
+            "source_rank": 1,
+            "source_field": "admission_criteria",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "The birth admission is the index inpatient stay (no ED-discharge\/observation alternative for the healthy newborn).",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "b88acd0c23912f74b4cc5f346a1054d100e8834c158e35850d7ad692c95b9e2e",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2078023a",
+            "source_rank": 1,
+            "source_field": "risk_stratification",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "APGAR at 1 and 5 min (>=7 normal",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "91ec8af3e93af45a4bf3045d7187f153caaa7804ca10e9811e8e8feecf80789a",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d212fde9c",
+            "source_rank": 1,
+            "source_field": "risk_stratification",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "if <7 at 5 min repeat q5min to 20 min)",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "c71d91bfab3f98d834f0bec7d3924fd9ac04a6e54dbc4dacb9aef8e1ac6ad219",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d21b461c1",
+            "source_rank": 1,
+            "source_field": "risk_stratification",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "Neonatal Early-Onset Sepsis (EOS) risk calculator (Kaiser\/Puopolo, for >=34-35 wks) using GBS status, intrapartum antibiotics, max maternal temp, ROM duration, GA -> EOS risk per 1000 driving routine care vs enhanced observation vs blood culture +\/- empiric antibiotics",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "25aa9c5696ff39cbeee8aa4de68dd69f699f574376e416ce86dd7e1d01edaef7",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d227116e5",
+            "source_rank": 1,
+            "source_field": "risk_stratification",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "AAP 2022 hyperbilirubinemia hour-specific nomogram plus neurotoxicity risk factors (isoimmune hemolytic disease, G6PD deficiency, sepsis, albumin <3.0) -> GA\/risk-specific phototherapy and escalation thresholds",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "8b4d9c09b565e3df5ae834fc21c598c8f9a854948f21ac047ddfdd9d77a2bee8",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d22961e20",
+            "source_rank": 1,
+            "source_field": "risk_stratification",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "protocolized hypoglycemia screening (AAP\/Adamkin) for at-risk (LGA, SGA, IDM, late-preterm) treating glucose <40-45 mg\/dL",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "a9aaef3450254a872faa348076f67e92b777865f5eb5691f632e0104288de330",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d23362e85",
+            "source_rank": 1,
+            "source_field": "risk_stratification",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "NEWT weight-loss nomogram (loss >75th percentile flags feeding failure).",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "9919375c3856f0e75fe2a28c542bf657c7b73cff28b77c93ff47c7b9da2e3945",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d23df5c9c",
+            "source_rank": 1,
+            "source_field": "initial_workup_labs",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "point-of-care glucose per hypoglycemia protocol in at-risk infants (first check ~30-60 min after first feed)",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "a985c23be9eef97c71a9a6aeb8da534eb0b97b3541db6e3161647f97c27e46aa",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d24d641f1",
+            "source_rank": 1,
+            "source_field": "initial_workup_labs",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "universal predischarge total serum or transcutaneous bilirubin at 24-48h",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "2979ceb0a40cabac2ced3b50ac79a964d3a866c19da1e26eb3fe57e7a76ee6d5",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d24f16a78",
+            "source_rank": 1,
+            "source_field": "initial_workup_labs",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "state newborn metabolic\/genetic screen (dried blood spot) drawn at 24-48h once feeding established.",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "57c8c446515f88b905aa0235fd088c2542b3904317a10d9a1edb072ce2f08042",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d256146ce",
+            "source_rank": 1,
+            "source_field": "initial_imaging_dx",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "universal CCHD pulse-oximetry screen at >=24h of age (pre-ductal right hand + post-ductal foot",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "bc371ed435816b88753085d6f05b33ee7b8e96d6bddcbcf2abe593b4362a16b5",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d25e194f8",
+            "source_rank": 1,
+            "source_field": "initial_imaging_dx",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "pass = SpO2 >=95% in both and <=3% difference",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "da9c2767263f04261a58ec32565630e33c03a05f7804f84c876d84b1c54340eb",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d26601cc6",
+            "source_rank": 1,
+            "source_field": "initial_imaging_dx",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "fail = <90% anywhere)",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "f89b0347a7990fd029ba03a90ee9442b2fb066e3c56c10a1e99c0ff99d1448f3",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d26809cf2",
+            "source_rank": 1,
+            "source_field": "initial_imaging_dx",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "universal newborn hearing screen (OAE or automated ABR) before discharge per EHDI 1-3-6",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "f54fc6f9c5ad31939858f9c510c4cdff0a14b33b12b809abdc1d1ae8cd5ac3e6",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2777f9e5",
+            "source_rank": 1,
+            "source_field": "initial_imaging_dx",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "hip exam (Ortolani\/Barlow) with targeted hip ultrasound at 4-6 wks only if risk factors (breech, positive family history).",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "c4730646720fb33e6380cb4fd36471154ce853a57bd7d8a25a5ff20513ce5ad4",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d28564e28",
+            "source_rank": 1,
+            "source_field": "time_critical_interventions",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "Delayed cord clamping >=30-60 sec for the vigorous infant (ACOG\/AAP)",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "cd8d1ac332d40f980eac38317dbb3cbeef3b223348c51e532d586981237cc678",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d288006df",
+            "source_rank": 1,
+            "source_field": "time_critical_interventions",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "immediate skin-to-skin with thermoregulation (axillary temp 36.5-37.5C)",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "9dd867234e3aefe21859b66c53bddfc74befc7c392256e9bbe71b98e69b51afa",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2914d114",
+            "source_rank": 1,
+            "source_field": "time_critical_interventions",
+            "claim_type": "time target",
+            "claim_excerpt": "initiate breastfeeding within the first hour",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "d5db08cbc4a8dcd235c301aed7acb34ab31649df49c9fbac5ff5e0331cbb51d7",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d29d44a69",
+            "source_rank": 1,
+            "source_field": "time_critical_interventions",
+            "claim_type": "time target",
+            "claim_excerpt": "IM vitamin K 0.5-1 mg within 6h to prevent VKDB (do not defer\/omit)",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "5d76a6154048818211968caec88e4a67c6d16fe5af9c20b9b6920559bb1c3602",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2a8a432e",
+            "source_rank": 1,
+            "source_field": "time_critical_interventions",
+            "claim_type": "time target",
+            "claim_excerpt": "erythromycin 0.5% ophthalmic ointment within 24h",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "12f0439a45bd90c30b02bb432178daa65d0d3704091e7ab0e9398901dd945e4c",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2aba23a0",
+            "source_rank": 1,
+            "source_field": "time_critical_interventions",
+            "claim_type": "time target",
+            "claim_excerpt": "hepatitis B birth-dose vaccine within 24h for stable infants >=2000g",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "9956deb5350afb16f8f5afeb7e53be6e531bcae6c0038ec83ee42fb856d4ecc2",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2b7650f9",
+            "source_rank": 1,
+            "source_field": "time_critical_interventions",
+            "claim_type": "time target",
+            "claim_excerpt": "if mother HBsAg-positive or unknown, give HBV vaccine + HBIG within 12h",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "69c440e15349b692bc57fe6d6ae4783d6c41d8894933e897648889a77bc9e61d",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2b82f1df",
+            "source_rank": 1,
+            "source_field": "time_critical_interventions",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "first glucose check within 30-60 min of first feed in at-risk infants.",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "7be71e79e835c2f8cc99e1f064ed21ead6befccf741a95cbf5ce1d0627079cbf",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2b8f2c98",
+            "source_rank": 1,
+            "source_field": "initial_management",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "Physiologic\/supportive care: rooming-in, on-demand breastfeeding 8-12x\/24h with lactation support (or iron-fortified formula), thermoneutral environment",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "4e703721918d7003b4300348a0d5dee753d1c396fbd1fbe6bcd5ba01452bf946",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2c7b072f",
+            "source_rank": 1,
+            "source_field": "initial_management",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "prophylaxis (vitamin K IM, erythromycin eye ointment, HBV vaccine) as above",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "0049cef47496f020c73111e1d0ac1ce311b6192d16b03b80de9ecdadbebda592",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2ccfc1d5",
+            "source_rank": 1,
+            "source_field": "initial_management",
+            "claim_type": "fluid\/transfusion",
+            "claim_excerpt": "hypoglycemia protocol = feed then recheck, buccal 40% dextrose gel 200 mg\/kg for asymptomatic transitional hypoglycemia to avoid NICU transfer, IV D10 2 mL\/kg bolus if symptomatic or refractory",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "bae4992d04f0fb598a53cebcd748df4fcfb43611afa2155583d3fc37522db35d",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2cdeb377",
+            "source_rank": 1,
+            "source_field": "initial_management",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "phototherapy when TSB at\/above the AAP 2022 GA- and risk-specific threshold",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "e21089fd4b7a4fe1ecd4c38f959d3436fa8bb6817c7f9c4ff7915b4c6c2e8a84",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2cf761fd",
+            "source_rank": 1,
+            "source_field": "initial_management",
+            "claim_type": "fluid\/transfusion",
+            "claim_excerpt": "escalation-of-care when TSB within 2 mg\/dL of the exchange-transfusion threshold",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "26ad48c327f78badc6bd7216b9a7ab906c0266b75e02e5aafc1c89c9b8ecbf31",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2d8e38da",
+            "source_rank": 1,
+            "source_field": "monitoring_level",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "Well-newborn nursery \/ mother-baby couplet (rooming-in) with routine vitals (temp, HR, RR, color, tone) each shift after transition, plus close observation during the first ~2h transition period",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "54e60c13bb00584aacca683d38a5771d3b06395df58729e9dc1037b8bf740f61",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2dbbd231",
+            "source_rank": 1,
+            "source_field": "monitoring_level",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "escalate to special care\/NICU for persistent respiratory distress (RR >60, grunting, retractions, sustained SpO2 <90%), temperature instability, recurrent or symptomatic hypoglycemia, poor perfusion, apnea, or clinical EOS signs",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "e50b490c8ff74524910140f0b3b00828c590edce80933d711adf04ed01f5526e",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2e4986da",
+            "source_rank": 1,
+            "source_field": "monitoring_level",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "TSB approaching the exchange threshold triggers escalation-of-care (intensive phototherapy, urgent labs, possible transfer).",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "2b36f5c205dca7a1b491c642fe2b04b688a2f28c4bfe0b7a47d3aa5b803e512c",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2ee60512",
+            "source_rank": 1,
+            "source_field": "nutrition_mobility_vte",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "Exclusive breastfeeding on demand (8-12 feeds\/24h) is the default per AAP 2022 (support skin-to-skin, rooming-in, avoid unnecessary supplementation)",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "88770e0bd74e1e7fc9caae1f2d1aedd84b9929ff1e7b1c3c1f54ebb3f72b7f6b",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d2f57592b",
+            "source_rank": 1,
+            "source_field": "nutrition_mobility_vte",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "VTE prophylaxis is NOT applicable to newborns",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "a1a550e2f52cb6c1c1f9f67dc86030cdc45b0def1b5e663be993eb743b8b7371",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d3008b06d",
+            "source_rank": 1,
+            "source_field": "discharge_criteria",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "AAP criteria: stable vitals >=12h (RR <60, HR 100-190, axillary temp 36.5-37.4C in an open crib)",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "7dbb3909ac8aab425d79b53aa94d2ed9c0507eea17ea9daee420227210a56f6b",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d304b6e1d",
+            "source_rank": 1,
+            "source_field": "discharge_criteria",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": ">=2 successful feeds with coordinated suck\/swallow documented",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "1d571467246e9ea4cfd502da9a8a7e1fe98a2a5a525d368687391d2aeb2425b0",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d3132972e",
+            "source_rank": 1,
+            "source_field": "discharge_criteria",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": ">=1 void and >=1-2 stools",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "6784230e0868879e9bbcebc7a73e93dcd439caf856e585098e2bf3fd713bb8f4",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d315c1bda",
+            "source_rank": 1,
+            "source_field": "discharge_criteria",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "no excessive bleeding at circumcision for >=2h",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "f90ffcf2b261cc2a04ab304bceff32d06aa5457d48536e7d12da5578380ad456",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d32369daa",
+            "source_rank": 1,
+            "source_field": "discharge_criteria",
+            "claim_type": "risk score\/threshold",
+            "claim_excerpt": "predischarge bilirubin measured with a risk-stratified follow-up plan",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "3b16d68b233b5d7bd8fefc0795ff69378acc604d4459ecb996cc6c2bca24779a",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d33305468",
+            "source_rank": 1,
+            "source_field": "discharge_criteria",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "no significant jaundice before 24h",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "4e3d21d1d67f002d5154110f929cd1170460ae0d0643e88032ca076e6308daec",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d33533382",
+            "source_rank": 1,
+            "source_field": "discharge_criteria",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "PCP follow-up arranged",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "f90f512a1a13fea3351f3c6080c26db69d94ed90132b50a85ea7479bb6e82beb",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d3368c68c",
+            "source_rank": 1,
+            "source_field": "discharge_criteria",
+            "claim_type": "high-stakes operational claim",
+            "claim_excerpt": "minimum stay per NMHPA (~48h vaginal \/ ~96h cesarean) unless all early-discharge criteria fully met.",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "c4a41811426223b61bdf7ab90cd13a2be455f797d70d0c67b97a7a91161e76a1",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d33f87d8d",
+            "source_rank": 1,
+            "source_field": "discharge_planning",
+            "claim_type": "medication\/treatment",
+            "claim_excerpt": "medication reconciliation (vitamin D 400 IU\/day for breastfed infants, HBV documented, maternal-medication lactation review)",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "c982447d7d6362b723becbc961884fca989d2dbb2d8b1eebfb7cc779d347cf27",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d33fb1238",
+            "source_rank": 1,
+            "source_field": "discharge_planning",
+            "claim_type": "time target",
+            "claim_excerpt": "schedule PCP visit within 48-72h (mandatory if discharged <48h) for weight, jaundice, and feeding recheck",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "795ab415f261de7c42ab7f548a6313c7d9babe48e837fb451e8494306107f787",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d34e9744f",
+            "source_rank": 1,
+            "source_field": "expected_los",
+            "claim_type": "length of stay",
+            "claim_excerpt": "Approximately 2 days typical: ~48h after uncomplicated vaginal delivery, ~3-4 days when the newborn rooms-in with a post-cesarean mother",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "2bfbf755f8b41ec2d683a0154ff7c1efd5ef713914448ffe3de11738bb2f2396",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d35c76a3f",
+            "source_rank": 1,
+            "source_field": "expected_los",
+            "claim_type": "length of stay",
+            "claim_excerpt": "CMS MS-DRG 795 GMLOS is approximately 2.5-3.0 days (approximate",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "3d52260386e6e8bb6f4a94b89f2b4ad1a333fdda8d115c11880335647cef9b45",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d36103c2e",
+            "source_rank": 1,
+            "source_field": "expected_los",
+            "claim_type": "length of stay",
+            "claim_excerpt": "low relative weight ~0.16-0.20).",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "df2c5b7d89e62129a0c6d4330e7d5c733644f1007d9c4058f14da6e496d80801",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        },
+        {
+            "claim_uuid": "019f95de-bc17-70c9-93e4-853d363c518e",
+            "source_rank": 1,
+            "source_field": "target_los",
+            "claim_type": "length of stay",
+            "claim_excerpt": "2 days (~48h) for the vaginal-delivery dyad",
+            "automated_review": {
+                "pass_1": "Source linkage and PMID resolution checked",
+                "pass_2": "No rule-based inconsistency detected"
+            },
+            "clinical_adjudication": "Pending institutional SME signoff",
+            "verification_date": "2026-07-21",
+            "claim_digest": "b3d4b95c2af9f20c161c5c4daf2da8d38b072dea33d90c2351cd091a06e19042",
+            "sources": [
+                {
+                    "source_uuid": "019f95de-b9bb-72f7-9e7e-1d72d4306da1",
+                    "pmid": "21357346",
+                    "title": "Postnatal glucose homeostasis in late-preterm and term infants.",
+                    "current_status": "current",
+                    "content_digest": "ac9afee4591772d7c54bbc336bd106e1d8c8fdc94c0efa7c4588d16158ac9273",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bd-718a-b30b-bd0769bb2857",
+                    "pmid": "30455342",
+                    "title": "Management of Neonates Born at \u226535 0\/7 Weeks' Gestation With Suspected or Proven Early-Onset Bacterial Sepsis.",
+                    "current_status": "current",
+                    "content_digest": "b4cc3f3a01eef195ff0cd8768feb378dcd0feb10a3aead178b065d56134c8247",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4bd2e9f7",
+                    "pmid": "35921640",
+                    "title": "Policy Statement: Breastfeeding and the Use of Human Milk.",
+                    "current_status": "current",
+                    "content_digest": "344f724b59987a26bb2907e1898fd23913ce728f7df1abe1459b5756d72b21ca",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4cf9bdb1",
+                    "pmid": "35927462",
+                    "title": "Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "b57ee7d01013dda6a6383d83b28bd1a963067087754393d0f14f263fa158bbb9",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                },
+                {
+                    "source_uuid": "019f95de-b9bf-70da-a056-a83c4d597b7c",
+                    "pmid": "35927519",
+                    "title": "Technical Report: Diagnosis and Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation.",
+                    "current_status": "current",
+                    "content_digest": "ed24772402a251e3eec6fdb462fd54a07b60766aeaef037e064bd170a1e04cba",
+                    "evidence_grade": null,
+                    "applicability_note": null
+                }
+            ]
+        }
+    ],
+    "meta": {
+        "schema": "care_pathway_governance.v1",
+        "catalog_release_uuid": "019f95de-b9a4-726a-91d3-41d6d911d4c4",
+        "dataset_key": "drg-care-pathways-verification-package-v43.1-20260721",
+        "grouper_version": "43.1",
+        "source_cutoff_date": "2026-07-21",
+        "as_of": "2026-07-24T20:50:14+00:00",
+        "clinical_approval_warning": "Automated evidence verification is not institutional clinical approval.",
+        "patient_serving": false,
+        "hummingbird_serving": false,
+        "eddy_serving": false,
+        "version": {
+            "version_uuid": "019f95de-b9ed-70ef-b85f-1dac743a04a3",
+            "semantic_version": "43.1-source.1",
+            "source_rank": null,
+            "content_digest": "583ebb95d3289419d9899c8e828746eea9b4d0e25237a29b803fdb6f3b19202f",
+            "effective_period": {
+                "start": "2026-04-01",
+                "end": "2026-09-30"
+            },
+            "source_cutoff_date": "2026-07-21",
+            "exact_version": true
+        },
+        "pagination": {
+            "page": 1,
+            "per_page": 50,
+            "total": 58,
+            "last_page": 2
+        }
+    }
+}

--- a/tests/js/carePathways/__fixtures__/pathways-page1.json
+++ b/tests/js/carePathways/__fixtures__/pathways-page1.json
@@ -1,0 +1,2177 @@
+{
+    "data": [
+        {
+            "pathway": {
+                "uuid": "019f95de-b9ec-700b-836f-45996908b180",
+                "key": "drgcp-normal-newborn-liveborn-uncomplicated-385d4e9bf2c3",
+                "name": "Normal Newborn (liveborn, uncomplicated)",
+                "mdc": "15 \u2014 Newborns & Other Neonates (Perinatal Period)",
+                "care_type": "Neonatal",
+                "source_service_line": "Neonatal \/ Newborn",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-b9ed-70ef-b85f-1dac743a04a3",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 1,
+                "content_digest": "583ebb95d3289419d9899c8e828746eea9b4d0e25237a29b803fdb6f3b19202f",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "795",
+                    "title": "Normal Newborn",
+                    "mdc": "15",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 58,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-b9f0-73db-99f8-0ef507903eff",
+                "key": "drgcp-vaginal-delivery-2fd506169d41",
+                "name": "Vaginal Delivery",
+                "mdc": "14 \u2014 Pregnancy, Childbirth & the Puerperium",
+                "care_type": "Obstetric",
+                "source_service_line": "Obstetrics",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-b9f0-73db-99f8-0ef5083f8ec6",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 2,
+                "content_digest": "765fbd1540477491bcca69ff5e88ddf2f6d72f7af1ffffd3179d577539d08586",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "768",
+                    "title": "Vaginal Delivery with O.R. Procedures Except Sterilization and\/or D&C",
+                    "mdc": "14",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "796",
+                    "title": "Vaginal Delivery with Sterilization and\/or D&C with MCC",
+                    "mdc": "14",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "797",
+                    "title": "Vaginal Delivery with Sterilization and\/or D&C with CC",
+                    "mdc": "14",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "798",
+                    "title": "Vaginal Delivery with Sterilization and\/or D&C without CC\/MCC",
+                    "mdc": "14",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "805",
+                    "title": "Vaginal Delivery without Sterilization or D&C with MCC",
+                    "mdc": "14",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "806",
+                    "title": "Vaginal Delivery without Sterilization or D&C with CC",
+                    "mdc": "14",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "807",
+                    "title": "Vaginal Delivery without Sterilization or D&C without CC\/MCC",
+                    "mdc": "14",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 57,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-b9f2-713c-b09b-d1cd54588d06",
+                "key": "drgcp-sepsis-septicemia-0be7d2e08cd4",
+                "name": "Sepsis \/ Septicemia",
+                "mdc": "18 \u2014 Infectious & Parasitic Diseases (Systemic)",
+                "care_type": "Medical",
+                "source_service_line": "Critical Care",
+                "service_line_code": "critical_care",
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-b9f3-7116-bc46-59f4120f6bea",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 3,
+                "content_digest": "ffe706abdb07e45b0999678b58ec1c1305271f0071db89b135bff6625689bdd3",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "870",
+                    "title": "Septicemia or Severe Sepsis with MV >96 Hours",
+                    "mdc": "18",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "871",
+                    "title": "Septicemia or Severe Sepsis without MV >96 Hours with MCC",
+                    "mdc": "18",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "872",
+                    "title": "Septicemia or Severe Sepsis without MV >96 Hours without MCC",
+                    "mdc": "18",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 57,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-b9f5-70b0-8de9-91c70d50f4d8",
+                "key": "drgcp-covid-19-viral-pneumonia-respiratory-infection-c9bf25fb99fc",
+                "name": "COVID-19 (viral pneumonia \/ respiratory infection)",
+                "mdc": "04 \u2014 Respiratory System",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-b9f5-70b0-8de9-91c70d81832a",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 4,
+                "content_digest": "083ab1cb69ecb86a5176d3668e9186a1f014828cb44f581a0ad60ab33ee5ee5a",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "177",
+                    "title": "Respiratory Infections and Inflammations with MCC",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "178",
+                    "title": "Respiratory Infections and Inflammations with CC",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "179",
+                    "title": "Respiratory Infections and Inflammations without CC\/MCC",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Verification complete with limitations \u2014 clinician signoff required",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for specialist review with documented limitations",
+                "claim_count": 54,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-b9f7-70d7-853e-0c4a40fd1b94",
+                "key": "drgcp-cesarean-delivery-0fab5563f871",
+                "name": "Cesarean Delivery",
+                "mdc": "14 \u2014 Pregnancy, Childbirth & the Puerperium",
+                "care_type": "Obstetric",
+                "source_service_line": "Obstetrics",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-b9f7-70d7-853e-0c4a41812c54",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 5,
+                "content_digest": "9a6927f0ec27b8fb9c179cc958ce02a3b1d12934408a63cf61c6d3dee5c6295e",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "783",
+                    "title": "Cesarean Section with Sterilization with MCC",
+                    "mdc": "14",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "784",
+                    "title": "Cesarean Section with Sterilization with CC",
+                    "mdc": "14",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "785",
+                    "title": "Cesarean Section with Sterilization without CC\/MCC",
+                    "mdc": "14",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "786",
+                    "title": "Cesarean Section without Sterilization with MCC",
+                    "mdc": "14",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "787",
+                    "title": "Cesarean Section without Sterilization with CC",
+                    "mdc": "14",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "788",
+                    "title": "Cesarean Section without Sterilization without CC\/MCC",
+                    "mdc": "14",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 57,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-b9f9-701a-83d7-dc05f025f6c6",
+                "key": "drgcp-heart-failure-671d63b4d61b",
+                "name": "Heart Failure",
+                "mdc": "05 \u2014 Circulatory System",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-b9f9-701a-83d7-dc05f0b0724d",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 6,
+                "content_digest": "3214433b4eb8c07094028d14aab1e851c99867a36db0863f3add994cb71eaaf7",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "291",
+                    "title": "Heart Failure and Shock with MCC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "292",
+                    "title": "Heart Failure and Shock with CC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "293",
+                    "title": "Heart Failure and Shock without CC\/MCC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 61,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-b9fb-70de-9b95-35ff0caa7c77",
+                "key": "drgcp-simple-pneumonia-pleurisy-337d0f29a350",
+                "name": "Simple Pneumonia & Pleurisy",
+                "mdc": "04 \u2014 Respiratory System",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-b9fb-70de-9b95-35ff0cf8b45f",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 7,
+                "content_digest": "722acf9837098181f9e616a5e710b83a3e4cbcfc497e19959ac21eeb51f74768",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "193",
+                    "title": "Simple Pneumonia and Pleurisy with MCC",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "194",
+                    "title": "Simple Pneumonia and Pleurisy with CC",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "195",
+                    "title": "Simple Pneumonia and Pleurisy without CC\/MCC",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 71,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-b9fd-716b-a7c2-e8659d15172e",
+                "key": "drgcp-major-joint-replacement-hipknee-lower-extremity-a7fc97e65adc",
+                "name": "Major Joint Replacement (Hip\/Knee, Lower Extremity)",
+                "mdc": "08 \u2014 Musculoskeletal System & Connective Tissue",
+                "care_type": "Surgical",
+                "source_service_line": "Perioperative \/ Surgical",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-b9fd-716b-a7c2-e8659d38a1b1",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 8,
+                "content_digest": "95767f816daa3674aa704baf437062fc348da5cb370a3f06210171257b8097f9",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "469",
+                    "title": "Major Hip and Knee Joint Replacement or Reattachment of Lower Extremity with MCC or Total Ankle Replacement",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "470",
+                    "title": "Major Hip and Knee Joint Replacement or Reattachment of Lower Extremity without MCC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 54,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-b9ff-7026-9a6f-1c8025473a44",
+                "key": "drgcp-acute-myocardial-infarction-dd339f0d6655",
+                "name": "Acute Myocardial Infarction",
+                "mdc": "05 \u2014 Circulatory System",
+                "care_type": "Medical",
+                "source_service_line": "Critical Care",
+                "service_line_code": "critical_care",
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-b9ff-7026-9a6f-1c80260ec03b",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 9,
+                "content_digest": "cb3c6860866592d5efe420fb1360a7c79c46b539d8c85701b4470e1571e731e9",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "280",
+                    "title": "Acute Myocardial Infarction, Discharged Alive with MCC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "281",
+                    "title": "Acute Myocardial Infarction, Discharged Alive with CC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "282",
+                    "title": "Acute Myocardial Infarction, Discharged Alive without CC\/MCC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "283",
+                    "title": "Acute Myocardial Infarction, Expired with MCC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "284",
+                    "title": "Acute Myocardial Infarction, Expired with CC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "285",
+                    "title": "Acute Myocardial Infarction, Expired without CC\/MCC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 53,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba01-71f9-b106-fe06f82914a3",
+                "key": "drgcp-cardiac-dysrhythmias-atrial-fibrillation-50144b3fea66",
+                "name": "Cardiac Dysrhythmias \/ Atrial Fibrillation",
+                "mdc": "05 \u2014 Circulatory System",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba02-7263-b920-9dd252a057e4",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 10,
+                "content_digest": "34a20ee41e9e343b449a19493573cc17eb55937c255f70d1ac6bef8d6346f764",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "308",
+                    "title": "Cardiac Arrhythmia and Conduction Disorders with MCC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "309",
+                    "title": "Cardiac Arrhythmia and Conduction Disorders with CC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "310",
+                    "title": "Cardiac Arrhythmia and Conduction Disorders without CC\/MCC",
+                    "mdc": "05",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 47,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba04-735d-9977-378be8a43aea",
+                "key": "drgcp-neonate-with-significant-problems-prematurity-755aedd4b5c0",
+                "name": "Neonate with Significant Problems \/ Prematurity",
+                "mdc": "15 \u2014 Newborns & Other Neonates (Perinatal Period)",
+                "care_type": "Neonatal",
+                "source_service_line": "Neonatal \/ Newborn",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba04-735d-9977-378be9671693",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 11,
+                "content_digest": "2210a98effe06693320ca708733518c3dd380a157760243c2bf67a0271f44a65",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "789",
+                    "title": "Neonates, Died or Transferred to Another Acute Care Facility",
+                    "mdc": "15",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "790",
+                    "title": "Extreme Immaturity or Respiratory Distress Syndrome, Neonate",
+                    "mdc": "15",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "791",
+                    "title": "Prematurity with Major Problems",
+                    "mdc": "15",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "792",
+                    "title": "Prematurity without Major Problems",
+                    "mdc": "15",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "793",
+                    "title": "Full Term Neonate with Major Problems",
+                    "mdc": "15",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "794",
+                    "title": "Neonate with Other Significant Problems",
+                    "mdc": "15",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 74,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba06-71c7-b45f-ca8ce8cd76f2",
+                "key": "drgcp-acute-kidney-injury-renal-failure-ab461c418a62",
+                "name": "Acute Kidney Injury \/ Renal Failure",
+                "mdc": "11 \u2014 Kidney & Urinary Tract",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba06-71c7-b45f-ca8ce9b6ee3a",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 12,
+                "content_digest": "bb2c1beb63e151b2ffc9137801e060084161f08b4b4e8a9a9b8322b50a39b2e6",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "682",
+                    "title": "Renal Failure with MCC",
+                    "mdc": "11",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "683",
+                    "title": "Renal Failure with CC",
+                    "mdc": "11",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "684",
+                    "title": "Renal Failure without CC\/MCC",
+                    "mdc": "11",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 49,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba08-7302-9fd3-532122262cfd",
+                "key": "drgcp-diabetes-with-complications-incl-dka-hhs-9758f56058ff",
+                "name": "Diabetes with Complications (incl. DKA \/ HHS)",
+                "mdc": "10 \u2014 Endocrine, Nutritional & Metabolic",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba08-7302-9fd3-5321223fb083",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 13,
+                "content_digest": "51607c20af42404d10e0b45b1d24984970f9efd1cabca74d557e8acc9103436c",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "637",
+                    "title": "Diabetes with MCC",
+                    "mdc": "10",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "638",
+                    "title": "Diabetes with CC",
+                    "mdc": "10",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "639",
+                    "title": "Diabetes without CC\/MCC",
+                    "mdc": "10",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Verification complete with limitations \u2014 clinician signoff required",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for specialist review with documented limitations",
+                "claim_count": 69,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba0a-70b1-ac19-886af2cddded",
+                "key": "drgcp-copd-exacerbation-dd86233bb4ae",
+                "name": "COPD Exacerbation",
+                "mdc": "04 \u2014 Respiratory System",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba0a-70b1-ac19-886af2edda87",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 14,
+                "content_digest": "e7421056d1fcb33ec72c0e5b6262b7997b0976774e369154bdfc1d17eaf963d7",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "190",
+                    "title": "Chronic Obstructive Pulmonary Disease with MCC",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "191",
+                    "title": "Chronic Obstructive Pulmonary Disease with CC",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "192",
+                    "title": "Chronic Obstructive Pulmonary Disease without CC\/MCC",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 63,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba0c-7135-8888-4c61ff090327",
+                "key": "drgcp-acute-ischemic-stroke-cerebral-infarction-6accb6ed03b7",
+                "name": "Acute Ischemic Stroke \/ Cerebral Infarction",
+                "mdc": "01 \u2014 Nervous System",
+                "care_type": "Medical",
+                "source_service_line": "Critical Care",
+                "service_line_code": "critical_care",
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba0c-7135-8888-4c61ff0d3568",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 15,
+                "content_digest": "33d4f2ade3a3bb24b574e85f10f3d832f6a9b3e3f6e2ad6c7bf9b155e0810a3b",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "061",
+                    "title": "Ischemic Stroke, Precerebral Occlusion or Transient Ischemia with Thrombolytic Agent with MCC",
+                    "mdc": "01",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "062",
+                    "title": "Ischemic Stroke, Precerebral Occlusion or Transient Ischemia with Thrombolytic Agent with CC",
+                    "mdc": "01",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "063",
+                    "title": "Ischemic Stroke, Precerebral Occlusion or Transient Ischemia with Thrombolytic Agent without CC\/MCC",
+                    "mdc": "01",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "064",
+                    "title": "Intracranial Hemorrhage or Cerebral Infarction with MCC",
+                    "mdc": "01",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "065",
+                    "title": "Intracranial Hemorrhage or Cerebral Infarction with CC or tPA in 24 Hours",
+                    "mdc": "01",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "066",
+                    "title": "Intracranial Hemorrhage or Cerebral Infarction without CC\/MCC",
+                    "mdc": "01",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 47,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba0e-7263-9124-9df40cfb4f3b",
+                "key": "drgcp-urinary-tract-infection-kidney-infection-c0bcbd5cbc95",
+                "name": "Urinary Tract Infection \/ Kidney Infection",
+                "mdc": "11 \u2014 Kidney & Urinary Tract",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba0f-72fd-8b26-86f6a87e4f0e",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 16,
+                "content_digest": "620d3c32ef481a85ba66ac802f1dc0735dbcb231773c3d3e3188ccd82c87041d",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "689",
+                    "title": "Kidney and Urinary Tract Infections with MCC",
+                    "mdc": "11",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "690",
+                    "title": "Kidney and Urinary Tract Infections without MCC",
+                    "mdc": "11",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 61,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba11-7172-85fb-51c49cda2db9",
+                "key": "drgcp-cellulitis-skin-soft-tissue-infection-b64692676d19",
+                "name": "Cellulitis \/ Skin & Soft Tissue Infection",
+                "mdc": "09 \u2014 Skin, Subcutaneous Tissue & Breast",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba11-7172-85fb-51c49d7820b0",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 17,
+                "content_digest": "a5840263180b9f157e7c64fe4b7540efbe6a9fb04e5ac21e44aa2f88894f3057",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "602",
+                    "title": "Cellulitis with MCC",
+                    "mdc": "09",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "603",
+                    "title": "Cellulitis without MCC",
+                    "mdc": "09",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 42,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba12-7049-bc8b-185faa0493f1",
+                "key": "drgcp-psychoses-schizophrenia-bipolar-disorder-e05814e32135",
+                "name": "Psychoses \/ Schizophrenia \/ Bipolar Disorder",
+                "mdc": "19 \u2014 Mental Diseases & Disorders",
+                "care_type": "Medical",
+                "source_service_line": "Behavioral Health",
+                "service_line_code": "behavioral_health",
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba13-7354-9b4d-0f1c735d5ea1",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 18,
+                "content_digest": "0e8c915ffaaece7615326bb7e3b9a762095e6d9ba83cd317d8a691589337b105",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "885",
+                    "title": "Psychoses",
+                    "mdc": "19",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 43,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba14-72be-9f1c-2b4cc4a158e0",
+                "key": "drgcp-respiratory-failure-0f60b78bec3e",
+                "name": "Respiratory Failure",
+                "mdc": "04 \u2014 Respiratory System",
+                "care_type": "Medical",
+                "source_service_line": "Critical Care",
+                "service_line_code": "critical_care",
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba15-70fd-a8f7-289050a68f88",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 19,
+                "content_digest": "c34943394d58055b67b7dcf6dede8e3608589de72ca759be7e359f011d22fe39",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "189",
+                    "title": "Pulmonary Edema and Respiratory Failure",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "207",
+                    "title": "Respiratory System Diagnosis with Ventilator Support >96 Hours",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "208",
+                    "title": "Respiratory System Diagnosis with Ventilator Support",
+                    "mdc": "04",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 58,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba17-730b-8131-ecf9a8b10568",
+                "key": "drgcp-spinal-fusion-44a1197d9c12",
+                "name": "Spinal Fusion",
+                "mdc": "08 \u2014 Musculoskeletal System & Connective Tissue",
+                "care_type": "Surgical",
+                "source_service_line": "Perioperative \/ Surgical",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba17-730b-8131-ecf9a94e1f0b",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 20,
+                "content_digest": "a73b557e38cc2eb32d45f5111e39f6a38ca542aa44c0fc5ed7c6fc4a3e284740",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "402",
+                    "title": "Single Level Combined Anterior and Posterior Spinal Fusion Except Cervical",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "426",
+                    "title": "Multiple Level Combined Anterior and Posterior Spinal Fusion Except Cervical with MCC or Custom-Made Anatomically Designed Interbody Fusion Device",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "427",
+                    "title": "Multiple Level Combined Anterior and Posterior Spinal Fusion Except Cervical with CC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "428",
+                    "title": "Multiple Level Combined Anterior and Posterior Spinal Fusion Except Cervical without CC\/MCC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "429",
+                    "title": "Combined Anterior and Posterior Cervical Spinal Fusion with MCC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "430",
+                    "title": "Combined Anterior and Posterior Cervical Spinal Fusion without MCC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "447",
+                    "title": "Multiple Level Spinal Fusion Except Cervical with MCC or Custom-Made Anatomically Designed Interbody Fusion Device",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "448",
+                    "title": "Multiple Level Spinal Fusion Except Cervical without MCC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "450",
+                    "title": "Single Level Spinal Fusion Except Cervical with MCC or Custom-Made Anatomically Designed Interbody Fusion Device",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "451",
+                    "title": "Single Level Spinal Fusion Except Cervical without MCC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "456",
+                    "title": "Spinal Fusion Except Cervical with Spinal Curvature, Malignancy, Infection or Extensive Fusions with MCC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "457",
+                    "title": "Spinal Fusion Except Cervical with Spinal Curvature, Malignancy, Infection or Extensive Fusions with CC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "458",
+                    "title": "Spinal Fusion Except Cervical with Spinal Curvature, Malignancy, Infection or Extensive Fusions without CC\/MCC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "471",
+                    "title": "Cervical Spinal Fusion with MCC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "472",
+                    "title": "Cervical Spinal Fusion with CC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "473",
+                    "title": "Cervical Spinal Fusion without CC\/MCC",
+                    "mdc": "08",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 66,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba1a-71d5-89ef-cd3ed82bd0c2",
+                "key": "drgcp-percutaneous-coronary-intervention-pci-62b92e563d72",
+                "name": "Percutaneous Coronary Intervention (PCI)",
+                "mdc": "05 \u2014 Circulatory System",
+                "care_type": "Surgical",
+                "source_service_line": "Perioperative \/ Surgical",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba1a-71d5-89ef-cd3ed9087b29",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 21,
+                "content_digest": "979c299cf00b103d1710df9f9b039b9e869e7449ed93fdeaa25eeb19fd68e2b9",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "250",
+                    "title": "Percutaneous Cardiovascular Procedures without Intraluminal Device with MCC",
+                    "mdc": "05",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "251",
+                    "title": "Percutaneous Cardiovascular Procedures without Intraluminal Device without MCC",
+                    "mdc": "05",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "318",
+                    "title": "Percutaneous Coronary Atherectomy without Intraluminal Device",
+                    "mdc": "05",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "321",
+                    "title": "Percutaneous Cardiovascular Procedures with Intraluminal Device with MCC or 4+ Arteries\/Intraluminal Devices",
+                    "mdc": "05",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "322",
+                    "title": "Percutaneous Cardiovascular Procedures with Intraluminal Device without MCC",
+                    "mdc": "05",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "323",
+                    "title": "Coronary Intravascular Lithotripsy with Intraluminal Device with MCC",
+                    "mdc": "05",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "324",
+                    "title": "Coronary Intravascular Lithotripsy with Intraluminal Device without MCC",
+                    "mdc": "05",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "325",
+                    "title": "Coronary Intravascular Lithotripsy without Intraluminal Device",
+                    "mdc": "05",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "359",
+                    "title": "Percutaneous Coronary Atherectomy with Intraluminal Device with MCC",
+                    "mdc": "05",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "360",
+                    "title": "Percutaneous Coronary Atherectomy with Intraluminal Device without MCC",
+                    "mdc": "05",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 71,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba1d-708d-9ac6-c286c40fe297",
+                "key": "drgcp-acute-gi-hemorrhage-upper-lower-2437190ac1d2",
+                "name": "Acute GI Hemorrhage (upper & lower)",
+                "mdc": "06 \u2014 Digestive System",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba1d-708d-9ac6-c286c43b2d55",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 22,
+                "content_digest": "268a3d3da43186f4880770356c6530746124cea3e7fd9b600858ff1f07887293",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "377",
+                    "title": "Gastrointestinal Hemorrhage with MCC",
+                    "mdc": "06",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "378",
+                    "title": "Gastrointestinal Hemorrhage with CC",
+                    "mdc": "06",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "379",
+                    "title": "Gastrointestinal Hemorrhage without CC\/MCC",
+                    "mdc": "06",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Evidence verified \u2014 automated independent review complete",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for institutional clinician signoff",
+                "claim_count": 64,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba1f-71c5-913e-f74009f2f0ee",
+                "key": "drgcp-cholecystectomy-biliary-procedures-61bacdd829bb",
+                "name": "Cholecystectomy \/ Biliary Procedures",
+                "mdc": "07 \u2014 Hepatobiliary System & Pancreas",
+                "care_type": "Surgical",
+                "source_service_line": "Perioperative \/ Surgical",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba1f-71c5-913e-f7400a77735c",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 23,
+                "content_digest": "b871663f5efed12ca9fdf3df3289bf0720a5e52a32c064b931bed9f554c74416",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "411",
+                    "title": "Cholecystectomy with C.D.E. with MCC",
+                    "mdc": "07",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "412",
+                    "title": "Cholecystectomy with C.D.E. with CC",
+                    "mdc": "07",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "413",
+                    "title": "Cholecystectomy with C.D.E. without CC\/MCC",
+                    "mdc": "07",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "414",
+                    "title": "Cholecystectomy Except by Laparoscope without C.D.E. with MCC",
+                    "mdc": "07",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "415",
+                    "title": "Cholecystectomy Except by Laparoscope without C.D.E. with CC",
+                    "mdc": "07",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "416",
+                    "title": "Cholecystectomy Except by Laparoscope without C.D.E. without CC\/MCC",
+                    "mdc": "07",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "417",
+                    "title": "Laparoscopic Cholecystectomy without C.D.E. with MCC",
+                    "mdc": "07",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "418",
+                    "title": "Laparoscopic Cholecystectomy without C.D.E. with CC",
+                    "mdc": "07",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "419",
+                    "title": "Laparoscopic Cholecystectomy without C.D.E. without CC\/MCC",
+                    "mdc": "07",
+                    "type_code": "P",
+                    "type_label": "Procedural\/Surgical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Verification complete with limitations \u2014 clinician signoff required",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for specialist review with documented limitations",
+                "claim_count": 57,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba21-72ca-b978-d2a78126d510",
+                "key": "drgcp-esophagitis-gastroenteritis-misc-digestive-disorders-5d6a0939ebed",
+                "name": "Esophagitis, Gastroenteritis & Misc. Digestive Disorders",
+                "mdc": "06 \u2014 Digestive System",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba21-72ca-b978-d2a781e6cf9c",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 24,
+                "content_digest": "028ce3c7576df415adda444178934b47fe46f9e67e8a4b5e2e29a7901944d49e",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "391",
+                    "title": "Esophagitis, Gastroenteritis and Miscellaneous Digestive Disorders with MCC",
+                    "mdc": "06",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "392",
+                    "title": "Esophagitis, Gastroenteritis and Miscellaneous Digestive Disorders without MCC",
+                    "mdc": "06",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Verification complete with limitations \u2014 clinician signoff required",
+                "confidence": "Medium",
+                "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+                "release_disposition": "Ready for specialist review with documented limitations",
+                "claim_count": 49,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        },
+        {
+            "pathway": {
+                "uuid": "019f95de-ba23-73e2-a887-68834b75af62",
+                "key": "drgcp-fluid-electrolyte-disorders-c28ef98c6007",
+                "name": "Fluid & Electrolyte Disorders",
+                "mdc": "10 \u2014 Endocrine, Nutritional & Metabolic",
+                "care_type": "Medical",
+                "source_service_line": "RTDC \/ Medical Capacity",
+                "service_line_code": null,
+                "lifecycle_state": "candidate"
+            },
+            "version": {
+                "version_uuid": "019f95de-ba23-73e2-a887-68834bd67d39",
+                "semantic_version": "43.1-source.1",
+                "source_rank": 25,
+                "content_digest": "f4f6f5ead38d3545bb02067d840fbd06c123d9b2d24cba3e1713ea9585597010",
+                "effective_period": {
+                    "start": "2026-04-01",
+                    "end": "2026-09-30"
+                },
+                "source_cutoff_date": "2026-07-21",
+                "exact_version": true
+            },
+            "drg_candidates": [
+                {
+                    "ms_drg": "640",
+                    "title": "Miscellaneous Disorders of Nutrition, Metabolism, Fluids and Electrolytes with MCC",
+                    "mdc": "10",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                },
+                {
+                    "ms_drg": "641",
+                    "title": "Miscellaneous Disorders of Nutrition, Metabolism, Fluids and Electrolytes without MCC",
+                    "mdc": "10",
+                    "type_code": "M",
+                    "type_label": "Medical",
+                    "mapping_role": "candidate",
+                    "ambiguity_note": null,
+                    "requires_clinician_confirmation": true
+                }
+            ],
+            "evidence": {
+                "status": "Verification complete with limitations \u2014 clinician signoff required",
+                "confidence": "Medium",
+                "source_specificity": "Low \u2014 citation resolvability confirmed but title-level condition specificity is weak",
+                "release_disposition": "Ready for specialist review with documented limitations",
+                "claim_count": 62,
+                "source_currency": "current"
+            },
+            "governance": {
+                "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+                "institutional_approval_status": "not_reviewed",
+                "activation_status": "inactive",
+                "section_count": 28,
+                "approved_section_count": 0,
+                "review_count": 0,
+                "approval_count": 0
+            }
+        }
+    ],
+    "meta": {
+        "schema": "care_pathway_governance.v1",
+        "catalog_release_uuid": "019f95de-b9a4-726a-91d3-41d6d911d4c4",
+        "dataset_key": "drg-care-pathways-verification-package-v43.1-20260721",
+        "grouper_version": "43.1",
+        "source_cutoff_date": "2026-07-21",
+        "as_of": "2026-07-24T20:50:14+00:00",
+        "clinical_approval_warning": "Automated evidence verification is not institutional clinical approval.",
+        "patient_serving": false,
+        "hummingbird_serving": false,
+        "eddy_serving": false,
+        "pagination": {
+            "page": 1,
+            "per_page": 25,
+            "total": 250,
+            "last_page": 10
+        }
+    }
+}

--- a/tests/js/carePathways/__fixtures__/summary.json
+++ b/tests/js/carePathways/__fixtures__/summary.json
@@ -1,0 +1,85 @@
+{
+    "data": {
+        "release": {
+            "catalog_release_uuid": "019f95de-b9a4-726a-91d3-41d6d911d4c4",
+            "dataset_key": "drg-care-pathways-verification-package-v43.1-20260721",
+            "grouper_version": "43.1",
+            "grouper_effective_period": {
+                "start": "2026-04-01",
+                "end": "2026-09-30"
+            },
+            "state": "inactive",
+            "clinical_signoff_complete": false,
+            "clinical_signoff_count": 0,
+            "pathway_count": 250,
+            "adopted_at": "2026-07-24 20:43:49+00",
+            "activated_at": null,
+            "withdrawn_at": null
+        },
+        "catalog": {
+            "definitions": 250,
+            "versions": 250,
+            "institutionally_approved_versions": 0,
+            "active_versions": 0,
+            "sections": 7000,
+            "approved_sections": 0,
+            "patient_or_caregiver_sections": 0,
+            "drg_codebook_entries": 770,
+            "drg_mappings": 802,
+            "evidence_claims": 10123,
+            "sources": 811,
+            "current_sources": 811,
+            "noncurrent_sources": 0,
+            "changes": 324
+        },
+        "review_queues": {
+            "evidence_verified": 96,
+            "evidence_limitations": 154,
+            "institutional_signoff": 96,
+            "specialist_review": 148,
+            "redesign": 6,
+            "recorded_reviews": 0,
+            "recorded_approvals": 0
+        },
+        "controls": {
+            "by_status": {
+                "accepted_discrepancy": 3,
+                "passed": 21
+            },
+            "failed": 0,
+            "residual_unknowns": 0,
+            "service_line_mappings": {
+                "mapped": 3,
+                "pending": 23
+            }
+        },
+        "serving_flags": {
+            "approved_catalog": false,
+            "assignment": false,
+            "rounds": false,
+            "staff_mobile": false,
+            "patient": false,
+            "eddy_reference": false,
+            "eddy_instance": false,
+            "writeback": false
+        },
+        "release_readiness": {
+            "clinical_signoff_complete": false,
+            "may_serve_approved_catalog": false,
+            "patient_projection_released": false,
+            "eddy_retrieval_released": false
+        }
+    },
+    "meta": {
+        "schema": "care_pathway_governance.v1",
+        "catalog_release_uuid": "019f95de-b9a4-726a-91d3-41d6d911d4c4",
+        "dataset_key": "drg-care-pathways-verification-package-v43.1-20260721",
+        "grouper_version": "43.1",
+        "source_cutoff_date": "2026-07-21",
+        "as_of": "2026-07-24T20:50:14+00:00",
+        "clinical_approval_warning": "Automated evidence verification is not institutional clinical approval.",
+        "patient_serving": false,
+        "hummingbird_serving": false,
+        "eddy_serving": false
+    }
+}

--- a/tests/js/carePathways/__fixtures__/version-detail.json
+++ b/tests/js/carePathways/__fixtures__/version-detail.json
@@ -1,0 +1,422 @@
+{
+    "data": {
+        "pathway": {
+            "uuid": "019f95de-b9ec-700b-836f-45996908b180",
+            "key": "drgcp-normal-newborn-liveborn-uncomplicated-385d4e9bf2c3",
+            "name": "Normal Newborn (liveborn, uncomplicated)",
+            "mdc": "15 \u2014 Newborns & Other Neonates (Perinatal Period)",
+            "care_type": "Neonatal",
+            "source_service_line": "Neonatal \/ Newborn",
+            "service_line_code": null,
+            "lifecycle_state": "candidate"
+        },
+        "version": {
+            "version_uuid": "019f95de-b9ed-70ef-b85f-1dac743a04a3",
+            "semantic_version": "43.1-source.1",
+            "source_rank": 1,
+            "content_digest": "583ebb95d3289419d9899c8e828746eea9b4d0e25237a29b803fdb6f3b19202f",
+            "effective_period": {
+                "start": "2026-04-01",
+                "end": "2026-09-30"
+            },
+            "source_cutoff_date": "2026-07-21",
+            "exact_version": true,
+            "source_digest": "4db7e02ae66e3b951e654348dc60df09a0c7c619c48c879963c6c211c222b949",
+            "unresolved_flags": []
+        },
+        "drg_candidates": [
+            {
+                "ms_drg": "795",
+                "title": "Normal Newborn",
+                "mdc": "15",
+                "type_code": "M",
+                "type_label": "Medical",
+                "mapping_role": "candidate",
+                "ambiguity_note": null,
+                "requires_clinician_confirmation": true
+            }
+        ],
+        "evidence": {
+            "status": "Evidence verified \u2014 automated independent review complete",
+            "confidence": "Medium",
+            "source_specificity": "Medium \u2014 relevant existing sources resolved; no stronger new guideline selected",
+            "release_disposition": "Ready for institutional clinician signoff",
+            "claim_count": 58,
+            "source_currency": "current"
+        },
+        "governance": {
+            "clinical_signoff_status": "Not clinically approved \u2014 institutional SME signoff required",
+            "institutional_approval_status": "not_reviewed",
+            "activation_status": "inactive",
+            "reviews": [],
+            "approvals": []
+        },
+        "sections": [
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b3403fb7",
+                "section_code": "admission_criteria",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Liveborn infant delivered in-hospital, gestational age >=35 0\/7 wks, birth weight typically >=2000-2500g, physiologically stable transitioning newborn assigned to well-newborn\/mother-baby couplet (rooming-in) care; requires no resuscitation beyond routine drying\/stimulation; APGAR >=7 at 5 min and no supplemental O2 requirement. NOT DRG 795 (route to NICU\/special care): persistent respiratory distress, GA <35 wks, major congenital anomaly, sustained hypoglycemia\/hypothermia, or clinical sepsis. The birth admission is the index inpatient stay (no ED-discharge\/observation alternative for the healthy newborn).",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "c000fbabd91d9b51901990c12aea08f2bb9e5738c3ae0a286ca9c9fa60ab6d08",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079c1ea795c",
+                "section_code": "clinical_verification_basis",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Independent automated evidence pass over all 250 rows: CMS taxonomy validation; PubMed identifier resolution and retraction scan; guideline-year and title\/topic relevance scoring; claim inventory; structural safety checks; cross-row overlap and volume arithmetic review. Clinical-signoff boundary: a licensed institutional physician\/pharmacist\/nurse\/coding\/UM review is still required before protocol, order-set, formulary or utilization use.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "00578bbe10c7d41f651bf64535a6ca95c33dacb6f8386bdc85e23dda707564ca",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079bcc2e924",
+                "section_code": "common_complications",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Hyperbilirubinemia\/jaundice (most common; mitigated by universal predischarge bilirubin + nomogram-guided phototherapy\/follow-up); transitional or at-risk hypoglycemia (protocolized screening + dextrose gel to avoid NICU transfer); suboptimal breastfeeding with excess weight loss and dehydration (lactation support, output\/weight tracking, NEWT); early-onset sepsis (EOS-calculator-guided to avoid over-treatment); hypothermia (skin-to-skin, thermoregulation); undetected CCHD or hearing loss (universal screening).",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "a9a617401358cd907fa1ae3886b0931b768e3ca34889b94baf7eba5f44f28bce",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b7d0c842",
+                "section_code": "consults_multidisciplinary",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Lactation\/IBCLC for all breastfeeding dyads (early, especially if difficulty); audiology for hearing-screen fails; social work + case management for psychosocial risk (substance exposure, teen\/single parent, housing instability, prior CPS); pediatric cardiology if CCHD screen fails; neonatology\/NICU for instability; pharmacy for maternal-medication\/lactation compatibility and NAS management if opioid-exposed; nutrition if feeding\/weight concerns; interpreter\/child-life services as needed; confirm a primary-care medical home is identified before discharge.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "4c0dfdf66c52d775df2a2266ff6b6778cfd937e2460732319ce2977b2c793014",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079c259414a",
+                "section_code": "data_quality_notes",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Condition-level pathways may intentionally share DRGs; this is not a one-row-per-DRG crosswalk. Verification release 2026-07-21: evidence review is complete, but modeled volumes, heterogeneous DRG families and clinician-signoff limitations remain explicitly separated from taxonomy verification.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "54e0e97fa1599e43b7b5c49806225f2166254653f30189bcff4ecc7b27386f9d",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b59ceb20",
+                "section_code": "day1_milestones",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "DOL0 (birth day): complete delivery-room care and prophylaxis (vitamin K, eye ointment, HBV); confirm successful transition (stable vitals, temp, color, RR <60 without distress); establish feeding with latch assessment; document first void (expect <24h) and first meconium stool (expect <48h); record birth weight as baseline; initiate glucose protocol if at-risk; assign EOS risk category and act on it.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "833f5286929ea3b7bd80fe95ff291546d9c1eafb58f0e425928b9a318d05db8c",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b6518072",
+                "section_code": "day2_milestones",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "DOL1: ongoing feeding-effectiveness assessment (breastfeeding transfer, increasing voids\/stools); daily weight tracking percent loss vs NEWT (flag >7-10%); obtain predischarge bilirubin (TcB\/TSB) at 24-48h and plot on the AAP 2022 nomogram -> phototherapy decision plus risk-based follow-up timing; draw newborn metabolic screen after 24h of feeding; perform CCHD pulse-ox screen at >=24h; complete newborn hearing screen; jaundice and weight check.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "74f873ac07052b76862a87ceb479ab85dade17803d6d5f8df5311e64c8aedf62",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b7159ae3",
+                "section_code": "day3plus_milestones",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "DOL2+: confirm all universal screens complete and documented (metabolic, CCHD, hearing) with results\/plan; reassess bilirubin trajectory and set the specific outpatient recheck interval; ensure feeding established with acceptable weight-loss trend and adequate output; complete elective circumcision with pain control plus post-procedure bleeding check; verify all discharge criteria met and follow-up scheduled; for early discharge (<48h) mandate a 48-72h PCP visit.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "bc00eef7a2d96f8f4da2e30d4e246e1494494834c400057f684ce83e14aaaa60",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079ba2298e3",
+                "section_code": "discharge_criteria",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "AAP criteria: stable vitals >=12h (RR <60, HR 100-190, axillary temp 36.5-37.4C in an open crib); >=2 successful feeds with coordinated suck\/swallow documented; >=1 void and >=1-2 stools; no excessive bleeding at circumcision for >=2h; predischarge bilirubin measured with a risk-stratified follow-up plan; no significant jaundice before 24h; EOS risk resolved\/observed; metabolic, CCHD, and hearing screens completed; HBV vaccine given or planned; maternal\/family education completed; PCP follow-up arranged; social\/environmental risks addressed; minimum stay per NMHPA (~48h vaginal \/ ~96h cesarean) unless all early-discharge criteria fully met.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "372ef8c8dc43621ba3b3184afe71038d7031dd0b66a481e2a4ed512ce9e7ed08",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079ba5b9825",
+                "section_code": "discharge_planning",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Home disposition with an identified medical home; medication reconciliation (vitamin D 400 IU\/day for breastfed infants, HBV documented, maternal-medication lactation review); schedule PCP visit within 48-72h (mandatory if discharged <48h) for weight, jaundice, and feeding recheck; teach return precautions (jaundice, poor feeding, lethargy, fever, decreased output, labored breathing); car-seat use plus car-seat tolerance screening for late-preterm\/low-birth-weight; safe-sleep ABCs, breastfeeding support\/resources, smoke-free home, and shaken-baby\/abusive-head-trauma prevention; ensure newborn-screen, hearing, and CCHD result tracking\/handoff to the PCP.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "723a3fb0cad9290d7e768b2adc480ab95e3953a6e4242b9b39740e3c8a308277",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079bfb2e1d6",
+                "section_code": "evidence_grade",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Strong for graded elements (Class I \/ Key Action Statements): AAP 2022 hyperbilirubinemia CPG (universal predischarge bilirubin, GA\/risk-based phototherapy thresholds), IM vitamin K, hepatitis B birth dose, and universal newborn\/CCHD\/hearing screening are evidence-based standards of care. Several bundle elements (rooming-in, safe sleep, discharge timing, EOS-calculator use, dextrose gel) rest on AAP policy\/consensus with observational\/RCT support = Moderate-to-consensus. Overall: Strong (Class I society guideline core) with some consensus\/expert components.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "0ba59262eca6d2ee2a8b52092b9f1a79a69b4194caa1dc9f870b2598ebf79c2c",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079bb41c36f",
+                "section_code": "expected_los",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Approximately 2 days typical: ~48h after uncomplicated vaginal delivery, ~3-4 days when the newborn rooms-in with a post-cesarean mother; CMS MS-DRG 795 GMLOS is approximately 2.5-3.0 days (approximate; low relative weight ~0.16-0.20).",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "b6c1449cf1882c7820eeb0951eaf540c775ea7cc24cfdf1ed0dcab5be84ebfea",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079be520856",
+                "section_code": "guideline_source",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "American Academy of Pediatrics (AAP). Primary: AAP 2022 Clinical Practice Guideline, Management of Hyperbilirubinemia in the Newborn Infant >=35 Weeks (Kemper et al., Pediatrics 2022); AAP Committee on Fetus and Newborn, Hospital Stay for Healthy Term Newborn Infants (Pediatrics 2015, reaffirmed); AAP\/COFN 2018 Management of Neonates >=35 Weeks With Suspected\/Proven Early-Onset Sepsis (Puopolo); AAP 2011 Postnatal Glucose Homeostasis (Adamkin); AAP 2022 Breastfeeding and the Use of Human Milk (Meek); plus ACOG\/AAP delayed cord clamping and state newborn-screening\/EHDI\/CCHD mandates.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "03e342abdec44ae0681cb26caa55352d35bee05b6f684b969a0dbc5b7c8c5ca6",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b4a78c2b",
+                "section_code": "initial_imaging_dx",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Routine normal newborn requires minimal imaging; universal CCHD pulse-oximetry screen at >=24h of age (pre-ductal right hand + post-ductal foot; pass = SpO2 >=95% in both and <=3% difference; fail = <90% anywhere); universal newborn hearing screen (OAE or automated ABR) before discharge per EHDI 1-3-6; echocardiogram\/pediatric cardiology only if CCHD screen fails or pathologic murmur; hip exam (Ortolani\/Barlow) with targeted hip ultrasound at 4-6 wks only if risk factors (breech, positive family history).",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "28991f76534f0eede0e4a6e6460f78e470a7a6f6e8c9c0db9bdd3dc0484b4c6a",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b58d43b7",
+                "section_code": "initial_management",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Physiologic\/supportive care: rooming-in, on-demand breastfeeding 8-12x\/24h with lactation support (or iron-fortified formula), thermoneutral environment; prophylaxis (vitamin K IM, erythromycin eye ointment, HBV vaccine) as above; hypoglycemia protocol = feed then recheck, buccal 40% dextrose gel 200 mg\/kg for asymptomatic transitional hypoglycemia to avoid NICU transfer, IV D10 2 mL\/kg bolus if symptomatic or refractory; phototherapy when TSB at\/above the AAP 2022 GA- and risk-specific threshold; escalation-of-care when TSB within 2 mg\/dL of the exchange-transfusion threshold; NO routine antibiotics (reserve for EOS-calculator-indicated cases).",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "b2ba94cc288b7597fbb548a5106674f523b253fcfdcb97ab0892f78e32b6c7fc",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b434bbe8",
+                "section_code": "initial_workup_labs",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Infant\/cord blood type, Rh, and direct antiglobulin test (DAT\/Coombs) if mother O and\/or Rh-negative or antibody positive; point-of-care glucose per hypoglycemia protocol in at-risk infants (first check ~30-60 min after first feed); universal predischarge total serum or transcutaneous bilirubin at 24-48h; CBC with differential, blood culture, and inflammatory markers ONLY when EOS risk is elevated; review maternal serologies (HBsAg, HIV, RPR\/syphilis, rubella, GBS); state newborn metabolic\/genetic screen (dried blood spot) drawn at 24-48h once feeding established.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "e16102147ffa4f4fb6b66583cb34f4f219848e7a15fa511a08ccca49328150f6",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079bf369cc7",
+                "section_code": "key_citations",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Per PubMed: Kemper AR et al. Clinical Practice Guideline Revision: Management of Hyperbilirubinemia in the Newborn Infant 35 or More Weeks of Gestation. Pediatrics 2022;150(3):e2022058859 (PMID 35927462; DOI 10.1542\/peds.2022-058859); Slaughter JL, Kemper AR, Newman TB. Technical Report: Diagnosis and Management of Hyperbilirubinemia. Pediatrics 2022;150(3):e2022058865 (PMID 35927519; DOI 10.1542\/peds.2022-058865); Puopolo KM et al. Management of Neonates Born at >=35 0\/7 Weeks With Suspected\/Proven Early-Onset Bacterial Sepsis. Pediatrics 2018;142(6):e20182894 (PMID 30455342); Adamkin DH. Postnatal Glucose Homeostasis in Late-Preterm and Term Infants. Pediatrics 2011;127(3):575-579 (PMID 21357346); Meek JY, Noble L. Breastfeeding and the Use of Human Milk. Pediatrics 2022;150(1) (PMID 35921640); AAP COFN. Hospital Stay for Healthy Term Newborn Infants. Pediatrics 2015;135(5):948-953.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "4c70aa7c49ba356a08f78d46a3f8364be1748c2c0d7dbcda95cb4dcd626af24e",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b869df07",
+                "section_code": "monitoring_level",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Well-newborn nursery \/ mother-baby couplet (rooming-in) with routine vitals (temp, HR, RR, color, tone) each shift after transition, plus close observation during the first ~2h transition period; escalate to special care\/NICU for persistent respiratory distress (RR >60, grunting, retractions, sustained SpO2 <90%), temperature instability, recurrent or symptomatic hypoglycemia, poor perfusion, apnea, or clinical EOS signs; TSB approaching the exchange threshold triggers escalation-of-care (intensive phototherapy, urgent labs, possible transfer).",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "797d40a7207d4b2d05d9f5c364880a8799b0e2a9ddcaab951ef9ff77c375f433",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b95b10ec",
+                "section_code": "nutrition_mobility_vte",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Exclusive breastfeeding on demand (8-12 feeds\/24h) is the default per AAP 2022 (support skin-to-skin, rooming-in, avoid unnecessary supplementation); iron-fortified formula if not breastfeeding or medically indicated; VTE prophylaxis is NOT applicable to newborns; glucose homeostasis maintained by early\/frequent feeding plus protocolized dextrose gel; no indwelling lines\/catheters in the normal newborn (umbilical lines only in NICU); model safe-sleep (supine, alone, firm bare crib) from admission.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "bb442afc02eac7eb1ae8ebf40a5d4bdda1df3a1b38d19a26cf08f2cc7c073f89",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079c076dbf6",
+                "section_code": "pathway_pearls",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "(1) Universal predischarge bilirubin (TcB\/TSB at 24-48h) plotted on the AAP 2022 GA\/risk nomogram with a hardwired, risk-based follow-up time is the single biggest lever against the #1 readmission (jaundice); never discharge without it. (2) Use the neonatal EOS risk calculator to keep low-risk babies with mom and avoid unnecessary separation, labs, and antibiotics. (3) Protocolized 40% dextrose gel for asymptomatic at-risk hypoglycemia prevents avoidable NICU transfers and preserves breastfeeding. (4) Guarantee a 48-72h PCP follow-up (mandatory if discharged <48h); the early weight\/jaundice\/feeding recheck is what makes a safe short stay safe.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "e293a11f9775aca86ce4c428a42b6207adf4b90b4627a4f33d6384a1452b70f1",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079bc524426",
+                "section_code": "quality_metrics",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Joint Commission Perinatal Care PC-05 exclusive breast-milk feeding rate; hepatitis B birth-dose immunization coverage; newborn metabolic-screen completion and timeliness; CCHD pulse-oximetry screening rate; newborn hearing-screening rate (EHDI 1-3-6, screen by 1 month); predischarge bilirubin screening rate; 7- and 30-day newborn readmission (esp. hyperbilirubinemia\/dehydration); breastfeeding-at-discharge rate; avoidance of unnecessary NICU admission and antibiotic exposure; timely (48-72h) PCP follow-up completion.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "45c95f459b87fadf8d307a405d383ec278f67b55c4593808b8ef9e0a7ed7c090",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079bd98c446",
+                "section_code": "readmission_drivers",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "#1 = hyperbilirubinemia requiring readmission\/phototherapy (lever: predischarge TSB plus risk-based 24-72h recheck; never discharge too early without follow-up); dehydration\/hypernatremia from inadequate breastfeeding intake (lever: lactation support, weight\/output monitoring, early weight-check visit); feeding difficulty\/failure to thrive; missed or late newborn-screen\/CCHD detection; late-preterm (35-36 wk) infants disproportionately bounce back (use a lower discharge threshold and closer follow-up).",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "4907c3f23e738a3c62c17c48b90215341eb3f684a19029258ca3d63feea0f4cd",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b38b42df",
+                "section_code": "risk_stratification",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "APGAR at 1 and 5 min (>=7 normal; if <7 at 5 min repeat q5min to 20 min); Neonatal Early-Onset Sepsis (EOS) risk calculator (Kaiser\/Puopolo, for >=34-35 wks) using GBS status, intrapartum antibiotics, max maternal temp, ROM duration, GA -> EOS risk per 1000 driving routine care vs enhanced observation vs blood culture +\/- empiric antibiotics; AAP 2022 hyperbilirubinemia hour-specific nomogram plus neurotoxicity risk factors (isoimmune hemolytic disease, G6PD deficiency, sepsis, albumin <3.0) -> GA\/risk-specific phototherapy and escalation thresholds; protocolized hypoglycemia screening (AAP\/Adamkin) for at-risk (LGA, SGA, IDM, late-preterm) treating glucose <40-45 mg\/dL; Ballard gestational-age assessment; NEWT weight-loss nomogram (loss >75th percentile flags feeding failure).",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "07cdde7d4c6c391e8ce460463fa6a8adac4432c77d1dff8d25c1b139dd1ef2b9",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079c19476cf",
+                "section_code": "scope_and_volume_notes",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Single largest inpatient category when neonates are included; ~3.0M of ~3.67M live births (2022 CDC). Remainder of births carry a problem\/prematurity DRG (see rank 11). Approximate.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "7870d8df2ee8f2ce2a4ce2e17d1874ecf9ec71e70cfa76ef78995352e2990db4",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079c0133c7e",
+                "section_code": "severity_cc_mcc_notes",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "DRG 795 is by definition the uncomplicated normal newborn (the no-problem tier). Complications shift the case OUT of 795 into the neonatal problem DRGs: 794 (neonate with other significant problems), 793 (full-term neonate with major problems), 792\/791 (prematurity without\/with MCC), 790 (extreme immaturity\/RDS), 789 (neonate died or transferred <5 days). Practically, phototherapy-requiring hyperbilirubinemia, hypoglycemia needing IV dextrose, EOS\/antibiotics, respiratory distress, or late-preterm status escalate LOS (often 3 to 7+ days), may trigger NICU\/step-down, and re-group the case; therefore 795 optimization = keeping the newborn correctly in the uncomplicated tier by preventing or early-treating these problems.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "c89efa49323d0050242cf87e10468eecee4173cd0b69cd7da09f18b80ffb3881",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079bc1bd21d",
+                "section_code": "target_los",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "2 days (~48h) for the vaginal-delivery dyad; ~3 days when linked to a cesarean; earlier discharge (24-48h) acceptable ONLY if all AAP discharge criteria are met and a guaranteed 48-72h follow-up is in place.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "848e965b2db19ec1b63a3d090af760475ff643d2ce4bdf32134f6d602022776e",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079b51ee3fb",
+                "section_code": "time_critical_interventions",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Delayed cord clamping >=30-60 sec for the vigorous infant (ACOG\/AAP); immediate skin-to-skin with thermoregulation (axillary temp 36.5-37.5C); initiate breastfeeding within the first hour; IM vitamin K 0.5-1 mg within 6h to prevent VKDB (do not defer\/omit); erythromycin 0.5% ophthalmic ointment within 24h; hepatitis B birth-dose vaccine within 24h for stable infants >=2000g; if mother HBsAg-positive or unknown, give HBV vaccine + HBIG within 12h; first glucose check within 30-60 min of first feed in at-risk infants.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "8fb9f31a5e74b3d79b542a71952c020ba9eee70ba167978291628bcabcd6ade4",
+                "approved_digest": null
+            },
+            {
+                "section_uuid": "019f95de-b9ee-739f-9452-d079c16be983",
+                "section_code": "verification_notes",
+                "audience": "staff_reference",
+                "language_code": "en",
+                "source_text": "Independent automated verification completed 2026-07-21. Pass 1 validated CMS v43.1 taxonomy, PMID resolvability, retraction indicators, source currency, topic relevance, code overlap and modeled-volume arithmetic. Pass 2 adversarially checked required fields, risk\/time\/LOS numerics, quality-metric detail, source years and clinical-template limitations. 58 high-stakes claim segments were inventoried. This is evidence verification, not institutional clinical approval. No automated critical or material issue remained.",
+                "approved_text": null,
+                "content_mode": "source",
+                "review_state": "source_candidate",
+                "source_digest": "9d06fc04e14b59b6f17e8cceefab116e10ec040e9d30e2133aca86bf1d9f09a7",
+                "approved_digest": null
+            }
+        ],
+        "authoring": {
+            "milestones": [],
+            "activities": [],
+            "goals": [],
+            "education": []
+        },
+        "changes": [
+            {
+                "change_uuid": "019f95de-c085-71ab-8249-29cb46f612a8",
+                "source_field": "verification_status",
+                "old_value": "Verified",
+                "new_value": "Evidence verified \u2014 automated independent review complete",
+                "reason": "Reclassified after current two-pass evidence verification; pending status eliminated without implying clinical approval",
+                "source_reference": "https:\/\/www.cms.gov\/medicare\/payment\/prospective-payment-systems\/acute-inpatient-pps\/ms-drg-classifications-and-software; https:\/\/www.ncbi.nlm.nih.gov\/home\/develop\/api\/",
+                "changed_on": null
+            }
+        ]
+    },
+    "meta": {
+        "schema": "care_pathway_governance.v1",
+        "catalog_release_uuid": "019f95de-b9a4-726a-91d3-41d6d911d4c4",
+        "dataset_key": "drg-care-pathways-verification-package-v43.1-20260721",
+        "grouper_version": "43.1",
+        "source_cutoff_date": "2026-07-21",
+        "as_of": "2026-07-24T20:50:14+00:00",
+        "clinical_approval_warning": "Automated evidence verification is not institutional clinical approval.",
+        "patient_serving": false,
+        "hummingbird_serving": false,
+        "eddy_serving": false
+    }
+}

--- a/tests/js/carePathways/catalogSchemas.test.ts
+++ b/tests/js/carePathways/catalogSchemas.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import claimsFixture from "./__fixtures__/claims-page1.json";
+import pathwaysFixture from "./__fixtures__/pathways-page1.json";
+import summaryFixture from "./__fixtures__/summary.json";
+import versionFixture from "./__fixtures__/version-detail.json";
+import {
+    claimsEnvelopeSchema,
+    pathwaysEnvelopeSchema,
+    summaryEnvelopeSchema,
+    versionEnvelopeSchema,
+} from "@/lib/carePathways/catalogSchemas";
+
+// Fixtures are real envelopes captured from CatalogGovernanceReadService
+// against the adopted v43.1 release (250 pathways). If the PHP service's
+// shape changes, these parses fail before any page breaks silently.
+describe("care pathway governance envelope schemas", () => {
+    it("parses the summary envelope", () => {
+        const parsed = summaryEnvelopeSchema.parse(summaryFixture);
+        expect(parsed.data.release.state).toBe("inactive");
+        expect(parsed.data.release.clinical_signoff_count).toBe(0);
+        expect(parsed.data.catalog.definitions).toBe(250);
+        expect(parsed.meta.patient_serving).toBe(false);
+        expect(parsed.meta.clinical_approval_warning).toContain(
+            "not institutional clinical approval",
+        );
+    });
+
+    it("parses the pathways index envelope", () => {
+        const parsed = pathwaysEnvelopeSchema.parse(pathwaysFixture);
+        expect(parsed.data.length).toBe(25);
+        expect(parsed.meta.pagination?.total).toBe(250);
+        expect(parsed.data[0].version.source_rank).toBe(1);
+        expect(parsed.data[0].drg_candidates.length).toBeGreaterThan(0);
+        expect(
+            parsed.data[0].drg_candidates[0].requires_clinician_confirmation,
+        ).toBe(true);
+    });
+
+    it("parses the version detail envelope", () => {
+        const parsed = versionEnvelopeSchema.parse(versionFixture);
+        expect(parsed.data.sections.length).toBeGreaterThan(0);
+        expect(parsed.data.governance.activation_status).toBe("inactive");
+        expect(parsed.data.version.content_digest).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("parses the claims envelope", () => {
+        const parsed = claimsEnvelopeSchema.parse(claimsFixture);
+        expect(parsed.data.length).toBeGreaterThan(0);
+        expect(parsed.data[0].claim_excerpt.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
## Summary
- **Catalog Explorer** — the first UI consumer of the care-pathways governance read API, elucidating all 250 governed DRG pathways:
  - `/care-pathways/catalog`: release overview (metric wall, evidence 96/154 + disposition 96/148/6 partitions, release controls, activation-readiness checklist) and a filterable, paginated 250-pathway index (search, DRG code, evidence state, disposition, approval status).
  - `/care-pathways/catalog/{versionUuid}`: per-DRG detail — all 28 clinical sections in canonical reading order with digest provenance, DRG candidates with clinician-confirmation framing, paginated evidence claims with PubMed-linked graded sources, structured-authoring state, and the append-only governance ledger.
- **Governance framing everywhere**: every surface carries the inactive / 0-sign-offs / not-clinically-approved banner from the server envelope; routes are gated identically to the JSON API (`EnsureCarePathwayGovernanceEnabled` + `can:viewCarePathwayCatalog`) and the nav leaf is gated on both the feature flag and the capability.
- **Typed data layer**: Zod schemas mirroring `CatalogGovernanceReadService`, validated against committed real-envelope fixtures; typed axios client + TanStack Query hooks; no `any`.
- **Demo rebuilt on the design canon**: healthcare-* tokens (in-file raw palette 104 → 0), `Surface` primitive, `tabular-nums`, typed projections, icon+label status, catalog cross-link. Raw-palette ratchet baseline lowered **180 → 76**.

No serving flag changes: `CARE_PATHWAYS_GOVERNANCE_ENABLED` remains **off in prod** (enabled on dev only). All clinical-serving gates untouched.

## Test plan
- [x] PHPUnit care-pathway lane: 53 passed (428 assertions), incl. new `CarePathwayCatalogPageTest` (fail-closed 404 / capability 403 / render assertions)
- [x] Contract lane: 59 passed (1,764 assertions)
- [x] vitest: 39 passed (envelope schemas vs captured real fixtures, demo envelope guard, navigation config)
- [x] `npx tsc --noEmit` + `npx vite build` clean; `check-ui-canon.sh` green at the new lower baseline
- [x] Browser-verified on dev against the fully adopted release (250/770/802/10123): index filters (`q=sepsis`, `drg=870`, limitations=154, redesign=6 all match release controls), Sepsis detail (28 sections, DRGs 870–872, 57 claims, PMID links), demo step boundaries intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)