### PR TITLE
perf(demo): index refresh hot paths and batch projection flips (plan D2)

### DIFF
--- a/app/Services/Demo/Ancillary/AbstractAncillaryDemoGenerator.php
+++ b/app/Services/Demo/Ancillary/AbstractAncillaryDemoGenerator.php
@@ -8,6 +8,7 @@ use App\Integrations\Healthcare\Services\CanonicalEventWriter;
 use App\Integrations\Healthcare\Services\ProjectionDispatcher;
 use App\Integrations\Healthcare\Services\SourceRegistryService;
 use App\Models\Ancillary\AncillaryOrder;
+use App\Models\Integration\CanonicalEventRecord;
 use App\Models\Integration\Source;
 use App\Services\Demo\DemoClock;
 use App\Services\Rtdc\DischargePrioritiesService;
@@ -77,6 +78,7 @@ abstract class AbstractAncillaryDemoGenerator implements AncillaryDemoGenerator
             $sources = $this->governedSources($owner);
             $this->removeOwnedRows($owner);
             $events = 0;
+            $projected = [];
 
             foreach ($scenarios as $scenario) {
                 foreach ($scenario['events'] as $ordinal => $event) {
@@ -84,7 +86,7 @@ abstract class AbstractAncillaryDemoGenerator implements AncillaryDemoGenerator
                     $canonical = $this->canonicalEvent($clock, $owner, $scenario, $event, $ordinal);
                     $record = $this->writer->write($canonical, $source, replaceOwnedSynthetic: true);
                     $this->projector->project($canonical->withEventId($record->event_id));
-                    $record->update(['projection_status' => 'projected', 'projected_at' => now()]);
+                    $projected[] = (int) $record->getKey();
                     $events++;
                 }
             }
@@ -95,9 +97,11 @@ abstract class AbstractAncillaryDemoGenerator implements AncillaryDemoGenerator
                 $canonical = $entry['event'];
                 $record = $this->writer->write($canonical, $source, replaceOwnedSynthetic: true);
                 $this->projector->project($canonical->withEventId($record->event_id));
-                $record->update(['projection_status' => 'projected', 'projected_at' => now()]);
+                $projected[] = (int) $record->getKey();
                 $operational++;
             }
+
+            $this->markProjected($projected);
 
             $orders = AncillaryOrder::query()->where('demo_owner', $owner)->where('department', $this->department())->count();
 
@@ -114,6 +118,25 @@ abstract class AbstractAncillaryDemoGenerator implements AncillaryDemoGenerator
                 'collisions' => [],
             ];
         }, 3);
+    }
+
+    /**
+     * Every event in one refresh shares the frozen anchor clock
+     * (AncillaryDemoScenarioService::refresh pins setTestNow for the whole
+     * run), so a single SET clause carries the exact timestamps the former
+     * per-event updates wrote. Bulk builder updates fire no model events;
+     * CanonicalEventRecord registers none — a future observer on it would
+     * not see these demo-refresh flips.
+     *
+     * @param  list<int>  $canonicalEventIds
+     */
+    private function markProjected(array $canonicalEventIds): void
+    {
+        foreach (array_chunk($canonicalEventIds, 500) as $chunk) {
+            CanonicalEventRecord::query()
+                ->whereIn('canonical_event_id', $chunk)
+                ->update(['projection_status' => 'projected', 'projected_at' => now()]);
+        }
     }
 
     /** @param list<array<string, mixed>> $scenarios @return list<string> */

--- a/database/migrations/2026_07_25_000100_add_ancillary_refresh_hot_path_indexes.php
+++ b/database/migrations/2026_07_25_000100_add_ancillary_refresh_hot_path_indexes.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // ancillary_orders_reconciliation_key_idx (2026_07_11_000400) carries a
+        // WHERE jsonb_exists(metadata, 'reconciliation_key') predicate that the
+        // planner cannot prove from the metadata->>'reconciliation_key' = ?
+        // clause every reconciliation lookup emits, so it is never chosen and
+        // those probes filter a department-index range row-by-row (D1 finding 2,
+        // docs/audits/D1-ancillary-refresh-profile-2026-07-25.md). An IS NOT
+        // NULL predicate on the indexed expression is provable from the strict
+        // ->> = ? operator, making the probes point index scans.
+        DB::statement(<<<'SQL'
+            CREATE INDEX IF NOT EXISTS ancillary_orders_reconciliation_lookup_idx
+            ON prod.ancillary_orders (department, (metadata->>'reconciliation_key'))
+            WHERE (metadata->>'reconciliation_key') IS NOT NULL
+        SQL);
+
+        // canonical_event_id is an unindexed FK: the owned-row provenance
+        // delete drives on canonical_event_id = ANY(...) but could only use
+        // provenance_target_idx's (target_schema, target_table) prefix,
+        // filtering ~635 unrelated rows per call (D1 finding 4).
+        DB::statement(<<<'SQL'
+            CREATE INDEX IF NOT EXISTS provenance_canonical_event_idx
+            ON integration.provenance_records (canonical_event_id)
+        SQL);
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS prod.ancillary_orders_reconciliation_lookup_idx');
+        DB::statement('DROP INDEX IF EXISTS integration.provenance_canonical_event_idx');
+    }
+};


### PR DESCRIPTION
## Summary

Plan D2 of `docs/superpowers/plans/2026-07-24-ci-duration-optimization-plan.md` — lands the three remediation candidates from the D1 profile (`docs/audits/D1-ancillary-refresh-profile-2026-07-25.md`).

- **Usable reconciliation index** (`ancillary_orders_reconciliation_lookup_idx`): the existing `ancillary_orders_reconciliation_key_idx` is provably dead — its `WHERE jsonb_exists(metadata, 'reconciliation_key')` partial predicate can never be matched by the `metadata->>'reconciliation_key' = ?` clause `AncillaryProjectionHandler::resolveOrder` and `RxAdministrationProjector::matchOrder` emit (seq scan persists even with `enable_seqscan=off`). The `IS NOT NULL`-predicate variant is provable from the strict `->>` operator; the 328-per-refresh reconciliation probes become point index scans. The dead index is deliberately left in place — dropping it is non-additive and gated on separate approval.
- **Provenance delete index** (`provenance_canonical_event_idx`): `canonical_event_id` was an unindexed FK; the owned-row delete drove on `canonical_event_id = ANY(...)` through the `(target_schema, target_table)` prefix of `provenance_target_idx`, filtering ~635 unrelated rows per call.
- **Batched projection flips** (`markProjected()`): 672 per-event `projection_status` updates per refresh collapse into chunked `whereIn` bulk updates inside the same transaction. The refresh clock is frozen to the anchor for the whole run, so the bulk SET writes byte-identical timestamps; `CanonicalEventRecord` registers no model events; no in-transaction reader of `projection_status` exists.

§3.2.9-clean: no dirty-DB reuse, no trigger/migration suppression, demo output unchanged (the determinism/idempotency/invariant tests are the contract and stay green).

## Measured (local, host PG17)

| | before | after |
|---|---:|---:|
| AncillaryDemoScenarioTest (9 tests) | 92.9 s | **82.0 s** (−12%) |
| RadiologyDemoGeneratorTest (1 mega-test) | 97.1 s | **90.0 s** (−7%) |

EXPLAIN in the real migrated schema confirms both plan flips: reconciliation lookup = Index Scan with both clauses as Index Cond; provenance delete = Index Scan on the new index with ~0 filtered rows (SET NULL trigger residual 1.7 ms — companion `ancillary_milestones(provenance_record_id)` index not warranted at this scale).

## Test plan

- [x] `tests/Feature/Ancillary` + `tests/Feature/Demo` + `tests/Feature/Integrations` — 419 tests, 76,728 assertions, green (includes the EXPLAIN plan-shape assertions and `projection_status` end-state tests)
- [x] Pint clean
- [x] EXPLAIN proof for both indexes in a migrated isolated test DB
- [ ] CI full suite green

## Deploy note

`deploy.sh` skips migrations — the two indexes reach prod only via an explicit `./deploy.sh --db`. Until then prod demo refresh runs unchanged (indexes are an optimization, not correctness). Shard-manifest weights for the scenario classes go stale-high; regenerate after 3 post-D2 evidence runs accrue (D1 follow-up 1).