### PR TITLE
docs: CI duration optimization plan (measured baseline + 3-tier program)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
+++ b/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
@@ -1,0 +1,143 @@
+# CI Duration Optimization Plan — 2026-07-24
+
+**Goal:** Cut nominal PR wall-clock from ~25–27 min to **~18–19 min this week** and **~13–14 min after the structural tier**, eliminate the unbudgeted **+35 min macOS queue tail** and the **~25 min merge→deploy duplication**, and make backend shard times *deterministic* — while honoring every §3.2.9 gate and the immutable-release evidence chain.
+
+**Method:** All numbers below are measured from step-level timing of three real runs (`30112436573` pre-#60 main 73 min; `30126216355` post-#60 main 24.4 min; `30130213593` PR #61 27 min) plus the per-test JUnit artifacts PR #60 added, parsed class-by-class. No estimate in this plan is un-sourced. Investigation evidence: `/tmp/ci-analysis/` (3 run JSONs + 4 dimension findings + critique); durable copies of the shard timings live in the 30-day `backend-feature-*-release-evidence` artifacts.
+
+**Prior art this plan extends (does not replace):** `docs/hummingbird/ZEPHYRUS-HUMMINGBIRD-FUNCTIONAL-PARITY-AND-PATIENT-EXPERIENCE-PLAN-2026-07-19.md` §3.2.9 — its gates, budgets, and ordering are binding. PR #60 executed the first gate (JUnit timing artifacts ✅, Cockpit payload amplification removal ✅: feature-7 4,265 s → 1,403 s, `LaboratoryCockpitMetricsTest` 2,701 s → 160 s).
+
+---
+
+## 1. The measured baseline — what actually takes so long
+
+### 1.1 Wall-clock anatomy (all-green runs)
+
+| | pre-#60 main | post-#60 main | PR #61 run |
+|---|---:|---:|---:|
+| Wall clock (nominal) | 73.0 m | 24.4 m | 26.9 m |
+| Critical-path job | feature-7 (72.9 m) | feature-7 (24.2 m) | staff iOS (26.9 m) |
+| Worst backend shard | 72.9 m | 24.2 m | 21.5 m |
+| Staff iOS | 20.7 m | 22.8 m | 26.9 m |
+| Total backend shard compute | 182.6 m | 98.4 m | 85.2 m |
+
+### 1.2 Four facts that reframe the problem
+
+1. **Staff iOS is NOT a required check.** Branch protection requires only **17 of the 19 contexts** — `Hummingbird staff (iOS)` and `Hummingbird staff (Android)` are not among them (verified via `gh api repos/sudoshi/Zephyrus/branches/main/protection`). The *merge-blocking* critical path is therefore the **worst backend shard (21.5–24.2 m)**, not iOS. iOS gates only the *deploy* path (deploy.sh requires the whole run green).
+2. **The true wall clock is sometimes 62 min, not 27.** On PR run `30130213593`, 18 jobs started at +0.0 m but staff iOS **queued 35.4 min** for a `macos-26` runner before its 26.9 m of work. The scarce `macos-26` pool (needed for the iOS-26 SDK) is the largest single source of unbudgeted variance; Linux queue delay measured 0–3 s across all runs — Linux concurrency is not a constraint.
+3. **87% of backend compute is repeated setup, not tests.** Of 5,104 s total suite time (PR run), **4,426 s** is consumed by 135 test cases across 26 classes whose `setUp()` re-runs 5–6 seeders + `AncillaryDemoScenarioService::refresh` (~33–44 s) before *every test method* (e.g. `tests/Feature/Cockpit/LaboratoryCockpitMetricsTest.php:47-55`). Those cases average 32.8 s each; the other 1,505 cases average **0.45 s**. Comparison: `RadiologyCockpitMetricsTest` — same seeders, no scenario dependence — runs 4 tests in 3.8 s.
+4. **Every merge pays CI twice.** The PR run proves the tree, then the squash commit re-runs the *identical tree* on main (~25 m) before `deploy.sh`'s gate clears. Because branch protection has `strict: true` (branches must be up to date), the squash tree-sha equals the tested PR head tree-sha essentially always — the second run adds no information.
+
+### 1.3 Where each critical job's minutes go (PR run `30130213593`)
+
+**Staff iOS (26.9 m):** setup/verify ~0.9 m → Build Debug 2.30 m → Build Release 2.18 m → **boot simulator 5.02 m** (variance 1.8–5.0 m; runs strictly *after* both builds, `ci.yml:694-700`) → XCTest 4.13 m (which **recompiles from scratch** — the Debug build at `ci.yml:671` writes to a derivedDataPath the test steps never read, `ci.yml:709/724`) → **XCUITest 12.07 m** (18 tests, 4 classes, `-parallel-testing-enabled NO` at `ci.yml:712/727`; `PatientCommunicationRoutingUITests` holds 11 of the 18 tests, ≥20 app launches, 12 `.keepAlways` screenshots — today's 57 s snapshot-timeout flake lives here and cost a 20 m full-job rerun).
+
+**Worst backend shard (21.5 m):** container init 21–33 s, composer (cached) 2–5 s, migrate 6–13 s **against a DB the tests never touch** (tests self-provision `zephyrus_test_<hex>` per process, `tests/bootstrap.php:12-14`), then PHPUnit 20.8 m. Shard membership is `sorted-filename index % 8` (`scripts/ci/run-backend-test-shard.sh:25-38`) — **adding 3 test files in PR #61 moved the heavy Ancillary/Lab classes from shard 7 to shard 0** (feature-0: 8.9 m → 21.5 m; feature-7: 24.2 m → 9.6 m). Load balance is a coin flip re-dealt by every test-file addition.
+
+**Duplicated work across jobs (per run):** vite production build ×3 (frontend 100 s + Playwright 71 s + ZAP 61 s), `composer install` ×12 (only quality + shards have the cache), migrate ×12, E2E seeding ×2 (Playwright + ZAP each re-migrate + `E2eTestSeeder`, `CommandCenterDemoSeeder` alone 15 s), Playwright chromium re-downloaded cold every run (no cache), plus 19 × container/checkout/setup ≈ 4.6 m of container init alone. A **docs-only commit pays all of it** — `ci.yml:3-7` has no paths filtering (today's regenerated `.md` report ran the full 19-job suite).
+
+**Velocity failure modes (not throughput):** (a) `npm audit` in the security gate red-flagged *main* for hours on a mid-day registry advisory unrelated to any diff; (b) `cancel-in-progress: true` applies to main pushes too (`ci.yml:9-11`) — two rapid merges cancel the first commit's run, leaving it **permanently unable to satisfy the deploy gate**; (c) a single flaky XCUITest costs a 20+ m full-job rerun because no in-job retry exists.
+
+---
+
+## 2. Binding constraints (violating any of these is a plan failure)
+
+- **§3.2.9 ordering gate:** setup-vs-body + query-count instrumentation must land **before** the weighted shard manifest ("must profile those paths and test setup directly BEFORE introducing a weighted manifest or any index"). The manifest requires **rolling medians from clean exact-SHA runs**.
+- **§3.2.9 prohibitions:** no SQLite swap, no trigger/migration suppression, no dirty-DB reuse, no shared mutable state between tests, budget changes need recorded evidence + review, a timeout *increase* is not optimization (a decrease is fine).
+- **Required-checks contract:** 17 required contexts exist by *name*. Any job rename/merge/removal must update branch protection in the same change window or PRs become unmergeable (this kills the "delete the DAST job" variant — DAST **is** required).
+- **Immutable-release evidence chain:** `deploy.sh` + `tests/Deployment/github-ci-gate.sh` require a green run on the exact release SHA. Any verdict-reuse/fast-path design must still produce a green, auditable run for that SHA (all-jobs-skipped runs conclude `success` and skipped required checks satisfy protection — verified — but the evidence-chain semantics need an explicit [SU] ruling; see item S4).
+- **Budget-evidence hygiene:** runs used to ratify §3.2.9 budgets must have flake-retries disabled.
+
+---
+
+## 3. Tier 1 — Quick wins (this week; each independently shippable)
+
+### Q1. Preboot the iOS simulator during the builds — **−3 to −5 m staff iOS**
+The boot step (1.8–5.0 m) runs strictly after both builds but depends on nothing they produce.
+- [ ] Move `Select and boot an available iPhone Simulator` (staff `ci.yml:694-700`, patient `903-909`) to immediately after checkout; make `xcrun simctl boot` non-blocking (background boot), and add a cheap `xcrun simctl bootstatus $UDID -b` wait right before the first test step. Boot then overlaps the ~4–5 m build window and its cost collapses to ~0.
+- Verify: staff iOS step timeline shows boot wait <30 s on 3 consecutive runs.
+
+### Q2. `build-for-testing` + `test-without-building` — **net ~−4 m staff iOS**
+The standalone Debug build's artifacts are never reused; XCTest recompiles everything.
+- [ ] Replace `Build Debug for iPhone Simulator` (`ci.yml:663-674`) with `xcodebuild build-for-testing` targeting `$RUNNER_TEMP/hummingbird-staff-ios-tests` (the derivedDataPath the test steps already use), and switch both test invocations (`ci.yml:709/724`) to `test-without-building`. Same change for patient iOS (`~884-939`).
+- Verify: one compile phase total in the job log; XCTest step drops from 4.1 m to ≤1.5 m.
+
+### Q3. In-job XCUITest flake retry (PR lanes only) — **−20 to −27 m per flake occurrence**
+- [ ] Add `-retry-tests-on-failure -maximum-test-repetitions 3` to the XCUITest invocations (`ci.yml:717-730`, `926-939`), gated on `github.event_name == 'pull_request'` so §3.2.9 budget-evidence runs (main) stay retry-free.
+- Verify: inject a known-flaky rerun; job self-heals without a full rerun.
+
+### Q4. Resequence Release build + transport verify after the test steps — **−2.2 m to first-failure**
+- [ ] Move `ci.yml:676-692` (Build Release + transport verify) after XCUITest so test failures surface ~2 m sooner; keep them in-job (the separate-job variant costs a scarce macOS slot — see S5).
+
+### Q5. Security gate: decouple dependency audits from live registry events — **kills red-main incidents**
+- [ ] In `scripts/security/run-security-suite.sh:19-22`, run `composer audit`/`npm audit`/`pip-audit` as **hard gates only when the diff touches the corresponding lockfile** (`git diff --name-only origin/main...HEAD`), plus an unconditional scheduled nightly workflow that opens an issue on new advisories. Gitleaks/semgrep/edge-security stay hard-gated on every run.
+- Rationale: today's `brace-expansion` advisory turned main red for hours and cost three CI round-trips on an unrelated one-line PR. Advisory response becomes a *scheduled, owned* activity instead of a merge-blocking ambush.
+
+### Q6. §3.2.9 instrumentation prerequisite — **unblocks the whole structural tier**
+- [ ] Add setup-vs-test-body wall-time split + aggregate DB query-count/time to the shard harness for the residual heavy classes (the JUnit artifacts already give per-test totals; add a `setUp` timer via a base-class hook + `DB::listen` counter emitted into the release-evidence dir). This is the unchecked §3.2.9 box that *gates* the weighted manifest (S1) and the seeding rework (S2).
+
+### Q7. Hygiene ratchets (all trivial, all off critical path)
+- [ ] `timeout-minutes: 90 → 30` on backend shards (`ci.yml:137`) — matches the ratified "no shard above 30 m" budget; caps hung-shard burn.
+- [ ] `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` (`ci.yml:11`) — closes the permanently-undeployable-superseded-main-commit hole.
+- [ ] Pint `--parallel` (`ci.yml:117`): quality job 101 s → ~35 s.
+- [ ] Cache Playwright chromium (`~/.cache/ms-playwright`, keyed on the lockfile's playwright version) + add the existing composer-cache block to browser (`ci.yml:~432`) and dast (`~517`) jobs.
+- [ ] Drop `--coverage` from PR-lane Vitest (`ci.yml:265`; nothing consumes the lcov — keep it on main pushes so the coverage record persists).
+
+**Tier-1 projected nominal wall:** staff iOS 26.9 m → **~16.5–18.6 m** (Q1+Q2+Q4 compose on the step chain; boot overlap bounded by build length). Backend untouched (gated by Q6→S1), so on an unlucky modulo deal the wall is the worst backend shard **~19–24 m**; median run **~18–19 m**. The macOS queue tail remains (addressed in S5).
+
+---
+
+## 4. Tier 2 — Structural (next sprint)
+
+### S1. Stable weighted shard manifest (LPT) — **worst shard 21.5 m → ~11.6 m, deterministically**
+*Gated behind Q6 per §3.2.9 ordering; weights from rolling medians of 3 clean exact-SHA runs.*
+- [ ] Replace the modulo deal (`run-backend-test-shard.sh:33-38`) with a committed `tests/ci/shard-manifest.json` (path → shard, LPT-packed from the JUnit medians). Unlisted files get a deterministic default weight + LPT slot at runtime. Add the §3.2.9-mandated verifier: every discovered test appears exactly once, no duplicates, no silent exclusions, manifest drift fails CI.
+- Arithmetic: LPT over measured class weights yields max bin ≈ **638 s** PHPUnit (~11.6 m job) vs 1,245 s observed; more shards buy ≤12 s because `AncillaryDemoScenarioTest` (625.8 s) is itself the floor — do not add shards.
+
+### S2. Kill setup amplification in the ~21 consumer classes — **−38 m suite compute**
+*The sanctioned §3.2.9 shape: minimal governed fixtures + at least one full-seeder integration case per protected invariant; no dirty-DB reuse, isolation preserved.*
+- [ ] Build the smallest governed ancillary fixture for service-level cases; keep `AncillaryDemoScenarioTest` + one full-refresh integration case per invariant on the full pipeline. Target: 4,426 s → ~900 s (26 × one-time class setup + ~110 cases × ~1 s). Suite compute 85 m → ~46 m; every non-floor shard lands ~5–6 m.
+
+### S3. Parallelize XCUITest (2 simulator clones) + split the 11-test routing class — **staff iOS UI step 12.1 m → ~6.5–7.5 m**
+- [ ] `project.yml:19-20` `parallelizable: true`, `-parallel-testing-enabled YES -parallel-testing-worker-count 2` (`ci.yml:727`), and split `PatientCommunicationRoutingUITests` (11 of 18 tests; XCTest distributes per-class, so without the split two workers cap at −4 m).
+
+### S4. Tree-sha verdict reuse on the squash push + docs-only fast path — **merge→deploy ~25 m → ~1–2 m** *(needs an explicit [SU] evidence-chain ruling first)*
+- [ ] Add a 30 s `changes` gatekeeper job: (a) on main pushes, if a successful run exists whose head tree-sha equals this commit's tree-sha, output `reuse=true`; (b) on any event, output `docs_only` from the diff. All 11 job definitions gain `needs: changes` + skip conditions. Skipped required checks satisfy branch protection and the run concludes `success` (verified), so the deploy gate passes on the exact SHA — but the run's evidence artifacts would point at the PR run, which is precisely the [SU] ruling to record before landing. `strict: true` makes tree matches near-universal.
+
+### S5. De-risk the `macos-26` queue tail — **removes the +35 m variance**
+- [ ] In order: (a) test whether `macos-15`'s Xcode selection now covers the needed iOS-26 SDK — if yes, leave the scarce pool entirely; (b) evaluate larger-runner pools; (c) failing both, move XCUITest journeys to main-push/nightly lanes only (permissible — staff iOS is not a required PR check — but record the coverage trade-off explicitly).
+- [ ] Either way: emit queue-delay (job `started_at` − run `created_at`) into release evidence so the tail is *measured* continuously.
+
+### S6. Single vite build per run — **browser 9.0 → ~7.5 m, DAST 4.3 → ~2.5 m**
+- [ ] Frontend job uploads `public/build`; browser + DAST download it and set the already-existing `PLAYWRIGHT_SKIP_BUILD` / `DAST_SKIP_BUILD` flags (`run-browser-suite.sh:74`, `run-dast-suite.sh:75`). Optionally fold ZAP into the browser job against the still-running server later — but DAST is a *required check by name*, so any fold must ship with a branch-protection update in the same window.
+
+---
+
+## 5. Tier 3 — Deep (§3.2.9 query/test remediation; the floor-setters)
+
+- [ ] **D1. Profile `AncillaryDemoScenarioService::refresh` + `SnapshotBuilder::buildWithContext` + Lab services** with `EXPLAIN (ANALYZE, BUFFERS, WAL)` on the 66-order/328-milestone fixture in a disposable DB (§3.2.9 verbatim). Every shard layout is lower-bounded by the 625.8 s `AncillaryDemoScenarioTest`; a 2× refresh cut takes backend to ~6.5–7 m and is what ratifies the stage-2 ≤15 m budget.
+- [ ] **D2. Request-scoped laboratory aggregate snapshot** (one governed calculation shared by Cockpit provider, health service, drill) — §3.2.9's named remediation.
+- [ ] **D3. Paratest spike** (per-process isolation already exists: DB name keys on pid, `IsolatedTestDatabase.php:27`; array cache/session; pid-scoped disk). Only after D1 — it cannot break the single-class floor. Success enables 8 → 4 shard consolidation.
+- [ ] **D4. Restore the two never-running tests**: `Api/ProcessAnalysisTest` + `Auth/AuthenticationFlowTest` are Pest-syntax, excluded by the sharder (`run-backend-test-shard.sh:27-28`) because Pest is uninstallable under PHP 8.5 — they run **nowhere** today. Convert to PHPUnit class syntax. Zero time saving; closes a silent coverage hole.
+
+**Do-NOT-do list (measured nulls — recorded so nobody re-spends the effort):** SPM/DerivedData caching (no SPM packages declared), per-job migrate-template DBs (in-process `migrate:fresh` ≈ 6 s and §3.2.9-sensitive), composer cache work in shards (installs already 2–5 s), Linux runner-pool changes (queue delay 0–3 s), adding backend shards past 8 (floor-bound), action version bumps (all current majors), Playwright sharding (off critical path; config `workers:1` is a deliberate SSE-safety choice — revisit only at stage-2).
+
+---
+
+## 6. Projected outcomes
+
+| Milestone | Nominal PR wall | Merge→deploy latency | Tail risk |
+|---|---:|---:|---|
+| Today | 24.3–26.9 m | ~25 m (second full run) | +35 m macOS queue; +20 m per iOS flake; red main on registry events |
+| After Tier 1 | **~18–19 m median** | ~25 m | flake tail closed (Q3); red-main closed (Q5); queue tail remains |
+| After Tier 2 | **~13–14 m** | **~1–2 m** (S4, post-ruling) | queue tail closed (S5); backend deterministic (S1) |
+| After Tier 3 (D1 ×2 refresh cut) | **~12.5–13 m** (iOS-owned) | ~1–2 m | — |
+
+Budgets (extend §3.2.9's): after S1 lands, ratchet backend `timeout-minutes` 30 → 20; after stage-2 ratification, adopt the ≤15 m backend critical-path budget with the mandated 3-clean-run evidence. Re-run the full 19-job suite with zero skipped tests before/after each tier and diff coverage counts, assertions, and invariants (§3.2.9 requirement) — a faster shard must not conceal a semantic regression.
+
+## 7. Sequencing
+
+Week 1: Q1–Q7 (all independent; Q6 first since S1/S2 wait on its data accumulating).
+Sprint: S1 (after 3 clean runs of Q6 medians) → S2 (largest compute win) ∥ S3 ∥ S5 ∥ S6; S4 after the [SU] evidence-chain ruling.
+Then: D1 → D2 → (D3 if D1 succeeds) ∥ D4 anytime.
+
+*Meta-lesson from today, encoded above: the three CI round-trips (~75 min) this very investigation ran alongside were caused by (a) a registry advisory ambush → Q5, (b) npm-version skew between beastmode and runners → recorded in memory (`feedback_npm10_lockfile_ops`), and (c) a 57 s XCUITest snapshot timeout → Q3. The plan fixes the class of each.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,6 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
             "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -4718,7 +4717,6 @@
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -4738,7 +4736,6 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -4747,14 +4744,12 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-            "dev": true
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-            "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -5220,7 +5215,6 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
@@ -5234,7 +5228,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -5244,7 +5237,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -8453,7 +8445,7 @@
             "version": "19.2.14",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.2.2"
@@ -8463,7 +8455,7 @@
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
@@ -8729,6 +8721,26 @@
                 "node": ">=12"
             }
         },
+        "node_modules/aframe": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aframe/-/aframe-1.8.0.tgz",
+            "integrity": "sha512-z+6TfUCEPQ2plWMyL6CAFS6+b6XWp6t8zrU9ZNdz4qBwks98tX/lhGrfUX0QFuwPZ7BNusB3u5o+q6q/P2CkKA==",
+            "peer": true,
+            "dependencies": {
+                "buffer": "^6.0.3",
+                "debug": "^4.3.4",
+                "deep-assign": "^2.0.0",
+                "load-bmfont": "^1.2.3",
+                "stats-gl": "^3.6.0",
+                "super-animejs": "^3.1.0",
+                "three": "npm:super-three@0.184.0",
+                "three-bmfont-text": "github:dmarcos/three-bmfont-text#c3eec235b9188aa0d8ed949101236e6d5fccf071"
+            },
+            "engines": {
+                "node": ">= 4.6.0",
+                "npm": ">= 2.15.9"
+            }
+        },
         "node_modules/aframe-extras": {
             "version": "7.5.4",
             "resolved": "https://registry.npmjs.org/aframe-extras/-/aframe-extras-7.5.4.tgz",
@@ -8761,6 +8773,13 @@
                 "aframe": "*"
             }
         },
+        "node_modules/aframe/node_modules/three": {
+            "name": "super-three",
+            "version": "0.184.0",
+            "resolved": "https://registry.npmjs.org/super-three/-/super-three-0.184.0.tgz",
+            "integrity": "sha512-9NSv1Ow/k/hevFC/VLeFoejnZSw72iz4e8Nt5LuDiSrkVinh7+r7lfb7Fxsl3aE+2yBP0tPRk1zLqX/aq6EYnQ==",
+            "peer": true
+        },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -8772,6 +8791,12 @@
             "engines": {
                 "node": ">= 6.0.0"
             }
+        },
+        "node_modules/an-array": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/an-array/-/an-array-1.0.0.tgz",
+            "integrity": "sha512-M175GYI7RmsYu24Ok383yZQa3eveDfNnmhTe3OQ3bm70bEovz2gWenH+ST/n32M8lrwLWk74hcPds5CDRPe2wg==",
+            "peer": true
         },
         "node_modules/ansi-escapes": {
             "version": "7.0.0",
@@ -8822,14 +8847,12 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
             "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "normalize-path": "^3.0.0",
@@ -8843,7 +8866,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -8855,7 +8877,6 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
             "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/aria-hidden": {
@@ -8878,6 +8899,12 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/as-number": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/as-number/-/as-number-1.0.0.tgz",
+            "integrity": "sha512-HkI/zLo2AbSRO4fqVkmyf3hms0bJDs3iboHqTrNuwTiCRvdYXM7HFhfhB6Dk51anV2LM/IMB83mtK9mHw4FlAg==",
+            "peer": true
         },
         "node_modules/assertion-error": {
             "version": "2.0.1",
@@ -8979,6 +9006,26 @@
                 "proxy-from-env": "^2.1.0"
             }
         },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "peer": true
+        },
         "node_modules/bezier-js": {
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
@@ -9002,7 +9049,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
             "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9015,7 +9061,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
@@ -9057,6 +9102,39 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
+        "node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "peer": true,
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/buffer-equal": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+            "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -9090,7 +9168,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -9127,6 +9204,15 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/centra": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
+            "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
+            "peer": true,
+            "dependencies": {
+                "follow-redirects": "^1.15.6"
             }
         },
         "node_modules/chai": {
@@ -9167,7 +9253,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
             "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "anymatch": "~3.1.2",
@@ -9192,7 +9277,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -9444,7 +9528,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
             "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -9557,7 +9640,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "cssesc": "bin/cssesc"
@@ -9902,7 +9984,6 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
             "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -9927,6 +10008,18 @@
             "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/deep-assign": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-2.0.0.tgz",
+            "integrity": "sha512-2QhG3Kxulu4XIF3WL5C5x0sc/S17JLgm1SfvDfIRsR/5m7ZGmcejII7fZ2RyWhN0UWIJm0TNM/eKow6LAn3evQ==",
+            "peer": true,
+            "dependencies": {
+                "is-obj": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -9974,14 +10067,12 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
             "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/dlv": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/dom-accessibility-api": {
@@ -9999,6 +10090,21 @@
             "dependencies": {
                 "@babel/runtime": "^7.8.7",
                 "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/dom-walk": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+            "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+            "peer": true
+        },
+        "node_modules/dtype": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
+            "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg==",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
         "node_modules/dunder-proto": {
@@ -10208,7 +10314,6 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -10225,7 +10330,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -10238,7 +10342,6 @@
             "version": "1.18.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
             "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -10248,7 +10351,6 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
             "engines": {
                 "node": ">=12.0.0"
             },
@@ -10271,7 +10373,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -10405,7 +10506,6 @@
             "version": "1.16.0",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
             "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -10508,7 +10608,6 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -10623,13 +10722,22 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/global": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+            "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+            "peer": true,
+            "dependencies": {
+                "min-document": "^2.19.0",
+                "process": "^0.11.10"
             }
         },
         "node_modules/goober": {
@@ -10751,6 +10859,26 @@
                 "node": ">=16.17.0"
             }
         },
+        "node_modules/ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "peer": true
+        },
         "node_modules/import-meta-resolve": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -10820,7 +10948,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "binary-extensions": "^2.0.0"
@@ -10828,6 +10955,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "peer": true
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
@@ -10848,7 +10981,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -10864,11 +10996,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/is-function": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+            "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+            "peer": true
+        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -10887,10 +11024,18 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-potential-custom-element-name": {
@@ -10979,7 +11124,6 @@
             "version": "1.21.7",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "jiti": "bin/jiti.js"
@@ -11121,7 +11265,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
             "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14"
@@ -11134,7 +11277,6 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/lint-staged": {
@@ -11254,6 +11396,22 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/load-bmfont": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
+            "integrity": "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==",
+            "peer": true,
+            "dependencies": {
+                "buffer-equal": "0.0.1",
+                "mime": "^1.3.4",
+                "parse-bmfont-ascii": "^1.0.3",
+                "parse-bmfont-binary": "^1.0.5",
+                "parse-bmfont-xml": "^1.1.4",
+                "phin": "^3.7.1",
+                "xhr": "^2.0.1",
+                "xtend": "^4.0.0"
             }
         },
         "node_modules/lodash": {
@@ -11501,7 +11659,6 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -11517,7 +11674,6 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
@@ -11531,12 +11687,23 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "peer": true,
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/mime-db": {
@@ -11584,6 +11751,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/min-document": {
+            "version": "2.19.2",
+            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
+            "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
+            "peer": true,
+            "dependencies": {
+                "dom-walk": "^0.1.0"
+            }
+        },
         "node_modules/min-indent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -11621,14 +11797,12 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/mz": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
             "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "any-promise": "^1.0.0",
@@ -11708,7 +11882,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -11764,7 +11937,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
             "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -11816,6 +11988,34 @@
             "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
             "dev": true
         },
+        "node_modules/parse-bmfont-ascii": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+            "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+            "peer": true
+        },
+        "node_modules/parse-bmfont-binary": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+            "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+            "peer": true
+        },
+        "node_modules/parse-bmfont-xml": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+            "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+            "peer": true,
+            "dependencies": {
+                "xml-parse-from-string": "^1.0.0",
+                "xml2js": "^0.5.0"
+            }
+        },
+        "node_modules/parse-headers": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+            "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+            "peer": true
+        },
         "node_modules/parse5": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
@@ -11849,6 +12049,19 @@
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true
+        },
+        "node_modules/phin": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
+            "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+            "peer": true,
+            "dependencies": {
+                "centra": "^2.7.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -11884,7 +12097,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -11894,7 +12106,6 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
             "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -11987,7 +12198,6 @@
             "version": "15.1.0",
             "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
             "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.0.0",
@@ -12005,7 +12215,6 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
             "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "camelcase-css": "^2.0.1"
@@ -12025,7 +12234,6 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
             "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -12061,7 +12269,6 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
             "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -12087,7 +12294,6 @@
             "version": "6.1.2",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
             "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -12101,7 +12307,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/preact": {
@@ -12154,6 +12359,15 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
+        },
+        "node_modules/process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
@@ -12215,11 +12429,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/quad-indices": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/quad-indices/-/quad-indices-2.0.1.tgz",
+            "integrity": "sha512-6jtmCsEbGAh5npThXrBaubbTjPcF0rMbn57XCJVI7LkW8PUT56V+uIrRCCWCn85PSgJC9v8Pm5tnJDwmOBewvA==",
+            "peer": true,
+            "dependencies": {
+                "an-array": "^1.0.0",
+                "dtype": "^2.0.0",
+                "is-buffer": "^1.0.2"
+            }
+        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -12240,7 +12464,6 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -12263,7 +12486,6 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -12498,7 +12720,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
             "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "pify": "^2.3.0"
@@ -12508,7 +12729,6 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
@@ -12521,7 +12741,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -12650,7 +12869,6 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
@@ -12674,7 +12892,7 @@
             "version": "4.62.2",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
             "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "@types/estree": "1.0.9"
             },
@@ -12718,7 +12936,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -12748,6 +12965,15 @@
                 "tslib": "^2.1.0"
             }
         },
+        "node_modules/sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "peer": true,
+            "engines": {
+                "node": ">=11.0.0"
+            }
+        },
         "node_modules/saxes": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -12764,7 +12990,6 @@
             "version": "0.23.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
             "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -12981,6 +13206,20 @@
             "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
             "dev": true
         },
+        "node_modules/stats-gl": {
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-3.8.0.tgz",
+            "integrity": "sha512-e11MQK0vzaiD7dX43McxOoPZfWA1IMq4i7XC6sLXLBfypVXRTXYdvikUmueHVWQn9QPXT8XBDz3SyMArocoAUg==",
+            "peer": true,
+            "peerDependencies": {
+                "three": "*"
+            },
+            "peerDependenciesMeta": {
+                "three": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/std-env": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -13040,7 +13279,7 @@
             "version": "3.35.1",
             "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
             "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-            "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "commander": "^4.0.0",
@@ -13057,6 +13296,12 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
+        },
+        "node_modules/super-animejs": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/super-animejs/-/super-animejs-3.1.0.tgz",
+            "integrity": "sha512-6MFAFJDRuvwkovxQZPruuyHinTa4rgj4hNLOndjcYYhZLckoXtVRY9rJPuq8p6c/tgZJrFYEAYAfJ2/hhNtUCA==",
+            "peer": true
         },
         "node_modules/supports-color": {
             "version": "8.1.1",
@@ -13138,7 +13383,6 @@
             "version": "3.4.17",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
             "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
@@ -13176,7 +13420,6 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
             "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "any-promise": "^1.0.0"
@@ -13186,7 +13429,6 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
             "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "thenify": ">= 3.1.0 < 4"
@@ -13199,6 +13441,19 @@
             "version": "0.185.0",
             "resolved": "https://registry.npmjs.org/three/-/three-0.185.0.tgz",
             "integrity": "sha512-+yRrcRO2iZa8uzvNNl0d7cL4huhgKgBvVJ0njcTe8xFqZ6DMAFZdCKDP91SEAuj25bNAj7k1QQdf+srZywVK6w=="
+        },
+        "node_modules/three-bmfont-text": {
+            "version": "3.0.0",
+            "resolved": "git+ssh://git@github.com/dmarcos/three-bmfont-text.git#c3eec235b9188aa0d8ed949101236e6d5fccf071",
+            "integrity": "sha512-7TJoaD1Yx/dHo/DYo0amdxV93VIr4fXzHDdYbxwdiTccbxdWSPb1/5CLE+8/9WB74k94xdj7iYgZiUr7zQVHjA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "as-number": "^1.0.0",
+                "quad-indices": "^2.0.1",
+                "word-wrapper": "^1.0.7",
+                "xtend": "^4.0.0"
+            }
         },
         "node_modules/three-forcegraph": {
             "version": "1.42.12",
@@ -13284,7 +13539,6 @@
             "version": "0.2.17",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
             "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-            "dev": true,
             "dependencies": {
                 "fdir": "^6.5.0",
                 "picomatch": "^4.0.4"
@@ -13327,7 +13581,6 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -13374,7 +13627,6 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/tslib": {
@@ -13559,7 +13811,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/victory-vendor": {
@@ -13847,6 +14098,24 @@
                 "node": ">=8"
             }
         },
+        "node_modules/word-wrapper": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/word-wrapper/-/word-wrapper-1.0.7.tgz",
+            "integrity": "sha512-VOPBFCm9b6FyYKQYfn9AVn2dQvdR/YOVFV6IBRA1TBMJWKffvhEX1af6FMGrttILs2Q9ikCRhLqkbY2weW6dOQ==",
+            "peer": true
+        },
+        "node_modules/xhr": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+            "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+            "peer": true,
+            "dependencies": {
+                "global": "~4.4.0",
+                "is-function": "^1.0.1",
+                "parse-headers": "^2.0.0",
+                "xtend": "^4.0.0"
+            }
+        },
         "node_modules/xml-name-validator": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -13856,11 +14125,48 @@
                 "node": ">=18"
             }
         },
+        "node_modules/xml-parse-from-string": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+            "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+            "peer": true
+        },
+        "node_modules/xml2js": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "peer": true,
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "peer": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
+        },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "peer": true,
+            "engines": {
+                "node": ">=0.4"
+            }
         },
         "node_modules/y18n": {
             "version": "5.0.8",
@@ -13882,7 +14188,6 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-            "dev": true,
             "bin": {
                 "yaml": "bin.mjs"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-    "name": "Zephyrus-admin-safety",
+    "name": "Zephyrus",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
+            "name": "Zephyrus",
             "dependencies": {
                 "@heroui/react": "^2.6.14",
                 "@iconify/icons-solar": "^1.2.3",
@@ -96,6 +97,7 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
             "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -4712,26 +4714,11 @@
                 "@swc/helpers": "^0.5.0"
             }
         },
-        "node_modules/@isaacs/cliui": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-            "dependencies": {
-                "string-width": "^5.1.2",
-                "string-width-cjs": "npm:string-width@^4.2.0",
-                "strip-ansi": "^7.0.1",
-                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-                "wrap-ansi": "^8.1.0",
-                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
             "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0",
                 "@jridgewell/trace-mapping": "^0.3.24"
@@ -4751,6 +4738,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -4759,12 +4747,14 @@
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.31",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
             "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -5230,6 +5220,7 @@
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
@@ -5243,6 +5234,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -5252,6 +5244,7 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -5259,15 +5252,6 @@
             },
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/@pkgjs/parseargs": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-            "optional": true,
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/@playwright/test": {
@@ -8469,7 +8453,7 @@
             "version": "19.2.14",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "csstype": "^3.2.2"
@@ -8479,7 +8463,7 @@
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "devOptional": true,
+            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "@types/react": "^19.2.0"
@@ -8745,26 +8729,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/aframe": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/aframe/-/aframe-1.8.0.tgz",
-            "integrity": "sha512-z+6TfUCEPQ2plWMyL6CAFS6+b6XWp6t8zrU9ZNdz4qBwks98tX/lhGrfUX0QFuwPZ7BNusB3u5o+q6q/P2CkKA==",
-            "peer": true,
-            "dependencies": {
-                "buffer": "^6.0.3",
-                "debug": "^4.3.4",
-                "deep-assign": "^2.0.0",
-                "load-bmfont": "^1.2.3",
-                "stats-gl": "^3.6.0",
-                "super-animejs": "^3.1.0",
-                "three": "npm:super-three@0.184.0",
-                "three-bmfont-text": "github:dmarcos/three-bmfont-text#c3eec235b9188aa0d8ed949101236e6d5fccf071"
-            },
-            "engines": {
-                "node": ">= 4.6.0",
-                "npm": ">= 2.15.9"
-            }
-        },
         "node_modules/aframe-extras": {
             "version": "7.5.4",
             "resolved": "https://registry.npmjs.org/aframe-extras/-/aframe-extras-7.5.4.tgz",
@@ -8797,13 +8761,6 @@
                 "aframe": "*"
             }
         },
-        "node_modules/aframe/node_modules/three": {
-            "name": "super-three",
-            "version": "0.184.0",
-            "resolved": "https://registry.npmjs.org/super-three/-/super-three-0.184.0.tgz",
-            "integrity": "sha512-9NSv1Ow/k/hevFC/VLeFoejnZSw72iz4e8Nt5LuDiSrkVinh7+r7lfb7Fxsl3aE+2yBP0tPRk1zLqX/aq6EYnQ==",
-            "peer": true
-        },
         "node_modules/agent-base": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -8815,12 +8772,6 @@
             "engines": {
                 "node": ">= 6.0.0"
             }
-        },
-        "node_modules/an-array": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/an-array/-/an-array-1.0.0.tgz",
-            "integrity": "sha512-M175GYI7RmsYu24Ok383yZQa3eveDfNnmhTe3OQ3bm70bEovz2gWenH+ST/n32M8lrwLWk74hcPds5CDRPe2wg==",
-            "peer": true
         },
         "node_modules/ansi-escapes": {
             "version": "7.0.0",
@@ -8842,6 +8793,7 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
             "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -8854,6 +8806,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -8869,12 +8822,14 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
             "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "normalize-path": "^3.0.0",
@@ -8888,6 +8843,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -8899,6 +8855,7 @@
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
             "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/aria-hidden": {
@@ -8921,12 +8878,6 @@
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/as-number": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/as-number/-/as-number-1.0.0.tgz",
-            "integrity": "sha512-HkI/zLo2AbSRO4fqVkmyf3hms0bJDs3iboHqTrNuwTiCRvdYXM7HFhfhB6Dk51anV2LM/IMB83mtK9mHw4FlAg==",
-            "peer": true
         },
         "node_modules/assertion-error": {
             "version": "2.0.1",
@@ -9028,31 +8979,6 @@
                 "proxy-from-env": "^2.1.0"
             }
         },
-        "node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-        },
-        "node_modules/base64-js": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "peer": true
-        },
         "node_modules/bezier-js": {
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
@@ -9076,6 +9002,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
             "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9084,18 +9011,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
         "node_modules/braces": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fill-range": "^7.1.1"
@@ -9137,39 +9057,6 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
-        "node_modules/buffer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "peer": true,
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
-        "node_modules/buffer-equal": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-            "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
-            "peer": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -9203,6 +9090,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
             "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -9239,15 +9127,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/centra": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
-            "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
-            "peer": true,
-            "dependencies": {
-                "follow-redirects": "^1.15.6"
             }
         },
         "node_modules/chai": {
@@ -9288,6 +9167,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
             "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "anymatch": "~3.1.2",
@@ -9312,6 +9192,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -9563,6 +9444,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
             "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -9641,6 +9523,7 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -9674,6 +9557,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "cssesc": "bin/cssesc"
@@ -10018,6 +9902,7 @@
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
             "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -10042,18 +9927,6 @@
             "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/deep-assign": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-2.0.0.tgz",
-            "integrity": "sha512-2QhG3Kxulu4XIF3WL5C5x0sc/S17JLgm1SfvDfIRsR/5m7ZGmcejII7fZ2RyWhN0UWIJm0TNM/eKow6LAn3evQ==",
-            "peer": true,
-            "dependencies": {
-                "is-obj": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/deepmerge": {
             "version": "4.3.1",
@@ -10101,12 +9974,14 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
             "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/dlv": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
             "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/dom-accessibility-api": {
@@ -10126,21 +10001,6 @@
                 "csstype": "^3.0.2"
             }
         },
-        "node_modules/dom-walk": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-            "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
-            "peer": true
-        },
-        "node_modules/dtype": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
-            "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg==",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -10155,22 +10015,12 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/eastasianwidth": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
-        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.88",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.88.tgz",
             "integrity": "sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
         },
         "node_modules/entities": {
             "version": "8.0.0",
@@ -10358,6 +10208,7 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
             "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -10374,6 +10225,7 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
@@ -10386,6 +10238,7 @@
             "version": "1.18.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
             "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -10418,6 +10271,7 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -10551,6 +10405,7 @@
             "version": "1.16.0",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
             "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -10590,22 +10445,6 @@
             },
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/foreground-child": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-            "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-            "license": "ISC",
-            "dependencies": {
-                "cross-spawn": "^7.0.0",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/form-data": {
@@ -10669,6 +10508,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -10779,46 +10619,17 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/glob": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/global": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-            "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-            "peer": true,
-            "dependencies": {
-                "min-document": "^2.19.0",
-                "process": "^0.11.10"
             }
         },
         "node_modules/goober": {
@@ -10940,26 +10751,6 @@
                 "node": ">=16.17.0"
             }
         },
-        "node_modules/ieee754": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "peer": true
-        },
         "node_modules/import-meta-resolve": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
@@ -11029,6 +10820,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "binary-extensions": "^2.0.0"
@@ -11036,12 +10828,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/is-buffer": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-            "peer": true
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
@@ -11062,6 +10848,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -11071,21 +10858,17 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/is-function": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-            "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
-            "peer": true
-        },
         "node_modules/is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -11104,18 +10887,10 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-            "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-potential-custom-element-name": {
@@ -11140,6 +10915,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/istanbul-lib-coverage": {
@@ -11190,20 +10966,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/jackspeak": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
-            }
-        },
         "node_modules/jerrypick": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.1.tgz",
@@ -11217,6 +10979,7 @@
             "version": "1.21.7",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "jiti": "bin/jiti.js"
@@ -11358,6 +11121,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
             "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14"
@@ -11370,6 +11134,7 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lint-staged": {
@@ -11489,22 +11254,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/load-bmfont": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
-            "integrity": "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==",
-            "peer": true,
-            "dependencies": {
-                "buffer-equal": "0.0.1",
-                "mime": "^1.3.4",
-                "parse-bmfont-ascii": "^1.0.3",
-                "parse-bmfont-binary": "^1.0.5",
-                "parse-bmfont-xml": "^1.1.4",
-                "phin": "^3.7.1",
-                "xhr": "^2.0.1",
-                "xtend": "^4.0.0"
             }
         },
         "node_modules/lodash": {
@@ -11752,6 +11501,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 8"
@@ -11767,6 +11517,7 @@
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
@@ -11780,23 +11531,12 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/mime": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-            "peer": true,
-            "bin": {
-                "mime": "cli.js"
-            },
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/mime-db": {
@@ -11844,15 +11584,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/min-document": {
-            "version": "2.19.2",
-            "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
-            "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
-            "peer": true,
-            "dependencies": {
-                "dom-walk": "^0.1.0"
-            }
-        },
         "node_modules/min-indent": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -11869,29 +11600,6 @@
             "license": "MIT",
             "bin": {
                 "mini-svg-data-uri": "cli.js"
-            }
-        },
-        "node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/motion-dom": {
@@ -11913,12 +11621,14 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/mz": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
             "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "any-promise": "^1.0.0",
@@ -11998,6 +11708,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -12053,6 +11764,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
             "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -12098,45 +11810,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/package-json-from-dist": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "license": "BlueOak-1.0.0"
-        },
         "node_modules/package-manager-detector": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
             "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
             "dev": true
-        },
-        "node_modules/parse-bmfont-ascii": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-            "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
-            "peer": true
-        },
-        "node_modules/parse-bmfont-binary": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-            "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
-            "peer": true
-        },
-        "node_modules/parse-bmfont-xml": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
-            "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
-            "peer": true,
-            "dependencies": {
-                "xml-parse-from-string": "^1.0.0",
-                "xml2js": "^0.5.0"
-            }
-        },
-        "node_modules/parse-headers": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
-            "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
-            "peer": true
         },
         "node_modules/parse5": {
             "version": "8.0.1",
@@ -12154,6 +11832,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -12165,44 +11844,11 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
         },
-        "node_modules/path-scurry": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/path-scurry/node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-        },
         "node_modules/pathe": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true
-        },
-        "node_modules/phin": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
-            "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "peer": true,
-            "dependencies": {
-                "centra": "^2.7.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -12238,6 +11884,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
             "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -12247,6 +11894,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
             "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
@@ -12339,6 +11987,7 @@
             "version": "15.1.0",
             "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
             "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "postcss-value-parser": "^4.0.0",
@@ -12356,6 +12005,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
             "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "camelcase-css": "^2.0.1"
@@ -12375,6 +12025,7 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
             "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -12410,6 +12061,7 @@
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
             "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -12435,6 +12087,7 @@
             "version": "6.1.2",
             "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
             "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -12448,6 +12101,7 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/preact": {
@@ -12500,15 +12154,6 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
             "dev": true
-        },
-        "node_modules/process": {
-            "version": "0.11.10",
-            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-            "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-            "peer": true,
-            "engines": {
-                "node": ">= 0.6.0"
-            }
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
@@ -12570,21 +12215,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/quad-indices": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/quad-indices/-/quad-indices-2.0.1.tgz",
-            "integrity": "sha512-6jtmCsEbGAh5npThXrBaubbTjPcF0rMbn57XCJVI7LkW8PUT56V+uIrRCCWCn85PSgJC9v8Pm5tnJDwmOBewvA==",
-            "peer": true,
-            "dependencies": {
-                "an-array": "^1.0.0",
-                "dtype": "^2.0.0",
-                "is-buffer": "^1.0.2"
-            }
-        },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -12605,6 +12240,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -12627,6 +12263,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -12861,6 +12498,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
             "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "pify": "^2.3.0"
@@ -12870,6 +12508,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "picomatch": "^2.2.1"
@@ -12882,6 +12521,7 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
             "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+            "dev": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -13010,6 +12650,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
@@ -13033,7 +12674,7 @@
             "version": "4.62.2",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
             "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "@types/estree": "1.0.9"
             },
@@ -13077,6 +12718,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -13106,15 +12748,6 @@
                 "tslib": "^2.1.0"
             }
         },
-        "node_modules/sax": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-            "peer": true,
-            "engines": {
-                "node": ">=11.0.0"
-            }
-        },
         "node_modules/saxes": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -13131,6 +12764,7 @@
             "version": "0.23.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
             "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "loose-envify": "^1.1.0"
@@ -13158,6 +12792,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -13170,6 +12805,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -13269,6 +12905,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=14"
@@ -13344,20 +12981,6 @@
             "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
             "dev": true
         },
-        "node_modules/stats-gl": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-3.8.0.tgz",
-            "integrity": "sha512-e11MQK0vzaiD7dX43McxOoPZfWA1IMq4i7XC6sLXLBfypVXRTXYdvikUmueHVWQn9QPXT8XBDz3SyMArocoAUg==",
-            "peer": true,
-            "peerDependencies": {
-                "three": "*"
-            },
-            "peerDependenciesMeta": {
-                "three": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/std-env": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -13373,64 +12996,11 @@
                 "node": ">=0.6.19"
             }
         },
-        "node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/string-width-cjs": {
-            "name": "string-width",
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width-cjs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/string-width-cjs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/strip-ansi": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
             "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^6.0.1"
@@ -13440,26 +13010,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/strip-ansi-cjs": {
-            "name": "strip-ansi",
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/strip-final-newline": {
@@ -13487,17 +13037,17 @@
             }
         },
         "node_modules/sucrase": {
-            "version": "3.35.0",
-            "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-            "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-            "license": "MIT",
+            "version": "3.35.1",
+            "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+            "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+            "dev": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "commander": "^4.0.0",
-                "glob": "^10.3.10",
                 "lines-and-columns": "^1.1.6",
                 "mz": "^2.7.0",
                 "pirates": "^4.0.1",
+                "tinyglobby": "^0.2.11",
                 "ts-interface-checker": "^0.1.9"
             },
             "bin": {
@@ -13507,12 +13057,6 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
-        },
-        "node_modules/super-animejs": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/super-animejs/-/super-animejs-3.1.0.tgz",
-            "integrity": "sha512-6MFAFJDRuvwkovxQZPruuyHinTa4rgj4hNLOndjcYYhZLckoXtVRY9rJPuq8p6c/tgZJrFYEAYAfJ2/hhNtUCA==",
-            "peer": true
         },
         "node_modules/supports-color": {
             "version": "8.1.1",
@@ -13594,6 +13138,7 @@
             "version": "3.4.17",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
             "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
@@ -13631,6 +13176,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
             "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "any-promise": "^1.0.0"
@@ -13640,6 +13186,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
             "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "thenify": ">= 3.1.0 < 4"
@@ -13652,19 +13199,6 @@
             "version": "0.185.0",
             "resolved": "https://registry.npmjs.org/three/-/three-0.185.0.tgz",
             "integrity": "sha512-+yRrcRO2iZa8uzvNNl0d7cL4huhgKgBvVJ0njcTe8xFqZ6DMAFZdCKDP91SEAuj25bNAj7k1QQdf+srZywVK6w=="
-        },
-        "node_modules/three-bmfont-text": {
-            "version": "3.0.0",
-            "resolved": "git+ssh://git@github.com/dmarcos/three-bmfont-text.git#c3eec235b9188aa0d8ed949101236e6d5fccf071",
-            "integrity": "sha512-7TJoaD1Yx/dHo/DYo0amdxV93VIr4fXzHDdYbxwdiTccbxdWSPb1/5CLE+8/9WB74k94xdj7iYgZiUr7zQVHjA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "as-number": "^1.0.0",
-                "quad-indices": "^2.0.1",
-                "word-wrapper": "^1.0.7",
-                "xtend": "^4.0.0"
-            }
         },
         "node_modules/three-forcegraph": {
             "version": "1.42.12",
@@ -13793,6 +13327,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
@@ -13839,6 +13374,7 @@
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
             "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/tslib": {
@@ -14023,6 +13559,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/victory-vendor": {
@@ -14282,6 +13819,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -14309,105 +13847,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/word-wrapper": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/word-wrapper/-/word-wrapper-1.0.7.tgz",
-            "integrity": "sha512-VOPBFCm9b6FyYKQYfn9AVn2dQvdR/YOVFV6IBRA1TBMJWKffvhEX1af6FMGrttILs2Q9ikCRhLqkbY2weW6dOQ==",
-            "peer": true
-        },
-        "node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-            "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi-cjs": {
-            "name": "wrap-ansi",
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi/node_modules/ansi-styles": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-            "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/xhr": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
-            "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-            "peer": true,
-            "dependencies": {
-                "global": "~4.4.0",
-                "is-function": "^1.0.1",
-                "parse-headers": "^2.0.0",
-                "xtend": "^4.0.0"
-            }
-        },
         "node_modules/xml-name-validator": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -14417,48 +13856,11 @@
                 "node": ">=18"
             }
         },
-        "node_modules/xml-parse-from-string": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-            "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
-            "peer": true
-        },
-        "node_modules/xml2js": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-            "peer": true,
-            "dependencies": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "~11.0.0"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/xmlbuilder": {
-            "version": "11.0.1",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-            "peer": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
             "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
             "dev": true
-        },
-        "node_modules/xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-            "peer": true,
-            "engines": {
-                "node": ">=0.4"
-            }
         },
         "node_modules/y18n": {
             "version": "5.0.8",
@@ -14480,6 +13882,7 @@
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "dev": true,
             "bin": {
                 "yaml": "bin.mjs"
             },


### PR DESCRIPTION
## Summary
- Adds `docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md`: a measured, step-level analysis of why CI takes 25–27 min (sometimes 62 min wall) and a 3-tier optimization program.
- Key findings encoded: merge-blocking path = worst backend shard (staff iOS is not a required check); macos-26 queue tail up to 35.4 min; 87% of backend compute is per-test setUp amplification; modulo-8 alphabetical sharding is unstable; every merge pays CI twice.
- Tiers: Q1–Q7 quick wins (→ ~18–19 min), S1–S6 structural (→ ~13–14 min, merge→deploy ~1–2 min), D1–D4 deep (§3.2.9-gated). Includes a do-not-do list of measured nulls and full sequencing against the §3.2.9 prohibitions and the 17 required-check contexts.

## Test plan
- [ ] Docs-only change; no code paths affected
- [ ] Plan projections to be validated per-item as tier-1 PRs land (Q1/Q2 already in progress on `feature/ci-duration-tier1`)