### PR TITLE
perf(ci): tree-sha verdict reuse on main squash pushes (plan S4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,75 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # Gatekeeper — tree-sha verdict reuse on main squash pushes (plan S4,
+  # [SU] evidence-chain ruling 2026-07-24). A squash merge under strict
+  # branch protection reproduces the PR head's git tree byte-for-byte
+  # (including this workflow file). When that exact tree already holds a
+  # green ci.yml verdict, re-running the suite proves nothing new: every
+  # job below skips, the run concludes success, and the deploy gate passes
+  # on the exact SHA with this job's summary pointing at the reused run.
+  # Every check fails OPEN (reuse=false -> full suite runs).
+  # ---------------------------------------------------------------------------
+  changes:
+    name: Changes (verdict-reuse gatekeeper)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
+    outputs:
+      reuse: ${{ steps.verdict.outputs.reuse }}
+    steps:
+      - name: Look up a green verdict for this exact tree
+        id: verdict
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo "reuse=false" >> "$GITHUB_OUTPUT"
+          if [[ "$GITHUB_EVENT_NAME" != "push" || "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "Not a main push — full suite runs."
+            exit 0
+          fi
+          fail_open() {
+            echo "::notice::Verdict reuse unavailable ($1) — running the full suite."
+            exit 0
+          }
+          commit_json="$(gh api "repos/$GITHUB_REPOSITORY/git/commits/$GITHUB_SHA")" || fail_open "commit lookup failed"
+          tree_now="$(jq -r '.tree.sha' <<<"$commit_json")"
+          subject="$(jq -r '.message' <<<"$commit_json" | head -n 1)"
+          # GitHub appends the real PR number last, so a spoofed "(#N)" in a
+          # PR title cannot displace it; tree equality below is the actual
+          # security property regardless.
+          pr_number="$(grep -oE '\(#[0-9]+\)$' <<<"$subject" | tr -dc '0-9')" || true
+          [[ -n "${pr_number:-}" ]] || fail_open "no PR number in squash subject"
+          pr_head="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$pr_number" --jq '.head.sha')" || fail_open "PR #$pr_number lookup failed"
+          tree_pr="$(gh api "repos/$GITHUB_REPOSITORY/git/commits/$pr_head" --jq '.tree.sha')" || fail_open "PR head commit lookup failed"
+          [[ "$tree_now" == "$tree_pr" ]] || fail_open "tree mismatch: squash $tree_now vs PR head $tree_pr"
+          run_url="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs?head_sha=$pr_head&status=success&per_page=1" --jq '.workflow_runs[0].html_url // empty')" || fail_open "run lookup failed"
+          [[ -n "$run_url" ]] || fail_open "no successful ci.yml run exists for PR head $pr_head"
+          echo "reuse=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Verdict reuse (plan S4)"
+            echo "- Squash commit: \`$GITHUB_SHA\` (PR #$pr_number)"
+            echo "- PR head: \`$pr_head\`"
+            echo "- Identical git tree: \`$tree_now\`"
+            echo "- Reused green run: $run_url"
+            echo ""
+            echo "All suite jobs are skipped; the verdict for this exact tree is the linked run ([SU] evidence-chain ruling, 2026-07-24)."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Reusing verdict from $run_url"
+
+  # ---------------------------------------------------------------------------
   # Backend — quality/migrations plus deterministic PHPUnit shards
   # ---------------------------------------------------------------------------
   backend-quality:
     name: Backend (Laravel / quality)
     runs-on: ubuntu-latest
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     timeout-minutes: 20
     env:
       APP_ENV: testing
@@ -137,6 +201,9 @@ jobs:
   backend-tests:
     name: Backend tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     # Matches the ratified "no shard above 30 m" budget; caps hung-shard burn.
     timeout-minutes: 30
     env:
@@ -245,6 +312,9 @@ jobs:
   frontend:
     name: Frontend (Vitest / Vite)
     runs-on: ubuntu-latest
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     timeout-minutes: 10
     env:
       RELEASE_EVIDENCE_DIR: artifacts/release-evidence/frontend
@@ -291,6 +361,9 @@ jobs:
   security:
     name: Security (dependencies / secrets / SAST)
     runs-on: ubuntu-latest
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     timeout-minutes: 20
     env:
       RELEASE_EVIDENCE_DIR: artifacts/release-evidence/security
@@ -341,6 +414,9 @@ jobs:
   arena:
     name: Arena sidecar (pytest / pm4py)
     runs-on: ubuntu-latest
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     timeout-minutes: 15
     env:
       RELEASE_EVIDENCE_DIR: artifacts/release-evidence/arena
@@ -379,6 +455,9 @@ jobs:
   browser:
     name: Browser (Playwright / Chromium)
     runs-on: ubuntu-latest
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     timeout-minutes: 20
     env:
       APP_ENV: testing
@@ -481,6 +560,9 @@ jobs:
   dast:
     name: DAST (OWASP ZAP baseline)
     runs-on: ubuntu-latest
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     timeout-minutes: 25
     env:
       APP_ENV: testing
@@ -569,6 +651,9 @@ jobs:
   hummingbird-staff-android:
     name: Hummingbird staff (Android)
     runs-on: ubuntu-24.04
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     timeout-minutes: 35
     defaults:
       run:
@@ -653,6 +738,9 @@ jobs:
     # Staff UI uses the iOS 26 liquid-glass SDK. macos-15 currently defaults
     # to Xcode 16.4, whose SDK cannot even parse those guarded symbols.
     runs-on: macos-26
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     timeout-minutes: 45
     env:
       IOS_STAFF_ROOT: hummingbird/iosApp
@@ -795,6 +883,9 @@ jobs:
   hummingbird-patient-android:
     name: Hummingbird patient (Android)
     runs-on: ubuntu-24.04
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     timeout-minutes: 30
     defaults:
       run:
@@ -886,6 +977,9 @@ jobs:
   hummingbird-patient-ios:
     name: Hummingbird patient (iOS)
     runs-on: macos-15
+    needs: changes
+    # Plan S4: skip when an identical tree already holds a green verdict.
+    if: needs.changes.outputs.reuse != 'true'
     timeout-minutes: 40
     env:
       IOS_PATIENT_ROOT: hummingbird/iosPatientApp

--- a/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
+++ b/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
@@ -100,8 +100,21 @@ The standalone Debug build's artifacts are never reused; XCTest recompiles every
 ### S3. Parallelize XCUITest (2 simulator clones) + split the 11-test routing class — **staff iOS UI step 12.1 m → ~6.5–7.5 m**
 - [ ] `project.yml:19-20` `parallelizable: true`, `-parallel-testing-enabled YES -parallel-testing-worker-count 2` (`ci.yml:727`), and split `PatientCommunicationRoutingUITests` (11 of 18 tests; XCTest distributes per-class, so without the split two workers cap at −4 m).
 
-### S4. Tree-sha verdict reuse on the squash push + docs-only fast path — **merge→deploy ~25 m → ~1–2 m** *(needs an explicit [SU] evidence-chain ruling first)*
-- [ ] Add a 30 s `changes` gatekeeper job: (a) on main pushes, if a successful run exists whose head tree-sha equals this commit's tree-sha, output `reuse=true`; (b) on any event, output `docs_only` from the diff. All 11 job definitions gain `needs: changes` + skip conditions. Skipped required checks satisfy branch protection and the run concludes `success` (verified), so the deploy gate passes on the exact SHA — but the run's evidence artifacts would point at the PR run, which is precisely the [SU] ruling to record before landing. `strict: true` makes tree matches near-universal.
+### S4. Tree-sha verdict reuse on the squash push + docs-only fast path — **merge→deploy ~25 m → ~1–2 m**
+> **[SU] evidence-chain ruling recorded 2026-07-24** ("Proceed"): on a reused main run, the verdict
+> evidence for the deployed SHA is the linked fully-green PR run for the byte-identical git tree; the
+> gatekeeper's step summary records both SHAs, the shared tree SHA, and the reused run URL.
+- [x] Verdict reuse (a): `changes` gatekeeper on main pushes resolves the squash subject's PR number,
+  compares the squash commit's tree-sha to the PR head's tree-sha via the git-objects API (no checkout),
+  and requires a **fully-successful** `ci.yml` run for that head — the same all-jobs-green bar the deploy
+  gate applies to main runs today, so a PR run that passed only its 17 required contexts (e.g. a
+  non-required staff-iOS flake) correctly fails open to a full main suite. All 11 job definitions gained
+  `needs: changes` + `if: needs.changes.outputs.reuse != 'true'`; reuse can never trigger on
+  `pull_request` events, so branch protection semantics are untouched. Empirically verified on real
+  history: PR #61 and #63 squash trees are byte-identical to their PR-head trees.
+- [ ] Docs-only fast path (b): deferred to a follow-up; `needs: changes` is already in place, so it is
+  an output + condition extension. Classification must exclude `docs/hummingbird/**` (generated docs are
+  contract-verified in CI) and keep gitleaks running on every diff.
 
 ### S5. De-risk the `macos-26` queue tail — **removes the +35 m variance**
 - [ ] In order: (a) test whether `macos-15`'s Xcode selection now covers the needed iOS-26 SDK — if yes, leave the scarce pool entirely; (b) evaluate larger-runner pools; (c) failing both, move XCUITest journeys to main-push/nightly lanes only (permissible — staff iOS is not a required PR check — but record the coverage trade-off explicitly).


### PR DESCRIPTION
## Summary
- Implements plan S4(a) from `docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md`: a `changes` gatekeeper job that, on main pushes, resolves the squash subject's PR number, compares the squash commit's **git tree SHA** to the PR head's tree SHA via the git-objects API (no checkout), and requires a **fully-successful** `ci.yml` run for that head. On a match, all 11 suite jobs skip, the run concludes `success` for the deploy gate, and the gatekeeper's step summary records both SHAs, the shared tree, and the reused run URL as the verdict evidence.
- **[SU] evidence-chain ruling recorded 2026-07-24** (in the plan doc): on a reused main run, the verdict evidence for the deployed SHA is the linked fully-green PR run for the byte-identical tree.
- Merge→deployable drops from ~25 m to ~1 m whenever the PR run was 19/19 green. A PR run that passed only its 17 required contexts (e.g. a non-required staff-iOS flake) correctly **fails open** to a full main suite — the all-jobs-green deploy bar is unchanged.
- Every lookup failure fails open. `pull_request` events never reuse, so branch-protection semantics are untouched. Tree equality covers `ci.yml` itself, so a reused verdict always comes from an identical workflow definition.
- Docs-only fast path S4(b) deferred to a follow-up (noted in the plan; `needs: changes` plumbing is now in place).

## Verification
- [x] Tree-identity premise verified on real history: PR #61 and #63 squash commits are byte-identical trees to their PR heads
- [x] Negative case verified: PR #63's head has **no** fully-successful run (iOS flake) → gatekeeper would fail open, exactly as intended
- [x] `actionlint` clean; YAML parses; 11 jobs wired with `needs: changes` + skip condition
- [ ] First live proof: this PR's own squash merge should produce a ~1 m main run whose summary links back to this PR's green run