### PR TITLE
chore(deps): bump laravel/pint to ^1.29 and apply the restyle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,7 +225,7 @@ jobs:
         run: bash scripts/ci/verify-shard-manifest.sh
 
       - name: Run Pint (code style)
-        run: ./vendor/bin/pint --test
+        run: ./vendor/bin/pint --test --parallel
 
       - name: Run migrations
         run: bash scripts/capture-release-evidence.sh backend-migration php artisan migrate --force

--- a/app/Console/Commands/OcelProjectCommand.php
+++ b/app/Console/Commands/OcelProjectCommand.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Domain\Ocel\OcelProjector;
+use App\Domain\Ocel\QuantityProjector;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 
@@ -61,7 +62,7 @@ class OcelProjectCommand extends Command
             $this->info('OCEL projection complete.');
         }
 
-        $quantities = app(\App\Domain\Ocel\QuantityProjector::class)->project($since, $until);
+        $quantities = app(QuantityProjector::class)->project($since, $until);
         $this->info("QEL quantities: {$quantities['operations']} operations, {$quantities['initial']} initial.");
 
         return self::SUCCESS;

--- a/app/Domain/Arena/FlowReviewService.php
+++ b/app/Domain/Arena/FlowReviewService.php
@@ -141,7 +141,7 @@ class FlowReviewService
      *
      * @return array<int, array<string, mixed>>
      */
-    private function openHumanBarriers(\Illuminate\Support\Carbon $to): array
+    private function openHumanBarriers(Carbon $to): array
     {
         return Barrier::query()
             ->open()

--- a/app/Domain/Cockpit/Metrics/EdMetrics.php
+++ b/app/Domain/Cockpit/Metrics/EdMetrics.php
@@ -3,6 +3,7 @@
 namespace App\Domain\Cockpit\Metrics;
 
 use App\Domain\Cockpit\SnapshotContext;
+use App\Models\Transport\TransportRequest;
 use App\Services\Cockpit\StatusEngine;
 use App\Services\Ed\NedocsService;
 use App\Support\Cockpit\MetricValue;
@@ -66,7 +67,7 @@ class EdMetrics extends BaseMetrics
 
         // Same convention as TransportOperationsService::overview()'s
         // metrics.ems_inbound — the model's active() scope.
-        $emsInbound = (int) \App\Models\Transport\TransportRequest::active()
+        $emsInbound = (int) TransportRequest::active()
             ->where('request_type', 'ems')
             ->count();
 

--- a/app/Domain/Cockpit/SnapshotContext.php
+++ b/app/Domain/Cockpit/SnapshotContext.php
@@ -3,6 +3,7 @@
 namespace App\Domain\Cockpit;
 
 use App\Models\Ops\MetricDefinition;
+use App\Services\Cockpit\MetricTrendReader;
 use App\Support\Cockpit\MetricValue;
 use Illuminate\Support\Collection;
 
@@ -50,7 +51,7 @@ class SnapshotContext
     {
         $trend = $this->trends[$key] ?? null;
 
-        return is_array($trend) && count($trend) >= \App\Services\Cockpit\MetricTrendReader::MIN_POINTS
+        return is_array($trend) && count($trend) >= MetricTrendReader::MIN_POINTS
             ? $trend
             : null;
     }

--- a/app/Domain/Ocel/OcelJsonExporter.php
+++ b/app/Domain/Ocel/OcelJsonExporter.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Ocel;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -191,6 +192,6 @@ final class OcelJsonExporter
 
     private function iso(string $value): string
     {
-        return \Carbon\Carbon::parse($value)->toIso8601String();
+        return Carbon::parse($value)->toIso8601String();
     }
 }

--- a/app/Domain/Ocel/QuantityExporter.php
+++ b/app/Domain/Ocel/QuantityExporter.php
@@ -2,6 +2,7 @@
 
 namespace App\Domain\Ocel;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -32,7 +33,7 @@ final class QuantityExporter
                 'object_id' => $r->object_id,
                 'item_type' => $r->item_type,
                 'delta' => (int) $r->delta,
-                'event_time' => \Carbon\Carbon::parse($r->event_time)->toIso8601String(),
+                'event_time' => Carbon::parse($r->event_time)->toIso8601String(),
             ])->all();
 
         return ['initial' => $initial, 'operations' => $operations];

--- a/app/Domain/Ocel/QuantityProjector.php
+++ b/app/Domain/Ocel/QuantityProjector.php
@@ -101,7 +101,7 @@ class QuantityProjector
                 'event_id' => $r->event_id,
                 'activity' => $r->activity,
                 'unit_id' => $r->unit_id,
-                'time' => \Carbon\Carbon::parse($r->time)->toIso8601String(),
+                'time' => Carbon::parse($r->time)->toIso8601String(),
             ])->all();
     }
 

--- a/app/Http/Controllers/Admin/EnterpriseRegistryController.php
+++ b/app/Http/Controllers/Admin/EnterpriseRegistryController.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Governance\GovernedChangeRequest;
 use App\Services\Authorization\RoleCapabilityService;
 use App\Services\Deployment\EnterpriseRegistryImportService;
+use App\Services\Governance\GovernedChangeService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -88,7 +89,7 @@ class EnterpriseRegistryController extends Controller
         ]);
         $this->assertImportChange($changeRequestUuid);
 
-        $decision = app(\App\Services\Governance\GovernedChangeService::class)->decide(
+        $decision = app(GovernedChangeService::class)->decide(
             $request,
             $changeRequestUuid,
             (bool) $validated['approve'],

--- a/app/Http/Controllers/Analytics/RoomRunningController.php
+++ b/app/Http/Controllers/Analytics/RoomRunningController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Analytics;
 
 use App\Http\Controllers\Controller;
+use App\Services\Analytics\RoomRunningService;
 use Inertia\Inertia;
 
 class RoomRunningController extends Controller
@@ -10,7 +11,7 @@ class RoomRunningController extends Controller
     public function index()
     {
         return Inertia::render('Analytics/RoomRunning', [
-            'roomRunning' => (new \App\Services\Analytics\RoomRunningService)->build(),
+            'roomRunning' => (new RoomRunningService)->build(),
         ]);
     }
 }

--- a/app/Http/Controllers/Api/Admin/EnterpriseConnectorController.php
+++ b/app/Http/Controllers/Api/Admin/EnterpriseConnectorController.php
@@ -2,12 +2,14 @@
 
 namespace App\Http\Controllers\Api\Admin;
 
+use App\Authorization\AuthorizationScope;
 use App\Authorization\GovernedAction;
 use App\Http\Controllers\Api\Admin\Concerns\ResolvesIntegrationCorrelation;
 use App\Http\Controllers\Controller;
 use App\Integrations\Healthcare\Services\EnterpriseConnectorControlService;
 use App\Integrations\Healthcare\Services\FhirConformanceObservationService;
 use App\Integrations\Healthcare\Services\FhirResourceProfileService;
+use App\Models\Integration\Source;
 use App\Services\Authorization\AdminScopeService;
 use App\Services\Governance\GovernedChangeService;
 use Illuminate\Http\JsonResponse;
@@ -242,7 +244,7 @@ class EnterpriseConnectorController extends Controller
     private function replayScope(Request $request): array
     {
         return $request->validate([
-            'source_id' => ['required', 'integer', 'min:1', Rule::exists(\App\Models\Integration\Source::class, 'source_id')],
+            'source_id' => ['required', 'integer', 'min:1', Rule::exists(Source::class, 'source_id')],
             'from' => ['required', 'date'],
             'to' => ['required', 'date'],
             'event_types' => ['sometimes', 'array', 'min:1', 'max:5'],
@@ -252,12 +254,12 @@ class EnterpriseConnectorController extends Controller
     }
 
     /** @param array<string, mixed> $scope */
-    private function replayAuthorizationScope(array $scope): \App\Authorization\AuthorizationScope
+    private function replayAuthorizationScope(array $scope): AuthorizationScope
     {
         $sourceId = $scope['sourceId'] ?? null;
         abort_unless(is_int($sourceId) && $sourceId > 0, 422);
 
-        return \App\Authorization\AuthorizationScope::facility(
+        return AuthorizationScope::facility(
             (int) DB::table('integration.sources')->where('source_id', $sourceId)->value('facility_id'),
         );
     }

--- a/app/Http/Controllers/Api/ArenaController.php
+++ b/app/Http/Controllers/Api/ArenaController.php
@@ -7,6 +7,7 @@ use App\Domain\Arena\FlowReviewService;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 
 /**
  * Zephyrus 2.0 Part X (X1) Arena serving API. The browser calls these; Laravel
@@ -162,7 +163,7 @@ class ArenaController extends Controller
             return null;
         }
 
-        \Illuminate\Support\Facades\Validator::make(
+        Validator::make(
             ['filters' => $decoded],
             [
                 'filters' => ['array', 'max:12'],

--- a/app/Http/Controllers/Api/CockpitController.php
+++ b/app/Http/Controllers/Api/CockpitController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Models\Cockpit\CockpitAlert;
 use App\Models\Ops\MetricDefinition;
 use App\Services\Audit\UserAuditRecorder;
+use App\Services\Cockpit\AlertEngine;
 use App\Services\Cockpit\DrillBuilder;
 use App\Services\Cockpit\ScopedFaceBuilder;
 use App\Services\Cockpit\SnapshotBuilder;
+use App\Services\Governance\CockpitThresholdPolicyService;
 use App\Support\Cockpit\CockpitScopeResolver;
 use App\Support\Hospital\HospitalManifest;
 use Illuminate\Http\JsonResponse;
@@ -116,11 +119,11 @@ class CockpitController extends Controller
      */
     public function acknowledgeAlert(Request $request, int $alertId): JsonResponse
     {
-        $row = \App\Models\Cockpit\CockpitAlert::query()
+        $row = CockpitAlert::query()
             ->whereKey($alertId)
             ->where('facility_key', $this->manifest->facilityCode())
             ->whereNull('cleared_at')
-            ->where('status', '!=', \App\Services\Cockpit\AlertEngine::STATUS_PENDING)
+            ->where('status', '!=', AlertEngine::STATUS_PENDING)
             ->first();
 
         if ($row === null) {
@@ -178,7 +181,7 @@ class CockpitController extends Controller
     public function updateKpiDefinition(
         Request $request,
         string $metricKey,
-        \App\Services\Governance\CockpitThresholdPolicyService $thresholdPolicy,
+        CockpitThresholdPolicyService $thresholdPolicy,
     ): JsonResponse {
         $validated = $request->validate([
             'ok_edge' => ['nullable', 'numeric'],

--- a/app/Http/Controllers/Api/Deployment/FacilityController.php
+++ b/app/Http/Controllers/Api/Deployment/FacilityController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Deployment;
 
+use App\Casts\PgTextArray;
 use App\Http\Controllers\Controller;
 use App\Models\Org\Facility;
 use Illuminate\Http\JsonResponse;
@@ -120,7 +121,7 @@ class FacilityController extends Controller
             'location_role' => $s->location_role,
             'acuity_level' => $s->acuity_level,
             'service_lines' => $serviceLinesBySpace[(int) $s->facility_space_id] ?? [],
-            'capability_tags' => \App\Casts\PgTextArray::parse($s->capability_tags),
+            'capability_tags' => PgTextArray::parse($s->capability_tags),
             'operational_targets' => $targetsBySpace[(int) $s->facility_space_id] ?? [],
             'status' => $s->status,
         ])->all();
@@ -148,7 +149,7 @@ class FacilityController extends Controller
                 'capability_level' => $r->capability_level,
                 'coverage_model' => $r->coverage_model,
                 'hours' => $r->hours,
-                'programs_present' => \App\Casts\PgTextArray::parse($r->programs_present),
+                'programs_present' => PgTextArray::parse($r->programs_present),
                 'source_evidence_type' => $r->source_evidence_type,
                 'review_status' => $r->review_status,
             ])->all();

--- a/app/Http/Controllers/Api/Deployment/Staffing/StaffingSourceController.php
+++ b/app/Http/Controllers/Api/Deployment/Staffing/StaffingSourceController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Deployment\Staffing;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Deployment\Staffing\StoreStaffingSourceRequest;
 use App\Models\Org\StaffingSource;
+use App\Services\Staffing\Contracts\StaffingConnector;
 use App\Services\Staffing\StaffingConnectorFactory;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -111,7 +112,7 @@ class StaffingSourceController extends Controller
      * Build the connector from request-supplied content (csv string / fhir bundle) +
      * an optional per-run mapping override.
      */
-    private function connectorFor(StaffingSource $source, Request $request): \App\Services\Staffing\Contracts\StaffingConnector
+    private function connectorFor(StaffingSource $source, Request $request): StaffingConnector
     {
         return $this->factory->make($source, array_filter([
             'csv' => $request->input('csv'),

--- a/app/Http/Controllers/Api/Eddy/EddyActionController.php
+++ b/app/Http/Controllers/Api/Eddy/EddyActionController.php
@@ -4,11 +4,13 @@ namespace App\Http\Controllers\Api\Eddy;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Eddy\EddyProposeActionRequest;
+use App\Models\User;
 use App\Services\Eddy\EddyActionService;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use InvalidArgumentException;
+use Laravel\Sanctum\TransientToken;
 
 class EddyActionController extends Controller
 {
@@ -47,11 +49,11 @@ class EddyActionController extends Controller
     }
 
     /** Session (web) or SPA-stateful auth = a human; a real personal access token = the agent. */
-    private function actsAsHuman(\App\Models\User $user): bool
+    private function actsAsHuman(User $user): bool
     {
         $token = $user->currentAccessToken();
 
-        return $token === null || $token instanceof \Laravel\Sanctum\TransientToken;
+        return $token === null || $token instanceof TransientToken;
     }
 
     /**

--- a/app/Http/Controllers/Api/Mobile/AuthController.php
+++ b/app/Http/Controllers/Api/Mobile/AuthController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Api\Mobile;
 
+use App\Http\Controllers\Auth\AuthenticatedSessionController;
+use App\Http\Controllers\Auth\ChangePasswordController;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Services\Audit\UserAuditRecorder;
@@ -22,8 +24,8 @@ use Laravel\Sanctum\PersonalAccessToken;
  * honors must_change_password exactly: a forced-change user receives only a
  * narrowly-scoped change token until they set a new password.
  *
- * @see \App\Http\Controllers\Auth\AuthenticatedSessionController  (web — untouched)
- * @see \App\Http\Controllers\Auth\ChangePasswordController        (web — untouched)
+ * @see AuthenticatedSessionController  (web — untouched)
+ * @see ChangePasswordController        (web — untouched)
  */
 class AuthController extends Controller
 {

--- a/app/Http/Controllers/Api/Mobile/MeController.php
+++ b/app/Http/Controllers/Api/Mobile/MeController.php
@@ -5,9 +5,12 @@ namespace App\Http\Controllers\Api\Mobile;
 use App\Authorization\Capability;
 use App\Http\Concerns\RendersMobileEnvelope;
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use App\Services\Authorization\RoleCapabilityService;
+use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 
 /**
  * GET  /api/mobile/v1/me              — profile, role, workflow, unit assignments.
@@ -51,9 +54,9 @@ class MeController extends Controller
      * none rather than failing the whole profile (the mobile onboarding falls back
      * to the census unit list in that case).
      *
-     * @return \Illuminate\Support\Collection<int, array<string, mixed>>
+     * @return Collection<int, array<string, mixed>>
      */
-    private function unitAssignments(\App\Models\User $user): \Illuminate\Support\Collection
+    private function unitAssignments(User $user): Collection
     {
         try {
             return $user->units()->get()->map(fn ($unit) => [
@@ -62,7 +65,7 @@ class MeController extends Controller
                 'role' => $unit->pivot->role,
                 'is_primary' => (bool) $unit->pivot->is_primary,
             ])->values();
-        } catch (\Illuminate\Database\QueryException $e) {
+        } catch (QueryException $e) {
             report($e);
 
             return collect();

--- a/app/Http/Controllers/Api/Mobile/TransportController.php
+++ b/app/Http/Controllers/Api/Mobile/TransportController.php
@@ -6,9 +6,12 @@ use App\Http\Concerns\AuthorizesMobilePersonaActions;
 use App\Http\Concerns\RendersMobileEnvelope;
 use App\Http\Concerns\RequiresIdempotencyKey;
 use App\Http\Controllers\Controller;
+use App\Models\Transport\TransportEvent;
 use App\Models\Transport\TransportRequest;
+use App\Models\User;
 use App\Services\Mobile\MobilePersonaCatalog;
 use App\Services\Mobile\OperationalActivityLedger;
+use App\Services\Transport\TransportLifecycleService;
 use App\Services\Transport\TransportOperationsService;
 use App\Support\Operations\DurationFormatter;
 use Illuminate\Http\JsonResponse;
@@ -49,7 +52,7 @@ class TransportController extends Controller
             'cursor' => ['nullable', 'string', 'max:1000'],
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
             'priority' => ['nullable', Rule::in(['routine', 'urgent', 'stat'])],
-            'status' => ['nullable', Rule::in(array_keys(\App\Services\Transport\TransportLifecycleService::TRANSITIONS))],
+            'status' => ['nullable', Rule::in(array_keys(TransportLifecycleService::TRANSITIONS))],
         ]);
         $actor = $request->user();
         $page = $this->transport->list(array_merge($validated, [
@@ -67,7 +70,7 @@ class TransportController extends Controller
             })
             ->get();
 
-        $completedToday = \App\Models\Transport\TransportEvent::query()
+        $completedToday = TransportEvent::query()
             ->where('event_type', 'transport.completed')
             ->whereDate('occurred_at', Carbon::today())
             ->distinct('transport_request_id')
@@ -238,7 +241,7 @@ class TransportController extends Controller
     // MARK: PHI-minimized shaping (mirrors TransportOperationsService::sla/isAtRisk semantics)
 
     /** @return array<string, mixed> */
-    private function shapeJob(TransportRequest $r, \App\Models\User $actor): array
+    private function shapeJob(TransportRequest $r, User $actor): array
     {
         $visualStatus = $this->tier($r);
         $serialized = $this->transport->serializeRequest($r, $actor);

--- a/app/Http/Controllers/Api/PatientFlow/PatientFlowController.php
+++ b/app/Http/Controllers/Api/PatientFlow/PatientFlowController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Barrier;
 use App\Models\PatientFlow\FlowEvent;
 use App\Services\Flow\FlowLensService;
+use App\Services\Flow\ForwardProjectionService;
 use App\Services\PatientFlow\AmbientSignalService;
 use App\Services\PatientFlow\FacilitySpaceLocationResolver;
 use App\Services\PatientFlow\FhirBundleFactory;
@@ -267,13 +268,13 @@ class PatientFlowController extends Controller
         $lens = $request->attributes->get('flow_lens');
         $roleId = (string) $request->attributes->get('flow_role_id');
 
-        $now = \Carbon\CarbonImmutable::now();
+        $now = CarbonImmutable::now();
         $to = $now->addHours(24);
         $context = $this->eventAccess->context($request);
         $scope = $context['scope'];
         $depth = $context['depth'];
 
-        $items = app(\App\Services\Flow\ForwardProjectionService::class)
+        $items = app(ForwardProjectionService::class)
             ->projections($now, $to, $scope, $lens['projection_kinds']);
 
         $items = array_map(

--- a/app/Http/Controllers/Api/Rounds/RoundQuestionController.php
+++ b/app/Http/Controllers/Api/Rounds/RoundQuestionController.php
@@ -10,6 +10,7 @@ use App\Services\Rounds\PatientRoundQuestionPromotionService;
 use App\Services\Rounds\RoundAuthorizationService;
 use App\Services\Rounds\RoundProjectionService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -47,7 +48,7 @@ class RoundQuestionController extends RoundsController
     }
 
     public function availablePatientQuestions(
-        \Illuminate\Http\Request $request,
+        Request $request,
         string $roundPatientUuid,
     ): JsonResponse {
         $patient = $this->resolvePatient($roundPatientUuid);
@@ -85,7 +86,7 @@ class RoundQuestionController extends RoundsController
         return response()->json($this->projection->patientDetail($patient->refresh(), $request->user()), 201);
     }
 
-    public function resolve(\Illuminate\Http\Request $request, string $questionUuid): JsonResponse
+    public function resolve(Request $request, string $questionUuid): JsonResponse
     {
         $question = RoundQuestion::query()->where('question_uuid', $questionUuid)->firstOrFail();
         $patient = $question->patient;

--- a/app/Http/Controllers/Api/Rtdc/BedRequestController.php
+++ b/app/Http/Controllers/Api/Rtdc/BedRequestController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers\Api\Rtdc;
 
+use App\Exceptions\BedUnavailableException;
+use App\Exceptions\UnsafePlacementException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Rtdc\BedPlacementDecisionRequest;
 use App\Http\Requests\Rtdc\CreateBedRequestRequest;
@@ -45,9 +47,9 @@ class BedRequestController extends Controller
                 $v['reason'] ?? null,
                 $request->user()?->id,
             );
-        } catch (\App\Exceptions\UnsafePlacementException $e) {
+        } catch (UnsafePlacementException $e) {
             return response()->json(['error' => $e->getMessage()], 422);
-        } catch (\App\Exceptions\BedUnavailableException $e) {
+        } catch (BedUnavailableException $e) {
             return response()->json(['error' => $e->getMessage()], 409);
         }
 

--- a/app/Http/Controllers/Api/Transport/TransportRequestController.php
+++ b/app/Http/Controllers/Api/Transport/TransportRequestController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\Transport\CompleteHandoffRequest;
 use App\Http\Requests\Transport\CreateTransportRequestRequest;
 use App\Http\Requests\Transport\TransportStatusUpdateRequest;
 use App\Models\Transport\TransportRequest;
+use App\Services\Transport\TransportLifecycleService;
 use App\Services\Transport\TransportOperationsService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -30,7 +31,7 @@ class TransportRequestController extends Controller
     {
         $filters = $request->validate([
             'request_type' => ['nullable', Rule::in(['inpatient', 'transfer', 'discharge', 'ems', 'care_transition'])],
-            'status' => ['nullable', Rule::in(array_keys(\App\Services\Transport\TransportLifecycleService::TRANSITIONS))],
+            'status' => ['nullable', Rule::in(array_keys(TransportLifecycleService::TRANSITIONS))],
             'priority' => ['nullable', Rule::in(['routine', 'urgent', 'stat'])],
             'scope' => ['nullable', Rule::in(['active', 'dispatch', 'history'])],
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -6,12 +6,15 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginRequest;
 use App\Providers\RouteServiceProvider;
 use App\Services\Auth\AccountSessionService;
+use App\Services\Auth\Oidc\OidcProviderConfig;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
-use Inertia\Response; // Import the RouteServiceProvider class
+use Inertia\Response;
+
+// Import the RouteServiceProvider class
 
 class AuthenticatedSessionController extends Controller
 {
@@ -22,7 +25,7 @@ class AuthenticatedSessionController extends Controller
      */
     public function create(): Response
     {
-        $oidc = app(\App\Services\Auth\Oidc\OidcProviderConfig::class);
+        $oidc = app(OidcProviderConfig::class);
 
         return Inertia::render('Auth/Login', [
             'canResetPassword' => Route::has('password.request'),

--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -32,7 +32,7 @@ class NewPasswordController extends Controller
     /**
      * Handle an incoming new password request.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request): RedirectResponse
     {

--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -25,7 +25,7 @@ class PasswordResetLinkController extends Controller
     /**
      * Handle an incoming password reset link request.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request): RedirectResponse
     {

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -30,7 +31,7 @@ class RegisteredUserController extends Controller
     /**
      * Handle an incoming registration request.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request): RedirectResponse
     {

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\ChangeWorkflowRequest;
 use App\Http\Requests\Improvement\StorePdsaCycleRequest;
 use App\Models\PdsaCycle;
+use App\Services\Dashboard\PerioperativeMetricsService;
 use App\Services\DashboardService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -26,7 +27,7 @@ class DashboardController extends Controller
 
         return Inertia::render('Dashboard/Perioperative', [
             'workflow' => $workflow,
-            'overview' => app(\App\Services\Dashboard\PerioperativeMetricsService::class)->build(),
+            'overview' => app(PerioperativeMetricsService::class)->build(),
         ]);
     }
 

--- a/app/Http/Controllers/EDDashboardController.php
+++ b/app/Http/Controllers/EDDashboardController.php
@@ -2,19 +2,30 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Controllers\Concerns\ResolvesFlowLens;
+use App\Services\Dashboard\EdDashboardService;
+use App\Services\Ed\AcuityPredictionService;
+use App\Services\Ed\ArrivalPredictionService;
+use App\Services\Ed\ResourceAnalyticsService;
+use App\Services\Ed\ResourceManagementService;
+use App\Services\Ed\ResourceOptimizationService;
+use App\Services\Ed\TreatmentService;
+use App\Services\Ed\TriageService;
+use App\Services\Ed\WaitTimeService;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class EDDashboardController extends Controller
 {
-    use \App\Http\Controllers\Concerns\ResolvesFlowLens;
+    use ResolvesFlowLens;
 
     /**
      * Display the ED dashboard.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
-    public function index(Request $request, \App\Services\Dashboard\EdDashboardService $edDashboard)
+    public function index(Request $request, EdDashboardService $edDashboard)
     {
         $request->session()->put('workflow', 'emergency');
 
@@ -26,9 +37,9 @@ class EDDashboardController extends Controller
     /**
      * Display the ED wait time analytics.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
-    public function waitTime(\App\Services\Ed\WaitTimeService $waitTime)
+    public function waitTime(WaitTimeService $waitTime)
     {
         return Inertia::render('ED/Analytics/WaitTime', $waitTime->build());
     }
@@ -36,7 +47,7 @@ class EDDashboardController extends Controller
     /**
      * Display the ED patient flow analytics.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
     public function flow(Request $request)
     {
@@ -49,9 +60,9 @@ class EDDashboardController extends Controller
     /**
      * Display the ED resource utilization analytics.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
-    public function resources(\App\Services\Ed\ResourceAnalyticsService $resourceAnalytics)
+    public function resources(ResourceAnalyticsService $resourceAnalytics)
     {
         return Inertia::render('ED/Analytics/Resources', $resourceAnalytics->build());
     }
@@ -59,9 +70,9 @@ class EDDashboardController extends Controller
     /**
      * Display the ED triage status board.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
-    public function triage(\App\Services\Ed\TriageService $triage)
+    public function triage(TriageService $triage)
     {
         return Inertia::render('ED/Operations/Triage', $triage->build());
     }
@@ -69,9 +80,9 @@ class EDDashboardController extends Controller
     /**
      * Display the ED treatment tracking board.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
-    public function treatment(\App\Services\Ed\TreatmentService $treatment)
+    public function treatment(TreatmentService $treatment)
     {
         return Inertia::render('ED/Operations/Treatment', $treatment->build());
     }
@@ -79,9 +90,9 @@ class EDDashboardController extends Controller
     /**
      * Display the ED resource management dashboard.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
-    public function resourceManagement(\App\Services\Ed\ResourceManagementService $resourceManagement)
+    public function resourceManagement(ResourceManagementService $resourceManagement)
     {
         return Inertia::render('ED/Operations/Resources', $resourceManagement->build());
     }
@@ -89,9 +100,9 @@ class EDDashboardController extends Controller
     /**
      * Display the ED arrival forecast dashboard.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
-    public function arrival(\App\Services\Ed\ArrivalPredictionService $arrivalPrediction)
+    public function arrival(ArrivalPredictionService $arrivalPrediction)
     {
         return Inertia::render('ED/Predictions/Arrival', $arrivalPrediction->build());
     }
@@ -99,9 +110,9 @@ class EDDashboardController extends Controller
     /**
      * Display the ED acuity prediction dashboard.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
-    public function acuity(\App\Services\Ed\AcuityPredictionService $acuityPrediction)
+    public function acuity(AcuityPredictionService $acuityPrediction)
     {
         return Inertia::render('ED/Predictions/Acuity', $acuityPrediction->build());
     }
@@ -109,9 +120,9 @@ class EDDashboardController extends Controller
     /**
      * Display the ED resource planning dashboard.
      *
-     * @return \Inertia\Response
+     * @return Response
      */
-    public function resourcePlanning(\App\Services\Ed\ResourceOptimizationService $resourceOptimization)
+    public function resourcePlanning(ResourceOptimizationService $resourceOptimization)
     {
         return Inertia::render('ED/Predictions/Resources', $resourceOptimization->build());
     }

--- a/app/Http/Controllers/HomeDashboardController.php
+++ b/app/Http/Controllers/HomeDashboardController.php
@@ -3,6 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Services\Home\HomeCensusService;
+use App\Services\Home\HomeCommandService;
+use App\Services\Home\HomeLogisticsService;
+use App\Services\Home\HomeReferralService;
+use App\Services\Home\HomeTransitionService;
 use Inertia\Inertia;
 use Inertia\Response as InertiaResponse;
 
@@ -17,22 +21,22 @@ class HomeDashboardController extends Controller
         return Inertia::render('Home/Census', $census->build());
     }
 
-    public function command(\App\Services\Home\HomeCommandService $command): InertiaResponse
+    public function command(HomeCommandService $command): InertiaResponse
     {
         return Inertia::render('Home/Command', $command->build());
     }
 
-    public function referrals(\App\Services\Home\HomeReferralService $referrals): InertiaResponse
+    public function referrals(HomeReferralService $referrals): InertiaResponse
     {
         return Inertia::render('Home/Referrals', $referrals->build());
     }
 
-    public function transitions(\App\Services\Home\HomeTransitionService $transitions): InertiaResponse
+    public function transitions(HomeTransitionService $transitions): InertiaResponse
     {
         return Inertia::render('Home/Transitions', $transitions->build());
     }
 
-    public function logistics(\App\Services\Home\HomeLogisticsService $logistics): InertiaResponse
+    public function logistics(HomeLogisticsService $logistics): InertiaResponse
     {
         return Inertia::render('Home/Logistics', $logistics->build());
     }

--- a/app/Http/Controllers/RTDCDashboardController.php
+++ b/app/Http/Controllers/RTDCDashboardController.php
@@ -2,6 +2,19 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Controllers\Concerns\ResolvesFlowLens;
+use App\Services\Dashboard\RtdcDashboardService;
+use App\Services\Rtdc\AncillaryServicesService;
+use App\Services\Rtdc\BedTrackingService;
+use App\Services\Rtdc\DemandForecastService;
+use App\Services\Rtdc\DischargePrioritiesService;
+use App\Services\Rtdc\PerformanceAnalyticsService;
+use App\Services\Rtdc\ResourceAnalyticsService;
+use App\Services\Rtdc\ResourcePlanningAnalyticsService;
+use App\Services\Rtdc\RiskAssessmentService;
+use App\Services\Rtdc\ServiceHuddleService;
+use App\Services\Rtdc\TrendsAnalyticsService;
+use App\Services\Rtdc\UtilizationAnalyticsService;
 use App\Services\RtdcService;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
@@ -9,7 +22,7 @@ use Inertia\Response as InertiaResponse;
 
 class RTDCDashboardController extends Controller
 {
-    use \App\Http\Controllers\Concerns\ResolvesFlowLens;
+    use ResolvesFlowLens;
 
     public function __construct(
         private readonly RtdcService $rtdcService,
@@ -18,7 +31,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the RTDC dashboard.
      */
-    public function index(Request $request, \App\Services\Dashboard\RtdcDashboardService $dashboard): InertiaResponse
+    public function index(Request $request, RtdcDashboardService $dashboard): InertiaResponse
     {
         $this->rtdcService->activateWorkflow($request);
 
@@ -36,7 +49,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the bed tracking page.
      */
-    public function bedTracking(\App\Services\Rtdc\BedTrackingService $bedTracking): InertiaResponse
+    public function bedTracking(BedTrackingService $bedTracking): InertiaResponse
     {
         return Inertia::render('RTDC/BedTracking', $bedTracking->build());
     }
@@ -59,7 +72,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the ancillary services page.
      */
-    public function ancillaryServices(\App\Services\Rtdc\AncillaryServicesService $service): InertiaResponse
+    public function ancillaryServices(AncillaryServicesService $service): InertiaResponse
     {
         return Inertia::render('RTDC/AncillaryServices', [
             'unitServices' => $service->build(),
@@ -69,7 +82,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the discharge priorities page (live, computed from prod.*).
      */
-    public function dischargePriorities(\App\Services\Rtdc\DischargePrioritiesService $service): InertiaResponse
+    public function dischargePriorities(DischargePrioritiesService $service): InertiaResponse
     {
         return Inertia::render('RTDC/DischargePriorities', $service->build());
     }
@@ -95,7 +108,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the service huddle page.
      */
-    public function serviceHuddle(Request $request, \App\Services\Rtdc\ServiceHuddleService $serviceHuddle): InertiaResponse
+    public function serviceHuddle(Request $request, ServiceHuddleService $serviceHuddle): InertiaResponse
     {
         $this->rtdcService->activateWorkflow($request);
 
@@ -128,7 +141,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the utilization page (live, computed from prod.*).
      */
-    public function utilization(\App\Services\Rtdc\UtilizationAnalyticsService $utilization): InertiaResponse
+    public function utilization(UtilizationAnalyticsService $utilization): InertiaResponse
     {
         return Inertia::render('RTDC/Analytics/Utilization', $utilization->build());
     }
@@ -136,7 +149,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the performance metrics page (live, computed from prod.*).
      */
-    public function performance(\App\Services\Rtdc\PerformanceAnalyticsService $service): InertiaResponse
+    public function performance(PerformanceAnalyticsService $service): InertiaResponse
     {
         return Inertia::render('RTDC/Analytics/Performance', $service->build());
     }
@@ -144,7 +157,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the resources analytics page (live, computed from prod.*).
      */
-    public function resources(\App\Services\Rtdc\ResourceAnalyticsService $service): InertiaResponse
+    public function resources(ResourceAnalyticsService $service): InertiaResponse
     {
         return Inertia::render('RTDC/Analytics/Resources', $service->build());
     }
@@ -152,7 +165,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the trends page (live, computed from prod.*).
      */
-    public function trends(\App\Services\Rtdc\TrendsAnalyticsService $trends): InertiaResponse
+    public function trends(TrendsAnalyticsService $trends): InertiaResponse
     {
         return Inertia::render('RTDC/Analytics/Trends', $trends->build());
     }
@@ -160,7 +173,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the demand forecast page (live, computed from prod.*).
      */
-    public function demandForecast(\App\Services\Rtdc\DemandForecastService $service): InertiaResponse
+    public function demandForecast(DemandForecastService $service): InertiaResponse
     {
         return Inertia::render('RTDC/Predictions/DemandForecast', $service->build());
     }
@@ -168,7 +181,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the resource planning page (live, computed from prod.*).
      */
-    public function resourcePlanning(\App\Services\Rtdc\ResourcePlanningAnalyticsService $service): InertiaResponse
+    public function resourcePlanning(ResourcePlanningAnalyticsService $service): InertiaResponse
     {
         return Inertia::render('RTDC/Predictions/ResourcePlanning', $service->build());
     }
@@ -176,7 +189,7 @@ class RTDCDashboardController extends Controller
     /**
      * Display the risk assessment page (live, computed from prod.*).
      */
-    public function riskAssessment(\App\Services\Rtdc\RiskAssessmentService $service): InertiaResponse
+    public function riskAssessment(RiskAssessmentService $service): InertiaResponse
     {
         return Inertia::render('RTDC/Predictions/RiskAssessment', $service->build());
     }

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -13,7 +13,7 @@ class AdminMiddleware
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/Http/Requests/Auth/LoginRequest.php
@@ -33,7 +33,7 @@ class LoginRequest extends FormRequest
     /**
      * Attempt to authenticate the request's credentials.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function authenticate(): void
     {
@@ -56,7 +56,7 @@ class LoginRequest extends FormRequest
     /**
      * Ensure the login request is not rate limited.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function ensureIsNotRateLimited(): void
     {

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -11,7 +12,7 @@ class ProfileUpdateRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Integrations/Healthcare/Contracts/CanonicalEventMapper.php
+++ b/app/Integrations/Healthcare/Contracts/CanonicalEventMapper.php
@@ -2,10 +2,11 @@
 
 namespace App\Integrations\Healthcare\Contracts;
 
+use App\Integrations\Healthcare\DTO\CanonicalOperationalEvent;
 use App\Integrations\Healthcare\DTO\NormalizedPayload;
 
 interface CanonicalEventMapper
 {
-    /** @return list<\App\Integrations\Healthcare\DTO\CanonicalOperationalEvent> */
+    /** @return list<CanonicalOperationalEvent> */
     public function map(NormalizedPayload $payload): array;
 }

--- a/app/Integrations/Healthcare/Rpm/SyntheticRpmConnector.php
+++ b/app/Integrations/Healthcare/Rpm/SyntheticRpmConnector.php
@@ -4,6 +4,7 @@ namespace App\Integrations\Healthcare\Rpm;
 
 use App\Integrations\Healthcare\Contracts\HealthcareConnector;
 use App\Integrations\Healthcare\DTO\BackfillRequest;
+use App\Integrations\Healthcare\DTO\CanonicalOperationalEvent;
 use App\Integrations\Healthcare\DTO\ConnectorCapabilities;
 use App\Integrations\Healthcare\DTO\ConnectorHealth;
 use App\Integrations\Healthcare\DTO\PollRequest;
@@ -16,6 +17,8 @@ use App\Integrations\Healthcare\Services\SourceRegistryService;
 use App\Models\Integration\CanonicalEventRecord;
 use App\Models\Integration\ConnectorWatermark;
 use App\Models\Integration\ProvenanceRecord;
+use App\Models\Integration\Source;
+use App\Models\Org\Facility;
 use App\Models\Raw\DeadLetter;
 use App\Models\Raw\InboundMessage;
 use App\Models\Raw\IngestRun;
@@ -258,7 +261,7 @@ class SyntheticRpmConnector implements HealthcareConnector
         return $run->fresh();
     }
 
-    private function source(): \App\Models\Integration\Source
+    private function source(): Source
     {
         $scope = $this->enterpriseScope();
 
@@ -283,7 +286,7 @@ class SyntheticRpmConnector implements HealthcareConnector
             return [];
         }
 
-        $facility = \App\Models\Org\Facility::query()
+        $facility = Facility::query()
             ->with('organization:organization_id,organization_key')
             ->where('facility_key', $facilityKey)
             ->where('is_active', true)
@@ -301,7 +304,7 @@ class SyntheticRpmConnector implements HealthcareConnector
     }
 
     private function startRun(
-        \App\Models\Integration\Source $source,
+        Source $source,
         string $runType,
         ?string $cursorBefore = null,
         array $metadata = [],
@@ -394,14 +397,14 @@ class SyntheticRpmConnector implements HealthcareConnector
 
     private function projectRecord(
         CanonicalEventRecord $record,
-        ?\App\Integrations\Healthcare\DTO\CanonicalOperationalEvent $event = null,
+        ?CanonicalOperationalEvent $event = null,
         bool $force = false,
     ): void {
         if ($record->projection_status === 'projected' && ! $force) {
             return;
         }
 
-        $event ??= new \App\Integrations\Healthcare\DTO\CanonicalOperationalEvent(
+        $event ??= new CanonicalOperationalEvent(
             eventId: $record->event_id,
             eventType: $record->event_type,
             entityType: $record->entity_type,

--- a/app/Integrations/Healthcare/Services/AncillaryProjectionHandler.php
+++ b/app/Integrations/Healthcare/Services/AncillaryProjectionHandler.php
@@ -13,6 +13,16 @@ use App\Models\Integration\ProvenanceRecord;
 use App\Models\Pharmacy\AdcTransaction;
 use App\Models\Pharmacy\MedicationOrder;
 use App\Services\Ancillary\AncillaryProjectionRebuilder;
+use App\Services\Ancillary\SlaEvaluator;
+use App\Services\Lab\LabCriticalValueProjector;
+use App\Services\Lab\LabOrderProjector;
+use App\Services\Lab\LabResultProjector;
+use App\Services\Pharmacy\AdcTransactionProjector;
+use App\Services\Pharmacy\PharmacyOrderProjector;
+use App\Services\Pharmacy\RxAdministrationProjector;
+use App\Services\Radiology\RadiologyCriticalResultProjector;
+use App\Services\Radiology\RadiologyOrderProjector;
+use App\Services\Radiology\RadiologyReadProjector;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -30,16 +40,16 @@ class AncillaryProjectionHandler implements ProjectionHandler
 
     public function __construct(
         private readonly AncillaryProjectionRebuilder $rebuilder,
-        private readonly \App\Services\Ancillary\SlaEvaluator $slaEvaluator,
-        private readonly \App\Services\Radiology\RadiologyOrderProjector $radiologyOrderProjector,
-        private readonly \App\Services\Radiology\RadiologyReadProjector $radiologyReadProjector,
-        private readonly \App\Services\Radiology\RadiologyCriticalResultProjector $radiologyCriticalResultProjector,
-        private readonly \App\Services\Lab\LabOrderProjector $labOrderProjector,
-        private readonly \App\Services\Lab\LabResultProjector $labResultProjector,
-        private readonly \App\Services\Lab\LabCriticalValueProjector $labCriticalValueProjector,
-        private readonly \App\Services\Pharmacy\PharmacyOrderProjector $pharmacyOrderProjector,
-        private readonly \App\Services\Pharmacy\AdcTransactionProjector $adcTransactionProjector,
-        private readonly \App\Services\Pharmacy\RxAdministrationProjector $rxAdministrationProjector,
+        private readonly SlaEvaluator $slaEvaluator,
+        private readonly RadiologyOrderProjector $radiologyOrderProjector,
+        private readonly RadiologyReadProjector $radiologyReadProjector,
+        private readonly RadiologyCriticalResultProjector $radiologyCriticalResultProjector,
+        private readonly LabOrderProjector $labOrderProjector,
+        private readonly LabResultProjector $labResultProjector,
+        private readonly LabCriticalValueProjector $labCriticalValueProjector,
+        private readonly PharmacyOrderProjector $pharmacyOrderProjector,
+        private readonly AdcTransactionProjector $adcTransactionProjector,
+        private readonly RxAdministrationProjector $rxAdministrationProjector,
     ) {}
 
     public function key(): string
@@ -299,7 +309,7 @@ class AncillaryProjectionHandler implements ProjectionHandler
                 );
             }
             if ($department === 'rx'
-                && in_array($milestoneCode, \App\Services\Pharmacy\PharmacyOrderProjector::MILESTONES, true)) {
+                && in_array($milestoneCode, PharmacyOrderProjector::MILESTONES, true)) {
                 // Order-linked ADC events resolve their station registry row
                 // before projection so the dispense satellite can carry it.
                 $adcStation = isset($event->payload['source_transaction_key'])

--- a/app/Integrations/Healthcare/Services/EnterpriseConnectorControlService.php
+++ b/app/Integrations/Healthcare/Services/EnterpriseConnectorControlService.php
@@ -2,6 +2,7 @@
 
 namespace App\Integrations\Healthcare\Services;
 
+use App\Integrations\Healthcare\Exceptions\IntegrationProtocolException;
 use App\Jobs\PollFhirResource;
 use App\Jobs\ReplayPendingIntegrationEvents;
 use App\Jobs\RunIntegrationProtocolHealthCheck;
@@ -11,6 +12,7 @@ use App\Models\Ops\Recommendation;
 use App\Security\ClinicalPayloads\ClinicalPayloadStore;
 use App\Support\Api\JsonMap;
 use Carbon\CarbonImmutable;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Throwable;
@@ -260,7 +262,7 @@ class EnterpriseConnectorControlService
             }
             try {
                 $this->fhirProfiles->requirePollable($sourceId, $resourceType);
-            } catch (\InvalidArgumentException|\App\Integrations\Healthcare\Exceptions\IntegrationProtocolException) {
+            } catch (\InvalidArgumentException|IntegrationProtocolException) {
                 abort(422, 'The FHIR resource profile is not enabled and capability-confirmed.');
             }
 
@@ -435,7 +437,7 @@ class EnterpriseConnectorControlService
     }
 
     /** @param array<string, mixed> $scope */
-    private function replayQuery(array $scope): \Illuminate\Database\Query\Builder
+    private function replayQuery(array $scope): Builder
     {
         return DB::table('integration.canonical_events')
             ->when($scope['sourceId'], fn ($query, $sourceId) => $query->where('source_id', $sourceId))

--- a/app/Integrations/Healthcare/Services/IntegrationConfigurationService.php
+++ b/app/Integrations/Healthcare/Services/IntegrationConfigurationService.php
@@ -4,6 +4,7 @@ namespace App\Integrations\Healthcare\Services;
 
 use App\Security\Network\IntegrationUrlPolicy;
 use Carbon\CarbonImmutable;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -430,7 +431,7 @@ class IntegrationConfigurationService
         }
     }
 
-    private function sourceQuery(): \Illuminate\Database\Query\Builder
+    private function sourceQuery(): Builder
     {
         return DB::table('integration.sources as source')
             ->leftJoin('hosp_org.organizations as organization', 'organization.organization_id', '=', 'source.organization_id')

--- a/app/Integrations/Healthcare/Services/RpmProjectionHandler.php
+++ b/app/Integrations/Healthcare/Services/RpmProjectionHandler.php
@@ -8,6 +8,8 @@ use App\Integrations\Healthcare\Rpm\RpmEventVocabulary;
 use App\Models\Home\RpmDevice;
 use App\Models\Home\RpmEnrollment;
 use App\Models\Home\RpmObservation;
+use App\Services\Home\RpmAlertEvaluator;
+use App\Services\Home\RpmFhirObservationRecorder;
 use InvalidArgumentException;
 use Ramsey\Uuid\Uuid;
 
@@ -22,8 +24,8 @@ use Ramsey\Uuid\Uuid;
 class RpmProjectionHandler implements ProjectionHandler
 {
     public function __construct(
-        private readonly \App\Services\Home\RpmAlertEvaluator $alerts,
-        private readonly \App\Services\Home\RpmFhirObservationRecorder $fhir,
+        private readonly RpmAlertEvaluator $alerts,
+        private readonly RpmFhirObservationRecorder $fhir,
     ) {}
 
     public function key(): string

--- a/app/Integrations/Healthcare/Services/SourceReadinessService.php
+++ b/app/Integrations/Healthcare/Services/SourceReadinessService.php
@@ -4,6 +4,7 @@ namespace App\Integrations\Healthcare\Services;
 
 use App\Security\ClinicalPayloads\ClinicalPayloadStore;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -417,7 +418,7 @@ final class SourceReadinessService
     /** @param list<array<string, string>> $checks */
     private function evidenceCheck(
         array &$checks,
-        \Illuminate\Support\Collection $evidence,
+        Collection $evidence,
         string $type,
         CarbonImmutable $evaluatedFor,
         bool $allowNotRequired,

--- a/app/Integrations/Healthcare/Synthetic/SyntheticCanonicalEventMapper.php
+++ b/app/Integrations/Healthcare/Synthetic/SyntheticCanonicalEventMapper.php
@@ -7,6 +7,7 @@ use App\Integrations\Healthcare\Contracts\CanonicalEventMapper;
 use App\Integrations\Healthcare\DTO\CanonicalOperationalEvent;
 use App\Integrations\Healthcare\DTO\NormalizedPayload;
 use App\Rtdc\Events\CanonicalEvent as RtdcCanonicalEvent;
+use Carbon\CarbonInterface;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -108,7 +109,7 @@ class SyntheticCanonicalEventMapper implements CanonicalEventMapper
     }
 
     /** @return list<CanonicalOperationalEvent> */
-    private function mapAncillary(NormalizedPayload $payload, string $eventId, \Carbon\CarbonInterface $occurredAt): array
+    private function mapAncillary(NormalizedPayload $payload, string $eventId, CarbonInterface $occurredAt): array
     {
         $data = $payload->payload;
         $milestoneCode = $this->requiredString($data, 'milestone_code');

--- a/app/Integrations/Healthcare/Synthetic/SyntheticHealthcareConnector.php
+++ b/app/Integrations/Healthcare/Synthetic/SyntheticHealthcareConnector.php
@@ -5,6 +5,7 @@ namespace App\Integrations\Healthcare\Synthetic;
 use App\Integrations\Healthcare\Ancillary\AncillaryEventVocabulary;
 use App\Integrations\Healthcare\Contracts\HealthcareConnector;
 use App\Integrations\Healthcare\DTO\BackfillRequest;
+use App\Integrations\Healthcare\DTO\CanonicalOperationalEvent;
 use App\Integrations\Healthcare\DTO\ConnectorCapabilities;
 use App\Integrations\Healthcare\DTO\ConnectorHealth;
 use App\Integrations\Healthcare\DTO\PollRequest;
@@ -17,6 +18,8 @@ use App\Integrations\Healthcare\Services\SourceRegistryService;
 use App\Models\Integration\CanonicalEventRecord;
 use App\Models\Integration\ConnectorWatermark;
 use App\Models\Integration\ProvenanceRecord;
+use App\Models\Integration\Source;
+use App\Models\Org\Facility;
 use App\Models\Raw\DeadLetter;
 use App\Models\Raw\InboundMessage;
 use App\Models\Raw\IngestRun;
@@ -262,7 +265,7 @@ class SyntheticHealthcareConnector implements HealthcareConnector
         return $run->fresh();
     }
 
-    private function source(): \App\Models\Integration\Source
+    private function source(): Source
     {
         $scope = $this->syntheticEnterpriseScope();
 
@@ -287,7 +290,7 @@ class SyntheticHealthcareConnector implements HealthcareConnector
             return [];
         }
 
-        $facility = \App\Models\Org\Facility::query()
+        $facility = Facility::query()
             ->with('organization:organization_id,organization_key')
             ->where('facility_key', $facilityKey)
             ->where('is_active', true)
@@ -305,7 +308,7 @@ class SyntheticHealthcareConnector implements HealthcareConnector
     }
 
     private function startRun(
-        \App\Models\Integration\Source $source,
+        Source $source,
         string $runType,
         ?string $cursorBefore = null,
         array $metadata = [],
@@ -398,14 +401,14 @@ class SyntheticHealthcareConnector implements HealthcareConnector
 
     private function projectRecord(
         CanonicalEventRecord $record,
-        ?\App\Integrations\Healthcare\DTO\CanonicalOperationalEvent $event = null,
+        ?CanonicalOperationalEvent $event = null,
         bool $force = false,
     ): void {
         if ($record->projection_status === 'projected' && ! $force) {
             return;
         }
 
-        $event ??= new \App\Integrations\Healthcare\DTO\CanonicalOperationalEvent(
+        $event ??= new CanonicalOperationalEvent(
             eventId: $record->event_id,
             eventType: $record->event_type,
             entityType: $record->entity_type,

--- a/app/Models/Ancillary/AncillaryOrder.php
+++ b/app/Models/Ancillary/AncillaryOrder.php
@@ -5,6 +5,12 @@ namespace App\Models\Ancillary;
 use App\Casts\JsonObject;
 use App\Models\Encounter;
 use App\Models\Integration\Source;
+use App\Models\Lab\AnatomicPathologyCase;
+use App\Models\Lab\BloodBankReadiness;
+use App\Models\Lab\Result;
+use App\Models\Lab\Specimen;
+use App\Models\Pharmacy\MedicationOrder;
+use App\Models\Radiology\Exam;
 use App\Models\Unit;
 use Database\Factories\Ancillary\AncillaryOrderFactory;
 use Illuminate\Database\Eloquent\Builder;
@@ -70,32 +76,32 @@ class AncillaryOrder extends Model
 
     public function radiologyExam(): HasOne
     {
-        return $this->hasOne(\App\Models\Radiology\Exam::class, 'ancillary_order_id', 'ancillary_order_id');
+        return $this->hasOne(Exam::class, 'ancillary_order_id', 'ancillary_order_id');
     }
 
     public function labSpecimens(): HasMany
     {
-        return $this->hasMany(\App\Models\Lab\Specimen::class, 'ancillary_order_id', 'ancillary_order_id');
+        return $this->hasMany(Specimen::class, 'ancillary_order_id', 'ancillary_order_id');
     }
 
     public function labResults(): HasMany
     {
-        return $this->hasMany(\App\Models\Lab\Result::class, 'ancillary_order_id', 'ancillary_order_id');
+        return $this->hasMany(Result::class, 'ancillary_order_id', 'ancillary_order_id');
     }
 
     public function anatomicPathologyCase(): HasOne
     {
-        return $this->hasOne(\App\Models\Lab\AnatomicPathologyCase::class, 'ancillary_order_id', 'ancillary_order_id');
+        return $this->hasOne(AnatomicPathologyCase::class, 'ancillary_order_id', 'ancillary_order_id');
     }
 
     public function bloodBankReadiness(): HasOne
     {
-        return $this->hasOne(\App\Models\Lab\BloodBankReadiness::class, 'ancillary_order_id', 'ancillary_order_id');
+        return $this->hasOne(BloodBankReadiness::class, 'ancillary_order_id', 'ancillary_order_id');
     }
 
     public function medicationOrder(): HasOne
     {
-        return $this->hasOne(\App\Models\Pharmacy\MedicationOrder::class, 'ancillary_order_id', 'ancillary_order_id');
+        return $this->hasOne(MedicationOrder::class, 'ancillary_order_id', 'ancillary_order_id');
     }
 
     public function scopeOpen(Builder $query): Builder

--- a/app/Models/Auth/UserExternalIdentity.php
+++ b/app/Models/Auth/UserExternalIdentity.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Auth;
 
+use App\Models\Governance\IdentityLinkEvent;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -34,6 +35,6 @@ class UserExternalIdentity extends Model
 
     public function events(): HasMany
     {
-        return $this->hasMany(\App\Models\Governance\IdentityLinkEvent::class, 'external_identity_id');
+        return $this->hasMany(IdentityLinkEvent::class, 'external_identity_id');
     }
 }

--- a/app/Models/Fhir/ResourceVersion.php
+++ b/app/Models/Fhir/ResourceVersion.php
@@ -4,6 +4,7 @@ namespace App\Models\Fhir;
 
 use App\Models\Integration\Source;
 use App\Models\Raw\IngestRun;
+use App\Security\ClinicalPayloads\ClinicalPayloadHydrator;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -24,7 +25,7 @@ class ResourceVersion extends Model
     protected function resourceData(): Attribute
     {
         return Attribute::make(get: fn (mixed $value, array $attributes): array => app(
-            \App\Security\ClinicalPayloads\ClinicalPayloadHydrator::class,
+            ClinicalPayloadHydrator::class,
         )->required(
             isset($attributes['payload_object_id']) ? (int) $attributes['payload_object_id'] : null,
             (int) $attributes['source_id'],

--- a/app/Models/Integration/CanonicalEventRecord.php
+++ b/app/Models/Integration/CanonicalEventRecord.php
@@ -4,6 +4,7 @@ namespace App\Models\Integration;
 
 use App\Models\Raw\InboundMessage;
 use App\Models\Raw\IngestRun;
+use App\Security\ClinicalPayloads\ClinicalPayloadHydrator;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -26,7 +27,7 @@ class CanonicalEventRecord extends Model
     protected function payload(): Attribute
     {
         return Attribute::make(get: fn (mixed $value, array $attributes): array => app(
-            \App\Security\ClinicalPayloads\ClinicalPayloadHydrator::class,
+            ClinicalPayloadHydrator::class,
         )->required(
             isset($attributes['payload_object_id']) ? (int) $attributes['payload_object_id'] : null,
             (int) $attributes['source_id'],

--- a/app/Models/MobileDevice.php
+++ b/app/Models/MobileDevice.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Str;
@@ -49,7 +50,7 @@ class MobileDevice extends Model
     }
 
     /**
-     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  Builder  $query
      */
     public function scopeActive($query)
     {

--- a/app/Models/ORCase.php
+++ b/app/Models/ORCase.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Models\Lab\AnatomicPathologyCase;
+use App\Models\Lab\BloodBankReadiness;
 use App\Models\Reference\CaseStatus;
 use App\Models\Reference\Service;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -109,12 +111,12 @@ class ORCase extends Model
 
     public function anatomicPathologyCases(): HasMany
     {
-        return $this->hasMany(\App\Models\Lab\AnatomicPathologyCase::class, 'case_id', 'case_id');
+        return $this->hasMany(AnatomicPathologyCase::class, 'case_id', 'case_id');
     }
 
     public function bloodBankReadiness(): HasMany
     {
-        return $this->hasMany(\App\Models\Lab\BloodBankReadiness::class, 'case_id', 'case_id');
+        return $this->hasMany(BloodBankReadiness::class, 'case_id', 'case_id');
     }
 
     // Scopes

--- a/app/Models/Ops/MetricDefinition.php
+++ b/app/Models/Ops/MetricDefinition.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Ops;
 
+use App\Services\Cockpit\StatusEngine;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
@@ -38,7 +39,7 @@ class MetricDefinition extends Model
             'ok' => $this->ok_edge !== null ? (float) $this->ok_edge : null,
             'warn' => $this->warn_edge !== null ? (float) $this->warn_edge : null,
             'crit' => $this->crit_edge !== null ? (float) $this->crit_edge : null,
-            'watch_band_pct' => (float) ($metadata['watch_band_pct'] ?? \App\Services\Cockpit\StatusEngine::DEFAULT_WATCH_BAND_PCT),
+            'watch_band_pct' => (float) ($metadata['watch_band_pct'] ?? StatusEngine::DEFAULT_WATCH_BAND_PCT),
         ];
     }
 

--- a/app/Models/Patient/PatientEncounterAccessGrant.php
+++ b/app/Models/Patient/PatientEncounterAccessGrant.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 
 class PatientEncounterAccessGrant extends Model
 {
@@ -75,7 +76,7 @@ class PatientEncounterAccessGrant extends Model
     {
         static::creating(function (PatientEncounterAccessGrant $grant): void {
             if (blank($grant->encounter_uuid)) {
-                $grant->encounter_uuid = (string) \Illuminate\Support\Str::uuid();
+                $grant->encounter_uuid = (string) Str::uuid();
             }
         });
     }

--- a/app/Models/Patient/PatientSession.php
+++ b/app/Models/Patient/PatientSession.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Str;
 
 class PatientSession extends Model
 {
@@ -66,7 +67,7 @@ class PatientSession extends Model
     {
         static::creating(function (PatientSession $session): void {
             if (blank($session->token_family_uuid)) {
-                $session->token_family_uuid = (string) \Illuminate\Support\Str::uuid();
+                $session->token_family_uuid = (string) Str::uuid();
             }
         });
     }

--- a/app/Models/PdsaCycle.php
+++ b/app/Models/PdsaCycle.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Ops\Intervention;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -28,6 +29,6 @@ class PdsaCycle extends Model
 
     public function interventions(): HasMany
     {
-        return $this->hasMany(\App\Models\Ops\Intervention::class, 'pdsa_cycle_id', 'pdsa_cycle_id');
+        return $this->hasMany(Intervention::class, 'pdsa_cycle_id', 'pdsa_cycle_id');
     }
 }

--- a/app/Models/Raw/InboundMessage.php
+++ b/app/Models/Raw/InboundMessage.php
@@ -3,10 +3,12 @@
 namespace App\Models\Raw;
 
 use App\Models\Integration\Source;
+use App\Security\ClinicalPayloads\ClinicalPayloadHydrator;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\DB;
 
 class InboundMessage extends Model
 {
@@ -24,7 +26,7 @@ class InboundMessage extends Model
     protected function payload(): Attribute
     {
         return Attribute::make(get: fn (mixed $value, array $attributes): ?array => app(
-            \App\Security\ClinicalPayloads\ClinicalPayloadHydrator::class,
+            ClinicalPayloadHydrator::class,
         )->optional(
             isset($attributes['payload_object_id']) ? (int) $attributes['payload_object_id'] : null,
             (int) $attributes['source_id'],
@@ -38,7 +40,7 @@ class InboundMessage extends Model
     protected function normalizedPayload(): Attribute
     {
         return Attribute::make(get: fn (mixed $value, array $attributes): ?array => app(
-            \App\Security\ClinicalPayloads\ClinicalPayloadHydrator::class,
+            ClinicalPayloadHydrator::class,
         )->optional(
             isset($attributes['normalized_payload_object_id']) ? (int) $attributes['normalized_payload_object_id'] : null,
             (int) $attributes['source_id'],
@@ -49,7 +51,7 @@ class InboundMessage extends Model
 
     private function objectKind(int $payloadObjectId): ?string
     {
-        return \Illuminate\Support\Facades\DB::table('raw.payload_objects')
+        return DB::table('raw.payload_objects')
             ->where('payload_object_id', $payloadObjectId)
             ->value('payload_kind');
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use App\Authorization\Capability;
 use App\Models\Auth\MobileTokenSession;
 use App\Models\Auth\UserAccessScope;
 use App\Models\Auth\UserExternalIdentity;
+use App\Models\Org\StaffMember;
 use App\Services\Authorization\RoleCapabilityService;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -136,7 +137,7 @@ class User extends Authenticatable
      */
     public function staffAssignments(): HasMany
     {
-        return $this->hasMany(\App\Models\Org\StaffMember::class, 'user_id', 'id');
+        return $this->hasMany(StaffMember::class, 'user_id', 'id');
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,18 +5,58 @@ namespace App\Providers;
 use App\Auth\AuthDriverRegistry;
 use App\Auth\Drivers\AuthentikOidcAuthDriver;
 use App\Database\ProductionDatabaseReadOnlyGuard;
+use App\Domain\Arena\Copilot\CopilotLlm;
+use App\Domain\Arena\Copilot\EddyProxyCopilotLlm;
+use App\Integrations\Healthcare\Ancillary\AncillaryHl7V2MessageNormalizer;
+use App\Integrations\Healthcare\Ancillary\AncillaryStructuredMessageNormalizer;
+use App\Integrations\Healthcare\Ancillary\LabOrderFhirNormalizer;
+use App\Integrations\Healthcare\Ancillary\LabOrderHl7V2Normalizer;
+use App\Integrations\Healthcare\Ancillary\LabResultFhirNormalizer;
+use App\Integrations\Healthcare\Ancillary\LabResultHl7V2Normalizer;
+use App\Integrations\Healthcare\Ancillary\PharmacyAdcTransactionNormalizer;
+use App\Integrations\Healthcare\Ancillary\PharmacyAdministrationImportNormalizer;
+use App\Integrations\Healthcare\Ancillary\PharmacyOrderFhirNormalizer;
+use App\Integrations\Healthcare\Ancillary\PharmacyOrderHl7V2Normalizer;
+use App\Integrations\Healthcare\Ancillary\PharmacyVerificationQueueNormalizer;
+use App\Integrations\Healthcare\Ancillary\RadiologyOperationalEventNormalizer;
+use App\Integrations\Healthcare\Ancillary\RadiologyOrderFhirNormalizer;
+use App\Integrations\Healthcare\Ancillary\RadiologyOrderHl7V2Normalizer;
+use App\Integrations\Healthcare\Ancillary\RadiologyResultFhirNormalizer;
+use App\Integrations\Healthcare\Ancillary\RadiologyResultHl7V2Normalizer;
+use App\Integrations\Healthcare\Ancillary\UnsupportedAncillaryMessageNormalizer;
+use App\Integrations\Healthcare\Contracts\BulkBackfillAdapter;
+use App\Integrations\Healthcare\Contracts\ProjectionHandler;
+use App\Integrations\Healthcare\Services\AdcStationEventProjectionHandler;
+use App\Integrations\Healthcare\Services\AncillaryBulkBackfillAdapter;
+use App\Integrations\Healthcare\Services\AncillaryNormalizerRegistry;
+use App\Integrations\Healthcare\Services\AncillaryProjectionHandler;
+use App\Integrations\Healthcare\Services\ProjectionDispatcher;
+use App\Integrations\Healthcare\Services\RpmProjectionHandler;
+use App\Integrations\Healthcare\Services\RtdcProjectionHandler;
+use App\Integrations\Healthcare\Services\RxAdministrationRecordProjectionHandler;
+use App\Observability\Contracts\MetricExporter;
+use App\Observability\Contracts\TraceExporter;
+use App\Observability\Exporters\InMemoryMetricExporter;
+use App\Observability\Exporters\NullMetricExporter;
+use App\Observability\Exporters\OtlpExporter;
+use App\Observability\Exporters\OtlpExporterFactory;
+use App\Observability\MetricRecorder;
+use App\Rtdc\Optimizer\Contracts\BedAssignmentOptimizer;
+use App\Rtdc\Optimizer\HeuristicBedAssignmentOptimizer;
 use App\Security\ClinicalPayloads\ClinicalContentGuard;
 use App\Security\ClinicalPayloads\ClinicalPayloadException;
 use App\Security\ClinicalPayloads\ClinicalPayloadSafeQueueJob;
 use App\Security\ClinicalPayloads\ClinicalPayloadStore;
 use App\Security\ClinicalPayloads\ClinicalSafeLogManager;
 use App\Security\ClinicalPayloads\EncryptedClinicalPayloadStore;
+use App\Security\Network\OidcUrlPolicy;
 use App\Security\Secrets\Providers\AwsSecretsManagerProvider;
 use App\Security\Secrets\Providers\AzureKeyVaultProvider;
 use App\Security\Secrets\Providers\FileSecretProvider;
 use App\Security\Secrets\Providers\GcpSecretManagerProvider;
 use App\Security\Secrets\Providers\VaultSecretProvider;
 use App\Security\Secrets\SecretProviderRegistry;
+use App\Services\Alerting\OperationalAlertDispatcher;
 use App\Services\Auth\Oidc\ExternalIdentityEventRecorder;
 use App\Services\Auth\Oidc\OidcDiscoveryService;
 use App\Services\Auth\Oidc\OidcHandshakeStore;
@@ -24,6 +64,18 @@ use App\Services\Auth\Oidc\OidcHttpClient;
 use App\Services\Auth\Oidc\OidcProviderConfig;
 use App\Services\Auth\Oidc\OidcReconciliationService;
 use App\Services\Auth\Oidc\OidcTokenValidator;
+use App\Services\Auth\ProductionSessionConfiguration;
+use App\Services\Authorization\RoleCapabilityService;
+use App\Services\Cockpit\AlertFanout;
+use App\Services\Cockpit\Channels\PushAlertChannel;
+use App\Services\Cockpit\Channels\TeamsAlertChannel;
+use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
+use App\Services\Demo\Ancillary\BloodBankDemoGenerator;
+use App\Services\Demo\Ancillary\LabDemoGenerator;
+use App\Services\Demo\Ancillary\PathologyDemoGenerator;
+use App\Services\Demo\Ancillary\PharmacyDemoGenerator;
+use App\Services\Demo\Ancillary\RadiologyDemoGenerator;
+use App\Services\Lab\LabAggregateSnapshotFactory;
 use Illuminate\Contracts\Queue\ShouldBeEncrypted;
 use Illuminate\Database\Events\ConnectionEstablished;
 use Illuminate\Support\Facades\Queue;
@@ -48,11 +100,11 @@ class AppServiceProvider extends ServiceProvider
 
         $this->app->singleton('log', fn ($app) => new ClinicalSafeLogManager($app));
 
-        $this->app->singleton(\App\Services\Authorization\RoleCapabilityService::class);
+        $this->app->singleton(RoleCapabilityService::class);
 
         $this->app->bind(
-            \App\Rtdc\Optimizer\Contracts\BedAssignmentOptimizer::class,
-            \App\Rtdc\Optimizer\HeuristicBedAssignmentOptimizer::class,
+            BedAssignmentOptimizer::class,
+            HeuristicBedAssignmentOptimizer::class,
         );
 
         // Part X (X4) — the Arena copilot's LLM seam. Bound to the Eddy-proxy driver,
@@ -60,8 +112,8 @@ class AppServiceProvider extends ServiceProvider
         // and ARENA_AI_ENABLED are on — so the copilot runs fully deterministic by
         // default and in tests, with the LLM as a pure enhancement when switched on.
         $this->app->bind(
-            \App\Domain\Arena\Copilot\CopilotLlm::class,
-            \App\Domain\Arena\Copilot\EddyProxyCopilotLlm::class,
+            CopilotLlm::class,
+            EddyProxyCopilotLlm::class,
         );
 
         $this->app->singleton(OidcProviderConfig::class);
@@ -69,7 +121,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(OidcDiscoveryService::class, fn ($app) => new OidcDiscoveryService(
             $app->make(OidcProviderConfig::class)->discoveryUrl(),
             $app->make(OidcHttpClient::class),
-            $app->make(\App\Security\Network\OidcUrlPolicy::class),
+            $app->make(OidcUrlPolicy::class),
         ));
 
         $this->app->bind(OidcTokenValidator::class, fn ($app) => new OidcTokenValidator(
@@ -103,54 +155,54 @@ class AppServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(
-            \App\Integrations\Healthcare\Services\ProjectionDispatcher::class,
-            fn ($app) => new \App\Integrations\Healthcare\Services\ProjectionDispatcher([
-                $app->make(\App\Integrations\Healthcare\Services\RtdcProjectionHandler::class),
-                $app->make(\App\Integrations\Healthcare\Services\AncillaryProjectionHandler::class),
-                $app->make(\App\Integrations\Healthcare\Services\AdcStationEventProjectionHandler::class),
-                $app->make(\App\Integrations\Healthcare\Services\RxAdministrationRecordProjectionHandler::class),
+            ProjectionDispatcher::class,
+            fn ($app) => new ProjectionDispatcher([
+                $app->make(RtdcProjectionHandler::class),
+                $app->make(AncillaryProjectionHandler::class),
+                $app->make(AdcStationEventProjectionHandler::class),
+                $app->make(RxAdministrationRecordProjectionHandler::class),
                 // Home Hospital RPM feed (ObservationRecorded / DeviceStatusChanged).
-                $app->make(\App\Integrations\Healthcare\Services\RpmProjectionHandler::class),
+                $app->make(RpmProjectionHandler::class),
             ]),
         );
         $this->app->alias(
-            \App\Integrations\Healthcare\Services\ProjectionDispatcher::class,
-            \App\Integrations\Healthcare\Contracts\ProjectionHandler::class,
+            ProjectionDispatcher::class,
+            ProjectionHandler::class,
         );
         $this->app->singleton(
-            \App\Integrations\Healthcare\Services\AncillaryNormalizerRegistry::class,
-            fn ($app) => new \App\Integrations\Healthcare\Services\AncillaryNormalizerRegistry([
-                $app->make(\App\Integrations\Healthcare\Ancillary\RadiologyOrderHl7V2Normalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\RadiologyResultHl7V2Normalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\RadiologyOrderFhirNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\RadiologyResultFhirNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\RadiologyOperationalEventNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\LabResultHl7V2Normalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\LabResultFhirNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\LabOrderHl7V2Normalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\LabOrderFhirNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\PharmacyOrderHl7V2Normalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\PharmacyOrderFhirNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\PharmacyVerificationQueueNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\PharmacyAdcTransactionNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\PharmacyAdministrationImportNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\AncillaryHl7V2MessageNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\AncillaryStructuredMessageNormalizer::class),
-                $app->make(\App\Integrations\Healthcare\Ancillary\UnsupportedAncillaryMessageNormalizer::class),
+            AncillaryNormalizerRegistry::class,
+            fn ($app) => new AncillaryNormalizerRegistry([
+                $app->make(RadiologyOrderHl7V2Normalizer::class),
+                $app->make(RadiologyResultHl7V2Normalizer::class),
+                $app->make(RadiologyOrderFhirNormalizer::class),
+                $app->make(RadiologyResultFhirNormalizer::class),
+                $app->make(RadiologyOperationalEventNormalizer::class),
+                $app->make(LabResultHl7V2Normalizer::class),
+                $app->make(LabResultFhirNormalizer::class),
+                $app->make(LabOrderHl7V2Normalizer::class),
+                $app->make(LabOrderFhirNormalizer::class),
+                $app->make(PharmacyOrderHl7V2Normalizer::class),
+                $app->make(PharmacyOrderFhirNormalizer::class),
+                $app->make(PharmacyVerificationQueueNormalizer::class),
+                $app->make(PharmacyAdcTransactionNormalizer::class),
+                $app->make(PharmacyAdministrationImportNormalizer::class),
+                $app->make(AncillaryHl7V2MessageNormalizer::class),
+                $app->make(AncillaryStructuredMessageNormalizer::class),
+                $app->make(UnsupportedAncillaryMessageNormalizer::class),
             ]),
         );
         $this->app->bind(
-            \App\Integrations\Healthcare\Contracts\BulkBackfillAdapter::class,
-            \App\Integrations\Healthcare\Services\AncillaryBulkBackfillAdapter::class,
+            BulkBackfillAdapter::class,
+            AncillaryBulkBackfillAdapter::class,
         );
         $this->app->singleton(
-            \App\Services\Demo\Ancillary\AncillaryDemoScenarioService::class,
-            fn ($app) => new \App\Services\Demo\Ancillary\AncillaryDemoScenarioService([
-                $app->make(\App\Services\Demo\Ancillary\RadiologyDemoGenerator::class),
-                $app->make(\App\Services\Demo\Ancillary\LabDemoGenerator::class),
-                $app->make(\App\Services\Demo\Ancillary\PathologyDemoGenerator::class),
-                $app->make(\App\Services\Demo\Ancillary\BloodBankDemoGenerator::class),
-                $app->make(\App\Services\Demo\Ancillary\PharmacyDemoGenerator::class),
+            AncillaryDemoScenarioService::class,
+            fn ($app) => new AncillaryDemoScenarioService([
+                $app->make(RadiologyDemoGenerator::class),
+                $app->make(LabDemoGenerator::class),
+                $app->make(PathologyDemoGenerator::class),
+                $app->make(BloodBankDemoGenerator::class),
+                $app->make(PharmacyDemoGenerator::class),
             ]),
         );
 
@@ -158,61 +210,61 @@ class AppServiceProvider extends ServiceProvider
         // scoped() (not singleton) — the container flushes it per FPM request
         // and per queue job, so it can never become a second cross-request
         // snapshot authority beside SnapshotBuilder's cache + persisted row.
-        $this->app->scoped(\App\Services\Lab\LabAggregateSnapshotFactory::class);
+        $this->app->scoped(LabAggregateSnapshotFactory::class);
 
         // P6: the alert fan-out lanes. Both are inert by default (push gated
         // by EDDY_PUSH_ENABLED, Teams by TEAMS_ALERT_WEBHOOK_URL) — adding a
         // lane means adding an AlertChannel here, not touching the engine.
-        $this->app->singleton(\App\Services\Cockpit\AlertFanout::class, fn ($app) => new \App\Services\Cockpit\AlertFanout([
-            $app->make(\App\Services\Cockpit\Channels\PushAlertChannel::class),
-            $app->make(\App\Services\Cockpit\Channels\TeamsAlertChannel::class),
+        $this->app->singleton(AlertFanout::class, fn ($app) => new AlertFanout([
+            $app->make(PushAlertChannel::class),
+            $app->make(TeamsAlertChannel::class),
         ]));
 
         // INT-OBS 5 + ADM-HEALTH 6: the shared on-call delivery abstraction for
         // integration SLO breaches and critical system-health observations.
         // Reuses the SAME inert-by-default channels — a new lane is a new
         // OperationalAlertChannel binding here, not a new delivery path.
-        $this->app->singleton(\App\Services\Alerting\OperationalAlertDispatcher::class, fn ($app) => new \App\Services\Alerting\OperationalAlertDispatcher([
-            $app->make(\App\Services\Cockpit\Channels\PushAlertChannel::class),
-            $app->make(\App\Services\Cockpit\Channels\TeamsAlertChannel::class),
+        $this->app->singleton(OperationalAlertDispatcher::class, fn ($app) => new OperationalAlertDispatcher([
+            $app->make(PushAlertChannel::class),
+            $app->make(TeamsAlertChannel::class),
         ], $app->make(ClinicalContentGuard::class)));
 
         // INT-OBS 4: the guarded application recorder can stay in-memory, discard,
         // or send OTLP/HTTP protobuf through the official OpenTelemetry SDK. Both
         // contracts resolve to one singleton so metrics and spans share config.
-        $this->app->singleton(\App\Observability\Exporters\InMemoryMetricExporter::class, fn ($app) => new \App\Observability\Exporters\InMemoryMetricExporter(
+        $this->app->singleton(InMemoryMetricExporter::class, fn ($app) => new InMemoryMetricExporter(
             (int) config('observability.memory_buffer', 512),
         ));
-        $this->app->singleton(\App\Observability\Exporters\OtlpExporter::class, fn ($app) => $app
-            ->make(\App\Observability\Exporters\OtlpExporterFactory::class)
+        $this->app->singleton(OtlpExporter::class, fn ($app) => $app
+            ->make(OtlpExporterFactory::class)
             ->make());
-        $this->app->singleton(\App\Observability\Contracts\MetricExporter::class, function ($app) {
+        $this->app->singleton(MetricExporter::class, function ($app) {
             if (! (bool) config('observability.enabled', false)) {
-                return $app->make(\App\Observability\Exporters\NullMetricExporter::class);
+                return $app->make(NullMetricExporter::class);
             }
 
             return match ((string) config('observability.exporter', 'memory')) {
-                'null' => $app->make(\App\Observability\Exporters\NullMetricExporter::class),
-                'memory' => $app->make(\App\Observability\Exporters\InMemoryMetricExporter::class),
-                'otlp' => $app->make(\App\Observability\Exporters\OtlpExporter::class),
+                'null' => $app->make(NullMetricExporter::class),
+                'memory' => $app->make(InMemoryMetricExporter::class),
+                'otlp' => $app->make(OtlpExporter::class),
                 default => throw new \InvalidArgumentException('observability_exporter_invalid'),
             };
         });
-        $this->app->singleton(\App\Observability\Contracts\TraceExporter::class, function ($app) {
+        $this->app->singleton(TraceExporter::class, function ($app) {
             if (! (bool) config('observability.enabled', false)) {
-                return $app->make(\App\Observability\Exporters\NullMetricExporter::class);
+                return $app->make(NullMetricExporter::class);
             }
 
             return match ((string) config('observability.exporter', 'memory')) {
-                'null' => $app->make(\App\Observability\Exporters\NullMetricExporter::class),
-                'memory' => $app->make(\App\Observability\Exporters\InMemoryMetricExporter::class),
-                'otlp' => $app->make(\App\Observability\Exporters\OtlpExporter::class),
+                'null' => $app->make(NullMetricExporter::class),
+                'memory' => $app->make(InMemoryMetricExporter::class),
+                'otlp' => $app->make(OtlpExporter::class),
                 default => throw new \InvalidArgumentException('observability_exporter_invalid'),
             };
         });
-        $this->app->singleton(\App\Observability\MetricRecorder::class, fn ($app) => new \App\Observability\MetricRecorder(
-            $app->make(\App\Observability\Contracts\MetricExporter::class),
-            $app->make(\App\Observability\Contracts\TraceExporter::class),
+        $this->app->singleton(MetricRecorder::class, fn ($app) => new MetricRecorder(
+            $app->make(MetricExporter::class),
+            $app->make(TraceExporter::class),
             $app->make(ClinicalContentGuard::class),
         ));
     }
@@ -223,7 +275,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         if ($this->app->environment('production')) {
-            $this->app->make(\App\Services\Auth\ProductionSessionConfiguration::class)->assertSecure();
+            $this->app->make(ProductionSessionConfiguration::class)->assertSecure();
         }
 
         Queue::createPayloadUsing(function (string $connection, ?string $queue, array $payload): array {

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Services\Patient\PatientHmac;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Http\Request;
@@ -81,7 +82,7 @@ class RouteServiceProvider extends ServiceProvider
             $principal = Str::lower(trim((string) $request->input('email')));
             $principalRef = $principal === ''
                 ? 'missing'
-                : app(\App\Services\Patient\PatientHmac::class)->digest('rate-limit-email', $principal);
+                : app(PatientHmac::class)->digest('rate-limit-email', $principal);
 
             return Limit::perMinute(
                 (int) config('ingress.rate_limits.patient_credential_exchange_per_minute', 5),

--- a/app/Rtdc/CensusProjector.php
+++ b/app/Rtdc/CensusProjector.php
@@ -7,6 +7,7 @@ use App\Models\CensusSnapshot;
 use App\Models\Encounter;
 use App\Models\Unit;
 use App\Rtdc\Events\CanonicalEvent;
+use App\Services\AcuityService;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -104,7 +105,7 @@ class CensusProjector
             'occupied' => $occupied,
             'available' => $available,
             'blocked' => $blocked,
-            'acuity_adjusted_capacity' => app(\App\Services\AcuityService::class)->adjustedCapacity($unitId),
+            'acuity_adjusted_capacity' => app(AcuityService::class)->adjustedCapacity($unitId),
         ]);
     }
 }

--- a/app/Rtdc/EventDispatcher.php
+++ b/app/Rtdc/EventDispatcher.php
@@ -3,6 +3,8 @@
 namespace App\Rtdc;
 
 use App\Events\Rtdc\CensusUpdated;
+use App\Models\Bed;
+use App\Models\Encounter;
 use App\Models\OperationalEvent;
 use App\Rtdc\Events\CanonicalEvent;
 use Illuminate\Support\Facades\DB;
@@ -56,8 +58,8 @@ class EventDispatcher
         return match ($event->type) {
             CanonicalEvent::ENCOUNTER_STARTED => $event->payload['unit_id'] ?? null,
             CanonicalEvent::ENCOUNTER_TRANSFERRED => $event->payload['to_unit_id'] ?? null,
-            CanonicalEvent::ENCOUNTER_DISCHARGED, CanonicalEvent::ACUITY_CHANGED => \App\Models\Encounter::where('patient_ref', $event->encounterRef)->value('unit_id'),
-            CanonicalEvent::BED_STATUS_CHANGED => \App\Models\Bed::where('bed_id', $event->payload['bed_id'] ?? 0)->value('unit_id'),
+            CanonicalEvent::ENCOUNTER_DISCHARGED, CanonicalEvent::ACUITY_CHANGED => Encounter::where('patient_ref', $event->encounterRef)->value('unit_id'),
+            CanonicalEvent::BED_STATUS_CHANGED => Bed::where('bed_id', $event->payload['bed_id'] ?? 0)->value('unit_id'),
             default => null,
         };
     }

--- a/app/Rtdc/Simulator/SyntheticEventSource.php
+++ b/app/Rtdc/Simulator/SyntheticEventSource.php
@@ -7,6 +7,9 @@ use App\Models\Encounter;
 use App\Models\Unit;
 use App\Rtdc\Contracts\EventSource;
 use App\Rtdc\Events\CanonicalEvent;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 /**
@@ -21,7 +24,7 @@ class SyntheticEventSource implements EventSource
     public function __construct(
         private readonly SimulatorConfig $config,
         private readonly int $seed = 0,
-        private readonly ?\Carbon\CarbonInterface $startAt = null,
+        private readonly ?CarbonInterface $startAt = null,
     ) {}
 
     public function pull(): iterable
@@ -72,8 +75,8 @@ class SyntheticEventSource implements EventSource
      * the seeded mt_rand(), then re-resolve it through the given scope. Returns
      * null when there are no candidates.
      *
-     * @param  \Illuminate\Support\Collection<int, int>  $ids
-     * @param  callable(int): ?\Illuminate\Database\Eloquent\Model  $resolve
+     * @param  Collection<int, int>  $ids
+     * @param  callable(int): ?Model  $resolve
      */
     private function pickDeterministic($ids, callable $resolve)
     {

--- a/app/Services/AcuityService.php
+++ b/app/Services/AcuityService.php
@@ -44,9 +44,9 @@ class AcuityService
      */
     public function remainingWorkload(int $unitId): float
     {
-        $unit = \App\Models\Unit::findOrFail($unitId);
-        $currentLoad = \App\Models\Encounter::active()->where('unit_id', $unitId)->get()
-            ->sum(fn (\App\Models\Encounter $e) => $this->tierWeight($e->acuity_tier));
+        $unit = Unit::findOrFail($unitId);
+        $currentLoad = Encounter::active()->where('unit_id', $unitId)->get()
+            ->sum(fn (Encounter $e) => $this->tierWeight($e->acuity_tier));
 
         return (float) $unit->staffed_bed_count - $currentLoad;
     }

--- a/app/Services/Cockpit/Channels/PushAlertChannel.php
+++ b/app/Services/Cockpit/Channels/PushAlertChannel.php
@@ -8,6 +8,7 @@ use App\Contracts\PushNotifier;
 use App\Models\Cockpit\CockpitAlert;
 use App\Models\User;
 use App\Services\Alerting\OperationalAlert;
+use Illuminate\Support\Collection;
 
 /**
  * Mobile paging for opened cockpit alerts AND shared operational alerts
@@ -86,7 +87,7 @@ class PushAlertChannel implements AlertChannel, OperationalAlertChannel
         return $dispatched;
     }
 
-    /** @return \Illuminate\Support\Collection<int, User> */
+    /** @return Collection<int, User> */
     private function recipients()
     {
         return User::query()

--- a/app/Services/Cockpit/DrillBuilder.php
+++ b/app/Services/Cockpit/DrillBuilder.php
@@ -3,13 +3,24 @@
 namespace App\Services\Cockpit;
 
 use App\Enums\CockpitStatus;
+use App\Models\DiversionEvent;
+use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeReferral;
+use App\Services\Ed\NedocsService;
+use App\Services\Ed\TreatmentService;
 use App\Services\Evs\EvsOperationsService;
+use App\Services\Home\HewsService;
+use App\Services\Mobile\MobilePatientContextService;
 use App\Services\Operations\RoomStatusService;
 use App\Services\Staffing\StaffingOperationsService;
 use App\Services\Transport\TransportOperationsService;
 use App\Support\Operations\DurationFormatter;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * Builds the per-domain drill payload (spec §3.3) in the §6.4 Cell grammar
@@ -174,8 +185,8 @@ class DrillBuilder
     /** @return list<array<string, mixed>> */
     private function edTables(): array
     {
-        $board = app(\App\Services\Ed\TreatmentService::class)->build();
-        $patients = app(\App\Services\Mobile\MobilePatientContextService::class);
+        $board = app(TreatmentService::class)->build();
+        $patients = app(MobilePatientContextService::class);
         $rows = [];
 
         $tables = [$this->edOvercrowdingTable()];
@@ -240,7 +251,7 @@ class DrillBuilder
      */
     private function edOvercrowdingTable(): ?array
     {
-        $nedocs = app(\App\Services\Ed\NedocsService::class);
+        $nedocs = app(NedocsService::class);
         $inputs = $nedocs->inputs();
 
         if ($inputs === null) {
@@ -248,7 +259,7 @@ class DrillBuilder
         }
 
         $score = (float) $nedocs->score();
-        $onDiversion = \App\Models\DiversionEvent::query()
+        $onDiversion = DiversionEvent::query()
             ->where('is_deleted', false)
             ->where('started_at', '<', now())
             ->whereNull('ended_at')
@@ -366,14 +377,14 @@ class DrillBuilder
      */
     private function pacuBayBoard(): ?array
     {
-        if (! \Illuminate\Support\Facades\Schema::hasTable('prod.or_logs')) {
+        if (! Schema::hasTable('prod.or_logs')) {
             return null;
         }
 
-        $holdThreshold = \Illuminate\Support\Carbon::now()->subMinutes(75)->toDateTimeString();
-        $now = \Illuminate\Support\Carbon::now()->toDateTimeString();
+        $holdThreshold = Carbon::now()->subMinutes(75)->toDateTimeString();
+        $now = Carbon::now()->toDateTimeString();
 
-        $bays = \Illuminate\Support\Facades\DB::select(
+        $bays = DB::select(
             'SELECT
                  c.patient_id,
                  l.primary_procedure,
@@ -396,7 +407,7 @@ class DrillBuilder
 
         // P8 — PACU rows descend to the A2P patient lens like the ED track board;
         // RBAC is enforced at the destination, the cell carries only the opaque ptok.
-        $patients = app(\App\Services\Mobile\MobilePatientContextService::class);
+        $patients = app(MobilePatientContextService::class);
 
         $rows = [];
         foreach ($bays as $i => $bay) {
@@ -552,14 +563,14 @@ class DrillBuilder
      */
     private function homeTables(): array
     {
-        $episodes = \App\Models\Home\HomeEpisode::query()
+        $episodes = HomeEpisode::query()
             ->with(['encounter.bed:bed_id,label'])
             ->active()
             ->orderBy('home_episode_id')
             ->limit(16)
             ->get();
 
-        $hews = app(\App\Services\Home\HewsService::class);
+        $hews = app(HewsService::class);
         $rows = [];
 
         foreach ($episodes as $episode) {
@@ -597,12 +608,12 @@ class DrillBuilder
                         'status' => $critOpen ? 'critical' : 'warning',
                     ]],
                 'next_visit' => ['v' => $nextVisit !== null
-                    ? $nextVisit->scheduled_start->diffForHumans(now(), ['short' => true, 'parts' => 1, 'syntax' => \Carbon\CarbonInterface::DIFF_RELATIVE_TO_NOW])
+                    ? $nextVisit->scheduled_start->diffForHumans(now(), ['short' => true, 'parts' => 1, 'syntax' => CarbonInterface::DIFF_RELATIVE_TO_NOW])
                     : '—', 'dim' => $nextVisit === null],
             ];
         }
 
-        $funnel = \App\Models\Home\HomeReferral::query()
+        $funnel = HomeReferral::query()
             ->where('is_deleted', false)
             ->selectRaw('status, count(*) AS n')
             ->groupBy('status')

--- a/app/Services/Cockpit/MetricValueWriter.php
+++ b/app/Services/Cockpit/MetricValueWriter.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Cockpit;
 
+use App\Models\Ops\MetricDefinition;
 use App\Support\Cockpit\MetricValue;
 use Carbon\CarbonInterface;
 use Illuminate\Support\Collection;
@@ -25,7 +26,7 @@ class MetricValueWriter
 
     /**
      * @param  array<string, MetricValue>  $values  keyed by metric_key
-     * @param  Collection<string, \App\Models\Ops\MetricDefinition>  $definitions  keyed by metric_key
+     * @param  Collection<string, MetricDefinition>  $definitions  keyed by metric_key
      * @return int rows written
      */
     public function write(array $values, Collection $definitions, CarbonInterface $measuredAt): int

--- a/app/Services/Cockpit/ScopedFaceBuilder.php
+++ b/app/Services/Cockpit/ScopedFaceBuilder.php
@@ -9,6 +9,7 @@ use App\Services\Mobile\MobilePatientContextService;
 use App\Services\Rtdc\BedTrackingService;
 use App\Support\Cockpit\CockpitScope;
 use App\Support\Hospital\HospitalManifest;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -309,7 +310,7 @@ class ScopedFaceBuilder
 
     /**
      * @param  array<string, mixed>  $row
-     * @param  \Illuminate\Support\Collection<int, Encounter>  $roster
+     * @param  Collection<int, Encounter>  $roster
      * @param  list<int>  $occupiedSeries
      * @param  array{in: int, out: int}  $movement
      * @return list<array<string, mixed>>
@@ -344,7 +345,7 @@ class ScopedFaceBuilder
      * identity stays gated at A2P behind EnforceFlowLens; the drill cell carries
      * only the opaque ptok.
      *
-     * @return \Illuminate\Support\Collection<int, Encounter>
+     * @return Collection<int, Encounter>
      */
     private function unitRoster(int $unitId)
     {
@@ -363,7 +364,7 @@ class ScopedFaceBuilder
      * (same affordance as the ED track board); RBAC is enforced at the
      * destination, so the opaque ptok is safe to carry.
      *
-     * @param  \Illuminate\Support\Collection<int, Encounter>  $roster
+     * @param  Collection<int, Encounter>  $roster
      * @return array<string, mixed>
      */
     private function unitRosterTable($roster): array

--- a/app/Services/Cockpit/SnapshotBuilder.php
+++ b/app/Services/Cockpit/SnapshotBuilder.php
@@ -17,10 +17,13 @@ use App\Domain\Cockpit\Metrics\RtdcMetrics;
 use App\Domain\Cockpit\Metrics\ServiceLineMetrics;
 use App\Domain\Cockpit\Metrics\StaffingMetrics;
 use App\Domain\Cockpit\SnapshotContext;
+use App\Events\Cockpit\CockpitSnapshotUpdated;
 use App\Integrations\Healthcare\Services\SourceHealthDigestService;
 use App\Models\Cockpit\CockpitSnapshot;
 use App\Models\Ops\MetricDefinition;
 use App\Services\CommandCenterDataService;
+use App\Services\Eddy\EddyActionService;
+use App\Services\Lab\LabAggregateSnapshotFactory;
 use App\Services\Ops\Agents\AgentToolRegistry;
 use App\Support\Cockpit\MetricValue;
 use App\Support\Hospital\HospitalManifest;
@@ -125,7 +128,7 @@ class SnapshotBuilder
         // processes (demo:seed roll-forward cycles, dispatch_sync callers)
         // reuse one container scope across refreshes, so the scoped lab
         // aggregate is invalidated here before recomputing.
-        app(\App\Services\Lab\LabAggregateSnapshotFactory::class)->flush();
+        app(LabAggregateSnapshotFactory::class)->flush();
 
         ['payload' => $payload, 'context' => $ctx] = $this->buildWithContext($facilityKey);
 
@@ -139,11 +142,11 @@ class SnapshotBuilder
         // ticker can hand off to the EddyDock pre-seeded (client stays
         // presentation-only; the mapping lives server-side).
         $payload['alerts'] = array_map(function (array $alert): array {
-            $action = \App\Services\Eddy\EddyActionService::actionForAlert($alert['key'], $alert['status']);
+            $action = EddyActionService::actionForAlert($alert['key'], $alert['status']);
 
             return $alert + [
                 'action' => $action,
-                'actionLabel' => \App\Services\Eddy\EddyActionService::CATALOG[$action]['label'],
+                'actionLabel' => EddyActionService::CATALOG[$action]['label'],
             ];
         }, $payload['alerts']);
 
@@ -164,7 +167,7 @@ class SnapshotBuilder
         // the snapshot over their own session. Broadcast trouble (Reverb down,
         // BROADCAST_CONNECTION=null) must never fail the refresh itself.
         try {
-            \App\Events\Cockpit\CockpitSnapshotUpdated::dispatch(
+            CockpitSnapshotUpdated::dispatch(
                 $facilityKey,
                 (string) ($payload['asOf'] ?? now()->toIso8601String()),
             );

--- a/app/Services/CommandCenterDataService.php
+++ b/app/Services/CommandCenterDataService.php
@@ -8,6 +8,7 @@ use App\Services\Analytics\MetricLineageService;
 use App\Services\Cockpit\StatusEngine;
 use App\Services\Rtdc\HouseCensusService;
 use App\Support\Operations\DurationFormatter;
+use App\Support\SurgeHeuristic;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -1088,7 +1089,7 @@ class CommandCenterDataService
 
         // Surge probability heuristic (documented, not a trained model) —
         // shared with the Flow Window projections via SurgeHeuristic.
-        $pressures = \App\Support\SurgeHeuristic::pressures(
+        $pressures = SurgeHeuristic::pressures(
             $occupancyPct, $netBeds, $predAdmissions, $sumWtDc, $avgReliability
         );
         $occupancyPressure = $pressures['occupancy_pressure'];

--- a/app/Services/Demo/DemoInvariantService.php
+++ b/app/Services/Demo/DemoInvariantService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Demo;
 
 use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
+use App\Services\Rtdc\HouseCensusService;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -156,7 +157,7 @@ final class DemoInvariantService
         // ED + periop beds legitimately exist; the invariant is that the CODE excludes them, not
         // that they are absent. We assert the returned denominator does not exceed the inpatient plant.
         $licensed = $this->profile->licensedInpatientBeds();
-        $house = app(\App\Services\Rtdc\HouseCensusService::class)->houseTotals();
+        $house = app(HouseCensusService::class)->houseTotals();
         $houseStaffed = (int) ($house['staffedBeds'] ?? 0);
         $ceiling = $licensed > 0 ? $licensed : $inpatientInventory;
         $out[] = $this->finding('capacity.house_denominator_inpatient_only', 'capacity', 'critical',

--- a/app/Services/Demo/DemoRefreshCoordinator.php
+++ b/app/Services/Demo/DemoRefreshCoordinator.php
@@ -4,6 +4,8 @@ namespace App\Services\Demo;
 
 use App\Jobs\RefreshCockpitSnapshot;
 use App\Services\Demo\Ancillary\AncillaryDemoScenarioService;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -199,7 +201,7 @@ final class DemoRefreshCoordinator
 
     // ---- ledger ----
 
-    private function openLedger(string $refreshId, DemoClock $clock, \Illuminate\Support\Carbon $startedAt): void
+    private function openLedger(string $refreshId, DemoClock $clock, Carbon $startedAt): void
     {
         DB::table('ops.demo_refresh_runs')->insert([
             'refresh_id' => $refreshId,
@@ -250,7 +252,7 @@ final class DemoRefreshCoordinator
         if ($latest === null) {
             return 'critical';
         }
-        $minutes = abs(now()->diffInMinutes(\Carbon\CarbonImmutable::parse($latest)));
+        $minutes = abs(now()->diffInMinutes(CarbonImmutable::parse($latest)));
         if ($minutes <= $expectedLag) {
             return 'success';
         }

--- a/app/Services/Ed/TreatmentService.php
+++ b/app/Services/Ed/TreatmentService.php
@@ -7,6 +7,7 @@ namespace App\Services\Ed;
 use App\Services\Ancillary\AncillaryReadinessService;
 use App\Support\Hospital\HospitalManifest;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -141,7 +142,7 @@ class TreatmentService
      * Sorted by acuity (ESI ascending, nulls last) then longest dwell first so
      * the most urgent / longest-waiting patients surface at the top of the board.
      *
-     * @return \Illuminate\Support\Collection<int,object>
+     * @return Collection<int,object>
      */
     private function treatmentCohort(Carbon $now)
     {
@@ -177,10 +178,10 @@ class TreatmentService
      * (seeded data straddles wall-clock now, so a provider_seen_at can be in the
      * future for not-yet-"happened" rows — clamp keeps the demo sane).
      *
-     * @param  \Illuminate\Support\Collection<int,object>  $rows
+     * @param  Collection<int,object>  $rows
      * @return list<array<string,mixed>>
      */
-    private function board($rows, Carbon $now, \Illuminate\Support\Collection $imagingByVisit, \Illuminate\Support\Collection $labByVisit, \Illuminate\Support\Collection $medicationByVisit): array
+    private function board($rows, Carbon $now, Collection $imagingByVisit, Collection $labByVisit, Collection $medicationByVisit): array
     {
         $board = [];
 

--- a/app/Services/Flow/FloorPlateAssetService.php
+++ b/app/Services/Flow/FloorPlateAssetService.php
@@ -6,6 +6,7 @@ use App\Models\Bed;
 use App\Models\Facility\FacilitySpace;
 use App\Models\Unit;
 use App\Support\Hospital\HospitalManifest;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 
 /**
@@ -131,7 +132,7 @@ class FloorPlateAssetService
     {
         $document = $this->build();
         Storage::disk('local')->put(self::ASSET_PATH, json_encode($document, JSON_UNESCAPED_SLASHES));
-        \Illuminate\Support\Facades\Cache::forget('flow:plates:doc');
+        Cache::forget('flow:plates:doc');
 
         return $document;
     }
@@ -146,7 +147,7 @@ class FloorPlateAssetService
      */
     public function load(): array
     {
-        return \Illuminate\Support\Facades\Cache::remember('flow:plates:doc', 300, function (): array {
+        return Cache::remember('flow:plates:doc', 300, function (): array {
             $disk = Storage::disk('local');
             if ($disk->exists(self::ASSET_PATH)) {
                 $decoded = json_decode((string) $disk->get(self::ASSET_PATH), true);

--- a/app/Services/Flow/FlowLensService.php
+++ b/app/Services/Flow/FlowLensService.php
@@ -2,12 +2,14 @@
 
 namespace App\Services\Flow;
 
+use App\Models\Encounter;
 use App\Models\Evs\EvsRequest;
 use App\Models\Transport\TransportRequest;
 use App\Models\Unit;
 use App\Models\User;
 use App\Services\Mobile\MobilePatientContextService;
 use App\Services\Mobile\MobilePersonaCatalog;
+use App\Support\Hospital\HospitalManifest;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Support\Facades\Schema;
 
@@ -337,7 +339,7 @@ class FlowLensService
         } else {
             // Default floor: the user's assigned unit's floor; the periop
             // floor for OR lenses; otherwise the lowest manifest floor.
-            $manifest = app(\App\Support\Hospital\HospitalManifest::class);
+            $manifest = app(HospitalManifest::class);
             $assigned = $user ? $this->defaultUnitFor($user) : null;
             $assignedFloor = $assigned !== null ? $this->floorForUnit($assigned) : null;
             $floor = match (true) {
@@ -413,7 +415,7 @@ class FlowLensService
         $context = $this->patientContext->build($arg, $user, $lens['role_id']);
         $patientRef = $this->patientContext->resolvePatientRef($arg);
 
-        $unitId = \App\Models\Encounter::query()
+        $unitId = Encounter::query()
             ->where('patient_ref', $patientRef)
             ->where('status', 'active')
             ->where('is_deleted', false)
@@ -479,7 +481,7 @@ class FlowLensService
 
     private function floorForUnit(Unit $unit): ?int
     {
-        $manifest = app(\App\Support\Hospital\HospitalManifest::class);
+        $manifest = app(HospitalManifest::class);
         $entry = $unit->abbreviation ? $manifest->unit($unit->abbreviation) : null;
 
         return isset($entry['floor']) ? (int) $entry['floor'] : null;

--- a/app/Services/Flow/ForwardProjectionService.php
+++ b/app/Services/Flow/ForwardProjectionService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Flow;
 
 use App\Models\Bed;
+use App\Models\BedRequest;
 use App\Models\Encounter;
 use App\Models\Evs\EvsRequest;
 use App\Models\ORCase;
@@ -15,10 +16,12 @@ use App\Services\Ed\ArrivalPredictionService;
 use App\Services\Mobile\MobilePatientContextService;
 use App\Support\Hospital\HospitalManifest;
 use App\Support\Operations\DurationFormatter;
+use App\Support\SurgeHeuristic;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * The prediction half of the Flow Window — FLOW-WINDOW-PLAN §6.3 (W3, G5).
@@ -398,7 +401,7 @@ class ForwardProjectionService
     /** @return Collection<int, array<string, mixed>> */
     private function scheduledOrCases(CarbonImmutable $from, CarbonImmutable $to): Collection
     {
-        if (! \Illuminate\Support\Facades\Schema::hasTable('prod.or_cases')) {
+        if (! Schema::hasTable('prod.or_cases')) {
             return collect(); // periop import is optional; degrade to an empty lane
         }
 
@@ -567,7 +570,7 @@ class ForwardProjectionService
         $occupied = (int) ($beds->occupied ?? 0);
         $available = (int) ($beds->available ?? 0);
         $occupancyPct = $staffed > 0 ? (int) round(100 * $occupied / $staffed) : 0;
-        $netBedsNow = $available - \App\Models\BedRequest::pending()->count();
+        $netBedsNow = $available - BedRequest::pending()->count();
 
         $row = RtdcPrediction::query()
             ->where('service_date', $from->toDateString())
@@ -579,7 +582,7 @@ class ForwardProjectionService
         $sumWtDc = (float) ($row->wdc ?? 0);
         $reliability = $this->houseReliability() ?? 0.8;
 
-        $surgePct = \App\Support\SurgeHeuristic::pressures(
+        $surgePct = SurgeHeuristic::pressures(
             $occupancyPct, $netBedsNow, $predAdmissions, $sumWtDc, $reliability
         )['surge_pct'];
 

--- a/app/Services/Flow/OperationalTimelineService.php
+++ b/app/Services/Flow/OperationalTimelineService.php
@@ -3,11 +3,13 @@
 namespace App\Services\Flow;
 
 use App\Models\Barrier;
+use App\Models\Bed;
 use App\Models\BedPlacementDecision;
 use App\Models\BedRequest;
 use App\Models\EdVisit;
 use App\Models\Evs\EvsEvent;
 use App\Models\OperationalEvent;
+use App\Models\ORLog;
 use App\Models\Staffing\StaffingEvent;
 use App\Models\Transport\TransportEvent;
 use App\Models\Unit;
@@ -15,6 +17,7 @@ use App\Services\Mobile\MobilePatientContextService;
 use App\Support\Hospital\HospitalManifest;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
 
 /**
  * The review half of the Flow Window — FLOW-WINDOW-PLAN §6.2 (W2, G4).
@@ -235,7 +238,7 @@ class OperationalTimelineService
                 ->get()
                 ->map(function (BedPlacementDecision $decision): array {
                     $bed = $decision->chosen_bed_id !== null
-                        ? \App\Models\Bed::find($decision->chosen_bed_id)
+                        ? Bed::find($decision->chosen_bed_id)
                         : null;
 
                     return $this->normalized(
@@ -420,7 +423,7 @@ class OperationalTimelineService
         ];
 
         $events = collect();
-        $logs = \App\Models\ORLog::query()
+        $logs = ORLog::query()
             ->from($table)
             ->with('case.room') // ORLog→case→room: OR-side milestones land in a named room
             ->where('is_deleted', false)
@@ -461,7 +464,7 @@ class OperationalTimelineService
     private function orlogTable(): ?string
     {
         foreach (['prod.orlog', 'prod.or_logs'] as $table) {
-            if (\Illuminate\Support\Facades\Schema::hasTable($table)) {
+            if (Schema::hasTable($table)) {
                 return $table;
             }
         }
@@ -542,7 +545,7 @@ class OperationalTimelineService
         return $unitId !== null ? ($this->unitLabels[$unitId] ?? null) : null;
     }
 
-    private function orMilestoneAt(\App\Models\ORLog $log, string $column): ?CarbonImmutable
+    private function orMilestoneAt(ORLog $log, string $column): ?CarbonImmutable
     {
         $value = $log->{$column};
         if ($value === null || $value === '') {

--- a/app/Services/Home/HomeTransitionService.php
+++ b/app/Services/Home/HomeTransitionService.php
@@ -3,11 +3,14 @@
 namespace App\Services\Home;
 
 use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeProgram;
 use App\Models\Home\HomeTransition;
 use App\Models\Home\RpmEnrollment;
+use App\Models\Home\RpmKit;
 use App\Models\Transport\TransportRequest;
 use App\Services\Transport\RegionalTransferService;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Ramsey\Uuid\Uuid;
 
@@ -133,7 +136,7 @@ class HomeTransitionService
 
         return DB::transaction(function () use ($episode, $receivingEntityType, $handoffOwner, $userId): array {
             $request = TransportRequest::create([
-                'request_uuid' => (string) \Illuminate\Support\Str::uuid(),
+                'request_uuid' => (string) Str::uuid(),
                 'request_type' => 'care_transition',
                 'priority' => 'routine',
                 'status' => 'requested',
@@ -235,7 +238,7 @@ class HomeTransitionService
      */
     private function enrollPostDischargeCohort(HomeEpisode $acute): void
     {
-        $program = \App\Models\Home\HomeProgram::query()
+        $program = HomeProgram::query()
             ->where('program_type', 'post_discharge_rpm')
             ->where('is_active', true)
             ->first();
@@ -265,7 +268,7 @@ class HomeTransitionService
             'enrollment_uuid' => Uuid::uuid4()->toString(),
             'home_episode_id' => $cohortEpisode->home_episode_id,
             'rpm_kit_id' => $acute->enrollments()->latest('rpm_enrollment_id')->value('rpm_kit_id')
-                ?? \App\Models\Home\RpmKit::query()->where('is_deleted', false)->orderBy('rpm_kit_id')->value('rpm_kit_id'),
+                ?? RpmKit::query()->where('is_deleted', false)->orderBy('rpm_kit_id')->value('rpm_kit_id'),
             'patient_ref' => $acute->patient_ref,
             'status' => 'active',
             // Step-down cadence: BP + SpO2 q12h, weight daily.

--- a/app/Services/Identity/UserLifecycleReadService.php
+++ b/app/Services/Identity/UserLifecycleReadService.php
@@ -5,6 +5,8 @@ namespace App\Services\Identity;
 use App\Models\Audit\UserEvent;
 use App\Models\Auth\UserExternalIdentity;
 use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -135,7 +137,7 @@ class UserLifecycleReadService
      *
      * @param  Collection<int, UserExternalIdentity>  $identities
      */
-    private function reconciliationState(Collection $identities, ?\Carbon\CarbonImmutable $lastOidcLoginAt): string
+    private function reconciliationState(Collection $identities, ?CarbonImmutable $lastOidcLoginAt): string
     {
         if ($identities->isEmpty()) {
             return 'not_applicable';
@@ -161,9 +163,9 @@ class UserLifecycleReadService
     }
 
     /**
-     * @param  \Illuminate\Database\Eloquent\Builder<UserEvent>  $query
+     * @param  Builder<UserEvent>  $query
      * @param  list<int>  $ids
-     * @return array<int, \Carbon\CarbonImmutable> latest occurred_at keyed by actor id
+     * @return array<int, CarbonImmutable> latest occurred_at keyed by actor id
      */
     private function latestByActor($query, array $ids): array
     {
@@ -172,7 +174,7 @@ class UserLifecycleReadService
             ->groupBy('actor_user_id')
             ->selectRaw('actor_user_id, max(occurred_at) as latest_at')
             ->pluck('latest_at', 'actor_user_id')
-            ->map(fn (mixed $value): \Carbon\CarbonImmutable => \Carbon\CarbonImmutable::parse((string) $value))
+            ->map(fn (mixed $value): CarbonImmutable => CarbonImmutable::parse((string) $value))
             ->all();
     }
 }

--- a/app/Services/Lab/AmReadiness/LabMorningReadinessService.php
+++ b/app/Services/Lab/AmReadiness/LabMorningReadinessService.php
@@ -4,6 +4,7 @@ namespace App\Services\Lab\AmReadiness;
 
 use Carbon\CarbonImmutable;
 use Carbon\CarbonInterface;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -340,7 +341,7 @@ final class LabMorningReadinessService
         return $observations;
     }
 
-    private function latestResult(): \Illuminate\Database\Query\Builder
+    private function latestResult(): Builder
     {
         return DB::table('prod.lab_results as lr')
             ->select('lr.ancillary_order_id', 'lr.analyzer_ref', DB::raw('lr.metadata as result_metadata'))

--- a/app/Services/Ops/Agents/AgentToolRegistry.php
+++ b/app/Services/Ops/Agents/AgentToolRegistry.php
@@ -4,6 +4,7 @@ namespace App\Services\Ops\Agents;
 
 use App\Models\User;
 use App\Services\Analytics\OperationsAnalyticsService;
+use App\Services\Cockpit\SnapshotBuilder;
 use App\Services\Ops\InterventionAttributionService;
 use App\Support\Operations\DurationFormatter;
 use Illuminate\Database\Query\Builder;
@@ -76,7 +77,7 @@ class AgentToolRegistry
      */
     private function cachedCapacitySnapshot(): array
     {
-        $cached = Cache::get(\App\Services\Cockpit\SnapshotBuilder::CACHE_KEY);
+        $cached = Cache::get(SnapshotBuilder::CACHE_KEY);
         $capacity = is_array($cached) ? ($cached['capacitySnapshot'] ?? null) : null;
 
         if (is_array($capacity) && ($capacity['tool'] ?? null) === 'capacity.snapshot') {

--- a/app/Services/Patient/Education/PatientEducationClarificationService.php
+++ b/app/Services/Patient/Education/PatientEducationClarificationService.php
@@ -15,6 +15,7 @@ use App\Services\Patient\PatientHmac;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
 
 /**
  * Accept a patient-authored request to clarify released education. This is not
@@ -119,7 +120,7 @@ class PatientEducationClarificationService
                     $replayed = true;
                 } else {
                     PatientEducationClarificationRequest::query()->create([
-                        'clarification_uuid' => (string) \Illuminate\Support\Str::uuid7(),
+                        'clarification_uuid' => (string) Str::uuid7(),
                         'principal_id' => $principal->getKey(),
                         'access_grant_id' => $grant->getKey(),
                         'pathway_projection_id' => $projection->getKey(),

--- a/app/Services/Patient/Messaging/PatientCommunicationLifecycleReconciliationService.php
+++ b/app/Services/Patient/Messaging/PatientCommunicationLifecycleReconciliationService.php
@@ -8,6 +8,7 @@ use App\Models\Patient\PatientMessage;
 use App\Models\Patient\PatientMessageDeliveryReceipt;
 use App\Models\Patient\PatientMessageRoutingEvent;
 use App\Models\Patient\PatientMessageThread;
+use App\Models\PatientCommunication\PoolMembership;
 use App\Models\PatientCommunication\ResponsibilityPool;
 use App\Models\PatientCommunication\StaffActionEvent;
 use App\Models\PatientCommunication\ThreadWorkItem;
@@ -499,7 +500,7 @@ class PatientCommunicationLifecycleReconciliationService
         ]);
     }
 
-    /** @param Collection<int, \App\Models\PatientCommunication\PoolMembership> $eligibleMemberships */
+    /** @param Collection<int, PoolMembership> $eligibleMemberships */
     private function pendingAssigneeIsNoLongerEligible(
         ThreadWorkItem $workItem,
         Collection $eligibleMemberships,

--- a/app/Services/Patient/Projection/PatientPathwayHistoryDraftService.php
+++ b/app/Services/Patient/Projection/PatientPathwayHistoryDraftService.php
@@ -10,6 +10,7 @@ use App\Models\Patient\PatientProjectionCursor;
 use App\Models\Patient\PatientProjectionFailure;
 use App\Models\Patient\PatientReleasePolicyVersion;
 use App\Services\Patient\PatientHmac;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
@@ -274,8 +275,8 @@ class PatientPathwayHistoryDraftService
         }
     }
 
-    /** @return \Illuminate\Database\Eloquent\Collection<int, PatientPathwayInstance> */
-    private function pendingInstances(int $limit): \Illuminate\Database\Eloquent\Collection
+    /** @return Collection<int, PatientPathwayInstance> */
+    private function pendingInstances(int $limit): Collection
     {
         return PatientPathwayInstance::query()
             ->orderBy('pathway_instance_id')

--- a/app/Services/PatientFlow/PatientFlowHl7IngestPipeline.php
+++ b/app/Services/PatientFlow/PatientFlowHl7IngestPipeline.php
@@ -13,6 +13,7 @@ use App\Models\Raw\InboundMessage;
 use App\Models\Raw\IngestRun;
 use App\Observability\MetricRecorder;
 use App\Security\ClinicalPayloads\ClinicalPayloadStore;
+use App\Services\Home\HomeEscalationService;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
@@ -295,7 +296,7 @@ class PatientFlowHl7IngestPipeline
             if ((bool) config('home_hospital.enabled')
                 && in_array((string) ($normalized['event_type'] ?? ''), ['admit', 'register'], true)) {
                 try {
-                    app(\App\Services\Home\HomeEscalationService::class)
+                    app(HomeEscalationService::class)
                         ->closeForEdReturn((string) $normalized['patient_id']);
                 } catch (Throwable $exception) {
                     Log::warning('home_hospital.escalation_close_failed', [

--- a/app/Services/ReconciliationService.php
+++ b/app/Services/ReconciliationService.php
@@ -6,6 +6,7 @@ use App\Models\Encounter;
 use App\Models\RtdcPrediction;
 use App\Models\RtdcReconciliation;
 use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
 
 /**
  * RTDC Step 4 — evaluate yesterday's plan. Reconciles predicted vs actual
@@ -16,7 +17,7 @@ class ReconciliationService
 {
     public function reconcile(int $unitId, CarbonInterface|string $serviceDate): RtdcReconciliation
     {
-        $date = \Illuminate\Support\Carbon::parse($serviceDate)->toDateString();
+        $date = Carbon::parse($serviceDate)->toDateString();
 
         $predictedDischarges = (float) RtdcPrediction::where('unit_id', $unitId)
             ->whereDate('service_date', $date)

--- a/app/Services/Rounds/PatientRoundQuestionPromotionService.php
+++ b/app/Services/Rounds/PatientRoundQuestionPromotionService.php
@@ -26,6 +26,7 @@ use App\Services\Patient\Messaging\PatientMessagingPolicyRegistry;
 use App\Services\Patient\PatientHmac;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -649,7 +650,7 @@ class PatientRoundQuestionPromotionService
         ];
     }
 
-    /** @param Builder<\Illuminate\Database\Eloquent\Model> $query */
+    /** @param Builder<Model> $query */
     private function applyLock(Builder $query, bool $forUpdate): void
     {
         if ($forUpdate) {

--- a/app/Services/Rounds/RoundCohortBuilder.php
+++ b/app/Services/Rounds/RoundCohortBuilder.php
@@ -11,6 +11,7 @@ use App\Models\Rounds\RoundRun;
 use App\Models\Rounds\RoundTemplate;
 use App\Models\Unit;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
@@ -229,7 +230,7 @@ class RoundCohortBuilder
         $map = (array) config('rounds.unit_role_map', []);
         $result = [];
 
-        $rows = \Illuminate\Support\Facades\DB::table('prod.user_unit')
+        $rows = DB::table('prod.user_unit')
             ->where('unit_id', $unit->unit_id)
             ->whereNotNull('role')
             ->get(['user_id', 'role']);

--- a/app/Services/Rounds/RoundCommandService.php
+++ b/app/Services/Rounds/RoundCommandService.php
@@ -14,6 +14,8 @@ use App\Models\Rounds\RoundPatient;
 use App\Models\Rounds\RoundRun;
 use App\Models\Rounds\RoundTemplate;
 use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -75,7 +77,7 @@ class RoundCommandService
         }
 
         if (! $this->authorization->canStartRun($actor, $unit)) {
-            throw new \Illuminate\Auth\Access\AuthorizationException('You are not authorized to start a round for this unit.');
+            throw new AuthorizationException('You are not authorized to start a round for this unit.');
         }
 
         $run = $this->execute(function () use ($actor, $input, $template, $unit): RoundRun {
@@ -596,7 +598,7 @@ class RoundCommandService
 
         try {
             $result = DB::transaction($fn);
-        } catch (\Illuminate\Database\QueryException $e) {
+        } catch (QueryException $e) {
             // A concurrent duplicate idempotency key hits the partial unique
             // index; surface it as a conflict, not a 500.
             if (str_contains($e->getMessage(), 'uq_rounds_events_idempotency')) {

--- a/app/Services/Staffing/Contracts/StaffingConnector.php
+++ b/app/Services/Staffing/Contracts/StaffingConnector.php
@@ -5,6 +5,7 @@ namespace App\Services\Staffing\Contracts;
 use App\Services\Staffing\Support\ConnectionResult;
 use App\Services\Staffing\Support\ConnectorCapabilities;
 use App\Services\Staffing\Support\PullWindow;
+use App\Services\Staffing\Support\RawStaffRecord;
 
 /**
  * Phase 7: the pluggable staffing-source contract (mirrors the Connector Contract
@@ -36,7 +37,7 @@ interface StaffingConnector
     /**
      * Stream RawStaffRecord value objects for the window.
      *
-     * @return iterable<\App\Services\Staffing\Support\RawStaffRecord>
+     * @return iterable<RawStaffRecord>
      */
     public function pullStaff(PullWindow $window): iterable;
 

--- a/app/Services/Staffing/StaffImportOrchestrator.php
+++ b/app/Services/Staffing/StaffImportOrchestrator.php
@@ -14,6 +14,7 @@ use App\Services\Staffing\Support\PullWindow;
 use App\Services\Staffing\Support\RawStaffRecord;
 use App\Services\Staffing\Support\ResolvedAssignment;
 use App\Services\Staffing\Support\StagedStaffMember;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -317,7 +318,7 @@ class StaffImportOrchestrator
     }
 
     /**
-     * @return \Illuminate\Support\Collection<int, object>
+     * @return Collection<int, object>
      */
     private function loadRules(StaffingSource $source)
     {
@@ -365,7 +366,7 @@ class StaffImportOrchestrator
 
     /**
      * @param  list<string>  $seenKeys
-     * @return \Illuminate\Support\Collection<int, StaffMember>
+     * @return Collection<int, StaffMember>
      */
     private function departedMembers(StaffingSource $source, array $seenKeys)
     {

--- a/app/Services/Transport/TransportOperationsService.php
+++ b/app/Services/Transport/TransportOperationsService.php
@@ -11,6 +11,7 @@ use App\Support\Operations\SourceFreshness;
 use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Pagination\Cursor;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 use Illuminate\Validation\ValidationException;
 
 class TransportOperationsService
@@ -321,7 +322,7 @@ class TransportOperationsService
     }
 
     /**
-     * @param  \Illuminate\Support\Collection<int, TransportEvent>  $events
+     * @param  Collection<int, TransportEvent>  $events
      */
     private function firstOccurrence($events, string $eventType): ?Carbon
     {

--- a/app/Traits/SafeMigration.php
+++ b/app/Traits/SafeMigration.php
@@ -2,6 +2,9 @@
 
 namespace App\Traits;
 
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
 trait SafeMigration
 {
     protected function isLocalEnvironment(): bool
@@ -12,20 +15,20 @@ trait SafeMigration
     protected function safeDropIfExists(string $table): void
     {
         if ($this->isLocalEnvironment()) {
-            \Illuminate\Support\Facades\Schema::dropIfExists($table);
+            Schema::dropIfExists($table);
         }
     }
 
     protected function safeDropSchema(string $schema): void
     {
         if ($this->isLocalEnvironment()) {
-            \Illuminate\Support\Facades\DB::unprepared("DROP SCHEMA IF EXISTS {$schema} CASCADE");
+            DB::unprepared("DROP SCHEMA IF EXISTS {$schema} CASCADE");
         }
     }
 
     protected function constraintExists(string $table, string $constraintName): bool
     {
-        $result = \Illuminate\Support\Facades\DB::select("
+        $result = DB::select("
             SELECT 1
             FROM information_schema.table_constraints
             WHERE table_schema = split_part(?, '.', 1)
@@ -38,7 +41,7 @@ trait SafeMigration
 
     protected function indexExists(string $table, string $indexName): bool
     {
-        $result = \Illuminate\Support\Facades\DB::select("
+        $result = DB::select("
             SELECT 1
             FROM pg_indexes
             WHERE schemaname = split_part(?, '.', 1)

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,9 +1,42 @@
 <?php
 
+use App\Http\Middleware\AssignRequestIdentity;
+use App\Http\Middleware\AuditUserRequests;
+use App\Http\Middleware\EnforceApiIngressContract;
+use App\Http\Middleware\EnsureClinicalFailureOutputSafe;
+use App\Http\Middleware\EnsureHummingbirdPatientEnabled;
+use App\Http\Middleware\EnsureHummingbirdPatientFeatureEnabled;
+use App\Http\Middleware\EnsurePatientRealm;
+use App\Http\Middleware\EnsurePatientStaffMessagingEnabled;
+use App\Http\Middleware\EnsureSessionIsCurrent;
+use App\Http\Middleware\EnsureStaffRealm;
+use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\ProtectMobileSessionResponse;
+use App\Http\Middleware\ProtectPatientResponse;
+use App\Http\Middleware\RequireAdminScope;
+use App\Http\Middleware\SecurityHeaders;
+use App\Jobs\DispatchScheduledFhirPolls;
+use App\Jobs\DispatchScheduledIntegrationHealthChecks;
+use App\Jobs\PruneCockpitMetricValues;
+use App\Jobs\ReconcileRtdcPredictions;
+use App\Jobs\RefreshArenaConformance;
+use App\Jobs\RefreshArenaPerformance;
+use App\Jobs\RefreshCockpitMaterializedViews;
+use App\Jobs\RefreshCockpitSnapshot;
+use App\Jobs\RefreshOcelLog;
+use App\Security\ClinicalPayloads\ClinicalPayloadException;
+use App\Services\Auth\StepUpRequired;
+use App\Services\Authorization\AdminScopeViolation;
+use App\Services\Governance\GovernanceViolation;
+use App\Services\Patient\PatientResponseDecorator;
 use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 $builder = Application::configure(basePath: dirname(__DIR__));
 
@@ -20,74 +53,74 @@ return $builder
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->alias([
-            'admin.scope' => \App\Http\Middleware\RequireAdminScope::class,
-            'patient.enabled' => \App\Http\Middleware\EnsureHummingbirdPatientEnabled::class,
-            'patient.feature' => \App\Http\Middleware\EnsureHummingbirdPatientFeatureEnabled::class,
-            'patient.realm' => \App\Http\Middleware\EnsurePatientRealm::class,
-            'patient.response' => \App\Http\Middleware\ProtectPatientResponse::class,
-            'patient.staff-messaging' => \App\Http\Middleware\EnsurePatientStaffMessagingEnabled::class,
-            'staff.realm' => \App\Http\Middleware\EnsureStaffRealm::class,
+            'admin.scope' => RequireAdminScope::class,
+            'patient.enabled' => EnsureHummingbirdPatientEnabled::class,
+            'patient.feature' => EnsureHummingbirdPatientFeatureEnabled::class,
+            'patient.realm' => EnsurePatientRealm::class,
+            'patient.response' => ProtectPatientResponse::class,
+            'patient.staff-messaging' => EnsurePatientStaffMessagingEnabled::class,
+            'staff.realm' => EnsureStaffRealm::class,
         ]);
 
         // Patient product and feature gates must execute before Laravel's
         // authentication priority so disabled capabilities are indistinguishable
         // from absent routes. The response guard wraps both gates and auth errors.
         $middleware->prependToPriorityList(
-            \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
-            \App\Http\Middleware\EnsureHummingbirdPatientFeatureEnabled::class,
+            AuthenticatesRequests::class,
+            EnsureHummingbirdPatientFeatureEnabled::class,
         );
         $middleware->prependToPriorityList(
-            \App\Http\Middleware\EnsureHummingbirdPatientFeatureEnabled::class,
-            \App\Http\Middleware\EnsureHummingbirdPatientEnabled::class,
+            EnsureHummingbirdPatientFeatureEnabled::class,
+            EnsureHummingbirdPatientEnabled::class,
         );
         $middleware->prependToPriorityList(
-            \App\Http\Middleware\EnsureHummingbirdPatientEnabled::class,
-            \App\Http\Middleware\ProtectPatientResponse::class,
+            EnsureHummingbirdPatientEnabled::class,
+            ProtectPatientResponse::class,
         );
         // The staff session-inventory guard must wrap Sanctum and every later
         // failure path so device metadata is never cacheable, even on denial.
         $middleware->prependToPriorityList(
-            \Illuminate\Contracts\Auth\Middleware\AuthenticatesRequests::class,
-            \App\Http\Middleware\ProtectMobileSessionResponse::class,
+            AuthenticatesRequests::class,
+            ProtectMobileSessionResponse::class,
         );
 
-        $middleware->prepend(\App\Http\Middleware\AssignRequestIdentity::class);
+        $middleware->prepend(AssignRequestIdentity::class);
 
         $middleware->append([
-            \App\Http\Middleware\SecurityHeaders::class,
-            \App\Http\Middleware\AuditUserRequests::class,
-            \App\Http\Middleware\EnsureClinicalFailureOutputSafe::class,
+            SecurityHeaders::class,
+            AuditUserRequests::class,
+            EnsureClinicalFailureOutputSafe::class,
         ]);
 
         $middleware->api(
             append: [
-                \App\Http\Middleware\EnforceApiIngressContract::class,
+                EnforceApiIngressContract::class,
             ]
         );
 
         $middleware->web(
             append: [
-                \App\Http\Middleware\EnsureSessionIsCurrent::class,
-                \App\Http\Middleware\HandleInertiaRequests::class,
-                \Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets::class,
+                EnsureSessionIsCurrent::class,
+                HandleInertiaRequests::class,
+                AddLinkHeadersForPreloadedAssets::class,
             ]
         );
     })
     ->withExceptions(function (Exceptions $exceptions) {
         $exceptions->respond(function (
-            \Symfony\Component\HttpFoundation\Response $response,
-            \Throwable $exception,
-            \Illuminate\Http\Request $request,
+            Response $response,
+            Throwable $exception,
+            Request $request,
         ) {
             if ($request->is('api/patient/v1', 'api/patient/v1/*')) {
-                return app(\App\Services\Patient\PatientResponseDecorator::class)
+                return app(PatientResponseDecorator::class)
                     ->decorate($response, $request);
             }
 
             return $response;
         });
 
-        $exceptions->render(function (\App\Services\Auth\StepUpRequired $exception, \Illuminate\Http\Request $request) {
+        $exceptions->render(function (StepUpRequired $exception, Request $request) {
             if ($request->expectsJson()) {
                 return response()->json([
                     'error' => [
@@ -101,7 +134,7 @@ return $builder
             return redirect()->guest(route('password.confirm'))
                 ->with('status', $exception->getMessage());
         });
-        $exceptions->render(function (\App\Services\Governance\GovernanceViolation $exception, \Illuminate\Http\Request $request) {
+        $exceptions->render(function (GovernanceViolation $exception, Request $request) {
             $status = match ($exception->reason) {
                 'authorization_denied', 'actor_missing' => 403,
                 'subject_invalid', 'reason_invalid', 'payload_hash_invalid' => 422,
@@ -115,7 +148,7 @@ return $builder
                 ],
             ], $status);
         });
-        $exceptions->render(function (\App\Security\ClinicalPayloads\ClinicalPayloadException $exception) {
+        $exceptions->render(function (ClinicalPayloadException $exception) {
             $code = explode(':', $exception->errorCode, 2)[0];
             $status = match ($code) {
                 'clinical_payload_authority_mismatch',
@@ -158,7 +191,7 @@ return $builder
 
             return response()->json(['error' => ['code' => $code, 'message' => $message]], $status);
         });
-        $exceptions->render(function (\App\Services\Authorization\AdminScopeViolation $exception, \Illuminate\Http\Request $request) {
+        $exceptions->render(function (AdminScopeViolation $exception, Request $request) {
             if ($request->expectsJson()) {
                 return response()->json([
                     'error' => [
@@ -172,13 +205,13 @@ return $builder
         });
     })
     ->withSchedule(function (Schedule $schedule) {
-        $schedule->job(new \App\Jobs\ReconcileRtdcPredictions)->dailyAt('02:00');
+        $schedule->job(new ReconcileRtdcPredictions)->dailyAt('02:00');
         // Flow Window hourly checkpoints (census + per-space occupancy) — W2.
         $schedule->command('flow:snapshot')->hourly();
         // Zephyrus 2.0 P1: the ONE server-computed cockpit snapshot —
         // /api/cockpit/snapshot becomes a pure cache lookup. Requires a
         // running queue worker + schedule runner in prod.
-        $schedule->job(new \App\Jobs\RefreshCockpitSnapshot)->everyMinute()->withoutOverlapping();
+        $schedule->job(new RefreshCockpitSnapshot)->everyMinute()->withoutOverlapping();
         // Ancillary operational clocks are evaluated on projection and caught
         // up every minute. The command locks one order at a time, so an isolated
         // malformed order cannot abort the remaining queue.
@@ -186,16 +219,16 @@ return $builder
         // Zephyrus 2.0 P7 (WS-5): the heavy MTD Quality/Service/Financial
         // materialized views refresh CONCURRENTLY hourly — off the per-minute
         // snapshot path so the wall never waits on a full aggregate.
-        $schedule->job(new \App\Jobs\RefreshCockpitMaterializedViews)->hourly()->withoutOverlapping();
+        $schedule->job(new RefreshCockpitMaterializedViews)->hourly()->withoutOverlapping();
         // Retention for the snapshot scalars the refresh job writes — the
         // writer and the pruner ship together (P1 execution notes).
-        $schedule->job(new \App\Jobs\PruneCockpitMetricValues)->dailyAt('03:40');
+        $schedule->job(new PruneCockpitMetricValues)->dailyAt('03:40');
         // Zephyrus 2.0 Part X (X0): the object-centric event log (OCEL 2.0)
         // incremental projection — read-side, additive, PHI-safe. Runs on the
         // SAME clock as the cockpit snapshot so A0 (cockpit) and A3 (Arena)
         // never disagree (Principle 7). Idempotent upserts, so the 2-day
         // trailing window overlapping the prior run is harmless.
-        $schedule->job(new \App\Jobs\RefreshOcelLog)->everyFifteenMinutes()->withoutOverlapping();
+        $schedule->job(new RefreshOcelLog)->everyFifteenMinutes()->withoutOverlapping();
         // Nightly full reconcile: re-project the trailing window and diff
         // projected counts against prod.*/flow_core.* source counts (§X.3.3).
         $schedule->command('ocel:project --days=90 --reconcile')->dailyAt('02:30');
@@ -208,11 +241,11 @@ return $builder
         // cadence and cache the rate for the cockpit. ARENA_ENABLED-gated (no-op
         // when off). Off the per-minute snapshot path — the heavy sidecar call
         // never blocks the wall.
-        $schedule->job(new \App\Jobs\RefreshArenaConformance)->everyThirtyMinutes()->withoutOverlapping();
+        $schedule->job(new RefreshArenaConformance)->everyThirtyMinutes()->withoutOverlapping();
         // Zephyrus 2.0 Part X (X2): recompute object-centric performance (OPerA)
         // and cache the worst hand-off synchronization wait as a flow-domain
         // cockpit tile. Same ARENA_ENABLED gate + off-snapshot cadence discipline.
-        $schedule->job(new \App\Jobs\RefreshArenaPerformance)->everyThirtyMinutes()->withoutOverlapping();
+        $schedule->job(new RefreshArenaPerformance)->everyThirtyMinutes()->withoutOverlapping();
         // Flow Reconciliation: rebuild the 48-Hour Flow Review baseline artifact
         // (arena.reviews) on a slow cadence — the window is 48h wide, so a 6-hourly
         // refresh keeps GET /api/arena/review fresh without hammering the sidecar.
@@ -241,9 +274,9 @@ return $builder
 
         // Governed integration runtime: dispatch protocol checks to the dedicated
         // database-backed queue. Health observations never advance data cursors.
-        $schedule->job(new \App\Jobs\DispatchScheduledIntegrationHealthChecks)
+        $schedule->job(new DispatchScheduledIntegrationHealthChecks)
             ->everyFiveMinutes()->withoutOverlapping();
-        $schedule->job(new \App\Jobs\DispatchScheduledFhirPolls)
+        $schedule->job(new DispatchScheduledFhirPolls)
             ->everyFifteenMinutes()->withoutOverlapping();
         // Append-only, PHI-free evidence for the Admin System Health surface.
         // This must run synchronously on the scheduler so its own heartbeat does

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\HummingbirdServiceProvider;
+
 return [
-    App\Providers\AppServiceProvider::class,
-    App\Providers\HummingbirdServiceProvider::class,
+    AppServiceProvider::class,
+    HummingbirdServiceProvider::class,
     // App\Providers\CsrfServiceProvider::class, // Disabled to remove CSRF token requirement
 ];

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "fakerphp/faker": "^1.23",
         "laravel/breeze": "^2.4.2",
         "laravel/pail": "^1.2.7",
-        "laravel/pint": "1.20.0",
+        "laravel/pint": "^1.29",
         "laravel/sail": "^1.63",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.9.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06a458737871aac55878af0380789f17",
+    "content-hash": "556c5ac842b1495e5743ca3e6381de29",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -9129,16 +9129,16 @@
         },
         {
             "name": "laravel/pint",
-            "version": "v1.20.0",
+            "version": "v1.29.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "53072e8ea22213a7ed168a8a15b96fbb8b82d44b"
+                "reference": "da1d1111a6aa2e082d2a388b194afe1ba0a05d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/53072e8ea22213a7ed168a8a15b96fbb8b82d44b",
-                "reference": "53072e8ea22213a7ed168a8a15b96fbb8b82d44b",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/da1d1111a6aa2e082d2a388b194afe1ba0a05d14",
+                "reference": "da1d1111a6aa2e082d2a388b194afe1ba0a05d14",
                 "shasum": ""
             },
             "require": {
@@ -9146,16 +9146,17 @@
                 "ext-mbstring": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "php": "^8.1.0"
+                "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.66.0",
-                "illuminate/view": "^10.48.25",
-                "larastan/larastan": "^2.9.12",
-                "laravel-zero/framework": "^10.48.25",
+                "friendsofphp/php-cs-fixer": "^3.95.8",
+                "illuminate/view": "^12.62.0",
+                "larastan/larastan": "^3.10.0",
+                "laravel-zero/framework": "^12.1.0",
+                "laravel/agent-detector": "^2.0.2",
                 "mockery/mockery": "^1.6.12",
-                "nunomaduro/termwind": "^1.17.0",
-                "pestphp/pest": "^2.36.0"
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest": "^3.8.6"
             },
             "bin": [
                 "builds/pint"
@@ -9181,6 +9182,7 @@
             "description": "An opinionated code formatter for PHP.",
             "homepage": "https://laravel.com",
             "keywords": [
+                "dev",
                 "format",
                 "formatter",
                 "lint",
@@ -9191,7 +9193,7 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2025-01-14T16:20:53+00:00"
+            "time": "2026-06-16T15:34:04+00:00"
         },
         {
             "name": "laravel/sail",

--- a/config/app.php
+++ b/config/app.php
@@ -1,5 +1,31 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\RouteServiceProvider;
+use Illuminate\Auth\AuthServiceProvider;
+use Illuminate\Auth\Passwords\PasswordResetServiceProvider;
+use Illuminate\Broadcasting\BroadcastServiceProvider;
+use Illuminate\Bus\BusServiceProvider;
+use Illuminate\Cache\CacheServiceProvider;
+use Illuminate\Cookie\CookieServiceProvider;
+use Illuminate\Database\DatabaseServiceProvider;
+use Illuminate\Encryption\EncryptionServiceProvider;
+use Illuminate\Filesystem\FilesystemServiceProvider;
+use Illuminate\Foundation\Providers\ArtisanServiceProvider;
+use Illuminate\Foundation\Providers\ConsoleSupportServiceProvider;
+use Illuminate\Foundation\Providers\FoundationServiceProvider;
+use Illuminate\Hashing\HashServiceProvider;
+use Illuminate\Mail\MailServiceProvider;
+use Illuminate\Notifications\NotificationServiceProvider;
+use Illuminate\Pagination\PaginationServiceProvider;
+use Illuminate\Pipeline\PipelineServiceProvider;
+use Illuminate\Queue\QueueServiceProvider;
+use Illuminate\Redis\RedisServiceProvider;
+use Illuminate\Session\SessionServiceProvider;
+use Illuminate\Translation\TranslationServiceProvider;
+use Illuminate\Validation\ValidationServiceProvider;
+use Illuminate\View\ViewServiceProvider;
+
 return [
 
     /*
@@ -120,29 +146,29 @@ return [
         /*
          * Laravel Framework Service Providers...
          */
-        Illuminate\Foundation\Providers\ArtisanServiceProvider::class,
-        Illuminate\Auth\AuthServiceProvider::class,
-        Illuminate\Broadcasting\BroadcastServiceProvider::class,
-        Illuminate\Bus\BusServiceProvider::class,
-        Illuminate\Cache\CacheServiceProvider::class,
-        Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
-        Illuminate\Cookie\CookieServiceProvider::class,
-        Illuminate\Database\DatabaseServiceProvider::class,
-        Illuminate\Encryption\EncryptionServiceProvider::class,
-        Illuminate\Filesystem\FilesystemServiceProvider::class,
-        Illuminate\Foundation\Providers\FoundationServiceProvider::class,
-        Illuminate\Hashing\HashServiceProvider::class,
-        Illuminate\Mail\MailServiceProvider::class,
-        Illuminate\Notifications\NotificationServiceProvider::class,
-        Illuminate\Pagination\PaginationServiceProvider::class,
-        Illuminate\Pipeline\PipelineServiceProvider::class,
-        Illuminate\Queue\QueueServiceProvider::class,
-        Illuminate\Redis\RedisServiceProvider::class,
-        Illuminate\Auth\Passwords\PasswordResetServiceProvider::class,
-        Illuminate\Session\SessionServiceProvider::class,
-        Illuminate\Translation\TranslationServiceProvider::class,
-        Illuminate\Validation\ValidationServiceProvider::class,
-        Illuminate\View\ViewServiceProvider::class,
+        ArtisanServiceProvider::class,
+        AuthServiceProvider::class,
+        BroadcastServiceProvider::class,
+        BusServiceProvider::class,
+        CacheServiceProvider::class,
+        ConsoleSupportServiceProvider::class,
+        CookieServiceProvider::class,
+        DatabaseServiceProvider::class,
+        EncryptionServiceProvider::class,
+        FilesystemServiceProvider::class,
+        FoundationServiceProvider::class,
+        HashServiceProvider::class,
+        MailServiceProvider::class,
+        NotificationServiceProvider::class,
+        PaginationServiceProvider::class,
+        PipelineServiceProvider::class,
+        QueueServiceProvider::class,
+        RedisServiceProvider::class,
+        PasswordResetServiceProvider::class,
+        SessionServiceProvider::class,
+        TranslationServiceProvider::class,
+        ValidationServiceProvider::class,
+        ViewServiceProvider::class,
 
         /*
          * Package Service Providers...
@@ -151,11 +177,11 @@ return [
         /*
          * Application Service Providers...
          */
-        App\Providers\AppServiceProvider::class,
+        AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         // Laravel 11 auto-discovers app listeners during Application::configure().
         // Registering the legacy EventServiceProvider here duplicates every listener.
-        App\Providers\RouteServiceProvider::class,
+        RouteServiceProvider::class,
     ],
 
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,8 @@
 <?php
 
+use App\Models\Patient\PatientPrincipal;
+use App\Models\User;
+
 return [
 
     /*
@@ -71,12 +74,12 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', User::class),
         ],
 
         'patient_principals' => [
             'driver' => 'eloquent',
-            'model' => App\Models\Patient\PatientPrincipal::class,
+            'model' => PatientPrincipal::class,
         ],
 
         // 'users' => [

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Security\ClinicalPayloads\ClinicalContentLogTap;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -25,7 +26,7 @@ return [
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'replace_placeholders' => true,
-            'tap' => [\App\Security\ClinicalPayloads\ClinicalContentLogTap::class],
+            'tap' => [ClinicalContentLogTap::class],
         ],
 
         'daily' => [
@@ -34,7 +35,7 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => 14,
             'replace_placeholders' => true,
-            'tap' => [\App\Security\ClinicalPayloads\ClinicalContentLogTap::class],
+            'tap' => [ClinicalContentLogTap::class],
         ],
 
         'slack' => [
@@ -44,7 +45,7 @@ return [
             'emoji' => ':boom:',
             'level' => env('LOG_LEVEL', 'critical'),
             'replace_placeholders' => true,
-            'tap' => [\App\Security\ClinicalPayloads\ClinicalContentLogTap::class],
+            'tap' => [ClinicalContentLogTap::class],
         ],
 
         'papertrail' => [
@@ -57,7 +58,7 @@ return [
                 'connectionString' => 'tls://'.env('PAPERTRAIL_URL').':'.env('PAPERTRAIL_PORT'),
             ],
             'processors' => [PsrLogMessageProcessor::class],
-            'tap' => [\App\Security\ClinicalPayloads\ClinicalContentLogTap::class],
+            'tap' => [ClinicalContentLogTap::class],
         ],
 
         'stderr' => [
@@ -69,7 +70,7 @@ return [
                 'stream' => 'php://stderr',
             ],
             'processors' => [PsrLogMessageProcessor::class],
-            'tap' => [\App\Security\ClinicalPayloads\ClinicalContentLogTap::class],
+            'tap' => [ClinicalContentLogTap::class],
         ],
 
         'syslog' => [
@@ -77,14 +78,14 @@ return [
             'level' => env('LOG_LEVEL', 'debug'),
             'facility' => LOG_USER,
             'replace_placeholders' => true,
-            'tap' => [\App\Security\ClinicalPayloads\ClinicalContentLogTap::class],
+            'tap' => [ClinicalContentLogTap::class],
         ],
 
         'errorlog' => [
             'driver' => 'errorlog',
             'level' => env('LOG_LEVEL', 'debug'),
             'replace_placeholders' => true,
-            'tap' => [\App\Security\ClinicalPayloads\ClinicalContentLogTap::class],
+            'tap' => [ClinicalContentLogTap::class],
         ],
 
         'null' => [

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,5 +1,9 @@
 <?php
 
+use Spatie\Permission\DefaultTeamResolver;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
 return [
 
     'models' => [
@@ -13,7 +17,7 @@ return [
          * `Spatie\Permission\Contracts\Permission` contract.
          */
 
-        'permission' => Spatie\Permission\Models\Permission::class,
+        'permission' => Permission::class,
 
         /*
          * When using the "HasRoles" trait from this package, we need to know which
@@ -24,7 +28,7 @@ return [
          * `Spatie\Permission\Contracts\Role` contract.
          */
 
-        'role' => Spatie\Permission\Models\Role::class,
+        'role' => Role::class,
 
     ],
 
@@ -136,7 +140,7 @@ return [
     /*
      * The class to use to resolve the permissions team id
      */
-    'team_resolver' => \Spatie\Permission\DefaultTeamResolver::class,
+    'team_resolver' => DefaultTeamResolver::class,
 
     /*
      * Passport Client Credentials Grant
@@ -183,7 +187,7 @@ return [
          * When permissions or roles are updated the cache is flushed automatically.
          */
 
-        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+        'expiration_time' => DateInterval::createFromDateString('24 hours'),
 
         /*
          * The cache key used to store all permissions.

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
 use Laravel\Sanctum\Sanctum;
 
 return [
@@ -75,9 +78,9 @@ return [
     */
 
     'middleware' => [
-        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
-        'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
-        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+        'authenticate_session' => AuthenticateSession::class,
+        'encrypt_cookies' => EncryptCookies::class,
+        'validate_csrf_token' => ValidateCsrfToken::class,
     ],
 
 ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,12 +2,13 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {

--- a/database/migrations/2026_06_28_130000_add_eddy_knowledge_embeddings_and_curation.php
+++ b/database/migrations/2026_06_28_130000_add_eddy_knowledge_embeddings_and_curation.php
@@ -79,7 +79,7 @@ return new class extends Migration
             if ($available) {
                 DB::statement('CREATE EXTENSION IF NOT EXISTS vector');
             }
-        } catch (\Throwable $e) {
+        } catch (Throwable $e) {
             Log::warning('eddy.migration.pgvector_install_failed', ['error' => $e->getMessage()]);
         }
 

--- a/database/migrations/2026_07_13_000600_create_source_onboarding_and_activation_windows.php
+++ b/database/migrations/2026_07_13_000600_create_source_onboarding_and_activation_windows.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 return new class extends Migration
 {
@@ -356,7 +357,7 @@ return new class extends Migration
             ];
 
             DB::table('integration.source_onboarding_versions')->insert([
-                'onboarding_version_uuid' => (string) \Illuminate\Support\Str::uuid7(),
+                'onboarding_version_uuid' => (string) Str::uuid7(),
                 'source_id' => $source->source_id,
                 'version_number' => 1,
                 'previous_version_id' => null,

--- a/database/migrations/2026_07_13_000700_create_credential_and_network_governance.php
+++ b/database/migrations/2026_07_13_000700_create_credential_and_network_governance.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 
 return new class extends Migration
 {
@@ -420,7 +421,7 @@ return new class extends Migration
                     'rotation_overlap_ends_at' => null,
                 ];
                 $versionId = (int) DB::table('integration.source_credential_versions')->insertGetId([
-                    'credential_version_uuid' => (string) \Illuminate\Support\Str::uuid7(),
+                    'credential_version_uuid' => (string) Str::uuid7(),
                     'source_credential_id' => $credential->source_credential_id,
                     'source_id' => $credential->source_id,
                     'version_number' => 1,

--- a/database/migrations/2026_07_13_001000_create_source_observability_control_plane.php
+++ b/database/migrations/2026_07_13_001000_create_source_observability_control_plane.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 return new class extends Migration
 {
@@ -442,7 +443,7 @@ return new class extends Migration
                 $sourceId = (int) $onboarding->source_id;
                 $definition = $this->normalizeDefinition($onboarding->slo_definition);
                 $definitionId = (int) DB::table('integration.source_slo_definitions')->insertGetId([
-                    'slo_definition_uuid' => (string) \Illuminate\Support\Str::uuid7(),
+                    'slo_definition_uuid' => (string) Str::uuid7(),
                     'source_id' => $sourceId,
                     'source_onboarding_version_id' => (int) $onboarding->source_onboarding_version_id,
                     'version_number' => (int) $onboarding->version_number,

--- a/database/seeders/CommandCenterDemoSeeder.php
+++ b/database/seeders/CommandCenterDemoSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Jobs\RefreshCockpitMaterializedViews;
 use App\Models\Barrier;
 use App\Models\Bed;
 use App\Models\BedPlacementDecision;
@@ -14,6 +15,7 @@ use App\Models\PdsaCycle;
 use App\Models\RtdcPrediction;
 use App\Models\RtdcReconciliation;
 use App\Models\Unit;
+use App\Services\Demo\DistributionSampler;
 use App\Support\Hospital\HospitalManifest;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Carbon;
@@ -973,7 +975,7 @@ class CommandCenterDemoSeeder extends Seeder
 
         // Afternoon-peaked discharge hour (FEEDBACK Wave 2): a uniform 0–23h gave ~50%
         // discharge-before-noon, which no hospital achieves. This lands ~30% before noon.
-        $sampler = new \App\Services\Demo\DistributionSampler;
+        $sampler = new DistributionSampler;
         $dischargeHourWeights = [
             0 => 1, 1 => 1, 2 => 1, 3 => 1, 4 => 1, 5 => 2, 6 => 3, 7 => 4, 8 => 6, 9 => 8, 10 => 9, 11 => 10,
             12 => 14, 13 => 16, 14 => 16, 15 => 14, 16 => 12, 17 => 10, 18 => 8, 19 => 6, 20 => 5, 21 => 4, 22 => 2, 23 => 1,
@@ -1019,7 +1021,7 @@ class CommandCenterDemoSeeder extends Seeder
      */
     private function refreshCockpitMaterializedViews(): void
     {
-        foreach (\App\Jobs\RefreshCockpitMaterializedViews::VIEWS as $view) {
+        foreach (RefreshCockpitMaterializedViews::VIEWS as $view) {
             try {
                 DB::statement("REFRESH MATERIALIZED VIEW {$view}");
             } catch (\Throwable $e) {
@@ -1627,7 +1629,7 @@ class CommandCenterDemoSeeder extends Seeder
         // little and the crowding term must carry the score: 34 patients
         // currently in the department (none admitted → boarders unchanged),
         // 8 still waiting for a provider, 4 on ventilators.
-        $sampler = new \App\Services\Demo\DistributionSampler;
+        $sampler = new DistributionSampler;
         for ($k = 1; $k <= 34; $k++) {
             $seed = 20260701 + $k * 17;
             $arrivedAt = now()->subMinutes($this->seededRand($seed, 20, 360));

--- a/database/seeders/DemoTuningSeeder.php
+++ b/database/seeders/DemoTuningSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Services\Demo\DistributionSampler;
 use App\Services\Demo\OperationalDemoDataService;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
@@ -167,7 +168,7 @@ class DemoTuningSeeder extends Seeder
             ORDER BY u.unit_id
         ");
 
-        $sampler = new \App\Services\Demo\DistributionSampler;
+        $sampler = new DistributionSampler;
         $seq = 0;
         foreach ($units as $u) {
             // Per-type target + a small deterministic per-unit jitter so units within a type vary.

--- a/database/seeders/HomeHospitalDemoSeeder.php
+++ b/database/seeders/HomeHospitalDemoSeeder.php
@@ -5,13 +5,16 @@ namespace Database\Seeders;
 use App\Models\Bed;
 use App\Models\Encounter;
 use App\Models\Home\HomeEpisode;
+use App\Models\Home\HomeEscalation;
 use App\Models\Home\HomeProgram;
 use App\Models\Home\HomeReferral;
 use App\Models\Home\HomeVisit;
 use App\Models\Home\RpmDevice;
 use App\Models\Home\RpmEnrollment;
 use App\Models\Home\RpmKit;
+use App\Models\Home\RpmObservation;
 use App\Models\Unit;
+use App\Services\Home\RpmAlertEvaluator;
 use Illuminate\Database\Seeder;
 use Ramsey\Uuid\Uuid;
 
@@ -85,7 +88,7 @@ class HomeHospitalDemoSeeder extends Seeder
      */
     private function seedObservations(): void
     {
-        \App\Models\Home\RpmObservation::query()
+        RpmObservation::query()
             ->where('source_key', 'demo-seed')
             ->where('observed_at', '<', now()->subHours(48))
             ->delete();
@@ -97,7 +100,7 @@ class HomeHospitalDemoSeeder extends Seeder
             ->orderBy('rpm_enrollment_id')
             ->get();
 
-        $evaluator = app(\App\Services\Home\RpmAlertEvaluator::class);
+        $evaluator = app(RpmAlertEvaluator::class);
 
         foreach ($enrollments->values() as $index => $enrollment) {
             $ref = $enrollment->patient_ref;
@@ -146,7 +149,7 @@ class HomeHospitalDemoSeeder extends Seeder
                         $value = $mean + (11 - $hoursAgo) * 1.6;
                     }
 
-                    $observation = \App\Models\Home\RpmObservation::updateOrCreate(
+                    $observation = RpmObservation::updateOrCreate(
                         ['observation_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS,
                             "zephyrus.home.obs.{$ref}.{$loinc}.".$observedAt->format('YmdH'))->toString()],
                         [
@@ -201,7 +204,7 @@ class HomeHospitalDemoSeeder extends Seeder
 
             $initiated = now()->subDays($spec['daysAgo'])->setTime(14, 10);
 
-            \App\Models\Home\HomeEscalation::updateOrCreate(
+            HomeEscalation::updateOrCreate(
                 ['escalation_uuid' => Uuid::uuid5(Uuid::NAMESPACE_DNS, 'zephyrus.home.escalation.'.$spec['ref'].'.'.$spec['daysAgo'])->toString()],
                 [
                     'home_episode_id' => $episode->home_episode_id,

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,7 +15,11 @@ use App\Http\Controllers\Api\Admin\SourceObservabilityController;
 use App\Http\Controllers\Api\Admin\SourceOnboardingController;
 use App\Http\Controllers\Api\Admin\SourceStatusFacetController;
 use App\Http\Controllers\Api\AnalyticsController;
+use App\Http\Controllers\Api\ArenaController;
+use App\Http\Controllers\Api\ArenaCopilotController;
 use App\Http\Controllers\Api\BlockScheduleController;
+use App\Http\Controllers\Api\CockpitController;
+use App\Http\Controllers\Api\CockpitStreamController;
 use App\Http\Controllers\Api\Deployment\CapabilityMatrixController;
 use App\Http\Controllers\Api\Deployment\DeploymentReadinessController;
 use App\Http\Controllers\Api\Deployment\FacilityController as DeploymentFacilityController;
@@ -32,6 +36,14 @@ use App\Http\Controllers\Api\Eddy\EddyAdminController;
 use App\Http\Controllers\Api\Eddy\EddyChatController;
 use App\Http\Controllers\Api\Evs\EvsRequestController;
 use App\Http\Controllers\Api\Facility\FacilityModelController;
+use App\Http\Controllers\Api\Home\HomeCensusController;
+use App\Http\Controllers\Api\Home\HomeCommandController;
+use App\Http\Controllers\Api\Home\HomeDecantController;
+use App\Http\Controllers\Api\Home\HomeEscalationController;
+use App\Http\Controllers\Api\Home\HomeLogisticsController;
+use App\Http\Controllers\Api\Home\HomeReferralController;
+use App\Http\Controllers\Api\Home\HomeTransitionController;
+use App\Http\Controllers\Api\Home\RpmAlertController;
 use App\Http\Controllers\Api\Lab\LabFlowBoardController;
 use App\Http\Controllers\Api\Mobile\ActivityController as MobileActivityController;
 use App\Http\Controllers\Api\Mobile\AltitudeController as MobileAltitudeController;
@@ -54,6 +66,7 @@ use App\Http\Controllers\Api\Mobile\RtdcController as MobileRtdcController;
 use App\Http\Controllers\Api\Mobile\SessionController as MobileSessionController;
 use App\Http\Controllers\Api\Mobile\StaffingController as MobileStaffingController;
 use App\Http\Controllers\Api\Mobile\TransportController as MobileTransportController;
+use App\Http\Controllers\Api\OcelProcessLandscapeController;
 use App\Http\Controllers\Api\Ops\AgentController;
 use App\Http\Controllers\Api\Ops\OperationalActionController;
 use App\Http\Controllers\Api\Ops\OperationsGraphController;
@@ -70,6 +83,13 @@ use App\Http\Controllers\Api\Pharmacy\PharmacyIvRoomController;
 use App\Http\Controllers\Api\ProviderController;
 use App\Http\Controllers\Api\Radiology\RadiologyFlowBoardController;
 use App\Http\Controllers\Api\RoomController;
+use App\Http\Controllers\Api\Rounds\RoundContributionController;
+use App\Http\Controllers\Api\Rounds\RoundPatientController;
+use App\Http\Controllers\Api\Rounds\RoundQuestionController;
+use App\Http\Controllers\Api\Rounds\RoundRunController;
+use App\Http\Controllers\Api\Rounds\RoundScopeController;
+use App\Http\Controllers\Api\Rounds\RoundTaskController;
+use App\Http\Controllers\Api\Rounds\RoundTemplateController;
 use App\Http\Controllers\Api\Rtdc\BarrierController;
 use App\Http\Controllers\Api\Rtdc\BedRequestController;
 use App\Http\Controllers\Api\Rtdc\CensusController;
@@ -82,6 +102,20 @@ use App\Http\Controllers\Api\Staffing\StaffingFulfillmentController;
 use App\Http\Controllers\Api\Transport\RegionalTransferController;
 use App\Http\Controllers\Api\Transport\TransportRequestController;
 use App\Http\Controllers\CommandCenterController;
+use App\Http\Controllers\PatientLensController;
+use App\Http\Middleware\AdminMiddleware;
+use App\Http\Middleware\EnforceFlowLens;
+use App\Http\Middleware\EnsureActiveStaffAccount;
+use App\Http\Middleware\EnsureArenaAiEnabled;
+use App\Http\Middleware\EnsureArenaEnabled;
+use App\Http\Middleware\EnsureHomeHospitalEnabled;
+use App\Http\Middleware\EnsurePatientRoundsQuestionBridgeEnabled;
+use App\Http\Middleware\EnsureRoundsEnabled;
+use App\Http\Middleware\ProtectMobileSessionResponse;
+use App\Http\Middleware\ProtectPatientCommunicationResponse;
+use App\Http\Middleware\RequireMachineToken;
+use App\Http\Middleware\TouchMobileTokenSession;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 
@@ -94,14 +128,14 @@ use Laravel\Sanctum\Http\Middleware\CheckForAnyAbility;
 // Health Check
 Route::get('/health', function () {
     try {
-        \Illuminate\Support\Facades\DB::connection()->getPdo();
+        DB::connection()->getPdo();
 
         return response()->json([
             'status' => 'healthy',
             'database' => 'connected',
             'timestamp' => now()->toISOString(),
         ]);
-    } catch (\Exception $e) {
+    } catch (Exception $e) {
         return response()->json([
             'status' => 'unhealthy',
             'database' => 'disconnected',
@@ -117,62 +151,62 @@ Route::middleware(['web', 'auth', 'throttle:60,1'])->prefix('command-center')->g
 // Zephyrus 2.0 cockpit serving layer (web session auth). /snapshot is a
 // cached read of the single replaced cockpit_snapshots row (ETag/304).
 Route::middleware(['web', 'auth', 'throttle:60,1'])->prefix('cockpit')->group(function () {
-    Route::get('/snapshot', [\App\Http\Controllers\Api\CockpitController::class, 'snapshot']);
-    Route::get('/scopes', [\App\Http\Controllers\Api\CockpitController::class, 'scopes']);
-    Route::get('/face', [\App\Http\Controllers\Api\CockpitController::class, 'face']);
-    Route::get('/drill/{domain}', [\App\Http\Controllers\Api\CockpitController::class, 'drill'])
+    Route::get('/snapshot', [CockpitController::class, 'snapshot']);
+    Route::get('/scopes', [CockpitController::class, 'scopes']);
+    Route::get('/face', [CockpitController::class, 'face']);
+    Route::get('/drill/{domain}', [CockpitController::class, 'drill'])
         ->where('domain', '[a-z]+');
     // P8 WS-3 — the A2P patient lens as an in-place cockpit drill. Persona-gated
     // by EnforceFlowLens:patients (patient_dots=none personas get 403); the ptok
     // constraint 404s any non-context ref before it reaches the service.
-    Route::get('/patient/{contextRef}', [\App\Http\Controllers\PatientLensController::class, 'show'])
-        ->middleware(\App\Http\Middleware\EnforceFlowLens::class.':patients')
+    Route::get('/patient/{contextRef}', [PatientLensController::class, 'show'])
+        ->middleware(EnforceFlowLens::class.':patients')
         ->where('contextRef', 'ptok_[a-f0-9]{24}');
-    Route::get('/stream', \App\Http\Controllers\Api\CockpitStreamController::class);
+    Route::get('/stream', CockpitStreamController::class);
     // HFE Phase 1 — alert acknowledgement (any authenticated operator; the
     // engine clears the ack on warn->crit escalation so worsening re-alarms).
-    Route::post('/alerts/{alertId}/acknowledge', [\App\Http\Controllers\Api\CockpitController::class, 'acknowledgeAlert'])
+    Route::post('/alerts/{alertId}/acknowledge', [CockpitController::class, 'acknowledgeAlert'])
         ->whereNumber('alertId');
     // P8 WS-6b — the admin threshold editor's endpoints. Both admin-gated: the
     // read backs the editor page, the write is the audited band-edge tune.
-    Route::get('/kpi-definitions', [\App\Http\Controllers\Api\CockpitController::class, 'kpiDefinitions'])
-        ->middleware(\App\Http\Middleware\AdminMiddleware::class);
-    Route::put('/kpi-definitions/{metricKey}', [\App\Http\Controllers\Api\CockpitController::class, 'updateKpiDefinition'])
-        ->middleware(\App\Http\Middleware\AdminMiddleware::class);
+    Route::get('/kpi-definitions', [CockpitController::class, 'kpiDefinitions'])
+        ->middleware(AdminMiddleware::class);
+    Route::put('/kpi-definitions/{metricKey}', [CockpitController::class, 'updateKpiDefinition'])
+        ->middleware(AdminMiddleware::class);
 });
 
 // Zephyrus 2.0 Part X (X1) — Arena OCPM serving layer. Laravel proxies to the
 // PHI-free OCPM sidecar and caches discovered maps in arena.maps. Gated by
 // EnsureArenaEnabled (ARENA_ENABLED, default off) so the group 404s while off.
-Route::middleware(['web', 'auth', 'throttle:30,1', \App\Http\Middleware\EnsureArenaEnabled::class])
+Route::middleware(['web', 'auth', 'throttle:30,1', EnsureArenaEnabled::class])
     ->prefix('arena')->group(function () {
-        Route::get('/health', [\App\Http\Controllers\Api\ArenaController::class, 'health']);
-        Route::get('/summary', [\App\Http\Controllers\Api\ArenaController::class, 'summary']);
-        Route::get('/models', [\App\Http\Controllers\Api\OcelProcessLandscapeController::class, 'index']);
-        Route::get('/models/{processId}', [\App\Http\Controllers\Api\OcelProcessLandscapeController::class, 'show'])
+        Route::get('/health', [ArenaController::class, 'health']);
+        Route::get('/summary', [ArenaController::class, 'summary']);
+        Route::get('/models', [OcelProcessLandscapeController::class, 'index']);
+        Route::get('/models/{processId}', [OcelProcessLandscapeController::class, 'show'])
             ->where('processId', '[A-Ha-h](?:[1-9]|1[0-4])');
-        Route::get('/map', [\App\Http\Controllers\Api\ArenaController::class, 'map']);
-        Route::get('/performance', [\App\Http\Controllers\Api\ArenaController::class, 'performance']);
-        Route::get('/conformance', [\App\Http\Controllers\Api\ArenaController::class, 'conformance']);
-        Route::get('/petrinet', [\App\Http\Controllers\Api\ArenaController::class, 'petrinet']);
-        Route::get('/capacity', [\App\Http\Controllers\Api\ArenaController::class, 'capacity']);
+        Route::get('/map', [ArenaController::class, 'map']);
+        Route::get('/performance', [ArenaController::class, 'performance']);
+        Route::get('/conformance', [ArenaController::class, 'conformance']);
+        Route::get('/petrinet', [ArenaController::class, 'petrinet']);
+        Route::get('/capacity', [ArenaController::class, 'capacity']);
 
         // Flow Reconciliation — the 48-Hour Flow Review. GET reads the persisted
         // artifact (arena.reviews); POST /review/run rebuilds it (the Run-review
         // action). Not AI-gated: the review is observed signal + open barriers, no
         // model in the loop — corrective-action drafting rides the copilot below.
-        Route::get('/review', [\App\Http\Controllers\Api\ArenaController::class, 'review']);
-        Route::post('/review/run', [\App\Http\Controllers\Api\ArenaController::class, 'runReview']);
+        Route::get('/review', [ArenaController::class, 'review']);
+        Route::post('/review/run', [ArenaController::class, 'runReview']);
 
         // Part X (X4) — the governed AI copilot. Nested behind EnsureArenaAiEnabled
         // (ARENA_AI_ENABLED), so these 404 unless BOTH the Arena and its AI author
         // are on. Draft endpoints only ever land pending on the Eddy plane.
-        Route::middleware(\App\Http\Middleware\EnsureArenaAiEnabled::class)->prefix('copilot')->group(function () {
-            Route::get('/narrative', [\App\Http\Controllers\Api\ArenaCopilotController::class, 'narrative']);
-            Route::post('/query', [\App\Http\Controllers\Api\ArenaCopilotController::class, 'query']);
-            Route::post('/author-map', [\App\Http\Controllers\Api\ArenaCopilotController::class, 'authorMap']);
-            Route::post('/draft-pdsa', [\App\Http\Controllers\Api\ArenaCopilotController::class, 'draftPdsa']);
-            Route::post('/draft-correction', [\App\Http\Controllers\Api\ArenaCopilotController::class, 'draftCorrection']);
+        Route::middleware(EnsureArenaAiEnabled::class)->prefix('copilot')->group(function () {
+            Route::get('/narrative', [ArenaCopilotController::class, 'narrative']);
+            Route::post('/query', [ArenaCopilotController::class, 'query']);
+            Route::post('/author-map', [ArenaCopilotController::class, 'authorMap']);
+            Route::post('/draft-pdsa', [ArenaCopilotController::class, 'draftPdsa']);
+            Route::post('/draft-correction', [ArenaCopilotController::class, 'draftCorrection']);
         });
     });
 
@@ -197,7 +231,7 @@ Route::middleware(['web', 'auth', 'throttle:60,1'])->prefix('patient-flow')->gro
 
     // Patient-level reads — persona-lensed (FLOW-WINDOW-PLAN §6.4, closes G7):
     // requires a flow lens whose patient_dots policy is not `none`.
-    Route::middleware(\App\Http\Middleware\EnforceFlowLens::class.':scoped-patients')->group(function () {
+    Route::middleware(EnforceFlowLens::class.':scoped-patients')->group(function () {
         Route::get('/events', [PatientFlowController::class, 'events']);
         Route::get('/tracks', [PatientFlowController::class, 'tracks']);
         Route::get('/state', [PatientFlowController::class, 'state']);
@@ -209,11 +243,11 @@ Route::middleware(['web', 'auth', 'throttle:60,1'])->prefix('patient-flow')->gro
     // aggregate-safe: items are persona-clamped and identity-redacted by
     // the same lens the mobile window uses.
     Route::get('/projections', [PatientFlowController::class, 'projections'])
-        ->middleware(\App\Http\Middleware\EnforceFlowLens::class.':scoped');
+        ->middleware(EnforceFlowLens::class.':scoped');
     Route::get('/occupancy/history', [PatientFlowController::class, 'occupancyHistory'])
-        ->middleware(\App\Http\Middleware\EnforceFlowLens::class.':scoped');
+        ->middleware(EnforceFlowLens::class.':scoped');
     Route::get('/occupancy', [PatientFlowController::class, 'occupancy'])
-        ->middleware(\App\Http\Middleware\EnforceFlowLens::class.':scoped');
+        ->middleware(EnforceFlowLens::class.':scoped');
 });
 
 // Virtual Rounds — asynchronous/hybrid multidisciplinary rounds workflow
@@ -221,79 +255,79 @@ Route::middleware(['web', 'auth', 'throttle:60,1'])->prefix('patient-flow')->gro
 // Gated by VIRTUAL_ROUNDS_ENABLED (404 when off). Mutations accept an
 // Idempotency-Key header and expected versions; conflicts return 409 with the
 // current projection. All patient authorization is server-side.
-Route::middleware(['web', 'auth', 'throttle:60,1', \App\Http\Middleware\EnsureRoundsEnabled::class])
+Route::middleware(['web', 'auth', 'throttle:60,1', EnsureRoundsEnabled::class])
     ->prefix('rounds')->group(function () {
-        Route::get('/templates', [\App\Http\Controllers\Api\Rounds\RoundTemplateController::class, 'index']);
-        Route::get('/scopes', [\App\Http\Controllers\Api\Rounds\RoundScopeController::class, 'index']);
+        Route::get('/templates', [RoundTemplateController::class, 'index']);
+        Route::get('/scopes', [RoundScopeController::class, 'index']);
 
-        Route::get('/runs', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'index']);
-        Route::post('/runs', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'store']);
-        Route::get('/runs/{runUuid}', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'show']);
-        Route::post('/runs/{runUuid}/start', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'start']);
-        Route::post('/runs/{runUuid}/pause', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'pause']);
-        Route::post('/runs/{runUuid}/resume', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'resume']);
-        Route::post('/runs/{runUuid}/complete', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'complete']);
-        Route::post('/runs/{runUuid}/cancel', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'cancel']);
-        Route::get('/runs/{runUuid}/board', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'board']);
-        Route::get('/runs/{runUuid}/scene', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'scene']);
-        Route::post('/runs/{runUuid}/cohort/reconcile', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'reconcile']);
-        Route::patch('/runs/{runUuid}/queue', [\App\Http\Controllers\Api\Rounds\RoundRunController::class, 'queue']);
+        Route::get('/runs', [RoundRunController::class, 'index']);
+        Route::post('/runs', [RoundRunController::class, 'store']);
+        Route::get('/runs/{runUuid}', [RoundRunController::class, 'show']);
+        Route::post('/runs/{runUuid}/start', [RoundRunController::class, 'start']);
+        Route::post('/runs/{runUuid}/pause', [RoundRunController::class, 'pause']);
+        Route::post('/runs/{runUuid}/resume', [RoundRunController::class, 'resume']);
+        Route::post('/runs/{runUuid}/complete', [RoundRunController::class, 'complete']);
+        Route::post('/runs/{runUuid}/cancel', [RoundRunController::class, 'cancel']);
+        Route::get('/runs/{runUuid}/board', [RoundRunController::class, 'board']);
+        Route::get('/runs/{runUuid}/scene', [RoundRunController::class, 'scene']);
+        Route::post('/runs/{runUuid}/cohort/reconcile', [RoundRunController::class, 'reconcile']);
+        Route::patch('/runs/{runUuid}/queue', [RoundRunController::class, 'queue']);
 
-        Route::get('/patients/{roundPatientUuid}', [\App\Http\Controllers\Api\Rounds\RoundPatientController::class, 'show']);
-        Route::post('/patients/{roundPatientUuid}/mark-ready', [\App\Http\Controllers\Api\Rounds\RoundPatientController::class, 'markReady']);
-        Route::post('/patients/{roundPatientUuid}/complete', [\App\Http\Controllers\Api\Rounds\RoundPatientController::class, 'complete']);
-        Route::post('/patients/{roundPatientUuid}/reopen', [\App\Http\Controllers\Api\Rounds\RoundPatientController::class, 'reopen']);
-        Route::post('/patients/{roundPatientUuid}/defer', [\App\Http\Controllers\Api\Rounds\RoundPatientController::class, 'defer']);
-        Route::post('/patients/{roundPatientUuid}/skip', [\App\Http\Controllers\Api\Rounds\RoundPatientController::class, 'skip']);
-        Route::post('/patients/{roundPatientUuid}/pin', [\App\Http\Controllers\Api\Rounds\RoundPatientController::class, 'pin']);
-        Route::post('/patients/{roundPatientUuid}/contributions', [\App\Http\Controllers\Api\Rounds\RoundContributionController::class, 'store']);
-        Route::post('/patients/{roundPatientUuid}/questions', [\App\Http\Controllers\Api\Rounds\RoundQuestionController::class, 'store']);
-        Route::get('/patients/{roundPatientUuid}/patient-question-threads', [\App\Http\Controllers\Api\Rounds\RoundQuestionController::class, 'availablePatientQuestions'])
-            ->middleware(\App\Http\Middleware\EnsurePatientRoundsQuestionBridgeEnabled::class)
+        Route::get('/patients/{roundPatientUuid}', [RoundPatientController::class, 'show']);
+        Route::post('/patients/{roundPatientUuid}/mark-ready', [RoundPatientController::class, 'markReady']);
+        Route::post('/patients/{roundPatientUuid}/complete', [RoundPatientController::class, 'complete']);
+        Route::post('/patients/{roundPatientUuid}/reopen', [RoundPatientController::class, 'reopen']);
+        Route::post('/patients/{roundPatientUuid}/defer', [RoundPatientController::class, 'defer']);
+        Route::post('/patients/{roundPatientUuid}/skip', [RoundPatientController::class, 'skip']);
+        Route::post('/patients/{roundPatientUuid}/pin', [RoundPatientController::class, 'pin']);
+        Route::post('/patients/{roundPatientUuid}/contributions', [RoundContributionController::class, 'store']);
+        Route::post('/patients/{roundPatientUuid}/questions', [RoundQuestionController::class, 'store']);
+        Route::get('/patients/{roundPatientUuid}/patient-question-threads', [RoundQuestionController::class, 'availablePatientQuestions'])
+            ->middleware(EnsurePatientRoundsQuestionBridgeEnabled::class)
             ->whereUuid('roundPatientUuid');
-        Route::post('/patients/{roundPatientUuid}/patient-question-threads/{threadUuid}/promote', [\App\Http\Controllers\Api\Rounds\RoundQuestionController::class, 'promotePatientQuestion'])
-            ->middleware(\App\Http\Middleware\EnsurePatientRoundsQuestionBridgeEnabled::class)
+        Route::post('/patients/{roundPatientUuid}/patient-question-threads/{threadUuid}/promote', [RoundQuestionController::class, 'promotePatientQuestion'])
+            ->middleware(EnsurePatientRoundsQuestionBridgeEnabled::class)
             ->whereUuid(['roundPatientUuid', 'threadUuid']);
-        Route::post('/patients/{roundPatientUuid}/tasks', [\App\Http\Controllers\Api\Rounds\RoundTaskController::class, 'store']);
+        Route::post('/patients/{roundPatientUuid}/tasks', [RoundTaskController::class, 'store']);
 
-        Route::post('/contributions/{contributionUuid}/submit', [\App\Http\Controllers\Api\Rounds\RoundContributionController::class, 'submit']);
-        Route::post('/contributions/{contributionUuid}/withdraw', [\App\Http\Controllers\Api\Rounds\RoundContributionController::class, 'withdraw']);
-        Route::post('/questions/{questionUuid}/resolve', [\App\Http\Controllers\Api\Rounds\RoundQuestionController::class, 'resolve']);
-        Route::post('/tasks/{taskUuid}/transition', [\App\Http\Controllers\Api\Rounds\RoundTaskController::class, 'transition']);
+        Route::post('/contributions/{contributionUuid}/submit', [RoundContributionController::class, 'submit']);
+        Route::post('/contributions/{contributionUuid}/withdraw', [RoundContributionController::class, 'withdraw']);
+        Route::post('/questions/{questionUuid}/resolve', [RoundQuestionController::class, 'resolve']);
+        Route::post('/tasks/{taskUuid}/transition', [RoundTaskController::class, 'transition']);
     });
 
 // Home Hospital — virtual-ward live data (ACUM-PRD-HAH-001; docs/home-hospital/).
 // Gated by HOME_HOSPITAL_ENABLED (404 when off). Patient-level payloads travel
 // only on this authenticated API — public Reverb channels carry aggregate
 // pings, never vitals (PHI-free-wire rule).
-Route::middleware(['web', 'auth', 'throttle:60,1', \App\Http\Middleware\EnsureHomeHospitalEnabled::class])
+Route::middleware(['web', 'auth', 'throttle:60,1', EnsureHomeHospitalEnabled::class])
     ->prefix('home')->group(function () {
-        Route::get('/census', [\App\Http\Controllers\Api\Home\HomeCensusController::class, 'index']);
-        Route::get('/command', [\App\Http\Controllers\Api\Home\HomeCommandController::class, 'index']);
+        Route::get('/census', [HomeCensusController::class, 'index']);
+        Route::get('/command', [HomeCommandController::class, 'index']);
         // Patient-alert acknowledgement workflow — human actions, recorded.
-        Route::get('/alerts', [\App\Http\Controllers\Api\Home\RpmAlertController::class, 'index']);
-        Route::post('/alerts/{alertUuid}/acknowledge', [\App\Http\Controllers\Api\Home\RpmAlertController::class, 'acknowledge']);
-        Route::post('/alerts/{alertUuid}/resolve', [\App\Http\Controllers\Api\Home\RpmAlertController::class, 'resolve']);
+        Route::get('/alerts', [RpmAlertController::class, 'index']);
+        Route::post('/alerts/{alertUuid}/acknowledge', [RpmAlertController::class, 'acknowledge']);
+        Route::post('/alerts/{alertUuid}/resolve', [RpmAlertController::class, 'resolve']);
         // Escalation workflow — full response timing chain vs the 30-min floor.
-        Route::get('/escalations', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'index']);
-        Route::post('/escalations', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'store']);
-        Route::post('/escalations/{escalationUuid}/dispatch', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'dispatchResponse']);
-        Route::post('/escalations/{escalationUuid}/arrive', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'arrive']);
-        Route::post('/escalations/{escalationUuid}/resolve', [\App\Http\Controllers\Api\Home\HomeEscalationController::class, 'resolve']);
+        Route::get('/escalations', [HomeEscalationController::class, 'index']);
+        Route::post('/escalations', [HomeEscalationController::class, 'store']);
+        Route::post('/escalations/{escalationUuid}/dispatch', [HomeEscalationController::class, 'dispatchResponse']);
+        Route::post('/escalations/{escalationUuid}/arrive', [HomeEscalationController::class, 'arrive']);
+        Route::post('/escalations/{escalationUuid}/resolve', [HomeEscalationController::class, 'resolve']);
         // Referral funnel + eligibility worklists (declines always coded).
-        Route::get('/referrals', [\App\Http\Controllers\Api\Home\HomeReferralController::class, 'index']);
-        Route::post('/referrals', [\App\Http\Controllers\Api\Home\HomeReferralController::class, 'store']);
-        Route::post('/referrals/{referralUuid}/advance', [\App\Http\Controllers\Api\Home\HomeReferralController::class, 'advance']);
-        Route::post('/referrals/{referralUuid}/decline', [\App\Http\Controllers\Api\Home\HomeReferralController::class, 'decline']);
+        Route::get('/referrals', [HomeReferralController::class, 'index']);
+        Route::post('/referrals', [HomeReferralController::class, 'store']);
+        Route::post('/referrals/{referralUuid}/advance', [HomeReferralController::class, 'advance']);
+        Route::post('/referrals/{referralUuid}/decline', [HomeReferralController::class, 'decline']);
         // Transitions: inbound checklists, outbound governed handoffs, discharge.
-        Route::get('/transitions', [\App\Http\Controllers\Api\Home\HomeTransitionController::class, 'index']);
-        Route::post('/transitions/{transitionUuid}/checklist', [\App\Http\Controllers\Api\Home\HomeTransitionController::class, 'completeChecklistItem']);
-        Route::post('/episodes/{episodeUuid}/handoff', [\App\Http\Controllers\Api\Home\HomeTransitionController::class, 'startOutbound']);
-        Route::post('/episodes/{episodeUuid}/discharge', [\App\Http\Controllers\Api\Home\HomeTransitionController::class, 'discharge']);
+        Route::get('/transitions', [HomeTransitionController::class, 'index']);
+        Route::post('/transitions/{transitionUuid}/checklist', [HomeTransitionController::class, 'completeChecklistItem']);
+        Route::post('/episodes/{episodeUuid}/handoff', [HomeTransitionController::class, 'startOutbound']);
+        Route::post('/episodes/{episodeUuid}/discharge', [HomeTransitionController::class, 'discharge']);
         // Logistics — the ONE address-permitted surface.
-        Route::get('/logistics', [\App\Http\Controllers\Api\Home\HomeLogisticsController::class, 'index']);
+        Route::get('/logistics', [HomeLogisticsController::class, 'index']);
         // The decant line: home-eligible counts + free-slot forecast (huddle).
-        Route::get('/decant', [\App\Http\Controllers\Api\Home\HomeDecantController::class, 'index']);
+        Route::get('/decant', [HomeDecantController::class, 'index']);
     });
 
 // Machine-to-machine ingress only. This route intentionally lives outside the
@@ -302,7 +336,7 @@ Route::middleware(['web', 'auth', 'throttle:60,1', \App\Http\Middleware\EnsureHo
 Route::post('/integrations/v1/patient-flow/hl7v2', [PatientFlowIngestController::class, 'hl7v2'])
     ->middleware([
         'auth:sanctum',
-        \App\Http\Middleware\RequireMachineToken::class.':integration:patient-flow:ingest',
+        RequireMachineToken::class.':integration:patient-flow:ingest',
         'throttle:machine-ingest',
     ]);
 
@@ -500,7 +534,7 @@ Route::middleware(['web', 'auth', 'throttle:60,1'])->prefix('eddy')->group(funct
 // Eddy agent callback (scoped Sanctum token: ops:read/ops:draft, NEVER ops:approve).
 Route::middleware([
     'auth:sanctum',
-    \App\Http\Middleware\RequireMachineToken::class.':ops:draft',
+    RequireMachineToken::class.':ops:draft',
     'throttle:machine-agent',
 ])->prefix('eddy/agent')->group(function () {
     Route::post('/actions/propose', [EddyActionController::class, 'propose']);
@@ -826,17 +860,17 @@ Route::prefix('auth')->group(function () {
 Route::middleware([
     'auth:sanctum',
     'staff.realm',
-    \App\Http\Middleware\EnsureActiveStaffAccount::class,
+    EnsureActiveStaffAccount::class,
     CheckForAnyAbility::class.':mobile:read',
-    \App\Http\Middleware\TouchMobileTokenSession::class,
+    TouchMobileTokenSession::class,
     'throttle:mobile-api',
 ])->prefix('mobile/v1')->group(function () {
     Route::get('/me', [MobileMeController::class, 'show']);
     Route::put('/me/preferences', [MobileMeController::class, 'updatePreferences']);
     Route::get('/me/sessions', [MobileSessionController::class, 'index'])
-        ->middleware(\App\Http\Middleware\ProtectMobileSessionResponse::class);
+        ->middleware(ProtectMobileSessionResponse::class);
     Route::delete('/me/sessions/{sessionUuid}', [MobileSessionController::class, 'destroy'])
-        ->middleware(\App\Http\Middleware\ProtectMobileSessionResponse::class);
+        ->middleware(ProtectMobileSessionResponse::class);
 
     Route::post('/devices', [MobileDeviceController::class, 'store']);
     Route::delete('/devices/{device}', [MobileDeviceController::class, 'destroy']);
@@ -868,7 +902,7 @@ Route::middleware([
     // sufficient: the service also requires current responsibility-pool
     // membership for every read and mutation.
     Route::middleware([
-        \App\Http\Middleware\ProtectPatientCommunicationResponse::class,
+        ProtectPatientCommunicationResponse::class,
         'patient.staff-messaging',
         'can:viewPatientCommunications',
     ])

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,19 +3,27 @@
 use App\Http\Controllers\Admin\AccessReviewController;
 use App\Http\Controllers\Admin\AdminDashboardController;
 use App\Http\Controllers\Admin\AdminScopeController;
+use App\Http\Controllers\Admin\AiProviderPolicyController;
 use App\Http\Controllers\Admin\AuthorizationCatalogController;
 use App\Http\Controllers\Admin\AuthProviderController;
+use App\Http\Controllers\Admin\CockpitPolicyController;
+use App\Http\Controllers\Admin\DataProtectionController;
+use App\Http\Controllers\Admin\EnterpriseRegistryController;
 use App\Http\Controllers\Admin\ExternalIdentityController;
 use App\Http\Controllers\Admin\IdentityPurgeController;
 use App\Http\Controllers\Admin\SystemHealthController;
+use App\Http\Controllers\Admin\UserAccessAssignmentController;
 use App\Http\Controllers\Admin\UserAuditController;
+use App\Http\Controllers\Admin\UserBulkLifecycleController;
 use App\Http\Controllers\Analytics;
 use App\Http\Controllers\Analytics\LabTatController;
 use App\Http\Controllers\Analytics\PharmacyTatController;
 use App\Http\Controllers\Analytics\RadiologyTatController;
+use App\Http\Controllers\CarePathwayCatalogPageController;
 use App\Http\Controllers\CarePathwayDemoPageController;
 use App\Http\Controllers\CommandCenterController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\DemoHealthController;
 use App\Http\Controllers\Deployment\DeploymentConsoleController;
 use App\Http\Controllers\DesignController;
 use App\Http\Controllers\EDDashboardController;
@@ -34,6 +42,14 @@ use App\Http\Controllers\RTDCController;
 use App\Http\Controllers\RTDCDashboardController;
 use App\Http\Controllers\Staffing\StaffingDashboardController;
 use App\Http\Controllers\Transport\TransportDashboardController;
+use App\Http\Controllers\UserController;
+use App\Http\Middleware\EnsureArenaEnabled;
+use App\Http\Middleware\EnsureCarePathwayDemoEnabled;
+use App\Http\Middleware\EnsureCarePathwayGovernanceEnabled;
+use App\Http\Middleware\EnsureHomeHospitalEnabled;
+use App\Http\Middleware\EnsureRoundsEnabled;
+use App\Http\Middleware\ProtectPatientCommunicationResponse;
+use App\Http\Middleware\SessionAuthMiddleware;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -43,7 +59,7 @@ Route::get('/improvement/api/nursing-operations', [ProcessAnalysisController::cl
 
 // Rolling-demo health (FEEDBACK Wave 5) — public status for uptime monitors: last refresh,
 // source freshness, scheduler liveness. 200 healthy / 503 not. No PHI.
-Route::get('/up/demo', \App\Http\Controllers\DemoHealthController::class);
+Route::get('/up/demo', DemoHealthController::class);
 
 // Root route - redirect to login or dashboard based on auth state
 Route::get('/', function (Request $request) {
@@ -59,7 +75,7 @@ Route::get('/', function (Request $request) {
 // SessionAuthMiddleware is the existing local/demo auto-login gate. Keeping it
 // Direct viewer URLs create a valid session here, while API routes retain their
 // normal web-session authentication.
-Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
+Route::middleware([SessionAuthMiddleware::class])
     ->group(function () {
         // RTDC Routes
         Route::prefix('rtdc')->group(function () {
@@ -90,18 +106,18 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
         Route::get('/dashboard', [CommandCenterController::class, 'index'])->name('dashboard');
 
         Route::get('/care-pathways/demo', CarePathwayDemoPageController::class)
-            ->middleware(\App\Http\Middleware\EnsureCarePathwayDemoEnabled::class)
+            ->middleware(EnsureCarePathwayDemoEnabled::class)
             ->name('care-pathways.demo');
 
         // Read-only examination surface for the governed (inactive) DRG catalog.
         // Gated identically to the governance JSON API: feature flag + capability.
         Route::middleware([
-            \App\Http\Middleware\EnsureCarePathwayGovernanceEnabled::class,
+            EnsureCarePathwayGovernanceEnabled::class,
             'can:viewCarePathwayCatalog',
         ])->group(function (): void {
-            Route::get('/care-pathways/catalog', [\App\Http\Controllers\CarePathwayCatalogPageController::class, 'index'])
+            Route::get('/care-pathways/catalog', [CarePathwayCatalogPageController::class, 'index'])
                 ->name('care-pathways.catalog');
-            Route::get('/care-pathways/catalog/{versionUuid}', [\App\Http\Controllers\CarePathwayCatalogPageController::class, 'show'])
+            Route::get('/care-pathways/catalog/{versionUuid}', [CarePathwayCatalogPageController::class, 'show'])
                 ->whereUuid('versionUuid')
                 ->name('care-pathways.catalog.show');
         });
@@ -176,7 +192,7 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
             Route::get('/bed-placement', [RTDCDashboardController::class, 'bedPlacement'])->name('bed-placement');
             // Virtual Rounds board (gated by VIRTUAL_ROUNDS_ENABLED — 404 when off).
             Route::get('/virtual-rounds', [RTDCDashboardController::class, 'virtualRounds'])->name('virtual-rounds')
-                ->middleware(\App\Http\Middleware\EnsureRoundsEnabled::class);
+                ->middleware(EnsureRoundsEnabled::class);
 
             // Predictions Routes
             Route::prefix('predictions')->name('predictions.')->group(function () {
@@ -198,7 +214,7 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
         Route::get('/analytics/data-quality', [Analytics\AnalyticsController::class, 'dataQuality'])->name('analytics.data-quality');
         // Part X (X1) — Patient-Flow Arena Study surface. Gated by ARENA_ENABLED.
         Route::get('/analytics/arena', [Analytics\AnalyticsController::class, 'arena'])->name('analytics.arena')
-            ->middleware(\App\Http\Middleware\EnsureArenaEnabled::class);
+            ->middleware(EnsureArenaEnabled::class);
         Route::get('/analytics/block-utilization', [Analytics\BlockUtilizationController::class, 'index'])->name('analytics.block-utilization');
         Route::get('/analytics/or-utilization', [Analytics\ORUtilizationController::class, 'index'])->name('analytics.or-utilization');
         Route::get('/analytics/primetime-utilization', [Analytics\PrimetimeUtilizationController::class, 'index'])->name('analytics.primetime-utilization');
@@ -252,7 +268,7 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
         Route::prefix('patient-communications')
             ->name('patient-communications.')
             ->middleware([
-                \App\Http\Middleware\ProtectPatientCommunicationResponse::class,
+                ProtectPatientCommunicationResponse::class,
                 'patient.staff-messaging',
                 'can:viewPatientCommunications',
             ])
@@ -342,7 +358,7 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
         // (ACUM-PRD-HAH-001; docs/home-hospital/). Gated by
         // HOME_HOSPITAL_ENABLED (404 when off, nav hidden via features prop).
         Route::prefix('home')->name('home.')
-            ->middleware(\App\Http\Middleware\EnsureHomeHospitalEnabled::class)
+            ->middleware(EnsureHomeHospitalEnabled::class)
             ->group(function () {
                 Route::get('/command', [HomeDashboardController::class, 'command'])->name('command');
                 Route::get('/census', [HomeDashboardController::class, 'census'])->name('census');
@@ -382,7 +398,7 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
             Route::get('/admin/system-health', [SystemHealthController::class, 'index'])
                 ->middleware('can:viewSystemHealth')
                 ->name('admin.system-health.index');
-            Route::get('/admin/data-protection', \App\Http\Controllers\Admin\DataProtectionController::class)
+            Route::get('/admin/data-protection', DataProtectionController::class)
                 ->middleware('can:viewIntegrations')
                 ->name('admin.data-protection.index');
             Route::post('/admin/system-health/diagnostics', [SystemHealthController::class, 'diagnostics'])
@@ -396,31 +412,31 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
                 ->middleware('can:viewSystemHealth')
                 ->where('component', '[a-z][a-z0-9_]{0,79}')
                 ->name('admin.system-health.show');
-            Route::resource('users', \App\Http\Controllers\UserController::class)->except('show');
+            Route::resource('users', UserController::class)->except('show');
             // ADM-IAM: bulk deactivation is previewed, then executed as one
             // rollback-safe transaction; per-member audit inside the commit.
-            Route::post('/users/bulk-deactivation/preview', [\App\Http\Controllers\Admin\UserBulkLifecycleController::class, 'preview'])
+            Route::post('/users/bulk-deactivation/preview', [UserBulkLifecycleController::class, 'preview'])
                 ->middleware(['can:manageIdentity', 'throttle:12,1'])
                 ->name('users.bulk-deactivation.preview');
-            Route::post('/users/bulk-deactivation', [\App\Http\Controllers\Admin\UserBulkLifecycleController::class, 'execute'])
+            Route::post('/users/bulk-deactivation', [UserBulkLifecycleController::class, 'execute'])
                 ->middleware(['can:manageIdentity', 'throttle:6,1'])
                 ->name('users.bulk-deactivation.execute');
-            Route::post('/users/{user}/revoke-access', [\App\Http\Controllers\Admin\UserBulkLifecycleController::class, 'revokeAccess'])
+            Route::post('/users/{user}/revoke-access', [UserBulkLifecycleController::class, 'revokeAccess'])
                 ->middleware(['can:manageIdentity', 'throttle:6,1'])
                 ->name('users.revoke-access');
             // ADM-IAM: effective-dated org/facility scopes (manageIdentity) and
             // direct capability grants (managePrivileges); step-up enforced in
             // the controllers, audits appended inside the mutations.
-            Route::post('/users/{user}/access-scopes', [\App\Http\Controllers\Admin\UserAccessAssignmentController::class, 'storeScope'])
+            Route::post('/users/{user}/access-scopes', [UserAccessAssignmentController::class, 'storeScope'])
                 ->middleware(['can:manageIdentity', 'throttle:12,1'])
                 ->name('users.access-scopes.store');
-            Route::post('/users/{user}/access-scopes/{scope}/revoke', [\App\Http\Controllers\Admin\UserAccessAssignmentController::class, 'revokeScope'])
+            Route::post('/users/{user}/access-scopes/{scope}/revoke', [UserAccessAssignmentController::class, 'revokeScope'])
                 ->middleware(['can:manageIdentity', 'throttle:12,1'])
                 ->name('users.access-scopes.revoke');
-            Route::post('/users/{user}/capabilities', [\App\Http\Controllers\Admin\UserAccessAssignmentController::class, 'storeCapability'])
+            Route::post('/users/{user}/capabilities', [UserAccessAssignmentController::class, 'storeCapability'])
                 ->middleware(['can:managePrivileges', 'throttle:12,1'])
                 ->name('users.capabilities.store');
-            Route::post('/users/{user}/capabilities/revoke', [\App\Http\Controllers\Admin\UserAccessAssignmentController::class, 'revokeCapability'])
+            Route::post('/users/{user}/capabilities/revoke', [UserAccessAssignmentController::class, 'revokeCapability'])
                 ->middleware(['can:managePrivileges', 'throttle:12,1'])
                 ->name('users.capabilities.revoke');
             Route::post('/users/{user}/external-identities/{identity}/unlink', [ExternalIdentityController::class, 'unlink'])
@@ -466,22 +482,22 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
         // Reads require viewCockpitPolicy; every mutation is a governed change
         // (request → independent decision → execution) with step-up enforced
         // inside GovernedChangeService, throttled here.
-        Route::get('/admin/cockpit/thresholds', [\App\Http\Controllers\Admin\CockpitPolicyController::class, 'index'])
+        Route::get('/admin/cockpit/thresholds', [CockpitPolicyController::class, 'index'])
             ->middleware('can:viewCockpitPolicy')
             ->name('admin.cockpit.thresholds');
-        Route::post('/admin/cockpit/thresholds/{metricKey}/preview', [\App\Http\Controllers\Admin\CockpitPolicyController::class, 'preview'])
+        Route::post('/admin/cockpit/thresholds/{metricKey}/preview', [CockpitPolicyController::class, 'preview'])
             ->middleware(['can:manageCockpitPolicy', 'throttle:30,1'])
             ->where('metricKey', '[A-Za-z0-9_.:-]{1,160}')
             ->name('admin.cockpit.thresholds.preview');
-        Route::post('/admin/cockpit/thresholds/{metricKey}/changes', [\App\Http\Controllers\Admin\CockpitPolicyController::class, 'store'])
+        Route::post('/admin/cockpit/thresholds/{metricKey}/changes', [CockpitPolicyController::class, 'store'])
             ->middleware(['can:manageCockpitPolicy', 'throttle:12,1'])
             ->where('metricKey', '[A-Za-z0-9_.:-]{1,160}')
             ->name('admin.cockpit.thresholds.changes.store');
-        Route::post('/admin/cockpit/threshold-changes/{changeRequestUuid}/decision', [\App\Http\Controllers\Admin\CockpitPolicyController::class, 'decide'])
+        Route::post('/admin/cockpit/threshold-changes/{changeRequestUuid}/decision', [CockpitPolicyController::class, 'decide'])
             ->middleware(['can:manageCockpitPolicy', 'throttle:12,1'])
             ->where('changeRequestUuid', '[0-9a-fA-F-]{36}')
             ->name('admin.cockpit.thresholds.changes.decide');
-        Route::post('/admin/cockpit/threshold-changes/{changeRequestUuid}/apply', [\App\Http\Controllers\Admin\CockpitPolicyController::class, 'apply'])
+        Route::post('/admin/cockpit/threshold-changes/{changeRequestUuid}/apply', [CockpitPolicyController::class, 'apply'])
             ->middleware(['can:manageCockpitPolicy', 'throttle:12,1'])
             ->where('changeRequestUuid', '[0-9a-fA-F-]{36}')
             ->name('admin.cockpit.thresholds.changes.apply');
@@ -489,23 +505,23 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
         // ADM-POLICY — Zephyrus/Eddy AI provider governance. Same governed
         // contract as thresholds; the dry-run simulator is read-capability
         // gated, throttled, and never accepts prompt or patient content.
-        Route::get('/admin/ai-providers', [\App\Http\Controllers\Admin\AiProviderPolicyController::class, 'index'])
+        Route::get('/admin/ai-providers', [AiProviderPolicyController::class, 'index'])
             ->middleware('can:viewAiGovernance')
             ->name('admin.ai-providers.index');
-        Route::post('/admin/ai-providers/simulate', [\App\Http\Controllers\Admin\AiProviderPolicyController::class, 'simulate'])
+        Route::post('/admin/ai-providers/simulate', [AiProviderPolicyController::class, 'simulate'])
             ->middleware(['can:viewAiGovernance', 'throttle:30,1'])
             ->name('admin.ai-providers.simulate');
-        Route::post('/admin/ai-providers/preview', [\App\Http\Controllers\Admin\AiProviderPolicyController::class, 'preview'])
+        Route::post('/admin/ai-providers/preview', [AiProviderPolicyController::class, 'preview'])
             ->middleware(['can:manageAiGovernance', 'throttle:30,1'])
             ->name('admin.ai-providers.preview');
-        Route::post('/admin/ai-providers/changes', [\App\Http\Controllers\Admin\AiProviderPolicyController::class, 'store'])
+        Route::post('/admin/ai-providers/changes', [AiProviderPolicyController::class, 'store'])
             ->middleware(['can:manageAiGovernance', 'throttle:12,1'])
             ->name('admin.ai-providers.changes.store');
-        Route::post('/admin/ai-providers/changes/{changeRequestUuid}/decision', [\App\Http\Controllers\Admin\AiProviderPolicyController::class, 'decide'])
+        Route::post('/admin/ai-providers/changes/{changeRequestUuid}/decision', [AiProviderPolicyController::class, 'decide'])
             ->middleware(['can:manageAiGovernance', 'throttle:12,1'])
             ->where('changeRequestUuid', '[0-9a-fA-F-]{36}')
             ->name('admin.ai-providers.changes.decide');
-        Route::post('/admin/ai-providers/changes/{changeRequestUuid}/apply', [\App\Http\Controllers\Admin\AiProviderPolicyController::class, 'apply'])
+        Route::post('/admin/ai-providers/changes/{changeRequestUuid}/apply', [AiProviderPolicyController::class, 'apply'])
             ->middleware(['can:manageAiGovernance', 'throttle:12,1'])
             ->where('changeRequestUuid', '[0-9a-fA-F-]{36}')
             ->name('admin.ai-providers.changes.apply');
@@ -518,21 +534,21 @@ Route::middleware([\App\Http\Middleware\SessionAuthMiddleware::class])
         // These are NOT under api/admin/integrations, so the admin-scope boundary
         // inventory is unchanged: enterprise topology is cross-tenant, gated by
         // capability rather than per-source admin scope.
-        Route::post('/admin/enterprise/import/preview', [\App\Http\Controllers\Admin\EnterpriseRegistryController::class, 'preview'])
+        Route::post('/admin/enterprise/import/preview', [EnterpriseRegistryController::class, 'preview'])
             ->middleware(['can:viewDeploymentConsole', 'throttle:30,1'])
             ->name('admin.enterprise.import.preview');
-        Route::post('/admin/enterprise/import/changes', [\App\Http\Controllers\Admin\EnterpriseRegistryController::class, 'store'])
+        Route::post('/admin/enterprise/import/changes', [EnterpriseRegistryController::class, 'store'])
             ->middleware(['can:manageDeploymentConfig', 'throttle:12,1'])
             ->name('admin.enterprise.import.changes.store');
-        Route::post('/admin/enterprise/import/changes/{changeRequestUuid}/decision', [\App\Http\Controllers\Admin\EnterpriseRegistryController::class, 'decide'])
+        Route::post('/admin/enterprise/import/changes/{changeRequestUuid}/decision', [EnterpriseRegistryController::class, 'decide'])
             ->middleware(['can:manageDeploymentConfig', 'throttle:12,1'])
             ->where('changeRequestUuid', '[0-9a-fA-F-]{36}')
             ->name('admin.enterprise.import.changes.decide');
-        Route::post('/admin/enterprise/import/changes/{changeRequestUuid}/apply', [\App\Http\Controllers\Admin\EnterpriseRegistryController::class, 'apply'])
+        Route::post('/admin/enterprise/import/changes/{changeRequestUuid}/apply', [EnterpriseRegistryController::class, 'apply'])
             ->middleware(['can:manageDeploymentConfig', 'throttle:12,1'])
             ->where('changeRequestUuid', '[0-9a-fA-F-]{36}')
             ->name('admin.enterprise.import.changes.apply');
-        Route::put('/admin/enterprise/sources/{source}/required-topology', [\App\Http\Controllers\Admin\EnterpriseRegistryController::class, 'declareSourceTopology'])
+        Route::put('/admin/enterprise/sources/{source}/required-topology', [EnterpriseRegistryController::class, 'declareSourceTopology'])
             ->middleware(['can:manageDeploymentConfig', 'throttle:12,1'])
             ->whereNumber('source')
             ->name('admin.enterprise.sources.required-topology');

--- a/scripts/assert-test-environment.php
+++ b/scripts/assert-test-environment.php
@@ -1,9 +1,10 @@
 <?php
 
 declare(strict_types=1);
+use Tests\Support\TestEnvironmentGuard;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-Tests\Support\TestEnvironmentGuard::enforce(dirname(__DIR__));
+TestEnvironmentGuard::enforce(dirname(__DIR__));
 
 fwrite(STDOUT, "Test environment guard passed.\n");

--- a/tests/Feature/Admin/AuditRedactionTest.php
+++ b/tests/Feature/Admin/AuditRedactionTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Admin;
 
 use App\Models\Audit\UserEvent;
 use App\Models\User;
+use Carbon\CarbonInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia as Assert;
@@ -70,7 +71,7 @@ final class AuditRedactionTest extends TestCase
                 ->where('recentEvents.0.actor.email', 'c***@example.test'));
     }
 
-    private function loginEvent(User $actor, string $ip, \Carbon\CarbonInterface $occurredAt): UserEvent
+    private function loginEvent(User $actor, string $ip, CarbonInterface $occurredAt): UserEvent
     {
         return UserEvent::query()->create([
             'event_uuid' => (string) Str::uuid7(),

--- a/tests/Feature/Ancillary/AncillaryProjectionTest.php
+++ b/tests/Feature/Ancillary/AncillaryProjectionTest.php
@@ -14,6 +14,7 @@ use App\Integrations\Healthcare\Services\SourceRegistryService;
 use App\Integrations\Healthcare\Synthetic\SyntheticHealthcareConnector;
 use App\Jobs\ReplayPendingIntegrationEvents;
 use App\Models\Ancillary\AncillaryOrder;
+use App\Models\Integration\Source;
 use Carbon\CarbonImmutable;
 use Database\Seeders\AncillaryReferenceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -341,7 +342,7 @@ class AncillaryProjectionTest extends TestCase
     }
 
     private function projectDirect(
-        \App\Models\Integration\Source $source,
+        Source $source,
         string $milestoneCode,
         string $sourceOrderKey,
         string $reconciliationKey,

--- a/tests/Feature/Ancillary/PharmacyControlledTest.php
+++ b/tests/Feature/Ancillary/PharmacyControlledTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Ancillary;
 use App\Services\Pharmacy\ControlledSubstanceOperationsService;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Tests\Support\Scenario\UsesCommittedAncillaryScenario;
 use Tests\TestCase;
 
@@ -69,7 +70,7 @@ final class PharmacyControlledTest extends TestCase
         $this->assertNotNull($edOpen);
 
         DB::table('prod.adc_transactions')->insert([
-            'transaction_uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'transaction_uuid' => (string) Str::uuid(),
             'adc_station_id' => $edOpen->adc_station_id,
             'source_id' => $edOpen->source_id,
             'source_transaction_key' => $edOpen->source_transaction_key.'-resolved-test',
@@ -126,7 +127,7 @@ final class PharmacyControlledTest extends TestCase
         $this->assertNotNull($edOpen);
 
         DB::table('prod.adc_transactions')->insert([
-            'transaction_uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'transaction_uuid' => (string) Str::uuid(),
             'adc_station_id' => $edOpen->adc_station_id,
             'source_id' => $edOpen->source_id,
             'source_transaction_key' => 'demo:rx:txn:disc-fresh-test',
@@ -167,7 +168,7 @@ final class PharmacyControlledTest extends TestCase
             ['type' => 'override', 'suffix' => 'co-1'],
         ] as $row) {
             DB::table('prod.adc_transactions')->insert([
-                'transaction_uuid' => (string) \Illuminate\Support\Str::uuid(),
+                'transaction_uuid' => (string) Str::uuid(),
                 'adc_station_id' => $station,
                 'source_id' => $sourceId,
                 'source_transaction_key' => 'demo:rx:txn:ctrl-'.$row['suffix'],

--- a/tests/Feature/Arena/ArenaCopilotGovernanceTest.php
+++ b/tests/Feature/Arena/ArenaCopilotGovernanceTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Arena;
 
 use App\Domain\Arena\ArenaCopilotService;
+use App\Domain\Arena\ArenaSidecarClient;
 use App\Domain\Arena\Copilot\ArenaQueryCatalog;
 use App\Models\Ops\Approval;
 use App\Models\Ops\OperationalAction;
@@ -180,7 +181,7 @@ class ArenaCopilotGovernanceTest extends TestCase
     public function test_author_map_withholds_a_below_floor_model(): void
     {
         $this->enableCopilot();
-        $this->app->instance(\App\Domain\Arena\ArenaSidecarClient::class, new class extends \App\Domain\Arena\ArenaSidecarClient
+        $this->app->instance(ArenaSidecarClient::class, new class extends ArenaSidecarClient
         {
             public function __construct() {}
 
@@ -206,7 +207,7 @@ class ArenaCopilotGovernanceTest extends TestCase
     public function test_author_map_publishes_a_conformant_model(): void
     {
         $this->enableCopilot();
-        $this->app->instance(\App\Domain\Arena\ArenaSidecarClient::class, new class extends \App\Domain\Arena\ArenaSidecarClient
+        $this->app->instance(ArenaSidecarClient::class, new class extends ArenaSidecarClient
         {
             public function __construct() {}
 

--- a/tests/Feature/Cockpit/AlertFanoutTest.php
+++ b/tests/Feature/Cockpit/AlertFanoutTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Cockpit;
 use App\Contracts\AlertChannel;
 use App\Contracts\PushNotifier;
 use App\Models\Cockpit\CockpitAlert;
+use App\Models\Ops\MetricDefinition;
 use App\Models\User;
 use App\Services\Cockpit\AlertEngine;
 use App\Services\Cockpit\AlertFanout;
@@ -14,6 +15,7 @@ use App\Services\Eddy\EddyApprovalNotifier;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
@@ -102,8 +104,8 @@ class AlertFanoutTest extends TestCase
         $fanout->alertOpened($warn);
         $this->assertCount(0, $this->spy->sent);
 
-        \App\Models\Ops\MetricDefinition::query()->create([
-            'metric_definition_uuid' => (string) \Illuminate\Support\Str::uuid(),
+        MetricDefinition::query()->create([
+            'metric_definition_uuid' => (string) Str::uuid(),
             'metric_key' => 'staffing.overtime',
             'label' => 'Overtime',
             'domain' => 'staffing',

--- a/tests/Feature/Cockpit/CockpitSnapshotApiTest.php
+++ b/tests/Feature/Cockpit/CockpitSnapshotApiTest.php
@@ -6,8 +6,10 @@ use App\Models\Cockpit\CockpitSnapshot;
 use App\Models\Ops\MetricDefinition;
 use App\Models\User;
 use App\Services\Cockpit\SnapshotBuilder;
+use App\Services\Ops\Agents\AgentToolRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 /**
@@ -81,7 +83,7 @@ class CockpitSnapshotApiTest extends TestCase
     public function test_kpi_definitions_endpoint_exposes_direction_aware_edges(): void
     {
         MetricDefinition::query()->create([
-            'metric_definition_uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'metric_definition_uuid' => (string) Str::uuid(),
             'metric_key' => 'ed.nedocs',
             'label' => 'NEDOCS',
             'domain' => 'ed',
@@ -110,7 +112,7 @@ class CockpitSnapshotApiTest extends TestCase
     public function test_kpi_definition_update_is_admin_gated_and_audited(): void
     {
         MetricDefinition::query()->create([
-            'metric_definition_uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'metric_definition_uuid' => (string) Str::uuid(),
             'metric_key' => 'rtdc.occupancy',
             'label' => 'House occupancy',
             'domain' => 'rtdc',
@@ -151,7 +153,7 @@ class CockpitSnapshotApiTest extends TestCase
         $this->assertIsArray($cached['capacitySnapshot'] ?? null, 'snapshot must embed the capacity document');
 
         $user = User::factory()->create();
-        $toolResult = app(\App\Services\Ops\Agents\AgentToolRegistry::class)
+        $toolResult = app(AgentToolRegistry::class)
             ->call('capacity.snapshot', [], $user);
 
         // Same generatedAtIso ⇒ Eddy's worldview IS the cockpit snapshot,

--- a/tests/Feature/Cockpit/CockpitSnapshotSectionsTest.php
+++ b/tests/Feature/Cockpit/CockpitSnapshotSectionsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Cockpit;
 
+use App\Jobs\RefreshCockpitMaterializedViews;
 use App\Services\Cockpit\SnapshotBuilder;
 use Database\Seeders\CockpitKpiDefinitionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -70,7 +71,7 @@ class CockpitSnapshotSectionsTest extends TestCase
         }
         DB::table('prod.workforce_actuals')->insert($workforce);
 
-        foreach (\App\Jobs\RefreshCockpitMaterializedViews::VIEWS as $view) {
+        foreach (RefreshCockpitMaterializedViews::VIEWS as $view) {
             DB::statement("REFRESH MATERIALIZED VIEW {$view}");
         }
     }

--- a/tests/Feature/Cockpit/FlowLiveSourcesTest.php
+++ b/tests/Feature/Cockpit/FlowLiveSourcesTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Cockpit;
 use App\Services\Cockpit\SnapshotBuilder;
 use App\Services\Evs\EvsOperationsService;
 use App\Services\Transport\TransportOperationsService;
+use App\Support\Operations\DurationFormatter;
 use Database\Seeders\CockpitKpiDefinitionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -170,7 +171,7 @@ class FlowLiveSourcesTest extends TestCase
         $this->assertEqualsWithDelta(61.508333333333, $measure['value'], 0.0000001);
         $this->assertSame(
             '1 hr 1 min 31 sec',
-            \App\Support\Operations\DurationFormatter::minutes($measure['value']),
+            DurationFormatter::minutes($measure['value']),
         );
     }
 }

--- a/tests/Feature/Cockpit/PeriopDrillTest.php
+++ b/tests/Feature/Cockpit/PeriopDrillTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Cockpit;
 
 use App\Services\Cockpit\DrillBuilder;
 use App\Services\Cockpit\SnapshotBuilder;
+use App\Services\Operations\RoomStatusService;
 use Database\Seeders\CockpitKpiDefinitionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
@@ -134,7 +135,7 @@ class PeriopDrillTest extends TestCase
             'or_out_time' => now()->addHour(),
         ]);
 
-        $rooms = app(\App\Services\Operations\RoomStatusService::class)->build()['rooms'];
+        $rooms = app(RoomStatusService::class)->build()['rooms'];
         $this->assertNotEmpty($rooms);
         $this->assertSame('OR 1 — Cardiac', $rooms[0]['suiteName']);
         $this->assertArrayHasKey('delayMin', $rooms[0]);

--- a/tests/Feature/Cockpit/RadiologyCockpitMetricsTest.php
+++ b/tests/Feature/Cockpit/RadiologyCockpitMetricsTest.php
@@ -7,6 +7,7 @@ use App\Models\Ancillary\AncillaryBreach;
 use App\Models\Ancillary\AncillaryMilestone;
 use App\Models\Ancillary\AncillaryOrder;
 use App\Models\Integration\Source;
+use App\Models\Ops\MetricDefinition;
 use App\Models\Radiology\Exam;
 use App\Models\Radiology\Read;
 use App\Models\Radiology\Scanner;
@@ -98,7 +99,7 @@ class RadiologyCockpitMetricsTest extends TestCase
         $engine = app(StatusEngine::class);
         foreach ([$breaches, $unread, $scanners] as $tile) {
             $definition = DB::table('ops.metric_definitions')->where('metric_key', $tile['key'])->first();
-            $model = \App\Models\Ops\MetricDefinition::query()->findOrFail($definition->metric_definition_id);
+            $model = MetricDefinition::query()->findOrFail($definition->metric_definition_id);
             $this->assertSame($engine->resolveStatus($tile['value'], $model)->value, $tile['status']);
         }
         $this->assertSame('warn', $breaches['status']);

--- a/tests/Feature/Deployment/EnterpriseRegistryImportTest.php
+++ b/tests/Feature/Deployment/EnterpriseRegistryImportTest.php
@@ -2,13 +2,19 @@
 
 namespace Tests\Feature\Deployment;
 
+use App\Integrations\Healthcare\Services\SourceConfigurationVersionService;
+use App\Integrations\Healthcare\Services\SourceLifecycleService;
+use App\Integrations\Healthcare\Services\SourceOnboardingService;
+use App\Integrations\Healthcare\Services\SourceReadinessService;
 use App\Models\Org\Facility;
 use App\Models\Org\Organization;
 use App\Models\User;
 use App\Services\Auth\StepUpAuthenticationService;
 use Carbon\CarbonImmutable;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 /**
@@ -171,7 +177,7 @@ final class EnterpriseRegistryImportTest extends TestCase
     public function test_change_history_is_append_only(): void
     {
         DB::table('hosp_org.enterprise_change_history')->insert([
-            'change_history_uuid' => (string) \Illuminate\Support\Str::uuid7(),
+            'change_history_uuid' => (string) Str::uuid7(),
             'entity_type' => 'organization',
             'entity_natural_key' => 'ENT_LEDGER',
             'change_kind' => 'create',
@@ -182,7 +188,7 @@ final class EnterpriseRegistryImportTest extends TestCase
             'recorded_at' => now(),
         ]);
 
-        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectException(QueryException::class);
         DB::table('hosp_org.enterprise_change_history')
             ->where('entity_natural_key', 'ENT_LEDGER')
             ->update(['change_kind' => 'update']);
@@ -200,7 +206,7 @@ final class EnterpriseRegistryImportTest extends TestCase
             ])
             ->assertOk();
 
-        $assessment = app(\App\Integrations\Healthcare\Services\SourceReadinessService::class)
+        $assessment = app(SourceReadinessService::class)
             ->evaluate($sourceId, CarbonImmutable::now(), null, persist: false);
 
         $failed = collect($assessment['requirements'])->where('status', 'failed')->pluck('code')->all();
@@ -230,7 +236,7 @@ final class EnterpriseRegistryImportTest extends TestCase
             ])
             ->assertOk();
 
-        $assessment = app(\App\Integrations\Healthcare\Services\SourceReadinessService::class)
+        $assessment = app(SourceReadinessService::class)
             ->evaluate($sourceId, CarbonImmutable::now(), null, persist: false);
 
         $topologyChecks = collect($assessment['requirements'])
@@ -254,7 +260,7 @@ final class EnterpriseRegistryImportTest extends TestCase
         ]);
 
         $sourceId = (int) DB::table('integration.sources')->insertGetId([
-            'source_uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'source_uuid' => (string) Str::uuid(),
             'source_key' => 'ent.topology.source',
             'organization_id' => $organization->organization_id,
             'facility_id' => $facility->facility_id,
@@ -271,13 +277,13 @@ final class EnterpriseRegistryImportTest extends TestCase
             'updated_at' => now(),
         ], 'source_id');
 
-        app(\App\Integrations\Healthcare\Services\SourceConfigurationVersionService::class)->initialize(
-            $sourceId, null, 'Initial enterprise topology test configuration.', (string) \Illuminate\Support\Str::uuid(),
+        app(SourceConfigurationVersionService::class)->initialize(
+            $sourceId, null, 'Initial enterprise topology test configuration.', (string) Str::uuid(),
         );
-        app(\App\Integrations\Healthcare\Services\SourceLifecycleService::class)->initialize(
+        app(SourceLifecycleService::class)->initialize(
             $sourceId, null, 'Initial enterprise topology test lifecycle.',
         );
-        app(\App\Integrations\Healthcare\Services\SourceOnboardingService::class)->initialize($sourceId);
+        app(SourceOnboardingService::class)->initialize($sourceId);
 
         return [$sourceId, $facilityKey];
     }

--- a/tests/Feature/Eddy/EddyActionTest.php
+++ b/tests/Feature/Eddy/EddyActionTest.php
@@ -6,6 +6,7 @@ use App\Models\Ops\Approval;
 use App\Models\Ops\OperationalAction;
 use App\Models\Ops\Recommendation;
 use App\Models\User;
+use App\Services\Eddy\EddyActionService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -67,17 +68,17 @@ class EddyActionTest extends TestCase
     public function test_action_for_alert_resolves_the_p6_preseed_mapping(): void
     {
         // The acceptance case: a crit ED alert pre-seeds the surge plan.
-        $this->assertSame('propose_surge_plan', \App\Services\Eddy\EddyActionService::actionForAlert('ed.nedocs', 'crit'));
-        $this->assertSame('propose_bed_placement', \App\Services\Eddy\EddyActionService::actionForAlert('rtdc.occupancy', 'crit'));
-        $this->assertSame('propose_transport_dispatch', \App\Services\Eddy\EddyActionService::actionForAlert('flow.transport_wait', 'crit'));
-        $this->assertSame('propose_huddle_action', \App\Services\Eddy\EddyActionService::actionForAlert('staffing.callouts', 'crit'));
+        $this->assertSame('propose_surge_plan', EddyActionService::actionForAlert('ed.nedocs', 'crit'));
+        $this->assertSame('propose_bed_placement', EddyActionService::actionForAlert('rtdc.occupancy', 'crit'));
+        $this->assertSame('propose_transport_dispatch', EddyActionService::actionForAlert('flow.transport_wait', 'crit'));
+        $this->assertSame('propose_huddle_action', EddyActionService::actionForAlert('staffing.callouts', 'crit'));
 
         // Warns never escalate past the low-risk responses.
-        $this->assertSame('flag_barrier', \App\Services\Eddy\EddyActionService::actionForAlert('ed.los_admit', 'warn'));
-        $this->assertSame('propose_huddle_action', \App\Services\Eddy\EddyActionService::actionForAlert('staffing.overtime', 'warn'));
+        $this->assertSame('flag_barrier', EddyActionService::actionForAlert('ed.los_admit', 'warn'));
+        $this->assertSame('propose_huddle_action', EddyActionService::actionForAlert('staffing.overtime', 'warn'));
 
         // Unmapped domains fall back to the barrier flag.
-        $this->assertSame('flag_barrier', \App\Services\Eddy\EddyActionService::actionForAlert('quality.cdiff', 'crit'));
+        $this->assertSame('flag_barrier', EddyActionService::actionForAlert('quality.cdiff', 'crit'));
     }
 
     public function test_human_can_propose_and_approve_in_one_step(): void

--- a/tests/Feature/Governance/GovernedChangeServiceTest.php
+++ b/tests/Feature/Governance/GovernedChangeServiceTest.php
@@ -8,6 +8,7 @@ use App\Models\Governance\GovernedChangeExecution;
 use App\Models\Governance\GovernedChangeRequest;
 use App\Models\User;
 use App\Services\Auth\StepUpAuthenticationService;
+use App\Services\Auth\StepUpRequired;
 use App\Services\Governance\GovernanceViolation;
 use App\Services\Governance\GovernedChangeService;
 use Illuminate\Database\QueryException;
@@ -184,7 +185,7 @@ final class GovernedChangeServiceTest extends TestCase
                 $hash,
             );
             $this->fail('Step-up must be required.');
-        } catch (\App\Services\Auth\StepUpRequired) {
+        } catch (StepUpRequired) {
             $this->addToAssertionCount(1);
         }
 

--- a/tests/Feature/Home/HomeIntelligenceTest.php
+++ b/tests/Feature/Home/HomeIntelligenceTest.php
@@ -11,6 +11,7 @@ use App\Services\Flow\ForwardProjectionService;
 use Carbon\CarbonImmutable;
 use Database\Seeders\HomeHospitalDemoSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -62,7 +63,7 @@ class HomeIntelligenceTest extends TestCase
         $service = app(ForwardProjectionService::class);
         $scope = ['type' => 'house', 'floor' => null, 'unit_id' => null, 'patient_ref' => null];
 
-        \Illuminate\Support\Facades\Cache::flush();
+        Cache::flush();
         $items = $service->projections($from, $to, $scope, ['home_slot_free']);
         $this->assertNotEmpty($items);
         $this->assertSame('home_slot_free', $items[0]['kind']);
@@ -70,7 +71,7 @@ class HomeIntelligenceTest extends TestCase
         $this->assertSame('home_hospital.expected_discharge', $items[0]['provenance']['service']);
 
         config()->set('home_hospital.enabled', false);
-        \Illuminate\Support\Facades\Cache::flush();
+        Cache::flush();
         $this->assertSame([], $service->projections($from, $to, $scope, ['home_slot_free']));
     }
 

--- a/tests/Feature/Home/HomeObservabilityTest.php
+++ b/tests/Feature/Home/HomeObservabilityTest.php
@@ -7,13 +7,16 @@ use App\Integrations\Healthcare\Rpm\SyntheticRpmConnector;
 use App\Models\Home\HomeEpisode;
 use App\Models\Home\HomeEscalation;
 use App\Models\Home\RpmAlert;
+use App\Models\Home\RpmObservation;
 use App\Models\Org\Facility;
 use App\Models\Org\Organization;
 use App\Models\User;
 use App\Services\Cockpit\DrillBuilder;
+use App\Services\Cockpit\SnapshotBuilder;
 use App\Services\Eddy\EddyActionService;
 use App\Services\Home\HewsService;
 use App\Services\Home\HomeEscalationService;
+use Database\Seeders\CockpitKpiDefinitionSeeder;
 use Database\Seeders\HomeHospitalDemoSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -195,8 +198,8 @@ class HomeObservabilityTest extends TestCase
 
     public function test_cockpit_snapshot_carries_the_home_domain_and_crit_alert(): void
     {
-        $this->seed(\Database\Seeders\CockpitKpiDefinitionSeeder::class);
-        $snapshot = app(\App\Services\Cockpit\SnapshotBuilder::class)->build();
+        $this->seed(CockpitKpiDefinitionSeeder::class);
+        $snapshot = app(SnapshotBuilder::class)->build();
 
         $this->assertArrayHasKey('home', $snapshot['domains']);
         $tiles = collect($snapshot['domains']['home']['tiles']);
@@ -218,15 +221,15 @@ class HomeObservabilityTest extends TestCase
     {
         config()->set('home_hospital.enabled', false);
 
-        $snapshot = app(\App\Services\Cockpit\SnapshotBuilder::class)->build();
+        $snapshot = app(SnapshotBuilder::class)->build();
 
         $this->assertArrayNotHasKey('home', $snapshot['domains']);
     }
 
     public function test_home_drill_builds_ward_board_and_funnel(): void
     {
-        $this->seed(\Database\Seeders\CockpitKpiDefinitionSeeder::class);
-        app(\App\Services\Cockpit\SnapshotBuilder::class)->build();
+        $this->seed(CockpitKpiDefinitionSeeder::class);
+        app(SnapshotBuilder::class)->build();
 
         $drill = app(DrillBuilder::class)->build('home');
 
@@ -264,7 +267,7 @@ class HomeObservabilityTest extends TestCase
             'observed_at' => now()->toIso8601String(),
         ]]]));
 
-        $observation = \App\Models\Home\RpmObservation::query()
+        $observation = RpmObservation::query()
             ->where('transmission_id', 'TX-FHIR-1')
             ->firstOrFail();
 

--- a/tests/Feature/Home/HomeTransitionsTest.php
+++ b/tests/Feature/Home/HomeTransitionsTest.php
@@ -6,6 +6,7 @@ use App\Models\Bed;
 use App\Models\Encounter;
 use App\Models\Home\HomeEpisode;
 use App\Models\Home\HomeReferral;
+use App\Models\Home\RpmKit;
 use App\Models\Unit;
 use App\Models\User;
 use Database\Seeders\HomeHospitalDemoSeeder;
@@ -145,7 +146,7 @@ class HomeTransitionsTest extends TestCase
             ->assertJsonPath('episode.disposition', 'routine_discharge');
 
         $this->assertSame('available', Bed::find($bedId)->status);
-        $this->assertSame('available', \App\Models\Home\RpmKit::find($kitId)->status);
+        $this->assertSame('available', RpmKit::find($kitId)->status);
         $this->assertSame('discharged', $episode->fresh()->encounter->status);
 
         $cohort = HomeEpisode::query()

--- a/tests/Feature/Integrations/CredentialRotationAlertTest.php
+++ b/tests/Feature/Integrations/CredentialRotationAlertTest.php
@@ -4,6 +4,8 @@ namespace Tests\Feature\Integrations;
 
 use App\Contracts\OperationalAlertChannel;
 use App\Integrations\Healthcare\Services\CredentialRotationAlertService;
+use App\Integrations\Healthcare\Services\SourceConfigurationVersionService;
+use App\Integrations\Healthcare\Services\SourceLifecycleService;
 use App\Models\Org\Facility;
 use App\Models\Org\Organization;
 use App\Security\ClinicalPayloads\ClinicalContentGuard;
@@ -69,13 +71,13 @@ final class CredentialRotationAlertTest extends TestCase
             'created_at' => now(),
             'updated_at' => now(),
         ], 'source_id');
-        app(\App\Integrations\Healthcare\Services\SourceConfigurationVersionService::class)->initialize(
+        app(SourceConfigurationVersionService::class)->initialize(
             $this->sourceId,
             null,
             'Initialize rotation alert test configuration authority.',
             (string) Str::uuid7(),
         );
-        app(\App\Integrations\Healthcare\Services\SourceLifecycleService::class)->initialize(
+        app(SourceLifecycleService::class)->initialize(
             $this->sourceId,
             null,
             'Initialize rotation alert test lifecycle authority.',

--- a/tests/Feature/Integrations/IntegrationOperationalRuntimeTest.php
+++ b/tests/Feature/Integrations/IntegrationOperationalRuntimeTest.php
@@ -4,16 +4,20 @@ namespace Tests\Feature\Integrations;
 
 use App\Integrations\Healthcare\Exceptions\IntegrationProtocolException;
 use App\Integrations\Healthcare\Exceptions\IntegrationThrottledException;
+use App\Integrations\Healthcare\Services\EnterpriseConnectorControlService;
 use App\Integrations\Healthcare\Services\EpicSmartFhirClient;
 use App\Integrations\Healthcare\Services\FhirConformanceObservationService;
 use App\Integrations\Healthcare\Services\FhirResourceProfileService;
+use App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService;
 use App\Integrations\Healthcare\Services\IntegrationProtocolHealthService;
 use App\Integrations\Healthcare\Services\NetworkRouteService;
 use App\Integrations\Healthcare\Services\OperationalIntegrationConfigurator;
+use App\Integrations\Healthcare\Services\ProjectionDispatcher;
 use App\Integrations\Healthcare\Services\SmartBackendFhirClient;
 use App\Integrations\Healthcare\Services\SourceConfigurationVersionService;
 use App\Integrations\Healthcare\Services\SourceOnboardingService;
 use App\Integrations\Healthcare\Services\SourceRegistryService;
+use App\Integrations\Healthcare\Services\SourceStatusFacetService;
 use App\Jobs\DispatchScheduledFhirPolls;
 use App\Jobs\PollEpicFhirResource;
 use App\Jobs\PollFhirResource;
@@ -31,10 +35,12 @@ use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Factory as HttpFactory;
 use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Tests\TestCase;
 
 class IntegrationOperationalRuntimeTest extends TestCase
@@ -146,7 +152,7 @@ class IntegrationOperationalRuntimeTest extends TestCase
             return $job->runId === $runId && $job->connection === 'database' && $job->queue === 'integrations';
         });
         $job = new RunIntegrationProtocolHealthCheck($runId, null, (string) Str::uuid());
-        $job->handle(app(IntegrationProtocolHealthService::class), app(\App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService::class));
+        $job->handle(app(IntegrationProtocolHealthService::class), app(IntegrationConfigurationAuditService::class));
 
         $this->assertDatabaseHas('raw.ingest_runs', ['ingest_run_id' => $runId, 'status' => 'completed']);
         $this->assertDatabaseHas('integration.sources', ['source_id' => $sourceId, 'protocol_health_status' => 'healthy']);
@@ -696,7 +702,7 @@ class IntegrationOperationalRuntimeTest extends TestCase
             'updated_at' => now(),
         ]);
         Queue::fake();
-        (new DispatchScheduledFhirPolls)->handle(app(\App\Integrations\Healthcare\Services\EnterpriseConnectorControlService::class));
+        (new DispatchScheduledFhirPolls)->handle(app(EnterpriseConnectorControlService::class));
         Queue::assertPushed(PollFhirResource::class, 3);
         foreach (['Encounter', 'Location', 'Observation'] as $scheduledResourceType) {
             Queue::assertPushed(
@@ -827,7 +833,7 @@ class IntegrationOperationalRuntimeTest extends TestCase
         $job = new ReplayPendingIntegrationEvents($replayId, $user->id, (string) Str::uuid());
         $this->assertSame('database', $job->connection);
         $this->assertSame('integrations', $job->queue);
-        $job->handle(app(\App\Integrations\Healthcare\Services\ProjectionDispatcher::class), app(\App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService::class));
+        $job->handle(app(ProjectionDispatcher::class), app(IntegrationConfigurationAuditService::class));
 
         $this->assertDatabaseHas('integration.event_replay_jobs', [
             'event_replay_job_id' => $replayId,
@@ -896,7 +902,7 @@ class IntegrationOperationalRuntimeTest extends TestCase
 
         $failure = null;
         try {
-            $job->handle(app(EpicSmartFhirClient::class), app(\App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService::class));
+            $job->handle(app(EpicSmartFhirClient::class), app(IntegrationConfigurationAuditService::class));
             $this->fail('The invalid SMART client should fail the poll.');
         } catch (IntegrationProtocolException $exception) {
             $failure = $exception;
@@ -913,7 +919,7 @@ class IntegrationOperationalRuntimeTest extends TestCase
             'status' => 'open',
         ]);
 
-        $job->handle(app(EpicSmartFhirClient::class), app(\App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService::class));
+        $job->handle(app(EpicSmartFhirClient::class), app(IntegrationConfigurationAuditService::class));
 
         $this->assertDatabaseHas('raw.ingest_runs', ['ingest_run_id' => $runId, 'status' => 'completed']);
         $this->assertDatabaseHas('raw.dead_letters', [
@@ -952,7 +958,7 @@ class IntegrationOperationalRuntimeTest extends TestCase
         try {
             $job->handle(
                 app(EpicSmartFhirClient::class),
-                app(\App\Integrations\Healthcare\Services\IntegrationConfigurationAuditService::class),
+                app(IntegrationConfigurationAuditService::class),
             );
             $this->fail('A throttled FHIR search must not be reported as completed.');
         } catch (IntegrationProtocolException $exception) {
@@ -1086,7 +1092,7 @@ class IntegrationOperationalRuntimeTest extends TestCase
                 'activate' => true,
             ]);
             $this->fail('Ungoverned HL7 activation should be rejected.');
-        } catch (\Illuminate\Validation\ValidationException $exception) {
+        } catch (ValidationException $exception) {
             $this->assertArrayHasKey('activation', $exception->errors());
         }
 
@@ -1353,7 +1359,7 @@ class IntegrationOperationalRuntimeTest extends TestCase
         $this->assertSame(0, DB::table('integration.fhir_conformance_observations')->count());
     }
 
-    /** @return array<string, \Illuminate\Http\Client\Response> */
+    /** @return array<string, Response> */
     private function epicDiscoveryResponses(
         string $softwareName = 'Epic',
         array $resourceTypes = ['Encounter', 'Location'],
@@ -1602,9 +1608,9 @@ class IntegrationOperationalRuntimeTest extends TestCase
         // INT-LIFECYCLE: the tightened activation gate requires the governed
         // conformance/contract facets to be passed/active independently of
         // onboarding evidence.
-        $facets = app(\App\Integrations\Healthcare\Services\SourceStatusFacetService::class);
+        $facets = app(SourceStatusFacetService::class);
         $facets->recordConformance($sourceId, 'passed', 'hl7v2-adt', '2.5', 'Vendor conformance verified for HL7 activation.', null);
-        $contractEvidenceId = (int) \Illuminate\Support\Facades\DB::table('integration.source_evidence_records')
+        $contractEvidenceId = (int) DB::table('integration.source_evidence_records')
             ->where('source_id', $sourceId)
             ->where('evidence_type', 'contract')
             ->where('evidence_status', 'verified')

--- a/tests/Feature/Integrations/SourceObservabilityControlPlaneTest.php
+++ b/tests/Feature/Integrations/SourceObservabilityControlPlaneTest.php
@@ -14,6 +14,9 @@ use App\Integrations\Healthcare\Services\SourceRuntimePressureService;
 use App\Models\Org\Facility;
 use App\Models\Org\Organization;
 use App\Models\User;
+use App\Observability\Exporters\InMemoryMetricExporter;
+use App\Observability\SpanAttributes;
+use App\Security\ClinicalPayloads\ClinicalPayloadException;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -606,7 +609,7 @@ final class SourceObservabilityControlPlaneTest extends TestCase
         config()->set('observability.enabled', true);
         config()->set('observability.exporter', 'memory');
         $this->completeOnboarding();
-        $exporter = app(\App\Observability\Exporters\InMemoryMetricExporter::class);
+        $exporter = app(InMemoryMetricExporter::class);
         $exporter->flush();
 
         $observedAt = CarbonImmutable::parse('2026-07-13T14:00:00Z');
@@ -624,8 +627,8 @@ final class SourceObservabilityControlPlaneTest extends TestCase
         $this->assertStringNotContainsString('ZPHI', json_encode($attributes, JSON_THROW_ON_ERROR));
 
         // A clinical canary on an attribute is rejected by the safe-attribute contract.
-        $this->expectException(\App\Security\ClinicalPayloads\ClinicalPayloadException::class);
-        \App\Observability\SpanAttributes::make(['zephyrus.tainted' => 'ZPHI-OBSERVABILITY-CANARY']);
+        $this->expectException(ClinicalPayloadException::class);
+        SpanAttributes::make(['zephyrus.tainted' => 'ZPHI-OBSERVABILITY-CANARY']);
     }
 
     public function test_source_health_digest_labels_mode_and_staleness_for_downstream_contracts(): void

--- a/tests/Feature/Integrations/SourceStatusFacetTest.php
+++ b/tests/Feature/Integrations/SourceStatusFacetTest.php
@@ -15,6 +15,7 @@ use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Tests\TestCase;
 
 /**
@@ -162,7 +163,7 @@ final class SourceStatusFacetTest extends TestCase
     public function test_contract_facet_is_evidence_pointer_only_and_active_requires_a_pointer(): void
     {
         $facets = app(SourceStatusFacetService::class);
-        $this->expectException(\Illuminate\Validation\ValidationException::class);
+        $this->expectException(ValidationException::class);
         $facets->recordContract(
             $this->sourceId,
             'active',

--- a/tests/Feature/Integrations/SyntheticHealthcareConnectorTest.php
+++ b/tests/Feature/Integrations/SyntheticHealthcareConnectorTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Feature\Integrations;
 
+use App\Integrations\Healthcare\DTO\PollRequest;
 use App\Integrations\Healthcare\DTO\ReplayRequest;
 use App\Integrations\Healthcare\DTO\WebhookEnvelope;
+use App\Integrations\Healthcare\Services\EnterpriseConnectorControlService;
 use App\Integrations\Healthcare\Services\SourceRegistryService;
 use App\Integrations\Healthcare\Synthetic\SyntheticHealthcareConnector;
 use App\Models\Org\Facility;
@@ -231,7 +233,7 @@ class SyntheticHealthcareConnectorTest extends TestCase
     {
         $user = User::factory()->create(['role' => 'superuser', 'must_change_password' => false]);
         app(SyntheticHealthcareConnector::class)->healthCheck();
-        app(SyntheticHealthcareConnector::class)->poll(new \App\Integrations\Healthcare\DTO\PollRequest(messages: []));
+        app(SyntheticHealthcareConnector::class)->poll(new PollRequest(messages: []));
 
         $this->actingAs($user)->getJson('/api/admin/integrations/health')
             ->assertOk()
@@ -344,7 +346,7 @@ class SyntheticHealthcareConnectorTest extends TestCase
         $this->assertNotNull($draft->payload_object_id);
         $this->assertSame(
             'RECOGNIZABLE-WRITEBACK-PATIENT-4411',
-            app(\App\Integrations\Healthcare\Services\EnterpriseConnectorControlService::class)
+            app(EnterpriseConnectorControlService::class)
                 ->writebackPayload((int) $draft->writeback_draft_id, (int) $source->source_id)['description'],
         );
         $this->assertStringNotContainsString(

--- a/tests/Feature/Mobile/FlowFixtureRegenerationTest.php
+++ b/tests/Feature/Mobile/FlowFixtureRegenerationTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Feature\Mobile;
 
 use App\Models\User;
+use App\Services\Flow\FloorPlateAssetService;
+use App\Support\Hospital\HospitalManifest;
 use Database\Seeders\RtdcSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
 use Laravel\Sanctum\Sanctum;
 use Tests\Support\SeedsFlowStory;
 use Tests\TestCase;
@@ -43,8 +46,8 @@ class FlowFixtureRegenerationTest extends TestCase
             '--source-name' => 'flow-fixture-catalog',
             '--map-operational' => true,
         ])->assertSuccessful();
-        \Illuminate\Support\Facades\Storage::disk('local')
-            ->delete(\App\Services\Flow\FloorPlateAssetService::ASSET_PATH);
+        Storage::disk('local')
+            ->delete(FloorPlateAssetService::ASSET_PATH);
 
         $user = User::factory()->create(['role' => 'bed_manager', 'must_change_password' => false, 'is_active' => true]);
         Sanctum::actingAs($user, ['mobile:read']);
@@ -60,7 +63,7 @@ class FlowFixtureRegenerationTest extends TestCase
         // that exercises bed_statuses (+ task-depth redaction) in a fixture.
         $evsUser = User::factory()->create(['role' => 'evs', 'must_change_password' => false, 'is_active' => true]);
         Sanctum::actingAs($evsUser, ['mobile:read']);
-        $micuFloor = (int) app(\App\Support\Hospital\HospitalManifest::class)->unit('MICU')['floor'];
+        $micuFloor = (int) app(HospitalManifest::class)->unit('MICU')['floor'];
         $evsWindow = $this->getJson('/api/mobile/v1/flow/window?persona=evs&scope=floor:'.$micuFloor)
             ->assertOk()
             ->json();

--- a/tests/Feature/Mobile/FlowWindowTest.php
+++ b/tests/Feature/Mobile/FlowWindowTest.php
@@ -4,7 +4,9 @@ namespace Tests\Feature\Mobile;
 
 use App\Models\Unit;
 use App\Models\User;
+use App\Services\Mobile\MobilePatientContextService;
 use App\Services\Mobile\MobilePersonaCatalog;
+use App\Support\Hospital\HospitalManifest;
 use Database\Seeders\RtdcSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -151,12 +153,12 @@ class FlowWindowTest extends TestCase
             ->getContent();
 
         // The trip patient is task-linked → its ptok may appear …
-        $tripPtok = app(\App\Services\Mobile\MobilePatientContextService::class)
+        $tripPtok = app(MobilePatientContextService::class)
             ->contextRefFor('FLOWTEST-PAT-TRIP');
         $this->assertStringContainsString($tripPtok, $body);
 
         // … but the EDD patient (no transport request) must not.
-        $eddPtok = app(\App\Services\Mobile\MobilePatientContextService::class)
+        $eddPtok = app(MobilePatientContextService::class)
             ->contextRefFor('FLOWTEST-PAT-EDD');
         $this->assertStringNotContainsString($eddPtok, $body);
     }
@@ -164,7 +166,7 @@ class FlowWindowTest extends TestCase
     public function test_unit_depth_requires_a_shared_unit_assignment(): void
     {
         $micu = Unit::where('abbreviation', 'MICU')->firstOrFail();
-        $eddPtok = app(\App\Services\Mobile\MobilePatientContextService::class)
+        $eddPtok = app(MobilePatientContextService::class)
             ->contextRefFor('FLOWTEST-PAT-EDD');
 
         // A charge nurse NOT assigned to MICU: unit scope works, identity is stripped.
@@ -210,7 +212,7 @@ class FlowWindowTest extends TestCase
     public function test_bed_statuses_are_served_only_to_bed_status_lenses_at_floor_or_unit_scope(): void
     {
         $micu = Unit::where('abbreviation', 'MICU')->firstOrFail();
-        $floor = (int) app(\App\Support\Hospital\HospitalManifest::class)->unit('MICU')['floor'];
+        $floor = (int) app(HospitalManifest::class)->unit('MICU')['floor'];
 
         // EVS (event_kinds includes bed_status) at floor scope → the turn map.
         $this->actingAsRole('evs');
@@ -328,7 +330,7 @@ class FlowWindowTest extends TestCase
 
     public function test_bed_statuses_survive_a_qualifying_evs_floor_scope_delta(): void
     {
-        $floor = (int) app(\App\Support\Hospital\HospitalManifest::class)->unit('MICU')['floor'];
+        $floor = (int) app(HospitalManifest::class)->unit('MICU')['floor'];
         $this->actingAsRole('evs');
 
         $now = $this->getJson('/api/mobile/v1/flow/window?persona=evs&scope=floor:'.$floor)

--- a/tests/Feature/Mobile/MobileSessionManagementTest.php
+++ b/tests/Feature/Mobile/MobileSessionManagementTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Mobile;
 
 use App\Models\Auth\MobileTokenSession;
 use App\Models\User;
+use App\Services\Audit\UserAuditRecorder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -371,7 +372,7 @@ class MobileSessionManagementTest extends TestCase
             ->where('session_uuid', $target['session_uuid'])
             ->firstOrFail();
 
-        $this->mock(\App\Services\Audit\UserAuditRecorder::class, function (MockInterface $mock): void {
+        $this->mock(UserAuditRecorder::class, function (MockInterface $mock): void {
             $mock->shouldReceive('record')
                 ->once()
                 ->withArgs(static fn (
@@ -406,7 +407,7 @@ class MobileSessionManagementTest extends TestCase
         $user = $this->activeUser();
         $issued = $this->issue($user, 'ios', 'Sensitive Device Label');
 
-        $this->mock(\App\Services\Audit\UserAuditRecorder::class, function (MockInterface $mock): void {
+        $this->mock(UserAuditRecorder::class, function (MockInterface $mock): void {
             $mock->shouldReceive('record')
                 ->once()
                 ->withArgs(static fn (

--- a/tests/Feature/Patient/PatientAuthoredGoalApiTest.php
+++ b/tests/Feature/Patient/PatientAuthoredGoalApiTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Patient;
 use App\Contracts\Patient\PatientMessageHandoffReadiness;
 use App\Models\Encounter;
 use App\Models\Patient\PatientAuthoredGoal;
+use App\Models\Patient\PatientEncounterAccessGrant;
 use App\Models\Patient\PatientMessage;
 use App\Models\Patient\PatientPrincipal;
 use App\Models\Patient\PatientSession;
@@ -122,7 +123,7 @@ class PatientAuthoredGoalApiTest extends TestCase
         $this->assertDatabaseCount('patient_experience.messages', 1);
     }
 
-    /** @return array{principal: PatientPrincipal, grant: \App\Models\Patient\PatientEncounterAccessGrant, token: string} */
+    /** @return array{principal: PatientPrincipal, grant: PatientEncounterAccessGrant, token: string} */
     private function fixture(string $seed, bool $enabled): array
     {
         $fixture = $this->app->make(SyntheticPatientProjectionProvisioner::class)->provision($seed);
@@ -213,7 +214,7 @@ class PatientGoalHandoffReadiness implements PatientMessageHandoffReadiness
         string $policyVersion,
         string $topicCode,
         string $responsibilityPoolKey,
-        \App\Models\Patient\PatientEncounterAccessGrant $grant,
+        PatientEncounterAccessGrant $grant,
     ): bool {
         return $policyVersion === 'test-patient-goal-policy-v1'
             && in_array($topicCode, ['patient_goal', 'care_plan_question'], true)

--- a/tests/Feature/Patient/PatientCarePreferenceApiTest.php
+++ b/tests/Feature/Patient/PatientCarePreferenceApiTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Patient;
 use App\Contracts\Patient\PatientMessageHandoffReadiness;
 use App\Models\Encounter;
 use App\Models\Patient\PatientCarePreference;
+use App\Models\Patient\PatientEncounterAccessGrant;
 use App\Models\Patient\PatientMessage;
 use App\Models\Patient\PatientPrincipal;
 use App\Models\Patient\PatientSession;
@@ -122,7 +123,7 @@ class PatientCarePreferenceApiTest extends TestCase
         $this->assertDatabaseCount('patient_experience.messages', 1);
     }
 
-    /** @return array{principal: PatientPrincipal, grant: \App\Models\Patient\PatientEncounterAccessGrant, token: string} */
+    /** @return array{principal: PatientPrincipal, grant: PatientEncounterAccessGrant, token: string} */
     private function fixture(string $seed, bool $enabled): array
     {
         $fixture = $this->app->make(SyntheticPatientProjectionProvisioner::class)->provision($seed);
@@ -212,7 +213,7 @@ class CarePreferenceHandoffReadiness implements PatientMessageHandoffReadiness
         string $policyVersion,
         string $topicCode,
         string $responsibilityPoolKey,
-        \App\Models\Patient\PatientEncounterAccessGrant $grant,
+        PatientEncounterAccessGrant $grant,
     ): bool {
         return $policyVersion === 'test-care-preference-policy-v1'
             && in_array($topicCode, ['care_preference', 'care_plan_question'], true)

--- a/tests/Feature/Patient/PatientEducationClarificationApiTest.php
+++ b/tests/Feature/Patient/PatientEducationClarificationApiTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature\Patient;
 use App\Contracts\Patient\PatientMessageHandoffReadiness;
 use App\Models\Encounter;
 use App\Models\Patient\PatientEducationClarificationRequest;
+use App\Models\Patient\PatientEncounterAccessGrant;
+use App\Models\Patient\PatientEncounterProjection;
 use App\Models\Patient\PatientMessage;
 use App\Models\Patient\PatientPrincipal;
 use App\Models\Patient\PatientSession;
@@ -135,7 +137,7 @@ class PatientEducationClarificationApiTest extends TestCase
         $this->assertDatabaseCount('patient_experience.messages', 0);
     }
 
-    /** @return array{principal: PatientPrincipal, grant: \App\Models\Patient\PatientEncounterAccessGrant, pathway: \App\Models\Patient\PatientEncounterProjection, token: string} */
+    /** @return array{principal: PatientPrincipal, grant: PatientEncounterAccessGrant, pathway: PatientEncounterProjection, token: string} */
     private function fixture(string $seed): array
     {
         $fixture = $this->app->make(SyntheticPatientProjectionProvisioner::class)->provision($seed);
@@ -225,7 +227,7 @@ class EducationClarificationHandoffReadiness implements PatientMessageHandoffRea
         string $policyVersion,
         string $topicCode,
         string $responsibilityPoolKey,
-        \App\Models\Patient\PatientEncounterAccessGrant $grant,
+        PatientEncounterAccessGrant $grant,
     ): bool {
         return $policyVersion === 'test-messaging-policy-v1'
             && $topicCode === 'education_clarification'

--- a/tests/Feature/Rounds/RoundProjectionTest.php
+++ b/tests/Feature/Rounds/RoundProjectionTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Feature\Rounds;
 
+use App\Models\Rounds\RoundParticipant;
+use App\Models\Rounds\RoundRun;
 use App\Models\User;
+use App\Services\Rounds\RoundProjectionService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Tests\Support\SeedsRoundsStory;
 use Tests\TestCase;
 
@@ -71,8 +75,8 @@ class RoundProjectionTest extends TestCase
         // F-2 ruling (2026-07-19): under patient_dots = none, bed + queue +
         // status is re-identifiable at ward level on a shared wall — the
         // projection anchors at unit centroids (bed/facility_space stripped).
-        $run = \App\Models\Rounds\RoundRun::query()->where('run_uuid', $this->runUuid)->firstOrFail();
-        $scene = app(\App\Services\Rounds\RoundProjectionService::class)
+        $run = RoundRun::query()->where('run_uuid', $this->runUuid)->firstOrFail();
+        $scene = app(RoundProjectionService::class)
             ->scene($run, $this->chargeNurse, aggregate: true);
 
         $this->assertCount(3, $scene['data']['stops']);
@@ -85,7 +89,7 @@ class RoundProjectionTest extends TestCase
         }
 
         // The full-detail path is unchanged (contract test above still pins bed).
-        $full = app(\App\Services\Rounds\RoundProjectionService::class)
+        $full = app(RoundProjectionService::class)
             ->scene($run, $this->chargeNurse);
         $this->assertNotNull(collect($full['data']['stops'])->firstWhere('bed'));
     }
@@ -105,9 +109,9 @@ class RoundProjectionTest extends TestCase
         // Invite an off-unit consultant as a run participant: they can view,
         // but the aggregate lens must redact identifiers and clinical text.
         $consultant = User::factory()->create(['role' => 'user']);
-        $run = \App\Models\Rounds\RoundRun::query()->where('run_uuid', $this->runUuid)->firstOrFail();
-        \App\Models\Rounds\RoundParticipant::create([
-            'participant_uuid' => (string) \Illuminate\Support\Str::uuid(),
+        $run = RoundRun::query()->where('run_uuid', $this->runUuid)->firstOrFail();
+        RoundParticipant::create([
+            'participant_uuid' => (string) Str::uuid(),
             'run_id' => $run->run_id,
             'user_id' => $consultant->id,
             'role_code' => 'consultant',

--- a/tests/Feature/Rounds/RoundRunLifecycleTest.php
+++ b/tests/Feature/Rounds/RoundRunLifecycleTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Feature\Rounds;
 
+use App\Models\Encounter;
+use App\Models\Rounds\RoundPatient;
+use App\Models\Rounds\RoundRun;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Support\SeedsRoundsStory;
 use Tests\TestCase;
@@ -133,7 +136,7 @@ class RoundRunLifecycleTest extends TestCase
             ->assertCreated()->json('data.run.run_uuid');
 
         $this->assertSame($first, $second);
-        $this->assertSame(1, \App\Models\Rounds\RoundRun::query()->count());
+        $this->assertSame(1, RoundRun::query()->count());
     }
 
     public function test_reconcile_suggests_new_admission_without_rewriting_cohort(): void
@@ -141,7 +144,7 @@ class RoundRunLifecycleTest extends TestCase
         $board = $this->createRoundsRun();
         $runUuid = $board['data']['run']['run_uuid'];
 
-        $newEncounter = \App\Models\Encounter::create([
+        $newEncounter = Encounter::create([
             'patient_ref' => 'ROUNDS-PAT-NEW',
             'unit_id' => $this->roundsUnit->unit_id,
             'admitted_at' => now(),
@@ -156,7 +159,7 @@ class RoundRunLifecycleTest extends TestCase
 
         $this->assertCount(1, $suggestions['add']);
         $this->assertSame($newEncounter->encounter_id, $suggestions['add'][0]['prod_encounter_id']);
-        $this->assertSame(3, \App\Models\Rounds\RoundPatient::query()->count());
+        $this->assertSame(3, RoundPatient::query()->count());
 
         // Applying the suggestion enrolls the patient and bumps the queue version.
         $updated = $this->actingAs($this->chargeNurse)

--- a/tests/Feature/Rounds/RoundsSchemaTest.php
+++ b/tests/Feature/Rounds/RoundsSchemaTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\Rounds;
 
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
@@ -31,9 +33,9 @@ class RoundsSchemaTest extends TestCase
 
     public function test_contribution_partial_unique_blocks_duplicate_submitted_rows(): void
     {
-        $this->expectException(\Illuminate\Database\QueryException::class);
+        $this->expectException(QueryException::class);
 
-        \Illuminate\Support\Facades\DB::statement(<<<'SQL'
+        DB::statement(<<<'SQL'
             INSERT INTO rounds.templates (template_uuid, name) VALUES (gen_random_uuid(), 't');
             INSERT INTO rounds.runs (run_uuid, template_id, scope_type, scope_key)
                 VALUES (gen_random_uuid(), (SELECT template_id FROM rounds.templates LIMIT 1), 'unit', '1');

--- a/tests/Feature/Rounds/RoundsSeedDemoCommandTest.php
+++ b/tests/Feature/Rounds/RoundsSeedDemoCommandTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Rounds;
 
 use App\Models\Rounds\RoundRun;
+use App\Services\Rounds\RoundCommandService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Tests\Support\SeedsRoundsStory;
@@ -58,7 +59,7 @@ class RoundsSeedDemoCommandTest extends TestCase
 
     public function test_refresh_retires_every_open_run_so_a_daily_pass_never_leaks_stragglers(): void
     {
-        $commands = app(\App\Services\Rounds\RoundCommandService::class);
+        $commands = app(RoundCommandService::class);
         $make = fn () => $commands->createRun($this->admin, [
             'template_uuid' => $this->roundsTemplate->template_uuid,
             'scope_type' => 'unit',

--- a/tests/Feature/Rtdc/ApiSessionMiddlewareTest.php
+++ b/tests/Feature/Rtdc/ApiSessionMiddlewareTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Rtdc;
 
+use Illuminate\Session\Middleware\StartSession;
 use Tests\TestCase;
 
 class ApiSessionMiddlewareTest extends TestCase
@@ -22,6 +23,6 @@ class ApiSessionMiddlewareTest extends TestCase
             $route->excludedMiddleware(),
         );
 
-        $this->assertContains(\Illuminate\Session\Middleware\StartSession::class, $resolved);
+        $this->assertContains(StartSession::class, $resolved);
     }
 }

--- a/tests/Feature/Rtdc/HeuristicOptimizerTest.php
+++ b/tests/Feature/Rtdc/HeuristicOptimizerTest.php
@@ -7,6 +7,7 @@ use App\Models\BedRequest;
 use App\Models\Encounter;
 use App\Models\Unit;
 use App\Rtdc\Optimizer\HeuristicBedAssignmentOptimizer;
+use App\Services\AcuityService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -85,7 +86,7 @@ class HeuristicOptimizerTest extends TestCase
                 Encounter::create(['patient_ref' => "occ-{$u->unit_id}-$i", 'unit_id' => $u->unit_id, 'acuity_tier' => mt_rand(1, 4), 'status' => 'active']);
             }
         }
-        $acuity = app(\App\Services\AcuityService::class);
+        $acuity = app(AcuityService::class);
 
         foreach (['any', 'med_surg', 'icu', 'step_down'] as $type) {
             foreach (['none', 'contact'] as $iso) {

--- a/tests/Feature/Rtdc/ReconciliationJobTest.php
+++ b/tests/Feature/Rtdc/ReconciliationJobTest.php
@@ -4,8 +4,10 @@ namespace Tests\Feature\Rtdc;
 
 use App\Jobs\ReconcileRtdcPredictions;
 use App\Models\RtdcPrediction;
+use App\Models\RtdcReconciliation;
 use App\Models\Unit;
 use App\Models\User;
+use App\Services\ReconciliationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -21,7 +23,7 @@ class ReconciliationJobTest extends TestCase
         RtdcPrediction::create(['unit_id' => $a->unit_id, 'service_date' => $yesterday, 'horizon' => 'by_midnight', 'discharges_weighted' => 2]);
         RtdcPrediction::create(['unit_id' => $b->unit_id, 'service_date' => $yesterday, 'horizon' => 'by_midnight', 'discharges_weighted' => 1]);
 
-        (new ReconcileRtdcPredictions)->handle(app(\App\Services\ReconciliationService::class));
+        (new ReconcileRtdcPredictions)->handle(app(ReconciliationService::class));
 
         $this->assertDatabaseCount('prod.rtdc_reconciliations', 2);
     }
@@ -30,7 +32,7 @@ class ReconciliationJobTest extends TestCase
     {
         $user = User::factory()->create();
         $unit = Unit::create(['name' => 'A', 'type' => 'med_surg', 'staffed_bed_count' => 10, 'ratio_floor' => 5]);
-        \App\Models\RtdcReconciliation::create([
+        RtdcReconciliation::create([
             'unit_id' => $unit->unit_id, 'service_date' => today()->subDay(),
             'predicted_discharges' => 4, 'actual_discharges' => 5, 'reliability_score' => 0.8,
         ]);

--- a/tests/Feature/Rtdc/SimulatorTest.php
+++ b/tests/Feature/Rtdc/SimulatorTest.php
@@ -2,11 +2,15 @@
 
 namespace Tests\Feature\Rtdc;
 
+use App\Models\Bed;
+use App\Models\CensusSnapshot;
 use App\Models\Encounter;
+use App\Models\OperationalEvent;
 use App\Models\Unit;
 use App\Rtdc\EventDispatcher;
 use App\Rtdc\Simulator\SimulatorConfig;
 use App\Rtdc\Simulator\SyntheticEventSource;
+use Database\Seeders\RtdcSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -16,9 +20,9 @@ class SimulatorTest extends TestCase
 
     public function test_seeded_default_unit_mix_creates_units_and_beds(): void
     {
-        $this->seed(\Database\Seeders\RtdcSeeder::class);
+        $this->seed(RtdcSeeder::class);
         $this->assertEquals(25, Unit::count()); // full Summit Regional roster: 23 inpatient + ED + perioperative
-        $this->assertGreaterThan(0, \App\Models\Bed::count());
+        $this->assertGreaterThan(0, Bed::count());
     }
 
     public function test_simulator_with_fixed_seed_is_deterministic(): void
@@ -56,11 +60,11 @@ class SimulatorTest extends TestCase
         // availability. Avoids accumulating migrate:fresh DDL locks inside RefreshDatabase's
         // transaction — which overflowed max_locks_per_transaction at the 25-unit/692-bed
         // scale — and the schema re-bootstrap fragility of repeated migrate:fresh on the test DB.
-        $this->seed(\Database\Seeders\RtdcSeeder::class);
-        \App\Models\OperationalEvent::query()->delete();
-        \App\Models\CensusSnapshot::query()->delete();
+        $this->seed(RtdcSeeder::class);
+        OperationalEvent::query()->delete();
+        CensusSnapshot::query()->delete();
         Encounter::query()->delete();
-        \App\Models\Bed::query()->update(['status' => 'available']);
+        Bed::query()->update(['status' => 'available']);
 
         $dispatcher = app(EventDispatcher::class);
         // Small config: determinism is scale-independent, so we avoid seeding 70% of all
@@ -73,7 +77,7 @@ class SimulatorTest extends TestCase
             $dispatcher->dispatch($event);
         }
 
-        $rows = \App\Models\OperationalEvent::orderBy('operational_event_id')->get(['type', 'payload']);
+        $rows = OperationalEvent::orderBy('operational_event_id')->get(['type', 'payload']);
 
         $this->lastFingerprint = $rows
             ->map(fn ($r) => $r->type.'|'.($r->payload['bed_id'] ?? ''))

--- a/tests/Feature/Transport/TransportRequestApiTest.php
+++ b/tests/Feature/Transport/TransportRequestApiTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Transport;
 
 use App\Models\Transport\TransportRequest;
 use App\Models\User;
+use App\Services\Transport\TransportOperationsService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -81,7 +82,7 @@ class TransportRequestApiTest extends TestCase
         $user = $this->dispatcher();
 
         TransportRequest::create([
-            'request_uuid' => (string) \Illuminate\Support\Str::uuid(),
+            'request_uuid' => (string) Str::uuid(),
             'request_type' => 'transfer',
             'priority' => 'stat',
             'status' => 'requested',
@@ -240,7 +241,7 @@ class TransportRequestApiTest extends TestCase
             'is_deleted' => false,
         ]);
 
-        $measure = collect(app(\App\Services\Transport\TransportOperationsService::class)->measures())
+        $measure = collect(app(TransportOperationsService::class)->measures())
             ->firstWhere('key', 'vendor_acceptance_cancellation');
 
         $this->assertNotNull($internal);
@@ -285,7 +286,7 @@ class TransportRequestApiTest extends TestCase
             ]);
         }
 
-        $measures = collect(app(\App\Services\Transport\TransportOperationsService::class)->measures())
+        $measures = collect(app(TransportOperationsService::class)->measures())
             ->keyBy('key');
 
         $this->assertSame(5.0, (float) $measures['request_to_assign_min']['value']);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -11,8 +14,8 @@
 |
 */
 
-uses(Tests\TestCase::class, Illuminate\Foundation\Testing\RefreshDatabase::class)->in('Feature');
-uses(Tests\TestCase::class)->in('Unit');
+uses(TestCase::class, RefreshDatabase::class)->in('Feature');
+uses(TestCase::class)->in('Unit');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Unit/CarePathways/CarePathwayModelContractTest.php
+++ b/tests/Unit/CarePathways/CarePathwayModelContractTest.php
@@ -19,13 +19,14 @@ use App\Models\CarePathways\SectionSource;
 use App\Models\CarePathways\ServiceLineMapping;
 use App\Models\CarePathways\SourceChange;
 use App\Models\CarePathways\SourceEnrichment;
+use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class CarePathwayModelContractTest extends TestCase
 {
     /**
-     * @param  class-string<\Illuminate\Database\Eloquent\Model>  $modelClass
+     * @param  class-string<Model>  $modelClass
      */
     #[DataProvider('modelTables')]
     public function test_model_uses_the_canonical_schema_and_primary_key(
@@ -39,7 +40,7 @@ class CarePathwayModelContractTest extends TestCase
         $this->assertSame($primaryKey, $model->getKeyName());
     }
 
-    /** @return array<string, array{class-string<\Illuminate\Database\Eloquent\Model>, string, string}> */
+    /** @return array<string, array{class-string<Model>, string, string}> */
     public static function modelTables(): array
     {
         return [


### PR DESCRIPTION
## Summary
- The dedicated Pint bump+reformat PR the Tier-1 plan called for (never folded into another change): 1.20.0 → 1.29.3, 148 files restyled by the version gap's rule-default changes (`fully_qualified_strict_types`, `ordered_imports`, brace/spacing details).
- The backend-quality Pint gate gains `--parallel`: whole-repo `--test` in ~0.5 s wall vs ~40 s serial.

## Safety
- Branched from the current main tip (`2dc37a7e`) — no stale-base sweep risk; all in-flight program PRs are merged.
- Style-only fixers; unit suite verified locally post-restyle (270 tests / 9,035 assertions), full suite runs here.
- `composer audit` clean on the bump.

## Test plan
- [ ] Full PR suite green; backend-quality's Pint step drops to sub-second

🤖 Generated with [Claude Code](https://claude.com/claude-code)