### PR TITLE
CI duration optimization — Tier 1 quick wins (Q1–Q7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -737,7 +737,7 @@ jobs:
         # In-job flake retry on PR lanes only; §3.2.9 budget-evidence runs on
         # main must stay retry-free so ratified budgets measure true cost.
         env:
-          XCUITEST_RETRY_FLAGS: ${{ github.event_name == 'pull_request' && '-retry-tests-on-failure -maximum-test-repetitions 3' || '' }}
+          XCUITEST_RETRY_FLAGS: ${{ github.event_name == 'pull_request' && '-retry-tests-on-failure -test-iterations 3 -test-repetition-relaunch-enabled YES' || '' }}
         run: |
           xcodebuild \
             -project "$IOS_STAFF_ROOT/Hummingbird.xcodeproj" \
@@ -960,7 +960,7 @@ jobs:
         # In-job flake retry on PR lanes only; §3.2.9 budget-evidence runs on
         # main must stay retry-free so ratified budgets measure true cost.
         env:
-          XCUITEST_RETRY_FLAGS: ${{ github.event_name == 'pull_request' && '-retry-tests-on-failure -maximum-test-repetitions 3' || '' }}
+          XCUITEST_RETRY_FLAGS: ${{ github.event_name == 'pull_request' && '-retry-tests-on-failure -test-iterations 3 -test-repetition-relaunch-enabled YES' || '' }}
         run: |
           xcodebuild \
             -project "$IOS_PATIENT_ROOT/HummingbirdPatient.xcodeproj" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -686,24 +686,6 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             build-for-testing
 
-      - name: Build Release for iPhone Simulator
-        run: |
-          xcodebuild \
-            -project "$IOS_STAFF_ROOT/Hummingbird.xcodeproj" \
-            -scheme Hummingbird \
-            -configuration Release \
-            -sdk iphonesimulator \
-            -destination "generic/platform=iOS Simulator" \
-            -derivedDataPath "$RUNNER_TEMP/hummingbird-staff-ios-release" \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            build
-
-      - name: Verify staff Release app transport boundary
-        run: |
-          release_app="$RUNNER_TEMP/hummingbird-staff-ios-release/Build/Products/Release-iphonesimulator/Hummingbird.app"
-          bash scripts/ci/verify-hummingbird-ios-release-transport.sh "$release_app" staff
-
       - name: Wait for simulator boot to complete
         run: xcrun simctl bootstatus "${{ steps.simulator.outputs.udid }}" -b
 
@@ -741,6 +723,26 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             test-without-building
+
+      # The Release build gates the deploy path, not test feedback, so it
+      # runs after the tests to surface test failures sooner.
+      - name: Build Release for iPhone Simulator
+        run: |
+          xcodebuild \
+            -project "$IOS_STAFF_ROOT/Hummingbird.xcodeproj" \
+            -scheme Hummingbird \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination "generic/platform=iOS Simulator" \
+            -derivedDataPath "$RUNNER_TEMP/hummingbird-staff-ios-release" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            build
+
+      - name: Verify staff Release app transport boundary
+        run: |
+          release_app="$RUNNER_TEMP/hummingbird-staff-ios-release/Build/Products/Release-iphonesimulator/Hummingbird.app"
+          bash scripts/ci/verify-hummingbird-ios-release-transport.sh "$release_app" staff
 
       - name: Shut down test simulator
         if: always() && steps.simulator.outputs.udid != ''
@@ -907,25 +909,6 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             build-for-testing
 
-      - name: Build Release for iPhone Simulator
-        run: |
-          xcodebuild \
-            -project "$IOS_PATIENT_ROOT/HummingbirdPatient.xcodeproj" \
-            -scheme HummingbirdPatient \
-            -configuration Release \
-            -sdk iphonesimulator \
-            -destination "generic/platform=iOS Simulator" \
-            -derivedDataPath "$RUNNER_TEMP/hummingbird-patient-ios-release" \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            build
-
-      - name: Verify patient Release app boundary
-        run: |
-          release_app="$RUNNER_TEMP/hummingbird-patient-ios-release/Build/Products/Release-iphonesimulator/HummingbirdPatient.app"
-          bash scripts/ci/verify-hummingbird-patient-boundary.sh artifact "$release_app"
-          bash scripts/ci/verify-hummingbird-ios-release-transport.sh "$release_app" patient
-
       - name: Wait for simulator boot to complete
         run: xcrun simctl bootstatus "${{ steps.simulator.outputs.udid }}" -b
 
@@ -963,6 +946,27 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             test-without-building
+
+      # The Release build gates the deploy path, not test feedback, so it
+      # runs after the tests to surface test failures sooner.
+      - name: Build Release for iPhone Simulator
+        run: |
+          xcodebuild \
+            -project "$IOS_PATIENT_ROOT/HummingbirdPatient.xcodeproj" \
+            -scheme HummingbirdPatient \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination "generic/platform=iOS Simulator" \
+            -derivedDataPath "$RUNNER_TEMP/hummingbird-patient-ios-release" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            build
+
+      - name: Verify patient Release app boundary
+        run: |
+          release_app="$RUNNER_TEMP/hummingbird-patient-ios-release/Build/Products/Release-iphonesimulator/HummingbirdPatient.app"
+          bash scripts/ci/verify-hummingbird-patient-boundary.sh artifact "$release_app"
+          bash scripts/ci/verify-hummingbird-ios-release-transport.sh "$release_app" patient
 
       - name: Shut down test simulator
         if: always() && steps.simulator.outputs.udid != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,6 +631,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Booting a simulator takes 2-5 minutes and depends on nothing the
+      # builds produce, so start it immediately and let it overlap the build
+      # steps; the wait step before the first test blocks on readiness.
+      - name: Select and begin booting an available iPhone Simulator
+        id: simulator
+        run: |
+          simulator_udid="$(bash scripts/ci/select-ios-simulator.sh)"
+          echo "udid=$simulator_udid" >> "$GITHUB_OUTPUT"
+          xcrun simctl boot "$simulator_udid" 2>/dev/null || true
+
       - name: Install pinned XcodeGen
         env:
           XCODEGEN_VERSION: 2.46.0
@@ -691,13 +701,8 @@ jobs:
           release_app="$RUNNER_TEMP/hummingbird-staff-ios-release/Build/Products/Release-iphonesimulator/Hummingbird.app"
           bash scripts/ci/verify-hummingbird-ios-release-transport.sh "$release_app" staff
 
-      - name: Select and boot an available iPhone Simulator
-        id: simulator
-        run: |
-          simulator_udid="$(bash scripts/ci/select-ios-simulator.sh)"
-          echo "udid=$simulator_udid" >> "$GITHUB_OUTPUT"
-          xcrun simctl boot "$simulator_udid" 2>/dev/null || true
-          xcrun simctl bootstatus "$simulator_udid" -b
+      - name: Wait for simulator boot to complete
+        run: xcrun simctl bootstatus "${{ steps.simulator.outputs.udid }}" -b
 
       - name: Run XCTest unit suite
         run: |
@@ -849,6 +854,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Booting a simulator takes 2-5 minutes and depends on nothing the
+      # builds produce, so start it immediately and let it overlap the build
+      # steps; the wait step before the first test blocks on readiness.
+      - name: Select and begin booting an available iPhone Simulator
+        id: simulator
+        run: |
+          simulator_udid="$(bash scripts/ci/select-ios-simulator.sh)"
+          echo "udid=$simulator_udid" >> "$GITHUB_OUTPUT"
+          xcrun simctl boot "$simulator_udid" 2>/dev/null || true
+
       - name: Install pinned XcodeGen
         env:
           XCODEGEN_VERSION: 2.46.0
@@ -900,13 +915,8 @@ jobs:
           bash scripts/ci/verify-hummingbird-patient-boundary.sh artifact "$release_app"
           bash scripts/ci/verify-hummingbird-ios-release-transport.sh "$release_app" patient
 
-      - name: Select and boot an available iPhone Simulator
-        id: simulator
-        run: |
-          simulator_udid="$(bash scripts/ci/select-ios-simulator.sh)"
-          echo "udid=$simulator_udid" >> "$GITHUB_OUTPUT"
-          xcrun simctl boot "$simulator_udid" 2>/dev/null || true
-          xcrun simctl bootstatus "$simulator_udid" -b
+      - name: Wait for simulator boot to complete
+        run: xcrun simctl bootstatus "${{ steps.simulator.outputs.udid }}" -b
 
       - name: Run XCTest unit suite
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 concurrency:
   group: ci-full-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseding pushes cancel PR runs only. A cancelled main run can never
+  # satisfy the deploy gate for its commit, which left rapid back-to-back
+  # merges permanently undeployable.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -134,7 +137,8 @@ jobs:
   backend-tests:
     name: Backend tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Matches the ratified "no shard above 30 m" budget; caps hung-shard burn.
+    timeout-minutes: 30
     env:
       APP_ENV: testing
       APP_KEY: base64:MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=
@@ -261,8 +265,10 @@ jobs:
       - name: TypeScript type check
         run: bash scripts/capture-release-evidence.sh frontend-typescript npx tsc --noEmit
 
-      - name: Run Vitest with coverage
-        run: bash scripts/capture-release-evidence.sh frontend-vitest npx vitest run --coverage
+      # Coverage output has no PR-lane consumer; the lcov record persists
+      # from main pushes only.
+      - name: Run Vitest
+        run: bash scripts/capture-release-evidence.sh frontend-vitest npx vitest run ${{ github.event_name == 'push' && '--coverage' || '' }}
 
       - name: Vite production build
         run: bash scripts/capture-release-evidence.sh frontend-build npx vite build
@@ -429,6 +435,22 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/composer/files
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
+
+      # restore-keys keeps the last browser bundle warm across lockfile
+      # changes; playwright install then no-ops unless its version moved.
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-
+
       - name: Install application and browser dependencies
         run: |
           composer install --prefer-dist --no-interaction --no-progress
@@ -513,6 +535,13 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: package-lock.json
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/composer/files
+          key: composer-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-
 
       - name: Install application dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,7 +670,10 @@ jobs:
             -o "$RUNNER_TEMP/hummingbird-fixture-decoder"
           "$RUNNER_TEMP/hummingbird-fixture-decoder" "$GITHUB_WORKSPACE"
 
-      - name: Build Debug for iPhone Simulator
+      # build-for-testing writes app + test bundles into the derivedDataPath
+      # the test steps read, so XCTest/XCUITest run test-without-building
+      # instead of recompiling from scratch.
+      - name: Build Debug for testing (iPhone Simulator)
         run: |
           xcodebuild \
             -project "$IOS_STAFF_ROOT/Hummingbird.xcodeproj" \
@@ -678,10 +681,10 @@ jobs:
             -configuration Debug \
             -sdk iphonesimulator \
             -destination "generic/platform=iOS Simulator" \
-            -derivedDataPath "$RUNNER_TEMP/hummingbird-staff-ios-debug" \
+            -derivedDataPath "$RUNNER_TEMP/hummingbird-staff-ios-tests" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            build
+            build-for-testing
 
       - name: Build Release for iPhone Simulator
         run: |
@@ -717,7 +720,7 @@ jobs:
             -parallel-testing-enabled NO \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            test
+            test-without-building
 
       - name: Run XCUITest reference journeys
         run: |
@@ -732,7 +735,7 @@ jobs:
             -parallel-testing-enabled NO \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            test
+            test-without-building
 
       - name: Shut down test simulator
         if: always() && steps.simulator.outputs.udid != ''
@@ -883,7 +886,10 @@ jobs:
           bash scripts/ci/verify-hummingbird-patient-boundary.sh source "$IOS_PATIENT_ROOT"
           xcodebuild -project "$IOS_PATIENT_ROOT/HummingbirdPatient.xcodeproj" -list
 
-      - name: Build Debug for iPhone Simulator
+      # build-for-testing writes app + test bundles into the derivedDataPath
+      # the test steps read, so XCTest/XCUITest run test-without-building
+      # instead of recompiling from scratch.
+      - name: Build Debug for testing (iPhone Simulator)
         run: |
           xcodebuild \
             -project "$IOS_PATIENT_ROOT/HummingbirdPatient.xcodeproj" \
@@ -891,10 +897,10 @@ jobs:
             -configuration Debug \
             -sdk iphonesimulator \
             -destination "generic/platform=iOS Simulator" \
-            -derivedDataPath "$RUNNER_TEMP/hummingbird-patient-ios-debug" \
+            -derivedDataPath "$RUNNER_TEMP/hummingbird-patient-ios-tests" \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            build
+            build-for-testing
 
       - name: Build Release for iPhone Simulator
         run: |
@@ -931,7 +937,7 @@ jobs:
             -parallel-testing-enabled NO \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            test
+            test-without-building
 
       - name: Run XCUITest reference journeys
         run: |
@@ -946,7 +952,7 @@ jobs:
             -parallel-testing-enabled NO \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
-            test
+            test-without-building
 
       - name: Shut down test simulator
         if: always() && steps.simulator.outputs.udid != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -723,6 +723,10 @@ jobs:
             test-without-building
 
       - name: Run XCUITest reference journeys
+        # In-job flake retry on PR lanes only; §3.2.9 budget-evidence runs on
+        # main must stay retry-free so ratified budgets measure true cost.
+        env:
+          XCUITEST_RETRY_FLAGS: ${{ github.event_name == 'pull_request' && '-retry-tests-on-failure -maximum-test-repetitions 3' || '' }}
         run: |
           xcodebuild \
             -project "$IOS_STAFF_ROOT/Hummingbird.xcodeproj" \
@@ -733,6 +737,7 @@ jobs:
             -resultBundlePath "$RUNNER_TEMP/HummingbirdStaffUITests.xcresult" \
             -only-testing:HummingbirdUITests \
             -parallel-testing-enabled NO \
+            $XCUITEST_RETRY_FLAGS \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             test-without-building
@@ -940,6 +945,10 @@ jobs:
             test-without-building
 
       - name: Run XCUITest reference journeys
+        # In-job flake retry on PR lanes only; §3.2.9 budget-evidence runs on
+        # main must stay retry-free so ratified budgets measure true cost.
+        env:
+          XCUITEST_RETRY_FLAGS: ${{ github.event_name == 'pull_request' && '-retry-tests-on-failure -maximum-test-repetitions 3' || '' }}
         run: |
           xcodebuild \
             -project "$IOS_PATIENT_ROOT/HummingbirdPatient.xcodeproj" \
@@ -950,6 +959,7 @@ jobs:
             -resultBundlePath "$RUNNER_TEMP/HummingbirdPatientUITests.xcresult" \
             -only-testing:HummingbirdPatientUITests \
             -parallel-testing-enabled NO \
+            $XCUITEST_RETRY_FLAGS \
             CODE_SIGNING_ALLOWED=NO \
             CODE_SIGNING_REQUIRED=NO \
             test-without-building

--- a/.github/workflows/security-nightly.yml
+++ b/.github/workflows/security-nightly.yml
@@ -1,0 +1,79 @@
+name: Security nightly
+
+# Dependency audits on the CI merge gate run only when a change set touches
+# the corresponding manifest/lockfile (see scripts/security/run-security-suite.sh).
+# This scheduled sweep owns new-advisory response instead: it forces every
+# audit daily and opens (or updates) an issue on failure, so advisory triage
+# is a scheduled, owned activity rather than a merge-blocking ambush.
+
+on:
+  schedule:
+    - cron: "17 9 * * *" # daily 09:17 UTC (~05:17 ET)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  security-sweep:
+    name: Security sweep (all dependency audits)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RELEASE_EVIDENCE_DIR: artifacts/release-evidence/security-nightly
+      SECURITY_AUDIT_DEPENDENCIES: always
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Gitleaks must inspect the complete repository history.
+          fetch-depth: 0
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install pinned security tools
+        run: bash scripts/security/install-tools.sh
+
+      - name: Run full security suite (audits forced)
+        run: bash scripts/capture-release-evidence.sh security-nightly bash scripts/security/run-security-suite.sh
+
+      - name: Upload nightly security evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-nightly-evidence
+          path: artifacts/release-evidence/security-nightly
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Open or update advisory issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          title="Security nightly sweep failing"
+          existing="$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')"
+          if [[ -n "$existing" ]]; then
+            gh issue comment "$existing" --body "Nightly security sweep failed again: $run_url"
+          else
+            gh issue create \
+              --title "$title" \
+              --body "The scheduled dependency-advisory sweep failed. Triage the advisory and land the remediation as an owned change (bump the affected lockfile so the CI-gate audit re-arms). Run: $run_url"
+          fi

--- a/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
+++ b/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
@@ -1,0 +1,143 @@
+# CI Duration Optimization Plan — 2026-07-24
+
+**Goal:** Cut nominal PR wall-clock from ~25–27 min to **~18–19 min this week** and **~13–14 min after the structural tier**, eliminate the unbudgeted **+35 min macOS queue tail** and the **~25 min merge→deploy duplication**, and make backend shard times *deterministic* — while honoring every §3.2.9 gate and the immutable-release evidence chain.
+
+**Method:** All numbers below are measured from step-level timing of three real runs (`30112436573` pre-#60 main 73 min; `30126216355` post-#60 main 24.4 min; `30130213593` PR #61 27 min) plus the per-test JUnit artifacts PR #60 added, parsed class-by-class. No estimate in this plan is un-sourced. Investigation evidence: `/tmp/ci-analysis/` (3 run JSONs + 4 dimension findings + critique); durable copies of the shard timings live in the 30-day `backend-feature-*-release-evidence` artifacts.
+
+**Prior art this plan extends (does not replace):** `docs/hummingbird/ZEPHYRUS-HUMMINGBIRD-FUNCTIONAL-PARITY-AND-PATIENT-EXPERIENCE-PLAN-2026-07-19.md` §3.2.9 — its gates, budgets, and ordering are binding. PR #60 executed the first gate (JUnit timing artifacts ✅, Cockpit payload amplification removal ✅: feature-7 4,265 s → 1,403 s, `LaboratoryCockpitMetricsTest` 2,701 s → 160 s).
+
+---
+
+## 1. The measured baseline — what actually takes so long
+
+### 1.1 Wall-clock anatomy (all-green runs)
+
+| | pre-#60 main | post-#60 main | PR #61 run |
+|---|---:|---:|---:|
+| Wall clock (nominal) | 73.0 m | 24.4 m | 26.9 m |
+| Critical-path job | feature-7 (72.9 m) | feature-7 (24.2 m) | staff iOS (26.9 m) |
+| Worst backend shard | 72.9 m | 24.2 m | 21.5 m |
+| Staff iOS | 20.7 m | 22.8 m | 26.9 m |
+| Total backend shard compute | 182.6 m | 98.4 m | 85.2 m |
+
+### 1.2 Four facts that reframe the problem
+
+1. **Staff iOS is NOT a required check.** Branch protection requires only **17 of the 19 contexts** — `Hummingbird staff (iOS)` and `Hummingbird staff (Android)` are not among them (verified via `gh api repos/sudoshi/Zephyrus/branches/main/protection`). The *merge-blocking* critical path is therefore the **worst backend shard (21.5–24.2 m)**, not iOS. iOS gates only the *deploy* path (deploy.sh requires the whole run green).
+2. **The true wall clock is sometimes 62 min, not 27.** On PR run `30130213593`, 18 jobs started at +0.0 m but staff iOS **queued 35.4 min** for a `macos-26` runner before its 26.9 m of work. The scarce `macos-26` pool (needed for the iOS-26 SDK) is the largest single source of unbudgeted variance; Linux queue delay measured 0–3 s across all runs — Linux concurrency is not a constraint.
+3. **87% of backend compute is repeated setup, not tests.** Of 5,104 s total suite time (PR run), **4,426 s** is consumed by 135 test cases across 26 classes whose `setUp()` re-runs 5–6 seeders + `AncillaryDemoScenarioService::refresh` (~33–44 s) before *every test method* (e.g. `tests/Feature/Cockpit/LaboratoryCockpitMetricsTest.php:47-55`). Those cases average 32.8 s each; the other 1,505 cases average **0.45 s**. Comparison: `RadiologyCockpitMetricsTest` — same seeders, no scenario dependence — runs 4 tests in 3.8 s.
+4. **Every merge pays CI twice.** The PR run proves the tree, then the squash commit re-runs the *identical tree* on main (~25 m) before `deploy.sh`'s gate clears. Because branch protection has `strict: true` (branches must be up to date), the squash tree-sha equals the tested PR head tree-sha essentially always — the second run adds no information.
+
+### 1.3 Where each critical job's minutes go (PR run `30130213593`)
+
+**Staff iOS (26.9 m):** setup/verify ~0.9 m → Build Debug 2.30 m → Build Release 2.18 m → **boot simulator 5.02 m** (variance 1.8–5.0 m; runs strictly *after* both builds, `ci.yml:694-700`) → XCTest 4.13 m (which **recompiles from scratch** — the Debug build at `ci.yml:671` writes to a derivedDataPath the test steps never read, `ci.yml:709/724`) → **XCUITest 12.07 m** (18 tests, 4 classes, `-parallel-testing-enabled NO` at `ci.yml:712/727`; `PatientCommunicationRoutingUITests` holds 11 of the 18 tests, ≥20 app launches, 12 `.keepAlways` screenshots — today's 57 s snapshot-timeout flake lives here and cost a 20 m full-job rerun).
+
+**Worst backend shard (21.5 m):** container init 21–33 s, composer (cached) 2–5 s, migrate 6–13 s **against a DB the tests never touch** (tests self-provision `zephyrus_test_<hex>` per process, `tests/bootstrap.php:12-14`), then PHPUnit 20.8 m. Shard membership is `sorted-filename index % 8` (`scripts/ci/run-backend-test-shard.sh:25-38`) — **adding 3 test files in PR #61 moved the heavy Ancillary/Lab classes from shard 7 to shard 0** (feature-0: 8.9 m → 21.5 m; feature-7: 24.2 m → 9.6 m). Load balance is a coin flip re-dealt by every test-file addition.
+
+**Duplicated work across jobs (per run):** vite production build ×3 (frontend 100 s + Playwright 71 s + ZAP 61 s), `composer install` ×12 (only quality + shards have the cache), migrate ×12, E2E seeding ×2 (Playwright + ZAP each re-migrate + `E2eTestSeeder`, `CommandCenterDemoSeeder` alone 15 s), Playwright chromium re-downloaded cold every run (no cache), plus 19 × container/checkout/setup ≈ 4.6 m of container init alone. A **docs-only commit pays all of it** — `ci.yml:3-7` has no paths filtering (today's regenerated `.md` report ran the full 19-job suite).
+
+**Velocity failure modes (not throughput):** (a) `npm audit` in the security gate red-flagged *main* for hours on a mid-day registry advisory unrelated to any diff; (b) `cancel-in-progress: true` applies to main pushes too (`ci.yml:9-11`) — two rapid merges cancel the first commit's run, leaving it **permanently unable to satisfy the deploy gate**; (c) a single flaky XCUITest costs a 20+ m full-job rerun because no in-job retry exists.
+
+---
+
+## 2. Binding constraints (violating any of these is a plan failure)
+
+- **§3.2.9 ordering gate:** setup-vs-body + query-count instrumentation must land **before** the weighted shard manifest ("must profile those paths and test setup directly BEFORE introducing a weighted manifest or any index"). The manifest requires **rolling medians from clean exact-SHA runs**.
+- **§3.2.9 prohibitions:** no SQLite swap, no trigger/migration suppression, no dirty-DB reuse, no shared mutable state between tests, budget changes need recorded evidence + review, a timeout *increase* is not optimization (a decrease is fine).
+- **Required-checks contract:** 17 required contexts exist by *name*. Any job rename/merge/removal must update branch protection in the same change window or PRs become unmergeable (this kills the "delete the DAST job" variant — DAST **is** required).
+- **Immutable-release evidence chain:** `deploy.sh` + `tests/Deployment/github-ci-gate.sh` require a green run on the exact release SHA. Any verdict-reuse/fast-path design must still produce a green, auditable run for that SHA (all-jobs-skipped runs conclude `success` and skipped required checks satisfy protection — verified — but the evidence-chain semantics need an explicit [SU] ruling; see item S4).
+- **Budget-evidence hygiene:** runs used to ratify §3.2.9 budgets must have flake-retries disabled.
+
+---
+
+## 3. Tier 1 — Quick wins (this week; each independently shippable)
+
+### Q1. Preboot the iOS simulator during the builds — **−3 to −5 m staff iOS**
+The boot step (1.8–5.0 m) runs strictly after both builds but depends on nothing they produce.
+- [ ] Move `Select and boot an available iPhone Simulator` (staff `ci.yml:694-700`, patient `903-909`) to immediately after checkout; make `xcrun simctl boot` non-blocking (background boot), and add a cheap `xcrun simctl bootstatus $UDID -b` wait right before the first test step. Boot then overlaps the ~4–5 m build window and its cost collapses to ~0.
+- Verify: staff iOS step timeline shows boot wait <30 s on 3 consecutive runs.
+
+### Q2. `build-for-testing` + `test-without-building` — **net ~−4 m staff iOS**
+The standalone Debug build's artifacts are never reused; XCTest recompiles everything.
+- [ ] Replace `Build Debug for iPhone Simulator` (`ci.yml:663-674`) with `xcodebuild build-for-testing` targeting `$RUNNER_TEMP/hummingbird-staff-ios-tests` (the derivedDataPath the test steps already use), and switch both test invocations (`ci.yml:709/724`) to `test-without-building`. Same change for patient iOS (`~884-939`).
+- Verify: one compile phase total in the job log; XCTest step drops from 4.1 m to ≤1.5 m.
+
+### Q3. In-job XCUITest flake retry (PR lanes only) — **−20 to −27 m per flake occurrence**
+- [ ] Add `-retry-tests-on-failure -maximum-test-repetitions 3` to the XCUITest invocations (`ci.yml:717-730`, `926-939`), gated on `github.event_name == 'pull_request'` so §3.2.9 budget-evidence runs (main) stay retry-free.
+- Verify: inject a known-flaky rerun; job self-heals without a full rerun.
+
+### Q4. Resequence Release build + transport verify after the test steps — **−2.2 m to first-failure**
+- [ ] Move `ci.yml:676-692` (Build Release + transport verify) after XCUITest so test failures surface ~2 m sooner; keep them in-job (the separate-job variant costs a scarce macOS slot — see S5).
+
+### Q5. Security gate: decouple dependency audits from live registry events — **kills red-main incidents**
+- [ ] In `scripts/security/run-security-suite.sh:19-22`, run `composer audit`/`npm audit`/`pip-audit` as **hard gates only when the diff touches the corresponding lockfile** (`git diff --name-only origin/main...HEAD`), plus an unconditional scheduled nightly workflow that opens an issue on new advisories. Gitleaks/semgrep/edge-security stay hard-gated on every run.
+- Rationale: today's `brace-expansion` advisory turned main red for hours and cost three CI round-trips on an unrelated one-line PR. Advisory response becomes a *scheduled, owned* activity instead of a merge-blocking ambush.
+
+### Q6. §3.2.9 instrumentation prerequisite — **unblocks the whole structural tier**
+- [ ] Add setup-vs-test-body wall-time split + aggregate DB query-count/time to the shard harness for the residual heavy classes (the JUnit artifacts already give per-test totals; add a `setUp` timer via a base-class hook + `DB::listen` counter emitted into the release-evidence dir). This is the unchecked §3.2.9 box that *gates* the weighted manifest (S1) and the seeding rework (S2).
+
+### Q7. Hygiene ratchets (all trivial, all off critical path)
+- [ ] `timeout-minutes: 90 → 30` on backend shards (`ci.yml:137`) — matches the ratified "no shard above 30 m" budget; caps hung-shard burn.
+- [ ] `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` (`ci.yml:11`) — closes the permanently-undeployable-superseded-main-commit hole.
+- [ ] Pint `--parallel` (`ci.yml:117`): quality job 101 s → ~35 s.
+- [ ] Cache Playwright chromium (`~/.cache/ms-playwright`, keyed on the lockfile's playwright version) + add the existing composer-cache block to browser (`ci.yml:~432`) and dast (`~517`) jobs.
+- [ ] Drop `--coverage` from PR-lane Vitest (`ci.yml:265`; nothing consumes the lcov — keep it on main pushes so the coverage record persists).
+
+**Tier-1 projected nominal wall:** staff iOS 26.9 m → **~16.5–18.6 m** (Q1+Q2+Q4 compose on the step chain; boot overlap bounded by build length). Backend untouched (gated by Q6→S1), so on an unlucky modulo deal the wall is the worst backend shard **~19–24 m**; median run **~18–19 m**. The macOS queue tail remains (addressed in S5).
+
+---
+
+## 4. Tier 2 — Structural (next sprint)
+
+### S1. Stable weighted shard manifest (LPT) — **worst shard 21.5 m → ~11.6 m, deterministically**
+*Gated behind Q6 per §3.2.9 ordering; weights from rolling medians of 3 clean exact-SHA runs.*
+- [ ] Replace the modulo deal (`run-backend-test-shard.sh:33-38`) with a committed `tests/ci/shard-manifest.json` (path → shard, LPT-packed from the JUnit medians). Unlisted files get a deterministic default weight + LPT slot at runtime. Add the §3.2.9-mandated verifier: every discovered test appears exactly once, no duplicates, no silent exclusions, manifest drift fails CI.
+- Arithmetic: LPT over measured class weights yields max bin ≈ **638 s** PHPUnit (~11.6 m job) vs 1,245 s observed; more shards buy ≤12 s because `AncillaryDemoScenarioTest` (625.8 s) is itself the floor — do not add shards.
+
+### S2. Kill setup amplification in the ~21 consumer classes — **−38 m suite compute**
+*The sanctioned §3.2.9 shape: minimal governed fixtures + at least one full-seeder integration case per protected invariant; no dirty-DB reuse, isolation preserved.*
+- [ ] Build the smallest governed ancillary fixture for service-level cases; keep `AncillaryDemoScenarioTest` + one full-refresh integration case per invariant on the full pipeline. Target: 4,426 s → ~900 s (26 × one-time class setup + ~110 cases × ~1 s). Suite compute 85 m → ~46 m; every non-floor shard lands ~5–6 m.
+
+### S3. Parallelize XCUITest (2 simulator clones) + split the 11-test routing class — **staff iOS UI step 12.1 m → ~6.5–7.5 m**
+- [ ] `project.yml:19-20` `parallelizable: true`, `-parallel-testing-enabled YES -parallel-testing-worker-count 2` (`ci.yml:727`), and split `PatientCommunicationRoutingUITests` (11 of 18 tests; XCTest distributes per-class, so without the split two workers cap at −4 m).
+
+### S4. Tree-sha verdict reuse on the squash push + docs-only fast path — **merge→deploy ~25 m → ~1–2 m** *(needs an explicit [SU] evidence-chain ruling first)*
+- [ ] Add a 30 s `changes` gatekeeper job: (a) on main pushes, if a successful run exists whose head tree-sha equals this commit's tree-sha, output `reuse=true`; (b) on any event, output `docs_only` from the diff. All 11 job definitions gain `needs: changes` + skip conditions. Skipped required checks satisfy branch protection and the run concludes `success` (verified), so the deploy gate passes on the exact SHA — but the run's evidence artifacts would point at the PR run, which is precisely the [SU] ruling to record before landing. `strict: true` makes tree matches near-universal.
+
+### S5. De-risk the `macos-26` queue tail — **removes the +35 m variance**
+- [ ] In order: (a) test whether `macos-15`'s Xcode selection now covers the needed iOS-26 SDK — if yes, leave the scarce pool entirely; (b) evaluate larger-runner pools; (c) failing both, move XCUITest journeys to main-push/nightly lanes only (permissible — staff iOS is not a required PR check — but record the coverage trade-off explicitly).
+- [ ] Either way: emit queue-delay (job `started_at` − run `created_at`) into release evidence so the tail is *measured* continuously.
+
+### S6. Single vite build per run — **browser 9.0 → ~7.5 m, DAST 4.3 → ~2.5 m**
+- [ ] Frontend job uploads `public/build`; browser + DAST download it and set the already-existing `PLAYWRIGHT_SKIP_BUILD` / `DAST_SKIP_BUILD` flags (`run-browser-suite.sh:74`, `run-dast-suite.sh:75`). Optionally fold ZAP into the browser job against the still-running server later — but DAST is a *required check by name*, so any fold must ship with a branch-protection update in the same window.
+
+---
+
+## 5. Tier 3 — Deep (§3.2.9 query/test remediation; the floor-setters)
+
+- [ ] **D1. Profile `AncillaryDemoScenarioService::refresh` + `SnapshotBuilder::buildWithContext` + Lab services** with `EXPLAIN (ANALYZE, BUFFERS, WAL)` on the 66-order/328-milestone fixture in a disposable DB (§3.2.9 verbatim). Every shard layout is lower-bounded by the 625.8 s `AncillaryDemoScenarioTest`; a 2× refresh cut takes backend to ~6.5–7 m and is what ratifies the stage-2 ≤15 m budget.
+- [ ] **D2. Request-scoped laboratory aggregate snapshot** (one governed calculation shared by Cockpit provider, health service, drill) — §3.2.9's named remediation.
+- [ ] **D3. Paratest spike** (per-process isolation already exists: DB name keys on pid, `IsolatedTestDatabase.php:27`; array cache/session; pid-scoped disk). Only after D1 — it cannot break the single-class floor. Success enables 8 → 4 shard consolidation.
+- [ ] **D4. Restore the two never-running tests**: `Api/ProcessAnalysisTest` + `Auth/AuthenticationFlowTest` are Pest-syntax, excluded by the sharder (`run-backend-test-shard.sh:27-28`) because Pest is uninstallable under PHP 8.5 — they run **nowhere** today. Convert to PHPUnit class syntax. Zero time saving; closes a silent coverage hole.
+
+**Do-NOT-do list (measured nulls — recorded so nobody re-spends the effort):** SPM/DerivedData caching (no SPM packages declared), per-job migrate-template DBs (in-process `migrate:fresh` ≈ 6 s and §3.2.9-sensitive), composer cache work in shards (installs already 2–5 s), Linux runner-pool changes (queue delay 0–3 s), adding backend shards past 8 (floor-bound), action version bumps (all current majors), Playwright sharding (off critical path; config `workers:1` is a deliberate SSE-safety choice — revisit only at stage-2).
+
+---
+
+## 6. Projected outcomes
+
+| Milestone | Nominal PR wall | Merge→deploy latency | Tail risk |
+|---|---:|---:|---|
+| Today | 24.3–26.9 m | ~25 m (second full run) | +35 m macOS queue; +20 m per iOS flake; red main on registry events |
+| After Tier 1 | **~18–19 m median** | ~25 m | flake tail closed (Q3); red-main closed (Q5); queue tail remains |
+| After Tier 2 | **~13–14 m** | **~1–2 m** (S4, post-ruling) | queue tail closed (S5); backend deterministic (S1) |
+| After Tier 3 (D1 ×2 refresh cut) | **~12.5–13 m** (iOS-owned) | ~1–2 m | — |
+
+Budgets (extend §3.2.9's): after S1 lands, ratchet backend `timeout-minutes` 30 → 20; after stage-2 ratification, adopt the ≤15 m backend critical-path budget with the mandated 3-clean-run evidence. Re-run the full 19-job suite with zero skipped tests before/after each tier and diff coverage counts, assertions, and invariants (§3.2.9 requirement) — a faster shard must not conceal a semantic regression.
+
+## 7. Sequencing
+
+Week 1: Q1–Q7 (all independent; Q6 first since S1/S2 wait on its data accumulating).
+Sprint: S1 (after 3 clean runs of Q6 medians) → S2 (largest compute win) ∥ S3 ∥ S5 ∥ S6; S4 after the [SU] evidence-chain ruling.
+Then: D1 → D2 → (D3 if D1 succeeds) ∥ D4 anytime.
+
+*Meta-lesson from today, encoded above: the three CI round-trips (~75 min) this very investigation ran alongside were caused by (a) a registry advisory ambush → Q5, (b) npm-version skew between beastmode and runners → recorded in memory (`feedback_npm10_lockfile_ops`), and (c) a 57 s XCUITest snapshot timeout → Q3. The plan fixes the class of each.*

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,12 @@
             <exclude>tests/Feature/Auth/AuthenticationFlowTest.php</exclude>
         </testsuite>
     </testsuites>
+    <extensions>
+        <!-- §3.2.9 CI instrumentation: per-test setUp-vs-body wall-time and
+             DB query split, emitted as NDJSON into RELEASE_EVIDENCE_DIR.
+             A no-op when that env var is absent (all local runs). -->
+        <bootstrap class="Tests\Support\Timing\TestTimingEvidenceExtension"/>
+    </extensions>
     <source>
         <include>
             <directory>app</directory>

--- a/scripts/security/run-security-suite.sh
+++ b/scripts/security/run-security-suite.sh
@@ -16,10 +16,57 @@ if [[ ! -x "$GITLEAKS" || ! -x "$PIP_AUDIT" || ! -x "$SEMGREP" ]]; then
     bash scripts/security/install-tools.sh
 fi
 
-composer audit --locked --abandoned=fail
-npm audit --audit-level=high
-"$PIP_AUDIT" --requirement arena/requirements.txt
-"$PIP_AUDIT" --requirement eddy/requirements.txt
+# Dependency audits query live registries, so a new advisory on an untouched
+# dependency can red-flag main hours after an unrelated merge. They hard-gate
+# here only when this change set edits the corresponding manifest/lockfile;
+# the scheduled security-nightly workflow owns advisory response for
+# everything else. SECURITY_AUDIT_DEPENDENCIES=always (the nightly, or a
+# manual sweep) forces all four audits regardless of the diff.
+audit_scope="${SECURITY_AUDIT_DEPENDENCIES:-diff}"
+changed_files=""
+if [[ "$audit_scope" != "always" ]]; then
+    if ! changed_files="$(git diff --name-only origin/main...HEAD 2>/dev/null)"; then
+        # Diff base unavailable (shallow clone, missing ref): fail safe.
+        audit_scope="always"
+    fi
+fi
+
+should_run_dependency_audit() {
+    if [[ "$audit_scope" == "always" ]]; then
+        return 0
+    fi
+    local path
+    for path in "$@"; do
+        if grep -qxF "$path" <<<"$changed_files"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+if should_run_dependency_audit composer.json composer.lock; then
+    composer audit --locked --abandoned=fail
+else
+    echo "Skipping composer audit: composer.json/composer.lock untouched (nightly sweep owns advisories)"
+fi
+
+if should_run_dependency_audit package.json package-lock.json; then
+    npm audit --audit-level=high
+else
+    echo "Skipping npm audit: package.json/package-lock.json untouched (nightly sweep owns advisories)"
+fi
+
+if should_run_dependency_audit arena/requirements.txt; then
+    "$PIP_AUDIT" --requirement arena/requirements.txt
+else
+    echo "Skipping arena pip-audit: arena/requirements.txt untouched (nightly sweep owns advisories)"
+fi
+
+if should_run_dependency_audit eddy/requirements.txt; then
+    "$PIP_AUDIT" --requirement eddy/requirements.txt
+else
+    echo "Skipping eddy pip-audit: eddy/requirements.txt untouched (nightly sweep owns advisories)"
+fi
 
 # History and working-tree scans are both required. Redaction prevents a
 # finding from echoing credential material into CI logs or retained evidence.

--- a/tests/Support/Timing/QueryEvidence.php
+++ b/tests/Support/Timing/QueryEvidence.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Support\Timing;
+
+/**
+ * Per-test database query counters bridged from the Laravel application
+ * (Tests\TestCase registers a DB::listen hook on application boot) to the
+ * PHPUnit event subscribers, which run outside the application container.
+ */
+final class QueryEvidence
+{
+    private static int $count = 0;
+
+    private static float $timeMs = 0.0;
+
+    private static int $setupCount = 0;
+
+    private static float $setupTimeMs = 0.0;
+
+    public static function reset(): void
+    {
+        self::$count = 0;
+        self::$timeMs = 0.0;
+        self::$setupCount = 0;
+        self::$setupTimeMs = 0.0;
+    }
+
+    public static function record(float $timeMs): void
+    {
+        self::$count++;
+        self::$timeMs += $timeMs;
+    }
+
+    public static function markSetupComplete(): void
+    {
+        self::$setupCount = self::$count;
+        self::$setupTimeMs = self::$timeMs;
+    }
+
+    /** @return array{setup_queries: int, setup_query_ms: float, body_queries: int, body_query_ms: float} */
+    public static function split(): array
+    {
+        return [
+            'setup_queries' => self::$setupCount,
+            'setup_query_ms' => round(self::$setupTimeMs, 3),
+            'body_queries' => self::$count - self::$setupCount,
+            'body_query_ms' => round(self::$timeMs - self::$setupTimeMs, 3),
+        ];
+    }
+}

--- a/tests/Support/Timing/RecordFinished.php
+++ b/tests/Support/Timing/RecordFinished.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Support\Timing;
+
+use PHPUnit\Event\Test\Finished;
+use PHPUnit\Event\Test\FinishedSubscriber;
+
+final class RecordFinished implements FinishedSubscriber
+{
+    public function notify(Finished $event): void
+    {
+        TimingEvidence::finished($event->test()->id(), $event->telemetryInfo()->time());
+    }
+}

--- a/tests/Support/Timing/RecordPreparationStarted.php
+++ b/tests/Support/Timing/RecordPreparationStarted.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Support\Timing;
+
+use PHPUnit\Event\Test\PreparationStarted;
+use PHPUnit\Event\Test\PreparationStartedSubscriber;
+
+final class RecordPreparationStarted implements PreparationStartedSubscriber
+{
+    public function notify(PreparationStarted $event): void
+    {
+        TimingEvidence::preparationStarted($event->test()->id(), $event->telemetryInfo()->time());
+    }
+}

--- a/tests/Support/Timing/RecordPrepared.php
+++ b/tests/Support/Timing/RecordPrepared.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Support\Timing;
+
+use PHPUnit\Event\Test\Prepared;
+use PHPUnit\Event\Test\PreparedSubscriber;
+
+final class RecordPrepared implements PreparedSubscriber
+{
+    public function notify(Prepared $event): void
+    {
+        TimingEvidence::prepared($event->telemetryInfo()->time());
+    }
+}

--- a/tests/Support/Timing/TestTimingEvidenceExtension.php
+++ b/tests/Support/Timing/TestTimingEvidenceExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Support\Timing;
+
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+/**
+ * Registers the §3.2.9 timing subscribers. A no-op (zero overhead) when
+ * RELEASE_EVIDENCE_DIR is not set, i.e. every run outside CI evidence lanes.
+ */
+final class TestTimingEvidenceExtension implements Extension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        if (TimingEvidence::evidencePath() === null) {
+            return;
+        }
+
+        $facade->registerSubscribers(
+            new RecordPreparationStarted,
+            new RecordPrepared,
+            new RecordFinished,
+        );
+    }
+}

--- a/tests/Support/Timing/TimingEvidence.php
+++ b/tests/Support/Timing/TimingEvidence.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Support\Timing;
+
+use PHPUnit\Event\Telemetry\HRTime;
+
+/**
+ * §3.2.9 instrumentation: per-test setUp-vs-body wall-time split plus the
+ * database query counts from QueryEvidence, appended as NDJSON into the
+ * release-evidence directory. Inactive unless RELEASE_EVIDENCE_DIR is set.
+ */
+final class TimingEvidence
+{
+    private static ?string $currentTestId = null;
+
+    private static ?HRTime $preparationStartedAt = null;
+
+    private static ?HRTime $preparedAt = null;
+
+    public static function evidencePath(): ?string
+    {
+        $dir = getenv('RELEASE_EVIDENCE_DIR');
+        if ($dir === false || $dir === '') {
+            return null;
+        }
+
+        return rtrim($dir, '/').'/phpunit-setup-split.ndjson';
+    }
+
+    public static function preparationStarted(string $testId, HRTime $time): void
+    {
+        self::$currentTestId = $testId;
+        self::$preparationStartedAt = $time;
+        self::$preparedAt = null;
+        QueryEvidence::reset();
+    }
+
+    public static function prepared(HRTime $time): void
+    {
+        self::$preparedAt = $time;
+        QueryEvidence::markSetupComplete();
+    }
+
+    public static function finished(string $testId, HRTime $time): void
+    {
+        $path = self::evidencePath();
+
+        if ($path === null || self::$preparationStartedAt === null || self::$currentTestId !== $testId) {
+            return;
+        }
+
+        $totalSeconds = $time->duration(self::$preparationStartedAt)->asFloat();
+        $setupSeconds = self::$preparedAt?->duration(self::$preparationStartedAt)->asFloat();
+
+        // setup = PreparationStarted -> Prepared (the full setUp() chain,
+        // seeders included); body = Prepared -> Finished (test method plus
+        // tearDown). A test that failed during setUp never emits Prepared,
+        // so its split fields stay null while total_s remains accurate.
+        $record = [
+            'test' => $testId,
+            'setup_s' => $setupSeconds !== null ? round($setupSeconds, 6) : null,
+            'body_s' => $setupSeconds !== null ? round($totalSeconds - $setupSeconds, 6) : null,
+            'total_s' => round($totalSeconds, 6),
+            ...QueryEvidence::split(),
+        ];
+
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0775, true);
+        }
+
+        file_put_contents($path, json_encode($record).PHP_EOL, FILE_APPEND | LOCK_EX);
+
+        self::$currentTestId = null;
+        self::$preparationStartedAt = null;
+        self::$preparedAt = null;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,14 +9,33 @@ use App\Security\Secrets\SecretProviderRegistry;
 use App\Services\Auth\AccountSessionService;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Tests\Support\InMemorySecretProvider;
+use Tests\Support\Timing\QueryEvidence;
+use Tests\Support\Timing\TimingEvidence;
 
 abstract class TestCase extends BaseTestCase
 {
     /** @var array<string, int|string>|null */
     private ?array $canonicalIntegrationScope = null;
+
+    protected function refreshApplication(): void
+    {
+        parent::refreshApplication();
+
+        // §3.2.9 instrumentation bridge: count queries from the moment the
+        // application exists so trait-driven migrations and seeders inside
+        // setUp() are attributed to the setup phase. Inactive (no listener
+        // at all) outside CI evidence runs.
+        if (TimingEvidence::evidencePath() !== null) {
+            DB::listen(function (QueryExecuted $query): void {
+                QueryEvidence::record((float) $query->time);
+            });
+        }
+    }
 
     protected function setUp(): void
     {


### PR DESCRIPTION
## Summary

Executes Tier 1 of `docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md` (included as the first commit). Every number is sourced from step-level timing of three real runs plus the per-test JUnit artifacts PR #60 added.

- **Q1** Preboot the iOS simulator during the builds (staff + patient): boot (measured 1.8–5.0 m) now overlaps the build window; a `bootstatus` wait lands right before the first test step. **−3 to −5 m staff iOS**
- **Q2** `build-for-testing` + `test-without-building`: the standalone Debug build's products were never read by the test steps, which recompiled from scratch. **net ~−4 m staff iOS**
- **Q3** In-job XCUITest flake retry (`-retry-tests-on-failure -maximum-test-repetitions 3`), **PR lanes only** so §3.2.9 budget-evidence runs on main stay retry-free. **−20 to −27 m per flake occurrence** (PR #63's staff-iOS failure today was exactly this class)
- **Q4** Release build + transport verify resequenced after the test suites (deploy-path gate, not test feedback). **−2.2 m to first failure**
- **Q5** Dependency audits (composer/npm/pip ×2) hard-gate **only when the diff touches the corresponding manifest/lockfile**; fail-safe to always-run if the diff base is unavailable. New scheduled `security-nightly` workflow forces all four audits daily and opens/updates an issue on failure. Gitleaks/semgrep/edge-security stay hard-gated on every run. **Kills registry-advisory red-main incidents** (brace-expansion, today)
- **Q6** §3.2.9 instrumentation prerequisite gating S1/S2: PHPUnit 11 event extension records per-test **setUp-vs-body wall-time split** + **DB query count/time per phase** (DB::listen bridge registered at app boot in `Tests\TestCase`), emitted as NDJSON into `RELEASE_EVIDENCE_DIR` (ships in the existing 30-day shard artifacts). Complete no-op when the env var is absent.
- **Q7** Hygiene: shard `timeout-minutes` 90→30 (ratified budget), `cancel-in-progress` off-main only (closes the permanently-undeployable superseded-main-commit hole), Playwright Chromium cache + composer cache for browser/DAST, Vitest `--coverage` on main pushes only.

**Deferred from Q7:** Pint `--parallel` needs Pint ≥ 1.22; the 1.20→1.29.3 bump wants to restyle ~150 files (`fully_qualified_strict_types` et al.) — that's a dedicated bump+reformat PR, not a hygiene ratchet.

Projected (plan §6): median PR wall ~24–27 m → **~18–19 m**; iOS flake tail and registry-ambush red mains closed. Backend shards untouched by design — S1 (weighted manifest) waits on Q6 medians per the §3.2.9 ordering gate.

## Verification

- Q5 gating exercised locally in both modes: diff mode skipped composer/arena/eddy and correctly ran npm (branch touched `package-lock.json` pre-rebase); `SECURITY_AUDIT_DEPENDENCIES=always` ran all four (all clean).
- Q6 verified locally: `RadiologyCockpitMetricsTest` emits 4 NDJSON records with correct splits (e.g. 2.60 s setup / 0.12 s body; 2981/533 queries); no file and no listener without `RELEASE_EVIDENCE_DIR`; Unit suite unaffected; Pint clean on touched PHP.
- Both workflows YAML-validated; `bash -n` on the security suite.
- This PR's own run exercises Q1–Q4 (iOS step chain), Q5 (audits should all skip — no lockfile in diff), Q6 (shard artifacts gain `phpunit-setup-split.ndjson`), Q7 (caches cold-fill).

## Test plan

- [ ] All 17 required contexts green
- [ ] Staff iOS timeline: boot wait <30 s, single compile phase, XCTest step ≤1.5 m
- [ ] Security job log shows the four audit-skip lines
- [ ] `backend-feature-*-release-evidence` artifacts contain `phpunit-setup-split.ndjson`

🤖 Generated with [Claude Code](https://claude.com/claude-code)