### PR TITLE
fix(ci): expand the backend matrix on docs-only PRs so required contexts register

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,8 +246,13 @@ jobs:
     name: Backend tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
     needs: changes
-    # Plan S4/S4b: skip on verdict reuse or a provably docs-only change set.
-    if: needs.changes.outputs.reuse != 'true' && needs.changes.outputs.docs_only != 'true'
+    # Plan S4: skip on verdict reuse (main pushes only — branch protection
+    # never gates those runs). The S4b docs-only skip lives on the STEPS, not
+    # here: a job-level skip never expands the matrix, so the nine required
+    # "Backend tests (…)" contexts would stay "expected" forever and a
+    # docs-only PR could never merge. With step-level skips each shard boots,
+    # runs nothing, and reports success in ~1 minute.
+    if: needs.changes.outputs.reuse != 'true'
     # Ratcheted 30 -> 20 after S1/S2/D1: worst observed shard is ~10.5 m
     # (feature-1 carrying the RadiologyDemoGeneratorTest swing — evidence run
     # 30163345605), so 20 m keeps ~2x headroom while halving hung-shard burn.
@@ -313,8 +318,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.docs_only != 'true'
 
       - name: Setup PHP 8.4
+        if: needs.changes.outputs.docs_only != 'true'
         uses: shivammathur/setup-php@v2
         with:
           php-version: "8.4"
@@ -322,6 +329,7 @@ jobs:
           coverage: none
 
       - name: Cache Composer dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         uses: actions/cache@v4
         with:
           path: ~/.cache/composer/files
@@ -329,22 +337,27 @@ jobs:
           restore-keys: composer-
 
       - name: Install Composer dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         run: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Copy environment template
+        if: needs.changes.outputs.docs_only != 'true'
         run: cp .env.example .env
 
       - name: Prove test resource isolation
+        if: needs.changes.outputs.docs_only != 'true'
         run: php scripts/assert-test-environment.php
 
       - name: Run migrations
+        if: needs.changes.outputs.docs_only != 'true'
         run: bash scripts/capture-release-evidence.sh backend-migration php artisan migrate --force
 
       - name: Run PHPUnit shard
+        if: needs.changes.outputs.docs_only != 'true'
         run: bash scripts/capture-release-evidence.sh backend-phpunit-${{ matrix.shard }} scripts/ci/run-backend-test-shard.sh "${{ matrix.shard }}"
 
       - name: Upload backend shard evidence
-        if: always()
+        if: always() && needs.changes.outputs.docs_only != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: backend-${{ matrix.shard }}-release-evidence


### PR DESCRIPTION
## Summary
- Docs-only PRs were **unmergeable**: the S4b fast path skipped `backend-tests` at the job level, and a job-level skip never expands the matrix — the nine required `Backend tests (…)` contexts stayed "expected" forever (`9 of 17 required status checks are expected`). First hit: PR #80. Admin bypass is disabled, so there was no workaround.
- Fix: job-level `if` keeps only the verdict-reuse skip (main pushes — protection never gates those runs); the docs-only skip moves to step level. Each shard boots, skips every step, and reports success in ~1 minute. Single-job required contexts (frontend, browser, DAST, arena, patient jobs) are unaffected — skipped non-matrix jobs do register check runs, as PR #80's rollup shows.

## Behavior matrix
| Lane | Before | After |
|---|---|---|
| Normal PR | full shards | full shards (unchanged) |
| Docs-only PR | matrix never expands → unmergeable | 9 stub shards, ~1 m each in parallel |
| Main verdict reuse | job skipped | job skipped (unchanged) |
| Main docs-only push | job skipped | 9 stub shards (run still green) |

## Test plan
- [ ] Full PR suite green (this PR is a ci.yml change → full lane)
- [ ] After merge: update-branch on PR #80 → its docs-only rerun registers all 17 required contexts and merges cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)