### PR TITLE
perf(tests): class-scoped committed ancillary demo scenario (plan S2)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
+++ b/docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md
@@ -96,7 +96,18 @@ The standalone Debug build's artifacts are never reused; XCTest recompiles every
 
 ### S2. Kill setup amplification in the ~21 consumer classes — **−38 m suite compute**
 *The sanctioned §3.2.9 shape: minimal governed fixtures + at least one full-seeder integration case per protected invariant; no dirty-DB reuse, isolation preserved.*
-- [ ] Build the smallest governed ancillary fixture for service-level cases; keep `AncillaryDemoScenarioTest` + one full-refresh integration case per invariant on the full pipeline. Target: 4,426 s → ~900 s (26 × one-time class setup + ~110 cases × ~1 s). Suite compute 85 m → ~46 m; every non-floor shard lands ~5–6 m.
+- [x] Shipped as a **class-scoped committed scenario** rather than minimal fixtures — stronger than the
+  original sketch because every test keeps the FULL governed scenario: `UsesCommittedAncillaryScenario`
+  builds the 5 seeders + `refresh()` once per class, committed (RefreshDatabase disconnects after each
+  per-test rollback, so an open outer transaction cannot span tests), before the per-test transaction
+  begins; each test still runs in its own rollback transaction over a byte-identical baseline — this is
+  NOT dirty-DB reuse, and isolation is preserved. Grounded in a 26-class + full-service audit
+  (2026-07-25): builds self-clear via owner-scoped DELETEs + idempotent upserts, single connection,
+  no commits/TRUNCATE/DDL, fully anchor-derived; all 22 pure consumers share one anchor. The 4
+  generator-contract tests hoist seeders only — `refresh()` in their bodies IS the subject.
+  `tests/TestCase.php` guard wipes all schemas (`IsolatedTestDatabase::resetAllSchemas`) + re-migrates
+  when a non-scenario class follows in-process; `resolve-shard-files.py` orders scenario classes last
+  per shard so CI never pays that path. Scenario builds: 135 → ~26 per full run.
 
 ### S3. Parallelize XCUITest (2 simulator clones) + split the 11-test routing class — **staff iOS UI step 12.1 m → ~6.5–7.5 m**
 - [ ] `project.yml:19-20` `parallelizable: true`, `-parallel-testing-enabled YES -parallel-testing-worker-count 2` (`ci.yml:727`), and split `PatientCommunicationRoutingUITests` (11 of 18 tests; XCTest distributes per-class, so without the split two workers cap at −4 m).

--- a/scripts/ci/resolve-shard-files.py
+++ b/scripts/ci/resolve-shard-files.py
@@ -78,7 +78,21 @@ def main() -> None:
 
     if not 0 <= args.shard < shard_count:
         raise SystemExit(f"Shard index {args.shard} out of range 0-{shard_count - 1}")
-    for f in sorted(f for f, s in resolved.items() if s == args.shard):
+
+    # Plan S2: classes using UsesCommittedAncillaryScenario leave a committed
+    # demo baseline behind, and the tests/TestCase.php boundary guard pays a
+    # full schema wipe + re-migration when a non-scenario class follows one.
+    # Emitting scenario classes LAST inside the shard means that guard never
+    # fires in CI. Detection is content-based so newly converted classes
+    # order correctly without touching this script.
+    def uses_committed_scenario(path: str) -> bool:
+        try:
+            return "UsesCommittedAncillaryScenario" in Path(path).read_text()
+        except OSError:
+            return False
+
+    shard_files = (f for f, s in resolved.items() if s == args.shard)
+    for f in sorted(shard_files, key=lambda f: (uses_committed_scenario(f), f)):
         print(f)
 
 

--- a/tests/Feature/Ancillary/AnatomicPathologyServiceTest.php
+++ b/tests/Feature/Ancillary/AnatomicPathologyServiceTest.php
@@ -4,26 +4,19 @@ namespace Tests\Feature\Ancillary;
 
 use App\Integrations\Healthcare\Services\SourceConfigurationVersionService;
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Lab\AnatomicPathologyService;
 use App\Services\Operations\CaseManagementService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class AnatomicPathologyServiceTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -32,8 +25,6 @@ final class AnatomicPathologyServiceTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/BloodBankReadinessServiceTest.php
+++ b/tests/Feature/Ancillary/BloodBankReadinessServiceTest.php
@@ -3,25 +3,18 @@
 namespace Tests\Feature\Ancillary;
 
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Lab\BloodBankReadinessService;
 use App\Services\Operations\CaseManagementService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class BloodBankReadinessServiceTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -30,8 +23,6 @@ final class BloodBankReadinessServiceTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/LabAmReadinessForecastTest.php
+++ b/tests/Feature/Ancillary/LabAmReadinessForecastTest.php
@@ -4,19 +4,12 @@ namespace Tests\Feature\Ancillary;
 
 use App\Models\User;
 use App\Services\Ancillary\AncillaryReadinessService;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Lab\AmReadiness\LabMorningReadinessService;
 use App\Services\Lab\LabDecisionPendingService;
 use App\Services\Rtdc\ServiceHuddleService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 /**
@@ -29,7 +22,7 @@ use Tests\TestCase;
  */
 class LabAmReadinessForecastTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -39,8 +32,6 @@ class LabAmReadinessForecastTest extends TestCase
         // Anchor before the 08:00 rounds cutoff so the cutoff is in the future.
         $this->anchor = CarbonImmutable::parse('2026-07-11T06:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/LabDecisionPendingServiceTest.php
+++ b/tests/Feature/Ancillary/LabDecisionPendingServiceTest.php
@@ -4,25 +4,18 @@ namespace Tests\Feature\Ancillary;
 
 use App\Models\Lab\Result;
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Lab\LabDecisionPendingService;
 use App\Services\Lab\LabSpecimenService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class LabDecisionPendingServiceTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -31,8 +24,6 @@ final class LabDecisionPendingServiceTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/LabFlowBoardTest.php
+++ b/tests/Feature/Ancillary/LabFlowBoardTest.php
@@ -4,24 +4,17 @@ namespace Tests\Feature\Ancillary;
 
 use App\Models\Ancillary\AncillaryOrder;
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Lab\LabFlowBoardService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 class LabFlowBoardTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -30,8 +23,6 @@ class LabFlowBoardTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/LabSpecimenServiceTest.php
+++ b/tests/Feature/Ancillary/LabSpecimenServiceTest.php
@@ -7,23 +7,17 @@ use App\Models\Lab\Result;
 use App\Models\Lab\Specimen;
 use App\Models\User;
 use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Lab\LabSpecimenService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 class LabSpecimenServiceTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -32,8 +26,6 @@ class LabSpecimenServiceTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/LabTatAnalyticsTest.php
+++ b/tests/Feature/Ancillary/LabTatAnalyticsTest.php
@@ -7,24 +7,17 @@ namespace Tests\Feature\Ancillary;
 use App\Http\Controllers\Analytics\LabTatController;
 use App\Http\Controllers\Api\Lab\LabFlowBoardController;
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Lab\LabTatAnalyticsService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\DB;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class LabTatAnalyticsTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -33,11 +26,6 @@ final class LabTatAnalyticsTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-12T14:30:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([
-            RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/LabTatAnalyticsTest.php
+++ b/tests/Feature/Ancillary/LabTatAnalyticsTest.php
@@ -19,6 +19,11 @@ final class LabTatAnalyticsTest extends TestCase
 {
     use UsesCommittedAncillaryScenario;
 
+    protected static function committedScenarioAnchor(): string
+    {
+        return '2026-07-12T14:30:00Z';
+    }
+
     private CarbonImmutable $anchor;
 
     protected function setUp(): void

--- a/tests/Feature/Ancillary/LaboratoryReadinessIntegrationTest.php
+++ b/tests/Feature/Ancillary/LaboratoryReadinessIntegrationTest.php
@@ -9,24 +9,17 @@ use App\Models\Lab\LabTestCatalog;
 use App\Models\Lab\Result;
 use App\Models\Lab\Specimen;
 use App\Services\Ancillary\AncillaryReadinessService;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Ed\TreatmentService;
 use App\Services\Lab\LabDecisionPendingService;
 use App\Services\Rtdc\DischargePrioritiesService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class LaboratoryReadinessIntegrationTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -35,14 +28,6 @@ final class LaboratoryReadinessIntegrationTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([
-            RtdcSeeder::class,
-            CaseManagementSeeder::class,
-            StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class,
-            AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/PharmacyControlledAuthTest.php
+++ b/tests/Feature/Ancillary/PharmacyControlledAuthTest.php
@@ -5,15 +5,8 @@ declare(strict_types=1);
 namespace Tests\Feature\Ancillary;
 
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 /**
@@ -24,21 +17,13 @@ use Tests\TestCase;
  */
 final class PharmacyControlledAuthTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     protected function setUp(): void
     {
         parent::setUp();
         $anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($anchor);
-        $this->seed([
-            RtdcSeeder::class,
-            CaseManagementSeeder::class,
-            StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class,
-            AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/PharmacyControlledTest.php
+++ b/tests/Feature/Ancillary/PharmacyControlledTest.php
@@ -4,17 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Ancillary;
 
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Pharmacy\ControlledSubstanceOperationsService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 /**
@@ -26,7 +19,7 @@ use Tests\TestCase;
  */
 final class PharmacyControlledTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -35,14 +28,6 @@ final class PharmacyControlledTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([
-            RtdcSeeder::class,
-            CaseManagementSeeder::class,
-            StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class,
-            AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/PharmacyDischargeReadinessTest.php
+++ b/tests/Feature/Ancillary/PharmacyDischargeReadinessTest.php
@@ -5,23 +5,16 @@ declare(strict_types=1);
 namespace Tests\Feature\Ancillary;
 
 use App\Services\Ancillary\AncillaryReadinessService;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Pharmacy\PharmacyDischargeReadinessService;
 use App\Services\Rtdc\DischargePrioritiesService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class PharmacyDischargeReadinessTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -30,14 +23,6 @@ final class PharmacyDischargeReadinessTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([
-            RtdcSeeder::class,
-            CaseManagementSeeder::class,
-            StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class,
-            AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/PharmacyDispenseTest.php
+++ b/tests/Feature/Ancillary/PharmacyDispenseTest.php
@@ -4,22 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Ancillary;
 
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Pharmacy\PharmacyDispenseService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class PharmacyDispenseTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -28,14 +21,6 @@ final class PharmacyDispenseTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([
-            RtdcSeeder::class,
-            CaseManagementSeeder::class,
-            StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class,
-            AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/PharmacyFlowBoardTest.php
+++ b/tests/Feature/Ancillary/PharmacyFlowBoardTest.php
@@ -5,24 +5,17 @@ namespace Tests\Feature\Ancillary;
 use App\Models\Ancillary\AncillaryOrder;
 use App\Models\Pharmacy\MedicationOrder;
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Pharmacy\PharmacyFlowBoardService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 class PharmacyFlowBoardTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -31,8 +24,6 @@ class PharmacyFlowBoardTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/PharmacyForecastTest.php
+++ b/tests/Feature/Ancillary/PharmacyForecastTest.php
@@ -4,25 +4,18 @@ namespace Tests\Feature\Ancillary;
 
 use App\Models\Pharmacy\AdcStation;
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Pharmacy\PharmacyDispenseService;
 use App\Services\Pharmacy\PharmacyFlowBoardService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 /** End-to-end acceptance for the opt-in P4-3 Pharmacy planning forecasts. */
 class PharmacyForecastTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -31,8 +24,6 @@ class PharmacyForecastTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/PharmacyIvRoomTest.php
+++ b/tests/Feature/Ancillary/PharmacyIvRoomTest.php
@@ -4,22 +4,15 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Ancillary;
 
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Pharmacy\PharmacyIvRoomService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class PharmacyIvRoomTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -30,14 +23,6 @@ final class PharmacyIvRoomTest extends TestCase
         // calendar day, exercising the across-midnight case.
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([
-            RtdcSeeder::class,
-            CaseManagementSeeder::class,
-            StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class,
-            AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/PharmacyPhaseSafetyGateTest.php
+++ b/tests/Feature/Ancillary/PharmacyPhaseSafetyGateTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Ancillary;
 
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Pharmacy\ControlledSubstanceOperationsService;
 use App\Services\Pharmacy\PharmacyDischargeReadinessService;
 use App\Services\Pharmacy\PharmacyDispenseService;
@@ -13,12 +11,7 @@ use App\Services\Pharmacy\PharmacyFlowBoardService;
 use App\Services\Pharmacy\PharmacyIvRoomService;
 use App\Services\Pharmacy\PharmacyTatAnalyticsService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 /**
@@ -38,7 +31,7 @@ use Tests\TestCase;
  */
 final class PharmacyPhaseSafetyGateTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -81,14 +74,6 @@ final class PharmacyPhaseSafetyGateTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([
-            RtdcSeeder::class,
-            CaseManagementSeeder::class,
-            StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class,
-            AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/PharmacyTatAnalyticsTest.php
+++ b/tests/Feature/Ancillary/PharmacyTatAnalyticsTest.php
@@ -7,24 +7,17 @@ namespace Tests\Feature\Ancillary;
 use App\Http\Controllers\Analytics\PharmacyTatController;
 use App\Http\Controllers\Api\Pharmacy\PharmacyFlowBoardController;
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Pharmacy\PharmacyTatAnalyticsService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\DB;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class PharmacyTatAnalyticsTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -34,11 +27,6 @@ final class PharmacyTatAnalyticsTest extends TestCase
         // A Monday so the queue-depth heatmap resolves to a single known weekday.
         $this->anchor = CarbonImmutable::parse('2026-07-13T14:30:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([
-            RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/PharmacyTatAnalyticsTest.php
+++ b/tests/Feature/Ancillary/PharmacyTatAnalyticsTest.php
@@ -19,6 +19,11 @@ final class PharmacyTatAnalyticsTest extends TestCase
 {
     use UsesCommittedAncillaryScenario;
 
+    protected static function committedScenarioAnchor(): string
+    {
+        return '2026-07-13T14:30:00Z';
+    }
+
     private CarbonImmutable $anchor;
 
     protected function setUp(): void

--- a/tests/Feature/Ancillary/RadiologyBreachRiskSortingTest.php
+++ b/tests/Feature/Ancillary/RadiologyBreachRiskSortingTest.php
@@ -3,17 +3,10 @@
 namespace Tests\Feature\Ancillary;
 
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Radiology\RadiologyWorklistService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 /**
@@ -24,7 +17,7 @@ use Tests\TestCase;
  */
 class RadiologyBreachRiskSortingTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -33,8 +26,6 @@ class RadiologyBreachRiskSortingTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/RadiologyFlowBoardTest.php
+++ b/tests/Feature/Ancillary/RadiologyFlowBoardTest.php
@@ -4,23 +4,16 @@ namespace Tests\Feature\Ancillary;
 
 use App\Models\Ancillary\AncillaryOrder;
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Radiology\RadiologyFlowBoardService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 class RadiologyFlowBoardTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -29,8 +22,6 @@ class RadiologyFlowBoardTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Ancillary/RadiologyWorklistTest.php
+++ b/tests/Feature/Ancillary/RadiologyWorklistTest.php
@@ -4,23 +4,16 @@ namespace Tests\Feature\Ancillary;
 
 use App\Models\Ancillary\AncillaryOrder;
 use App\Models\User;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Radiology\RadiologyWorklistService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Inertia\Testing\AssertableInertia as Assert;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 class RadiologyWorklistTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private CarbonImmutable $anchor;
 
@@ -29,8 +22,6 @@ class RadiologyWorklistTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Cockpit/LaboratoryCockpitMetricsTest.php
+++ b/tests/Feature/Cockpit/LaboratoryCockpitMetricsTest.php
@@ -8,27 +8,19 @@ use App\Services\Cockpit\MetricValueWriter;
 use App\Services\Cockpit\SnapshotBuilder;
 use App\Services\Cockpit\StatusEngine;
 use App\Services\CommandCenterDataService;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Lab\LabCockpitHealthService;
 use App\Services\Lab\LabDecisionPendingService;
 use App\Services\Lab\LabFlowBoardService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CockpitKpiDefinitionSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Mockery\MockInterface;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class LaboratoryCockpitMetricsTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private const KEYS = [
         'flow.ancillary_lab_stat_compliance',
@@ -44,15 +36,6 @@ final class LaboratoryCockpitMetricsTest extends TestCase
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
         Cache::forget(SnapshotBuilder::CACHE_KEY);
-        $this->seed([
-            RtdcSeeder::class,
-            CaseManagementSeeder::class,
-            StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class,
-            CockpitKpiDefinitionSeeder::class,
-            AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
         $this->mock(CommandCenterDataService::class, function (MockInterface $mock): void {
             $mock->shouldReceive('build')->andReturn([
                 'generatedAtIso' => $this->anchor->toIso8601String(),

--- a/tests/Feature/Cockpit/PharmacyCockpitMetricsTest.php
+++ b/tests/Feature/Cockpit/PharmacyCockpitMetricsTest.php
@@ -8,26 +8,18 @@ use App\Services\Cockpit\MetricValueWriter;
 use App\Services\Cockpit\SnapshotBuilder;
 use App\Services\Cockpit\StatusEngine;
 use App\Services\CommandCenterDataService;
-use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
-use App\Services\Demo\DemoClock;
 use App\Services\Pharmacy\PharmacyCockpitHealthService;
 use App\Services\Pharmacy\PharmacyFlowBoardService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CockpitKpiDefinitionSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Mockery\MockInterface;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 final class PharmacyCockpitMetricsTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
 
     private const KEYS = [
         'flow.ancillary_rx_verification_queue',
@@ -50,15 +42,6 @@ final class PharmacyCockpitMetricsTest extends TestCase
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
         Cache::forget(SnapshotBuilder::CACHE_KEY);
-        $this->seed([
-            RtdcSeeder::class,
-            CaseManagementSeeder::class,
-            StaffingReferenceSeeder::class,
-            CommandCenterDemoSeeder::class,
-            CockpitKpiDefinitionSeeder::class,
-            AncillaryReferenceSeeder::class,
-        ]);
-        app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($this->anchor));
         $this->mock(CommandCenterDataService::class, function (MockInterface $mock): void {
             $mock->shouldReceive('build')->andReturn([
                 'generatedAtIso' => $this->anchor->toIso8601String(),

--- a/tests/Feature/Demo/AncillaryDemoScenarioTest.php
+++ b/tests/Feature/Demo/AncillaryDemoScenarioTest.php
@@ -11,21 +11,21 @@ use App\Services\Demo\DemoClock;
 use App\Services\Demo\DemoInvariantService;
 use App\Services\Demo\DemoRefreshCoordinator;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\DB;
 use RuntimeException;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 class AncillaryDemoScenarioTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
+
+    protected static function committedScenarioIncludesRefresh(): bool
+    {
+        return false;
+    }
 
     private CarbonImmutable $anchor;
 
@@ -34,7 +34,6 @@ class AncillaryDemoScenarioTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
         $unitId = (int) DB::table('prod.units')->orderBy('unit_id')->value('unit_id');
         DB::table('prod.encounters')->insert([
             'patient_ref' => 'demo-discharge-candidate', 'unit_id' => $unitId, 'status' => 'active',

--- a/tests/Feature/Demo/LabDemoGeneratorTest.php
+++ b/tests/Feature/Demo/LabDemoGeneratorTest.php
@@ -12,18 +12,18 @@ use App\Services\Demo\DemoClock;
 use App\Services\Demo\DemoInvariantService;
 use App\Services\Rtdc\DischargePrioritiesService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 class LabDemoGeneratorTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
+
+    protected static function committedScenarioIncludesRefresh(): bool
+    {
+        return false;
+    }
 
     private CarbonImmutable $anchor;
 
@@ -32,7 +32,6 @@ class LabDemoGeneratorTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Demo/PharmacyDemoGeneratorTest.php
+++ b/tests/Feature/Demo/PharmacyDemoGeneratorTest.php
@@ -18,18 +18,18 @@ use App\Services\Pharmacy\AdcStationSignalService;
 use App\Services\Pharmacy\PharmacyAdministrationFreshnessService;
 use App\Services\Rtdc\DischargePrioritiesService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 class PharmacyDemoGeneratorTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
+
+    protected static function committedScenarioIncludesRefresh(): bool
+    {
+        return false;
+    }
 
     private CarbonImmutable $anchor;
 
@@ -38,7 +38,6 @@ class PharmacyDemoGeneratorTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
     }
 
     protected function tearDown(): void

--- a/tests/Feature/Demo/RadiologyDemoGeneratorTest.php
+++ b/tests/Feature/Demo/RadiologyDemoGeneratorTest.php
@@ -10,18 +10,18 @@ use App\Services\Radiology\IrSuiteAnalyticsService;
 use App\Services\Radiology\ModalityUtilizationService;
 use App\Services\Radiology\RadiologyReadsService;
 use Carbon\CarbonImmutable;
-use Database\Seeders\AncillaryReferenceSeeder;
-use Database\Seeders\CaseManagementSeeder;
-use Database\Seeders\CommandCenterDemoSeeder;
-use Database\Seeders\RtdcSeeder;
-use Database\Seeders\StaffingReferenceSeeder;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
 class RadiologyDemoGeneratorTest extends TestCase
 {
-    use RefreshDatabase;
+    use UsesCommittedAncillaryScenario;
+
+    protected static function committedScenarioIncludesRefresh(): bool
+    {
+        return false;
+    }
 
     private CarbonImmutable $anchor;
 
@@ -30,7 +30,6 @@ class RadiologyDemoGeneratorTest extends TestCase
         parent::setUp();
         $this->anchor = CarbonImmutable::parse('2026-07-11T14:00:00Z');
         CarbonImmutable::setTestNow($this->anchor);
-        $this->seed([RtdcSeeder::class, CaseManagementSeeder::class, StaffingReferenceSeeder::class, CommandCenterDemoSeeder::class, AncillaryReferenceSeeder::class]);
     }
 
     protected function tearDown(): void

--- a/tests/Support/IsolatedTestDatabase.php
+++ b/tests/Support/IsolatedTestDatabase.php
@@ -42,6 +42,48 @@ final class IsolatedTestDatabase
         return self::$database;
     }
 
+    /**
+     * Drop every non-system schema in the CURRENT test database and
+     * recreate an empty public schema — the same state a freshly
+     * provisioned database presents (migrations recreate all schemas and
+     * extensions via CREATE ... IF NOT EXISTS). Needed because
+     * migrate:fresh only drops search_path tables and this application
+     * spans many PG schemas. Used by the CI plan S2 boundary guard in
+     * tests/TestCase.php when a non-scenario class follows a class-scoped
+     * committed scenario in the same process.
+     */
+    public static function resetAllSchemas(): void
+    {
+        $database = (string) (getenv('DB_DATABASE') ?: '');
+        if (! preg_match('/^zephyrus_test(?:_[a-z0-9]+)?$/', $database)) {
+            throw new RuntimeException(
+                'Refusing to reset schemas because DB_DATABASE is not test-scoped.',
+            );
+        }
+
+        $host = (string) (getenv('DB_HOST') ?: '127.0.0.1');
+        $port = (string) (getenv('DB_PORT') ?: '5432');
+        $username = (string) (getenv('DB_USERNAME') ?: 'postgres');
+        $password = (string) (getenv('DB_PASSWORD') ?: '');
+
+        $pdo = new PDO(
+            "pgsql:host={$host};port={$port};dbname={$database}",
+            $username,
+            $password,
+            [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION],
+        );
+
+        $schemas = $pdo->query(
+            "SELECT nspname FROM pg_namespace WHERE nspname NOT LIKE 'pg\\_%' AND nspname <> 'information_schema'",
+        )->fetchAll(PDO::FETCH_COLUMN);
+
+        foreach ($schemas as $schema) {
+            $pdo->exec('DROP SCHEMA '.self::identifier((string) $schema).' CASCADE');
+        }
+
+        $pdo->exec('CREATE SCHEMA public');
+    }
+
     private static function drop(): void
     {
         $database = self::$database;

--- a/tests/Support/Scenario/CommittedScenarioState.php
+++ b/tests/Support/Scenario/CommittedScenarioState.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Scenario;
+
+/**
+ * Process-wide registry for the class-scoped committed ancillary demo
+ * scenario (CI plan S2). Tracks which test class currently owns the
+ * committed baseline so consumer classes rebuild it exactly once and the
+ * base TestCase can force a fresh migration when a non-scenario class
+ * follows a scenario class in the same PHP process.
+ */
+final class CommittedScenarioState
+{
+    /** Class name that built the currently committed baseline, if any. */
+    public static ?string $activeClass = null;
+
+    public static function reset(): void
+    {
+        self::$activeClass = null;
+    }
+}

--- a/tests/Support/Scenario/UsesCommittedAncillaryScenario.php
+++ b/tests/Support/Scenario/UsesCommittedAncillaryScenario.php
@@ -15,6 +15,7 @@ use Database\Seeders\StaffingReferenceSeeder;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\RefreshDatabaseState;
+use Illuminate\Support\Facades\DB;
 
 /**
  * CI plan S2 — class-scoped committed demo scenario.
@@ -88,6 +89,11 @@ trait UsesCommittedAncillaryScenario
 
         $anchor = CarbonImmutable::parse(static::committedScenarioAnchor());
 
+        // The build runs during parent::setUp(), before TestCase::setUp()
+        // reaches its per-test wiring — apply the payload-store wiring the
+        // scenario's CanonicalEventWriter path depends on.
+        $this->wireClinicalPayloadTestStore();
+
         CarbonImmutable::setTestNow($anchor);
 
         try {
@@ -105,6 +111,14 @@ trait UsesCommittedAncillaryScenario
         } finally {
             CarbonImmutable::setTestNow();
         }
+
+        // Committed baselines live across many DELETE+INSERT build cycles
+        // in one process; without this, autovacuum timing leaves planner
+        // statistics AND visibility-map coverage (which prices the suite's
+        // Index Only Scan plan-shape assertions) nondeterministic. VACUUM
+        // is legal here — the build runs in autocommit, outside any test
+        // transaction. Same data -> same stats + VM -> same plans.
+        DB::statement('VACUUM ANALYZE');
 
         CommittedScenarioState::$activeClass = static::class;
     }

--- a/tests/Support/Scenario/UsesCommittedAncillaryScenario.php
+++ b/tests/Support/Scenario/UsesCommittedAncillaryScenario.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support\Scenario;
+
+use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
+use App\Services\Demo\DemoClock;
+use Carbon\CarbonImmutable;
+use Database\Seeders\AncillaryReferenceSeeder;
+use Database\Seeders\CaseManagementSeeder;
+use Database\Seeders\CommandCenterDemoSeeder;
+use Database\Seeders\RtdcSeeder;
+use Database\Seeders\StaffingReferenceSeeder;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabaseState;
+
+/**
+ * CI plan S2 — class-scoped committed demo scenario.
+ *
+ * The ancillary demo scenario (5 seeders + AncillaryDemoScenarioService::
+ * refresh, ~30 s) used to be rebuilt inside setUp() for EVERY test method,
+ * where RefreshDatabase's per-test transaction rolled it back each time —
+ * 87% of backend suite compute. This trait builds it ONCE PER CLASS,
+ * COMMITTED (per-test transactions cannot survive between tests because
+ * RefreshDatabase disconnects the connection after each rollback), before
+ * the per-test transaction begins. Every test still runs inside its own
+ * rollback transaction, so each starts from a byte-identical baseline —
+ * mutations never leak between tests.
+ *
+ * Safety rests on audited properties of the build (2026-07-25 audit):
+ * the service and seeders self-clear via owner-scoped DELETEs and
+ * idempotent upserts, never COMMIT, never TRUNCATE, use one connection,
+ * and derive all content deterministically from the anchor. A successor
+ * scenario class simply rebuilds over the previous class's residue; a
+ * NON-scenario class following a scenario class gets a fresh migration
+ * via the guard in tests/TestCase.php.
+ */
+trait UsesCommittedAncillaryScenario
+{
+    use RefreshDatabase;
+
+    /**
+     * The anchor every current consumer class builds at. Override per
+     * class if a future consumer needs a different scenario clock.
+     */
+    protected static function committedScenarioAnchor(): string
+    {
+        return '2026-07-11T14:00:00Z';
+    }
+
+    /**
+     * Generator-contract tests exercise refresh() inside their test
+     * bodies; they override this to hoist only the seeders.
+     */
+    protected static function committedScenarioIncludesRefresh(): bool
+    {
+        return true;
+    }
+
+    protected function refreshTestDatabase(): void
+    {
+        if (! RefreshDatabaseState::$migrated) {
+            $this->migrateDatabases();
+
+            $this->app[Kernel::class]->setArtisan(null);
+
+            RefreshDatabaseState::$migrated = true;
+            CommittedScenarioState::reset();
+        }
+
+        $this->ensureCommittedScenario();
+
+        $this->beginDatabaseTransaction();
+    }
+
+    /**
+     * Build the committed baseline exactly once per class. Runs OUTSIDE
+     * any test transaction (autocommit), so the data survives the
+     * per-test rollback + disconnect cycle.
+     */
+    private function ensureCommittedScenario(): void
+    {
+        if (CommittedScenarioState::$activeClass === static::class) {
+            return;
+        }
+
+        $anchor = CarbonImmutable::parse(static::committedScenarioAnchor());
+
+        CarbonImmutable::setTestNow($anchor);
+
+        try {
+            $this->seed([
+                RtdcSeeder::class,
+                CaseManagementSeeder::class,
+                StaffingReferenceSeeder::class,
+                CommandCenterDemoSeeder::class,
+                AncillaryReferenceSeeder::class,
+            ]);
+
+            if (static::committedScenarioIncludesRefresh()) {
+                app(AncillaryDemoScenarioService::class)->refresh(new DemoClock($anchor));
+            }
+        } finally {
+            CarbonImmutable::setTestNow();
+        }
+
+        CommittedScenarioState::$activeClass = static::class;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,6 +51,10 @@ abstract class TestCase extends BaseTestCase
         // RefreshDatabaseState::$migrated.
         if (CommittedScenarioState::$activeClass !== null
             && ! in_array(UsesCommittedAncillaryScenario::class, class_uses_recursive(static::class), true)) {
+            // migrate:fresh only drops search_path tables while this app
+            // spans many PG schemas — wipe them all so the re-migration
+            // reproduces a freshly provisioned database.
+            Support\IsolatedTestDatabase::resetAllSchemas();
             RefreshDatabaseState::$migrated = false;
             CommittedScenarioState::reset();
         }
@@ -61,6 +65,21 @@ abstract class TestCase extends BaseTestCase
             Http::preventStrayRequests();
         }
 
+        $this->wireClinicalPayloadTestStore();
+
+        $this->withoutVite();
+    }
+
+    /**
+     * Test wiring for the encrypted clinical-payload store (in-memory
+     * secret providers + local disk). Applied on every test in setUp();
+     * also applied by UsesCommittedAncillaryScenario BEFORE the class-
+     * scoped scenario build, which runs during parent::setUp() — earlier
+     * than this method's setUp() invocation — and writes payloads
+     * through CanonicalEventWriter.
+     */
+    protected function wireClinicalPayloadTestStore(): void
+    {
         $this->app->singleton(SecretProviderRegistry::class, fn ($app) => new SecretProviderRegistry([
             $app->make(FileSecretProvider::class),
             new InMemorySecretProvider('vault'),
@@ -83,8 +102,6 @@ abstract class TestCase extends BaseTestCase
                 'report' => false,
             ],
         ]);
-
-        $this->withoutVite();
     }
 
     public function actingAs(Authenticatable $user, $guard = null)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,10 +10,13 @@ use App\Services\Auth\AccountSessionService;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Foundation\Testing\RefreshDatabaseState;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Tests\Support\InMemorySecretProvider;
+use Tests\Support\Scenario\CommittedScenarioState;
+use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\Support\Timing\QueryEvidence;
 use Tests\Support\Timing\TimingEvidence;
 
@@ -39,6 +42,19 @@ abstract class TestCase extends BaseTestCase
 
     protected function setUp(): void
     {
+        // CI plan S2: a scenario class leaves a COMMITTED demo baseline
+        // behind (see UsesCommittedAncillaryScenario). Scenario classes
+        // rebuild over it idempotently, but a non-scenario class expects
+        // the clean post-migration baseline — force a fresh migration
+        // before this test's application boots. Must run before
+        // parent::setUp(), which is where RefreshDatabase consults
+        // RefreshDatabaseState::$migrated.
+        if (CommittedScenarioState::$activeClass !== null
+            && ! in_array(UsesCommittedAncillaryScenario::class, class_uses_recursive(static::class), true)) {
+            RefreshDatabaseState::$migrated = false;
+            CommittedScenarioState::reset();
+        }
+
         parent::setUp();
 
         if (filter_var(getenv('TEST_NETWORK_GUARD') ?: 'false', FILTER_VALIDATE_BOOL)) {


### PR DESCRIPTION
## Summary
- Implements plan S2 — the largest backend win: the 5-seeder + `AncillaryDemoScenarioService::refresh` build (~33 s on CI) ran in `setUp()` inside every test's RefreshDatabase transaction, rebuilt and rolled back for **every test method** (135 methods; ~87% of suite compute). `UsesCommittedAncillaryScenario` builds it **once per class, committed** — an open outer transaction cannot span tests because RefreshDatabase disconnects after each per-test rollback — before the per-test transaction begins. Every test still runs in its own rollback transaction over a byte-identical baseline: isolation preserved, **not** dirty-DB reuse, and every test keeps the FULL governed scenario (stronger than the plan's minimal-fixture sketch).
- Grounded in a 26-class + full-service audit: builds self-clear via owner-scoped DELETEs + idempotent upserts, single connection, no COMMIT/TRUNCATE/DDL, fully anchor-derived. Successor scenario classes rebuild over residue; a non-scenario class following in-process gets a full schema wipe (`IsolatedTestDatabase::resetAllSchemas` — `migrate:fresh` only drops search_path tables in this multi-schema app) + re-migration via the `tests/TestCase.php` guard. `resolve-shard-files.py` orders scenario classes last per shard (content-detected) so CI never pays that path.
- 22 pure consumers share one anchor; `LabTatAnalyticsTest`/`PharmacyTatAnalyticsTest` override `committedScenarioAnchor()` (they anchor 1–2 days later). The 4 generator-contract tests hoist seeders only — in-body `refresh()` is their subject.
- `VACUUM ANALYZE` after each build keeps planner statistics and visibility-map coverage deterministic (the suite's EXPLAIN Index-Only-Scan assertions otherwise flip with autovacuum timing over repeated DELETE+INSERT cycles).
- Scenario builds per full run: **135 → ~26**; measured suite setup compute was 4,065 s/run (66–72% of backend wall).

## Verification (§3.2.9)
- [x] All 26 converted classes in one PHP process: **317 tests, 75,381 assertions, green**
- [x] Adversarial classes individually: GUC `SET LOCAL` classes, `DB::listen` class, generator idempotency/rolling-replacement/collision tests
- [x] Scenario→non-scenario boundary in one process (wipe + re-migrate): green
- [x] Shard manifest verifier passes; scenario classes emit last on every shard
- [ ] CI shards: expect identical test/assertion counts (1,916 suite-wide) with shard walls dropping sharply; regenerate the S1 manifest from post-S2 evidence as follow-up (weights shrink)