### PR TITLE
perf(ci): staff iOS on macos-15 + pinned Xcode 26.3 (plan S5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -809,15 +809,19 @@ jobs:
 
   hummingbird-staff-ios:
     name: Hummingbird staff (iOS)
-    # Staff UI uses the iOS 26 liquid-glass SDK. macos-15 currently defaults
-    # to Xcode 16.4, whose SDK cannot even parse those guarded symbols.
-    runs-on: macos-26
+    # Staff UI needs the iOS 26 liquid-glass SDK. macos-15 defaults to
+    # Xcode 16.4 but ships Xcode 26.0-26.3 side-by-side (probe 2026-07-25:
+    # full staff XCTest+XCUITest suites green under Xcode 26.3), so pin
+    # DEVELOPER_DIR instead of paying the scarce macos-26 pool's queue
+    # tail (measured up to 35.4 m; macos-15 queues in seconds).
+    runs-on: macos-15
     needs: changes
     # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
     if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
     timeout-minutes: 45
     env:
       IOS_STAFF_ROOT: hummingbird/iosApp
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Moves `hummingbird-staff-ios` off the scarce `macos-26` pool (queue tails measured up to **35.4 min** — the single largest source of unbudgeted CI variance) to `macos-15`, pinning `DEVELOPER_DIR` to the image's side-by-side Xcode 26.3 for the iOS 26 liquid-glass SDK. Patient iOS already runs on macos-15.
- The old comment ("macos-15 … cannot even parse those guarded symbols") described the image *default* (Xcode 16.4); the image also ships Xcode 26.0–26.3.

## Verification
- [x] Probe branch `probe/macos15-sdk` ran the staff job's exact steps (XcodeGen, build-for-testing, XCTest, XCUITest, Release build, transport-boundary check) on macos-15 + Xcode 26.3: **all green** (one first-attempt `PatientCommunicationRoutingUITests` flake — the same class that flakes on macos-26 — clean on rerun)
- [x] macos-15 offers iOS 26.0/26.1/26.2 simulator runtimes; the job's simulator-select step picks from available devices
- [ ] Watch this PR's staff iOS lane: expect seconds of queue delay instead of minutes-to-tens-of-minutes