### PR TITLE
ci: ratchet backend shard timeout 30 -> 20 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,8 +248,10 @@ jobs:
     needs: changes
     # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
     if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
-    # Matches the ratified "no shard above 30 m" budget; caps hung-shard burn.
-    timeout-minutes: 30
+    # Ratcheted 30 -> 20 after S1/S2/D1: worst observed shard is ~10.5 m
+    # (feature-1 carrying the RadiologyDemoGeneratorTest swing — evidence run
+    # 30163345605), so 20 m keeps ~2x headroom while halving hung-shard burn.
+    timeout-minutes: 20
     env:
       APP_ENV: testing
       APP_KEY: base64:MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA=


### PR DESCRIPTION
## Summary
- Lowers `backend-tests` shard `timeout-minutes` from 30 to 20, per the CI duration plan's ratchet gate (unblocked now that the feature-1 residual is explained).

## Evidence
- Post S1/S2/D1 + the #74 manifest regen, feature shards run 4–7 m; the floor shard ~10 m.
- The only outlier — feature-1 at 9.5–10.5 m on the #74 runs — is entirely `RadiologyDemoGeneratorTest`'s single mega-test (36,893 body queries) swinging 176 s ↔ ~450 s run-to-run; every other shard-1 file matched its manifest weight (NDJSON diff vs evidence run 30163345605). Worst observed swing keeps the job ≈ 10.5 m, giving ~2× headroom under 20 m.
- Per §3.2.9: a timeout change is a burn cap, not an optimization — no budget-evidence implications.

## Test plan
- [ ] Full PR suite green; all 8 backend shards complete well under 20 m

🤖 Generated with [Claude Code](https://claude.com/claude-code)