### PR TITLE
perf(ci): docs-only fast path in the gatekeeper (plan S4b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,12 @@ jobs:
   # job below skips, the run concludes success, and the deploy gate passes
   # on the exact SHA with this job's summary pointing at the reused run.
   # Every check fails OPEN (reuse=false -> full suite runs).
+  #
+  # Plan S4(b): the same job classifies docs-only change sets (docs/ plus
+  # root-level *.md, excluding docs/hummingbird/ whose generated files are
+  # contract-verified by backend-quality). Suite jobs skip on docs_only;
+  # the Security job deliberately keeps running on every change set so
+  # gitleaks/SAST still scan documentation diffs.
   # ---------------------------------------------------------------------------
   changes:
     name: Changes (verdict-reuse gatekeeper)
@@ -37,7 +43,42 @@ jobs:
       pull-requests: read
     outputs:
       reuse: ${{ steps.verdict.outputs.reuse }}
+      docs_only: ${{ steps.docs.outputs.docs_only }}
     steps:
+      - name: Classify docs-only change sets
+        id: docs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PUSH_BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          not_provable() {
+            echo "::notice::Docs-only not provable ($1) — full suite runs."
+            exit 0
+          }
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            files_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '[.[].filename]' | jq -cs 'add')" || not_provable "PR file list failed"
+          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+            [[ -n "$PUSH_BEFORE" && ! "$PUSH_BEFORE" =~ ^0+$ ]] || not_provable "no push base"
+            files_json="$(gh api "repos/$GITHUB_REPOSITORY/compare/$PUSH_BEFORE...$GITHUB_SHA" --jq '[.files[].filename]')" || not_provable "compare failed"
+            # The compare API truncates at 300 files; a truncated list cannot
+            # prove the change set is docs-only.
+            [[ "$(jq 'length' <<<"$files_json")" -lt 300 ]] || not_provable "change set too large to classify"
+          else
+            exit 0
+          fi
+          if jq -e 'length > 0 and all(test("^docs/|^[^/]+[.]md$")) and (any(test("^docs/hummingbird/")) | not)' <<<"$files_json" >/dev/null; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Docs-only fast path (plan S4b)"
+              echo "- Change set: $(jq 'length' <<<"$files_json") file(s), all under \`docs/\` or root-level \`*.md\` (\`docs/hummingbird/\` excluded)"
+              echo "- Suite jobs skip; Security (gitleaks / SAST) still runs on every change set."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "Docs-only change set — suite jobs skip, security still runs."
+          fi
+
       - name: Look up a green verdict for this exact tree
         id: verdict
         env:
@@ -85,8 +126,8 @@ jobs:
     name: Backend (Laravel / quality)
     runs-on: ubuntu-latest
     needs: changes
-    # Plan S4: skip when an identical tree already holds a green verdict.
-    if: needs.changes.outputs.reuse != 'true'
+    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
+    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 20
     env:
       APP_ENV: testing
@@ -202,8 +243,8 @@ jobs:
     name: Backend tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: changes
-    # Plan S4: skip when an identical tree already holds a green verdict.
-    if: needs.changes.outputs.reuse != 'true'
+    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
+    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     # Matches the ratified "no shard above 30 m" budget; caps hung-shard burn.
     timeout-minutes: 30
     env:
@@ -313,8 +354,8 @@ jobs:
     name: Frontend (Vitest / Vite)
     runs-on: ubuntu-latest
     needs: changes
-    # Plan S4: skip when an identical tree already holds a green verdict.
-    if: needs.changes.outputs.reuse != 'true'
+    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
+    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 10
     env:
       RELEASE_EVIDENCE_DIR: artifacts/release-evidence/frontend
@@ -415,8 +456,8 @@ jobs:
     name: Arena sidecar (pytest / pm4py)
     runs-on: ubuntu-latest
     needs: changes
-    # Plan S4: skip when an identical tree already holds a green verdict.
-    if: needs.changes.outputs.reuse != 'true'
+    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
+    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 15
     env:
       RELEASE_EVIDENCE_DIR: artifacts/release-evidence/arena
@@ -456,8 +497,8 @@ jobs:
     name: Browser (Playwright / Chromium)
     runs-on: ubuntu-latest
     needs: changes
-    # Plan S4: skip when an identical tree already holds a green verdict.
-    if: needs.changes.outputs.reuse != 'true'
+    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
+    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 20
     env:
       APP_ENV: testing
@@ -561,8 +602,8 @@ jobs:
     name: DAST (OWASP ZAP baseline)
     runs-on: ubuntu-latest
     needs: changes
-    # Plan S4: skip when an identical tree already holds a green verdict.
-    if: needs.changes.outputs.reuse != 'true'
+    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
+    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 25
     env:
       APP_ENV: testing
@@ -652,8 +693,8 @@ jobs:
     name: Hummingbird staff (Android)
     runs-on: ubuntu-24.04
     needs: changes
-    # Plan S4: skip when an identical tree already holds a green verdict.
-    if: needs.changes.outputs.reuse != 'true'
+    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
+    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 35
     defaults:
       run:
@@ -739,8 +780,8 @@ jobs:
     # to Xcode 16.4, whose SDK cannot even parse those guarded symbols.
     runs-on: macos-26
     needs: changes
-    # Plan S4: skip when an identical tree already holds a green verdict.
-    if: needs.changes.outputs.reuse != 'true'
+    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
+    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 45
     env:
       IOS_STAFF_ROOT: hummingbird/iosApp
@@ -884,8 +925,8 @@ jobs:
     name: Hummingbird patient (Android)
     runs-on: ubuntu-24.04
     needs: changes
-    # Plan S4: skip when an identical tree already holds a green verdict.
-    if: needs.changes.outputs.reuse != 'true'
+    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
+    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 30
     defaults:
       run:
@@ -978,8 +1019,8 @@ jobs:
     name: Hummingbird patient (iOS)
     runs-on: macos-15
     needs: changes
-    # Plan S4: skip when an identical tree already holds a green verdict.
-    if: needs.changes.outputs.reuse != 'true'
+    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
+    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 40
     env:
       IOS_PATIENT_ROOT: hummingbird/iosPatientApp

--- a/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
+++ b/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
@@ -112,9 +112,11 @@ The standalone Debug build's artifacts are never reused; XCTest recompiles every
   `needs: changes` + `if: needs.changes.outputs.reuse != 'true'`; reuse can never trigger on
   `pull_request` events, so branch protection semantics are untouched. Empirically verified on real
   history: PR #61 and #63 squash trees are byte-identical to their PR-head trees.
-- [ ] Docs-only fast path (b): deferred to a follow-up; `needs: changes` is already in place, so it is
-  an output + condition extension. Classification must exclude `docs/hummingbird/**` (generated docs are
-  contract-verified in CI) and keep gitleaks running on every diff.
+- [x] Docs-only fast path (b): the gatekeeper classifies the change set (PR file list, or the push
+  compare API on main with a 300-file truncation guard) as docs-only when every file is under `docs/`
+  or a root-level `*.md`, with `docs/hummingbird/**` excluded (generated docs are contract-verified by
+  backend-quality). The 10 suite jobs skip on `docs_only`; the Security job (gitleaks / SAST) runs on
+  every change set regardless. All classification failures fail open to the full suite.
 
 ### S5. De-risk the `macos-26` queue tail — **removes the +35 m variance**
 - [ ] In order: (a) test whether `macos-15`'s Xcode selection now covers the needed iOS-26 SDK — if yes, leave the scarce pool entirely; (b) evaluate larger-runner pools; (c) failing both, move XCUITest journeys to main-push/nightly lanes only (permissible — staff iOS is not a required PR check — but record the coverage trade-off explicitly).


### PR DESCRIPTION
## Summary
- Completes plan S4(b): the `changes` gatekeeper now classifies every change set — PR file list (paginated) on `pull_request`, compare API on main pushes (with a 300-file truncation guard) — and outputs `docs_only=true` when every file is under `docs/` or a root-level `*.md`.
- `docs/hummingbird/**` is excluded from the classification (its generated files are contract-verified by backend-quality, so edits there must run the suite).
- The 10 suite jobs skip on `docs_only`; the **Security job (gitleaks / SAST) deliberately keeps running on every change set**, so documentation diffs are still secret-scanned.
- Every classification failure (API error, no push base, truncated compare) fails open to the full suite.
- Docs-only PRs drop from ~19 m of CI to the gatekeeper + security lane (~2 m); docs-only merges whose PR run wasn't fully green (e.g. an iOS flake) now also fast-path on main instead of paying a full suite.

## Verification
- [x] `actionlint` clean; YAML parses; 10 jobs on the widened condition, security kept on reuse-only
- [ ] Live proof after merge: a docs-only PR should show gatekeeper + security running, 18 contexts skipped, and still be mergeable