### PR TITLE
CI: single vite production build per run (plan S6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,18 @@ jobs:
       - name: Vite production build
         run: bash scripts/capture-release-evidence.sh frontend-build npx vite build
 
+      # Plan S6: browser + DAST download this build and skip their own
+      # vite runs — one production build per CI run.
+      - name: Upload production build for browser/DAST reuse
+        uses: actions/upload-artifact@v4
+        with:
+          name: vite-production-build
+          path: public/build
+          if-no-files-found: error
+          # Long enough that a failed-job rerun a day or two later can still
+          # download it; the durable build record lives in release evidence.
+          retention-days: 3
+
       - name: UI canon check
         run: bash scripts/capture-release-evidence.sh frontend-ui-canon bash scripts/check-ui-canon.sh
 
@@ -499,7 +511,9 @@ jobs:
   browser:
     name: Browser (Playwright / Chromium)
     runs-on: ubuntu-latest
-    needs: changes
+    # frontend is needed for the shared vite build (plan S6); the implicit
+    # success() in `if` keeps this job skipped whenever frontend skips.
+    needs: [changes, frontend]
     # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
     if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 20
@@ -524,6 +538,7 @@ jobs:
       TEST_USERNAME: e2e_admin
       TEST_PASSWORD: BrowserOnlyPassword!123
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:8084
+      PLAYWRIGHT_SKIP_BUILD: "true"
       RELEASE_EVIDENCE_DIR: artifacts/release-evidence/browser
 
     services:
@@ -583,6 +598,12 @@ jobs:
       - name: Prepare test application
         run: cp .env.example .env
 
+      - name: Download production build from the frontend job
+        uses: actions/download-artifact@v4
+        with:
+          name: vite-production-build
+          path: public/build
+
       - name: Run Playwright
         run: bash scripts/run-browser-suite.sh
 
@@ -604,7 +625,9 @@ jobs:
   dast:
     name: DAST (OWASP ZAP baseline)
     runs-on: ubuntu-latest
-    needs: changes
+    # frontend is needed for the shared vite build (plan S6); the implicit
+    # success() in `if` keeps this job skipped whenever frontend skips.
+    needs: [changes, frontend]
     # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
     if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 25
@@ -628,6 +651,7 @@ jobs:
       DEMO_AUTO_LOGIN_ENABLED: "false"
       TEST_USERNAME: e2e_admin
       TEST_PASSWORD: BrowserOnlyPassword!123
+      DAST_SKIP_BUILD: "true"
       RELEASE_EVIDENCE_DIR: artifacts/release-evidence/dast
 
     services:
@@ -676,6 +700,12 @@ jobs:
 
       - name: Prepare test application
         run: cp .env.example .env
+
+      - name: Download production build from the frontend job
+        uses: actions/download-artifact@v4
+        with:
+          name: vite-production-build
+          path: public/build
 
       - name: Run pinned ZAP baseline
         run: bash scripts/capture-release-evidence.sh dast-zap bash scripts/run-dast-suite.sh

--- a/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
+++ b/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
@@ -124,7 +124,7 @@ The standalone Debug build's artifacts are never reused; XCTest recompiles every
 - [ ] Either way: emit queue-delay (job `started_at` − run `created_at`) into release evidence so the tail is *measured* continuously.
 
 ### S6. Single vite build per run — **browser 9.0 → ~7.5 m, DAST 4.3 → ~2.5 m**
-- [ ] Frontend job uploads `public/build`; browser + DAST download it and set the already-existing `PLAYWRIGHT_SKIP_BUILD` / `DAST_SKIP_BUILD` flags (`run-browser-suite.sh:74`, `run-dast-suite.sh:75`). Optionally fold ZAP into the browser job against the still-running server later — but DAST is a *required check by name*, so any fold must ship with a branch-protection update in the same window.
+- [x] Frontend job uploads `public/build`; browser + DAST download it and set the already-existing `PLAYWRIGHT_SKIP_BUILD` / `DAST_SKIP_BUILD` flags (`run-browser-suite.sh:74`, `run-dast-suite.sh:75`). Optionally fold ZAP into the browser job against the still-running server later — but DAST is a *required check by name*, so any fold must ship with a branch-protection update in the same window.
 
 ---
 


### PR DESCRIPTION
## Summary

Executes **S6** of `docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md`: the vite production build ran three times per run on identical inputs (frontend 100 s + Playwright 71 s + ZAP 61 s).

- Frontend uploads `public/build` as the `vite-production-build` artifact (3-day retention so failed-job reruns can still fetch it; the durable record stays in release evidence).
- Browser and DAST gain `needs: [changes, frontend]`, download the artifact into `public/build`, and set the **pre-existing** `PLAYWRIGHT_SKIP_BUILD` / `DAST_SKIP_BUILD` flags — no suite-script changes.
- Skip semantics are preserved by the implicit `success()` in each `if:`: verdict-reuse and docs-only paths skip frontend → browser/DAST skip too; a failed frontend build blocks both instead of testing against a stale bundle.
- ZAP job fold into browser deliberately **not** done (DAST is a required check by name; per plan any fold needs a same-window branch-protection update).

## Expected on this PR's run

- Browser job ~9.1 m → **~7.5–8 m**; DAST ~4.2 m → **~2.5–3 m**.
- Browser/DAST start after frontend (~4.3 m) — chain ends ≈12 m, still under the worst backend shard (~15.5 m), so nominal wall is unchanged while ~2.2 m of compute per run disappears.

## Test plan

- [ ] All required contexts green
- [ ] Browser + DAST logs show no `vite build` step (skip flags honored)
- [ ] DAST/browser job durations drop as projected

🤖 Generated with [Claude Code](https://claude.com/claude-code)