### PR TITLE
feat(flow4d): Patient Journey Drawer, trace mode, deep links, scented chronobar (plan Phase B)

### DIFF
--- a/docs/audits/FLOW-4D-USABILITY-PROTOCOL.md
+++ b/docs/audits/FLOW-4D-USABILITY-PROTOCOL.md
@@ -63,6 +63,20 @@ Start on the Rounds board: "Take this patient's stop into the 3D view, walk to t
 "Get me floor N, framed. Where are you now?" (camera readout should be usable as the answer).
 **Pass: floor rail or dropdown in ≤2 actions; participant can state floor/unit from the readout.**
 
+### T8 — Patient journey (Phase B claim; v1.1 addition, clinical personas only)
+"Find patient X and tell me their story: where have they been in the last 12 hours,
+and what are they waiting on right now?" Expected path: Find → select → journey
+drawer (segments + dwell) → Next block; scene trace + dwell markers as corroboration.
+**Pass: states the prior location(s), the current wait with an approximate duration,
+and the next step — unaided; keyboard-only variant for ≥1 participant (select from
+match list → drawer is plain HTML → F frames the trace).**
+
+### T9 — Journey deep link (Phase B claim; v1.1 addition)
+Hand the participant a `?patient=` link (as if sent by a colleague): "open this and
+tell me what your colleague wanted you to see."
+**Pass: lands selected + journey open + framed without any navigation help.**
+*(A per-patient adherence SAGAT probe joins as T10 when the Phase C surface ships.)*
+
 ## 4. Situation-awareness probes (SAGAT-lite)
 
 Three display freezes (moderator blanks the screen), placed after T2, T5, and T6:

--- a/resources/js/Components/PatientFlowNavigator/NavigatorChronobar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorChronobar.tsx
@@ -16,10 +16,19 @@ interface NavigatorChronobarProps {
   forecast: ForecastAggregates | null;
   /** When each open barrier began, for past-half ticks. */
   barrierTicks?: number[];
+  /** Scented-widget density (plan B5, TN-1): normalized 0..1 per bucket —
+   * information scent along the track so scrubbing is never blind. */
+  densityBuckets?: number[];
+  /** The selected patient's event instants (plan B3/B5): jump ticks in the
+   * selection style; empty when no journey is open. */
+  patientTicks?: number[];
   /** True while the stored-replay stream is connected (N-8: never "live"). */
   replaying?: boolean;
   onScrub: (timeMs: number) => void;
 }
+
+/** ±step affordance (SC 2.5.7 single-pointer alternative to drag-scrub). */
+const STEP_MS = 15 * 60 * 1_000;
 
 const SLIDER_STEPS = 10000;
 
@@ -73,6 +82,8 @@ export default function NavigatorChronobar({
   freshness,
   forecast,
   barrierTicks = [],
+  densityBuckets = [],
+  patientTicks = [],
   replaying = false,
   onScrub,
 }: NavigatorChronobarProps) {
@@ -102,16 +113,47 @@ export default function NavigatorChronobar({
               : `${replaying ? 'Replay stream · ' : ''}${inFuture ? 'Projected · ' : ''}${relativeLabel(currentTime, nowMs)}`}
           </span>
         </output>
-        <button
-          type="button"
-          className="patient-flow-chronobar-now-button"
-          disabled={historical}
-          title={historical ? 'Unavailable in historical replay' : 'Jump to now'}
-          onClick={() => onScrub(nowMs)}
-        >
-          Now
-        </button>
+        <div className="patient-flow-chronobar-buttons">
+          <button
+            type="button"
+            className="patient-flow-chronobar-step"
+            aria-label="Step back 15 minutes"
+            title="Step back 15 minutes"
+            onClick={() => onScrub(Math.max(windowStart, currentTime - STEP_MS))}
+          >
+            −15m
+          </button>
+          <button
+            type="button"
+            className="patient-flow-chronobar-step"
+            aria-label="Step forward 15 minutes"
+            title="Step forward 15 minutes"
+            onClick={() => onScrub(Math.min(windowEnd, currentTime + STEP_MS))}
+          >
+            +15m
+          </button>
+          <button
+            type="button"
+            className="patient-flow-chronobar-now-button"
+            disabled={historical}
+            title={historical ? 'Unavailable in historical replay' : 'Jump to now'}
+            onClick={() => onScrub(nowMs)}
+          >
+            Now
+          </button>
+        </div>
       </div>
+
+      {densityBuckets.length > 0 && (
+        <div aria-hidden="true" className="patient-flow-chronobar-density">
+          {densityBuckets.map((intensity, index) => (
+            <span
+              key={index}
+              style={{ opacity: 0.15 + 0.85 * Math.min(1, Math.max(0, intensity)) }}
+            />
+          ))}
+        </div>
+      )}
 
       {/* Detents and barrier ticks are jump buttons (N-2); the wash layers
           underneath stay decorative. */}
@@ -156,6 +198,19 @@ export default function NavigatorChronobar({
             onClick={() => onScrub(tick)}
           />
         ))}
+        {patientTicks
+          .filter((tick) => tick >= windowStart && tick <= windowEnd)
+          .map((tick, index) => (
+            <button
+              key={`patient-${index}-${tick}`}
+              type="button"
+              className="patient-flow-chronobar-patient-tick"
+              style={{ left: `${pct(tick)}%` }}
+              title={`Jump to patient event ${fmtTime(tick)}`}
+              aria-label={`Jump to patient event ${fmtTime(tick)}`}
+              onClick={() => onScrub(tick)}
+            />
+          ))}
         {!historical && nowMs >= windowStart && nowMs <= windowEnd && (
           <span aria-hidden="true" className="patient-flow-chronobar-now" style={{ left: `${pct(nowMs)}%` }} title="Now" />
         )}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorJourneyDrawer.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorJourneyDrawer.tsx
@@ -1,0 +1,275 @@
+import React from 'react';
+
+import {
+  alignAnchorMs,
+  alignedTimeLabel,
+  dwellLabel,
+} from '@/features/patientFlowNavigator/journey';
+import type { JourneyAlignAnchor } from '@/features/patientFlowNavigator/journey';
+import type { PatientJourney } from '@/features/patientFlowNavigator/journeySchemas';
+
+/**
+ * The Patient Journey Drawer (FLOW-4D plan §7.1, finding PJ-1) — the plain-
+ * HTML, AT-primary patient surface. Replaces the key/value inspector for
+ * PATIENT selections only; every label comes from the lens-redacted journey
+ * payload (the raw ref never reaches this component by construction).
+ * Interval-first: dwell segments and phases are the story, events the detail.
+ */
+
+export type JourneyDrawerState = 'idle' | 'loading' | 'ok' | 'forbidden' | 'error';
+
+interface NavigatorJourneyDrawerProps {
+  journey: PatientJourney | null;
+  state: JourneyDrawerState;
+  errorMessage?: string | null;
+  align: JourneyAlignAnchor;
+  onAlignChange: (anchor: JourneyAlignAnchor) => void;
+  onClose: () => void;
+  /** Frames the patient's trace in-scene (the explicit `F` path — G-6). */
+  onFocus: () => void;
+  followEnabled: boolean;
+  onFollowToggle: (enabled: boolean) => void;
+  onCopyLink: () => void;
+  copiedLink: boolean;
+}
+
+const ALIGN_OPTIONS: Array<{ key: JourneyAlignAnchor; label: string }> = [
+  { key: 'clock', label: 'Clock' },
+  { key: 'arrival', label: 'From arrival' },
+  { key: 'admit', label: 'From admit' },
+];
+
+function phaseLabel(phase: string): string {
+  return phase.replaceAll('_', ' ');
+}
+
+export default function NavigatorJourneyDrawer({
+  journey,
+  state,
+  errorMessage = null,
+  align,
+  onAlignChange,
+  onClose,
+  onFocus,
+  followEnabled,
+  onFollowToggle,
+  onCopyLink,
+  copiedLink,
+}: NavigatorJourneyDrawerProps) {
+  if (state === 'idle') return null;
+
+  const anchorMs = journey ? alignAnchorMs(journey, align) : null;
+  const at = (iso: string | null | undefined): string => alignedTimeLabel(iso, anchorMs);
+
+  return (
+    <aside className="patient-flow-journey" aria-label="Patient journey" aria-live="polite">
+      <header className="patient-flow-journey-head">
+        <div>
+          <strong>{journey?.patient.display_label ?? 'Patient journey'}</strong>
+          {journey?.header.current_location_name || journey?.header.current_location ? (
+            <span className="patient-flow-journey-loc">
+              {journey.header.current_location_name ?? journey.header.current_location}
+              {journey.header.current_unit_code ? ` · ${journey.header.current_unit_code}` : ''}
+            </span>
+          ) : null}
+          {typeof journey?.header.los_minutes === 'number' && (
+            <span className="patient-flow-journey-los">LOS {dwellLabel(journey.header.los_minutes)}</span>
+          )}
+        </div>
+        <button type="button" className="patient-flow-journey-close" aria-label="Close patient journey" onClick={onClose}>
+          ×
+        </button>
+      </header>
+
+      {state === 'loading' && <p className="patient-flow-journey-note">Loading journey…</p>}
+      {state === 'forbidden' && (
+        <p className="patient-flow-journey-note">
+          This persona has no patient-journey access. The inspector below still carries the scene detail.
+        </p>
+      )}
+      {state === 'error' && (
+        <p className="patient-flow-journey-note">{errorMessage ?? 'Journey unavailable'}</p>
+      )}
+
+      {state === 'ok' && journey && (
+        <>
+          <div className="patient-flow-journey-controls">
+            <div className="patient-flow-journey-align" role="radiogroup" aria-label="Align times">
+              {ALIGN_OPTIONS.map((option) => (
+                <button
+                  key={option.key}
+                  type="button"
+                  role="radio"
+                  aria-checked={align === option.key}
+                  className={align === option.key ? 'active' : ''}
+                  onClick={() => onAlignChange(option.key)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            <div className="patient-flow-journey-actions">
+              <button type="button" onClick={onFocus} title="Frame this patient's trace in the scene">
+                Focus trace
+              </button>
+              <button
+                type="button"
+                aria-pressed={followEnabled}
+                className={followEnabled ? 'active' : ''}
+                onClick={() => onFollowToggle(!followEnabled)}
+                title="Camera follows this patient during replay"
+              >
+                Follow
+              </button>
+              <button type="button" onClick={onCopyLink}>
+                {copiedLink ? 'Link copied' : 'Copy link'}
+              </button>
+            </div>
+          </div>
+
+          {(journey.next.target_location || journey.next.expected_discharge_date) && (
+            <section className="patient-flow-journey-section">
+              <h3>Next</h3>
+              <ul>
+                {journey.next.target_location && (
+                  <li>
+                    <span>Target</span>
+                    <span>{journey.next.target_location}</span>
+                  </li>
+                )}
+                {journey.next.transport_needed_at && (
+                  <li>
+                    <span>Transport needed</span>
+                    <span className="patient-flow-journey-num">{at(journey.next.transport_needed_at)}</span>
+                  </li>
+                )}
+                {journey.next.expected_discharge_date && (
+                  <li>
+                    <span>Expected discharge</span>
+                    <span className="patient-flow-journey-num">{journey.next.expected_discharge_date}</span>
+                  </li>
+                )}
+              </ul>
+            </section>
+          )}
+
+          <section className="patient-flow-journey-section">
+            <h3>Stay segments</h3>
+            {journey.segments.length === 0 && <p className="patient-flow-journey-note">No movement in window</p>}
+            <ol className="patient-flow-journey-segments">
+              {journey.segments.map((segment, index) => (
+                <li key={`${segment.started_at}-${index}`} className={segment.open ? 'open' : ''}>
+                  <div className="patient-flow-journey-segment-head">
+                    <span>{segment.location_name ?? segment.location ?? 'Unknown'}</span>
+                    <span className="patient-flow-journey-num">{dwellLabel(segment.dwell_minutes)}{segment.open ? ' · ongoing' : ''}</span>
+                  </div>
+                  <div className="patient-flow-journey-segment-sub patient-flow-journey-num">
+                    {at(segment.started_at)}
+                    {' → '}
+                    {segment.ended_at ? at(segment.ended_at) : 'now'}
+                    {segment.unit_code ? ` · ${segment.unit_code}` : ''}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          {(journey.phases.ed.length > 0 || journey.phases.periop.length > 0) && (
+            <section className="patient-flow-journey-section">
+              <h3>Phases</h3>
+              <ul>
+                {journey.phases.ed.map((phase, index) => (
+                  <li key={`ed-${phase.phase}-${index}`}>
+                    <span>ED · {phaseLabel(phase.phase)}</span>
+                    <span className="patient-flow-journey-num">
+                      {phase.minutes !== null && phase.minutes !== undefined ? dwellLabel(phase.minutes) : 'ongoing'}
+                    </span>
+                  </li>
+                ))}
+                {journey.phases.periop.map((phase, index) => (
+                  <li key={`periop-${phase.phase}-${index}`}>
+                    <span>Periop · {phaseLabel(phase.phase)}</span>
+                    <span className="patient-flow-journey-num">
+                      {phase.minutes !== null && phase.minutes !== undefined ? dwellLabel(phase.minutes) : 'ongoing'}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {journey.milestones.length > 0 && (
+            <section className="patient-flow-journey-section">
+              <h3>Milestones</h3>
+              <ul>
+                {journey.milestones.map((milestone, index) => (
+                  <li key={`${milestone.milestone_type}-${index}`}>
+                    <span>
+                      {phaseLabel(milestone.milestone_type)}
+                      {milestone.required ? ' *' : ''}
+                    </span>
+                    <span className="patient-flow-journey-num">
+                      {milestone.status}
+                      {milestone.completed_at ? ` · ${at(milestone.completed_at)}` : ''}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {journey.logistics.length > 0 && (
+            <section className="patient-flow-journey-section">
+              <h3>Logistics</h3>
+              <ul>
+                {journey.logistics.map((row, index) => (
+                  <li key={`${row.domain}-${index}`}>
+                    <span>
+                      {row.domain === 'bed_request' ? 'Bed request' : row.domain === 'evs' ? 'EVS' : 'Transport'}
+                      {row.destination ? ` → ${row.destination}` : row.required_unit_type ? ` → ${row.required_unit_type}` : ''}
+                    </span>
+                    <span className="patient-flow-journey-num">{row.status}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {journey.home.length > 0 && (
+            <section className="patient-flow-journey-section">
+              <h3>Home hospital</h3>
+              <ul>
+                {journey.home.map((episode, index) => (
+                  <li key={`home-${index}`}>
+                    <span>{episode.condition_label ?? 'Episode'}</span>
+                    <span className="patient-flow-journey-num">{episode.status}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {journey.unit_context_barriers.length > 0 && (
+            <section className="patient-flow-journey-section">
+              <h3>Open barriers on stay units</h3>
+              <p className="patient-flow-journey-note">Unit-level context — not attributed to this patient.</p>
+              <ul>
+                {journey.unit_context_barriers.map((barrier) => (
+                  <li key={barrier.barrier_id}>
+                    <span>{barrier.category}</span>
+                    <span className="patient-flow-journey-num">{barrier.description ?? '—'}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          <footer className="patient-flow-journey-foot patient-flow-journey-num">
+            As of {new Date(journey.as_of).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+            {journey.epoch ? ` · epoch ${journey.epoch.epoch.slice(0, 8)}` : ''}
+          </footer>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -14,7 +14,9 @@ import {
   ROUND_PINNED_COLOR,
   ROUND_STOP_COLORS,
   TIMER_PIP_COLORS,
+  dwellNodeScale,
   patientHue,
+  traceGradientRgb,
 } from '@/features/patientFlowNavigator/sceneVocabulary';
 import type { RoundRouteSegment, RoundStopCell } from '@/features/virtualRounds/roundsScene';
 import type {
@@ -157,6 +159,15 @@ export class NavigatorScene {
   private delayedCueMaterial: THREE.SpriteMaterial | null = null;
 
   private focusedRoundStopUuid: string | null = null;
+
+  // B3 trace mode (plan §7.1, PJ-2): the selected patient's story in-scene.
+  private tracePatientId: string | null = null;
+
+  private followPatientId: string | null = null;
+
+  private readonly followDelta = new THREE.Vector3();
+
+  private traceLineMaterial: THREE.LineBasicMaterial | null = null;
 
   private heatSingleMaterial: THREE.MeshStandardMaterial;
 
@@ -599,6 +610,7 @@ export class NavigatorScene {
 
   /** Cheap per-frame path: token creation/positioning only. */
   updateTokens(states: PatientVisibleState[], layerVisible: boolean, redactIdentity: boolean): void {
+    const trace = this.tracePatientId;
     const visible = new Set<string>();
     for (const state of states) {
       let token = this.tokenByPatient.get(state.patientId);
@@ -610,6 +622,15 @@ export class NavigatorScene {
       token.position.set(state.position.x, state.position.y, state.position.z);
       token.scale.setScalar(state.event.event_category === 'movement' ? 1 : 0.82);
       token.visible = layerVisible;
+      // Trace mode dims every OTHER token so the story reads (materials are
+      // per-patient cached, so this touches exactly one patient each).
+      const material = token.material as THREE.MeshStandardMaterial;
+      const dimmed = trace !== null && state.patientId !== trace;
+      const targetOpacity = dimmed ? 0.22 : 1;
+      if (material.transparent !== dimmed || material.opacity !== targetOpacity) {
+        material.transparent = dimmed;
+        material.opacity = targetOpacity;
+      }
       // Shared builder (H1.2): mesh userData and the search/feed selection
       // path must present identical inspector payloads.
       token.userData = patientTokenInspectorData(state, redactIdentity);
@@ -619,9 +640,27 @@ export class NavigatorScene {
     for (const [patientId, token] of this.tokenByPatient.entries()) {
       if (!visible.has(patientId)) token.visible = false;
     }
+
+    // Follow mode (B3): glide the orbit pivot (and camera, preserving the
+    // operator's framing) toward the followed token. Pre-allocated vector —
+    // zero per-frame allocation. Operator camera input clears follow at the
+    // orchestrator level (the 'start' listener), so this never fights a hand.
+    if (this.followPatientId) {
+      const followed = this.tokenByPatient.get(this.followPatientId);
+      if (followed?.visible) {
+        this.followDelta.subVectors(followed.position, this.orbit.target);
+        if (this.followDelta.lengthSq() > 0.01) {
+          this.followDelta.multiplyScalar(0.18);
+          this.orbit.target.add(this.followDelta);
+          this.camera.position.add(this.followDelta);
+        }
+      }
+    }
   }
 
-  /** Bucketed rebuild: trail polylines up to timeMs for the active patients. */
+  /** Bucketed rebuild: trail polylines up to timeMs for the active patients.
+   * In trace mode (B3) only the traced patient renders — a time-gradient
+   * line (dim slate → identity hue) with dwell markers where they stayed. */
   rebuildTrails(
     tracks: Map<string, PatientFlowEvent[]>,
     locations: PatientFlowLocations,
@@ -632,23 +671,109 @@ export class NavigatorScene {
     this.clearGroup(this.trailLayer);
     if (!layerVisible) return;
 
+    const trace = this.tracePatientId;
     const activePatients = new Set(states.map((state) => state.patientId));
     for (const [patientId, track] of tracks.entries()) {
-      if (!activePatients.has(patientId)) continue;
+      if (trace !== null) {
+        if (patientId !== trace) continue;
+      } else if (!activePatients.has(patientId)) {
+        continue;
+      }
+
       const points: THREE.Vector3[] = [];
+      const arrivals: number[] = [];
       for (const event of track) {
-        if (parseTime(event.occurred_at) > timeMs) break;
+        const eventMs = parseTime(event.occurred_at);
+        if (eventMs > timeMs) break;
         const position = positionFor(locations, event.to_location);
         if (!position) continue;
         const vector = new THREE.Vector3(position.x, position.y, position.z);
-        if (!points.length || !points[points.length - 1].equals(vector)) points.push(vector);
+        if (!points.length || !points[points.length - 1].equals(vector)) {
+          points.push(vector);
+          arrivals.push(eventMs);
+        }
       }
       if (points.length < 2) continue;
+
       const geometry = new THREE.BufferGeometry().setFromPoints(points);
+      if (trace !== null) {
+        const colors = new Float32Array(points.length * 3);
+        for (let index = 0; index < points.length; index += 1) {
+          const t = points.length === 1 ? 1 : index / (points.length - 1);
+          const [r, g, b] = traceGradientRgb(t, patientId);
+          colors[index * 3] = r;
+          colors[index * 3 + 1] = g;
+          colors[index * 3 + 2] = b;
+        }
+        geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+        const line = new THREE.Line(geometry, this.traceLineMaterialLazy());
+        line.userData = { kind: 'patient-trail', patient_id: patientId };
+        this.trailLayer.add(line);
+
+        // Dwell markers: arrival→next-arrival span at one spot (the open
+        // segment runs to the scrubbed time). Shared token geometry (guarded
+        // in clearGroup) + the patient's own cached identity material.
+        for (let index = 0; index < points.length; index += 1) {
+          const dwellMs = (index < points.length - 1 ? arrivals[index + 1] : timeMs) - arrivals[index];
+          const scale = dwellNodeScale(dwellMs / 60_000);
+          if (scale <= 0) continue;
+          const node = new THREE.Mesh(this.tokenGeometry, this.materialForPatient(patientId));
+          node.position.copy(points[index]);
+          node.position.y += 0.6;
+          node.scale.setScalar(scale * 0.5);
+          node.userData = { kind: 'trace-dwell', patient_id: patientId };
+          this.trailLayer.add(node);
+        }
+        continue;
+      }
+
       const line = new THREE.Line(geometry, this.trailMaterialForPatient(patientId));
       line.userData = { kind: 'patient-trail', patient_id: patientId };
       this.trailLayer.add(line);
     }
+  }
+
+  /** Trace mode on/off (B3). Caller owns triggering the bucketed rebuild. */
+  setTraceMode(patientId: string | null): void {
+    this.tracePatientId = patientId;
+  }
+
+  /** Camera follows this token during replay; null stops following. */
+  setFollowPatient(patientId: string | null): void {
+    this.followPatientId = patientId;
+  }
+
+  /** Frame the traced patient's whole story (trail + dwell + token). */
+  focusTrace(): boolean {
+    if (!this.tracePatientId) return this.focusSelection();
+
+    const points: Array<{ x: number; y: number; z: number }> = [];
+    for (const child of this.trailLayer.children) {
+      if (child.userData?.kind === 'trace-dwell') {
+        points.push({ x: child.position.x, y: child.position.y, z: child.position.z });
+        continue;
+      }
+      if ((child as THREE.Line).isLine && child.userData?.patient_id === this.tracePatientId) {
+        const positionAttr = (child as THREE.Line).geometry.getAttribute('position');
+        for (let index = 0; index < positionAttr.count; index += 1) {
+          points.push({ x: positionAttr.getX(index), y: positionAttr.getY(index), z: positionAttr.getZ(index) });
+        }
+      }
+    }
+    const token = this.tokenByPatient.get(this.tracePatientId);
+    if (token?.visible) {
+      points.push({ x: token.position.x, y: token.position.y, z: token.position.z });
+    }
+    if (!points.length) return this.focusSelection();
+    this.focusOn(points);
+    return true;
+  }
+
+  private traceLineMaterialLazy(): THREE.LineBasicMaterial {
+    if (!this.traceLineMaterial) {
+      this.traceLineMaterial = new THREE.LineBasicMaterial({ vertexColors: true, transparent: true, opacity: 0.95 });
+    }
+    return this.traceLineMaterial;
   }
 
   /** Bucketed rebuild: overhead occupancy disks with stay/timer state. */
@@ -1154,6 +1279,7 @@ export class NavigatorScene {
     this.clearSelection();
     this.hoverChip.remove();
     this.baseCategoryMaterials.forEach((material) => material.dispose());
+    this.traceLineMaterial?.dispose();
     this.baseObjects.forEach((object) => this.disposeObject(object));
     this.clearGroup(this.patientLayer);
     this.clearGroup(this.trailLayer);

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -17,6 +17,7 @@
 
 .patient-flow-toolbar,
 .patient-flow-inspector,
+.patient-flow-journey,
 .patient-flow-feed,
 .patient-flow-statusbar {
   position: absolute;
@@ -1387,6 +1388,148 @@
 
 .patient-flow-error-retry:hover {
   border-color: rgba(239, 234, 220, 0.55);
+}
+
+/* Patient Journey Drawer (plan §7.1, PJ-1) — the inspector's slot, promoted
+   to a story. Same overlay family; every value below already exists in this
+   file (the F-9-sanctioned scoped palette). */
+.patient-flow-journey {
+  right: 16px;
+  bottom: 48px;
+  width: min(390px, calc(100vw - 32px));
+  max-height: min(560px, calc(100% - 140px));
+  overflow: auto;
+  padding: 14px;
+  font-size: 12px;
+  color: #f3efe5;
+}
+
+.patient-flow-journey-num {
+  font-variant-numeric: tabular-nums;
+}
+
+.patient-flow-journey-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.patient-flow-journey-head strong {
+  display: block;
+  font-size: 15px;
+}
+
+.patient-flow-journey-loc,
+.patient-flow-journey-los {
+  display: block;
+  color: #ddd6c7;
+  margin-top: 2px;
+}
+
+.patient-flow-journey-close {
+  min-width: 24px;
+  min-height: 24px;
+  border: 1px solid rgba(239, 234, 220, 0.22);
+  border-radius: 5px;
+  background: rgba(27, 31, 29, 0.94);
+  color: #f3efe5;
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.patient-flow-journey-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.patient-flow-journey-align,
+.patient-flow-journey-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.patient-flow-journey-align button,
+.patient-flow-journey-actions button {
+  min-height: 24px;
+  border: 1px solid rgba(239, 234, 220, 0.22);
+  border-radius: 5px;
+  background: rgba(27, 31, 29, 0.94);
+  color: #ddd6c7;
+  font-size: 11px;
+  padding: 3px 8px;
+  cursor: pointer;
+}
+
+.patient-flow-journey-align button.active,
+.patient-flow-journey-actions button.active {
+  color: #f3efe5;
+  border-color: rgba(239, 234, 220, 0.55);
+}
+
+.patient-flow-journey-section {
+  margin: 0 0 10px;
+}
+
+.patient-flow-journey-section h3 {
+  margin: 0 0 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #ddd6c7;
+}
+
+.patient-flow-journey-section ul,
+.patient-flow-journey-segments {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.patient-flow-journey-section li {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 2px 0;
+}
+
+.patient-flow-journey-segments li {
+  display: block;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 5px;
+  padding: 6px 8px;
+  margin-bottom: 6px;
+}
+
+.patient-flow-journey-segments li.open {
+  border-color: rgba(239, 234, 220, 0.55);
+}
+
+.patient-flow-journey-segment-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.patient-flow-journey-segment-sub {
+  color: #ddd6c7;
+  margin-top: 2px;
+}
+
+.patient-flow-journey-note {
+  margin: 0 0 8px;
+  color: #ddd6c7;
+}
+
+.patient-flow-journey-foot {
+  margin-top: 6px;
+  color: #ddd6c7;
 }
 
 /* F-6 pt 2 — the atomic-rebootstrap notice: quiet, informational, never an

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -149,6 +149,43 @@
   cursor: pointer;
 }
 
+.patient-flow-chronobar-buttons {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+/* SC 2.5.7 (plan B5) — single-pointer stepping as the non-drag alternative;
+   neutral chrome so the gold Now button stays the emphasized action. */
+.patient-flow-chronobar-step {
+  flex: 0 0 auto;
+  min-height: 24px;
+  border: 1px solid rgba(239, 234, 220, 0.22);
+  border-radius: 5px;
+  background: rgba(27, 31, 29, 0.94);
+  color: #ddd6c7;
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 7px;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Scented scrubber (plan B5, TN-1): a quiet event-density row above the
+   track — intensity is opacity on one neutral ink, never a status color. */
+.patient-flow-chronobar-density {
+  display: flex;
+  gap: 1px;
+  height: 6px;
+  margin: 4px 0 2px;
+}
+
+.patient-flow-chronobar-density span {
+  flex: 1 1 0;
+  border-radius: 1px;
+  background: #ddd6c7;
+}
+
 .patient-flow-chronobar-now-button:disabled {
   opacity: 0.4;
   cursor: default;
@@ -272,6 +309,33 @@
   border: 0;
   background: transparent;
   cursor: pointer;
+}
+
+/* Selected-patient event ticks (plan B3/B5): the selection's own instants,
+   sky like the info family — never amber/coral (those are earned). */
+.patient-flow-chronobar-patient-tick {
+  position: absolute;
+  top: -8px;
+  bottom: -8px;
+  width: 24px;
+  margin-left: -12px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.patient-flow-chronobar-patient-tick::after {
+  content: '';
+  position: absolute;
+  bottom: 6px;
+  height: 5px;
+  left: 50%;
+  width: 2px;
+  margin-left: -1px;
+  border-radius: 1px;
+  background: #38bdf8;
+  box-shadow: 0 0 3px rgba(56, 189, 248, 0.7);
 }
 
 .patient-flow-chronobar-barrier::after {

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -1167,7 +1167,12 @@ export default function PatientFlowNavigator({
             closeJourneyRef.current();
           }
         },
-        onUserCameraStart: () => setTourAuto(false),
+        // The operator's hand always wins: camera input pauses the rounds
+        // Auto tour AND patient follow (B3) in one gesture.
+        onUserCameraStart: () => {
+          setTourAuto(false);
+          setJourneyFollow(false);
+        },
         // E-4 hover chip: identity-free by construction AND by guard test —
         // hoverLabelFor lives in sceneVocabulary, pinned by hoverLabel.test.ts.
         hoverLabel: hoverLabelFor,
@@ -1470,7 +1475,9 @@ export default function PatientFlowNavigator({
       if (key === 'h') {
         sceneRef.current?.resetCamera();
       } else if (key === 'f') {
-        if (!sceneRef.current?.focusSelection()) focusActivePatients();
+        // focusTrace frames the whole traced story when a journey is open
+        // and falls back to the plain selection focus otherwise (B3).
+        if (!sceneRef.current?.focusTrace()) focusActivePatients();
       } else if (key === 'n') {
         if (!historical) handleScrub(nowMsRef.current);
       } else if (event.key === '?') {
@@ -1480,6 +1487,23 @@ export default function PatientFlowNavigator({
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [closeJourney, dismissIntro, focusActivePatients, handleScrub, historical]);
+
+  // B3 — trace mode mirrors the journey drawer: open journey = traced story
+  // in-scene (gradient trail + dwell markers, others dimmed). Toggling clears
+  // the bucket key so the trail layer rebuilds immediately.
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    scene.setTraceMode(journeyState === 'ok' ? journeyPatientRef.current : null);
+    lastBucketKeyRef.current = '';
+    refreshScene();
+  }, [journeyData, journeyState, refreshScene]);
+
+  // B3 — follow-patient: explicit drawer toggle; operator camera input or
+  // closing the journey clears it.
+  useEffect(() => {
+    sceneRef.current?.setFollowPatient(journeyFollow ? journeyPatientRef.current : null);
+  }, [journeyData, journeyFollow]);
 
   // B4 — the ?patient= cross-surface pivot (PJ-3): once events are loaded,
   // select the patient and open their journey (one attempt per mount; the
@@ -1792,7 +1816,7 @@ export default function PatientFlowNavigator({
           onAlignChange={setJourneyAlign}
           onClose={closeJourney}
           onFocus={() => {
-            if (!sceneRef.current?.focusSelection()) focusActivePatients();
+            if (!sceneRef.current?.focusTrace()) focusActivePatients();
           }}
           followEnabled={journeyFollow}
           onFollowToggle={setJourneyFollow}

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -12,7 +12,7 @@ import {
   fetchPatientFlowSummary,
 } from '@/features/patientFlowNavigator/api';
 import { adoptEpoch } from '@/features/patientFlowNavigator/epoch';
-import { fetchPatientJourney } from '@/features/patientFlowNavigator/journey';
+import { eventDensityBuckets, fetchPatientJourney, journeyEventTicks } from '@/features/patientFlowNavigator/journey';
 import type { JourneyAlignAnchor } from '@/features/patientFlowNavigator/journey';
 import type { PatientJourney } from '@/features/patientFlowNavigator/journeySchemas';
 import NavigatorJourneyDrawer from './NavigatorJourneyDrawer';
@@ -523,6 +523,20 @@ export default function PatientFlowNavigator({
       .map((barrier) => (barrier.opened_at ? Date.parse(barrier.opened_at) : Number.NaN))
       .filter((ms) => Number.isFinite(ms) && ms <= nowMs),
     [barriers, nowMs],
+  );
+
+  // B5 — the scented scrubber: house event density across the window, so
+  // retrospective scrubbing is guided instead of blind (TN-1).
+  const chronobarDensity = useMemo(() => eventDensityBuckets(
+    events.map((event) => parseTime(event.occurred_at) ?? Number.NaN),
+    windowStart,
+    windowEnd,
+  ), [events, windowEnd, windowStart]);
+
+  // B3/B5 — the open journey's event instants as jump ticks.
+  const chronobarPatientTicks = useMemo(
+    () => (journeyData ? journeyEventTicks(journeyData) : []),
+    [journeyData],
   );
 
   const placementIndex = useMemo(
@@ -1708,6 +1722,8 @@ export default function PatientFlowNavigator({
             freshness={summary?.source.freshness ?? 'missing'}
             forecast={forecast}
             barrierTicks={barrierTicks}
+            densityBuckets={chronobarDensity}
+            patientTicks={chronobarPatientTicks}
             replaying={live}
             onScrub={handleScrub}
           />

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -12,6 +12,10 @@ import {
   fetchPatientFlowSummary,
 } from '@/features/patientFlowNavigator/api';
 import { adoptEpoch } from '@/features/patientFlowNavigator/epoch';
+import { fetchPatientJourney } from '@/features/patientFlowNavigator/journey';
+import type { JourneyAlignAnchor } from '@/features/patientFlowNavigator/journey';
+import type { PatientJourney } from '@/features/patientFlowNavigator/journeySchemas';
+import NavigatorJourneyDrawer from './NavigatorJourneyDrawer';
 import {
   parseTime,
   patientStatesAt,
@@ -133,11 +137,15 @@ export interface HandoffParams {
   t: number | null;
   /** Rounds board → 4D deep link: fly to this round stop once placed (R-1). */
   focusStop: string | null;
+  /** Cross-surface patient pivot (plan B4, PJ-3): select this patient and
+   * open their journey once events load. Opaque ptok only — a raw ref in
+   * the URL is dropped here, exactly like the /events filter contract. */
+  patient: string | null;
 }
 
-/** Mobile→web A3 handoff: ?persona=&scope=&t=&focus_stop= (persona is resolved server-side). Exported for tests. */
+/** Mobile→web A3 handoff: ?persona=&scope=&t=&focus_stop=&patient= (persona is resolved server-side). Exported for tests. */
 export function parseHandoff(): HandoffParams {
-  const empty: HandoffParams = { floor: null, unitRef: null, t: null, focusStop: null };
+  const empty: HandoffParams = { floor: null, unitRef: null, t: null, focusStop: null, patient: null };
   if (typeof window === 'undefined') return empty;
   const params = new URLSearchParams(window.location.search);
 
@@ -157,7 +165,10 @@ export function parseHandoff(): HandoffParams {
     if (Number.isFinite(parsed)) t = parsed;
   }
 
-  return { floor, unitRef, t, focusStop: params.get('focus_stop') };
+  const rawPatient = params.get('patient');
+  const patient = rawPatient && /^ptok_[A-Za-z0-9]{24}$/.test(rawPatient) ? rawPatient : null;
+
+  return { floor, unitRef, t, focusStop: params.get('focus_stop'), patient };
 }
 
 function defaultLayersForLens(lens: FlowLens | null | undefined): PatientLayerState {
@@ -355,6 +366,20 @@ export default function PatientFlowNavigator({
   const [rebuildNotice, setRebuildNotice] = useState<string | null>(null);
   const epochRef = useRef<string | null>(null);
   const rebootstrappingRef = useRef(false);
+
+  // ---- Patient Journey Drawer (plan §7.1 B, PJ-1) --------------------------
+  // The drawer replaces the inspector for PATIENT selections only; on a 403
+  // or fetch failure it falls back to the inspector (status line explains).
+  const [journeyState, setJourneyState] = useState<'idle' | 'loading' | 'ok'>('idle');
+  const [journeyData, setJourneyData] = useState<PatientJourney | null>(null);
+  const [journeyAlign, setJourneyAlign] = useState<JourneyAlignAnchor>('clock');
+  const [journeyFollow, setJourneyFollow] = useState(false);
+  const [journeyLinkCopied, setJourneyLinkCopied] = useState(false);
+  const journeyPatientRef = useRef<string | null>(null);
+  const journeyFollowRef = useRef(false);
+  useEffect(() => {
+    journeyFollowRef.current = journeyFollow;
+  }, [journeyFollow]);
 
   // One deliberate entry point for reloading the WORLD: the demo refresh
   // rebased every timestamp, so partial refetches would mix epochs. Clears
@@ -1120,6 +1145,13 @@ export default function PatientFlowNavigator({
               ? { label: 'Open in Rounds board', href: `/rtdc/virtual-rounds?patient=${data.round_patient_uuid}` }
               : null,
           );
+          // B1: a patient selection opens their journey; anything else closes
+          // it so the inspector slot always describes the current selection.
+          if (data.kind === 'patient') {
+            openJourneyRef.current(String(redacted.patient_context_ref ?? redacted.patient_id ?? ''));
+          } else {
+            closeJourneyRef.current();
+          }
         },
         onUserCameraStart: () => setTourAuto(false),
         // E-4 hover chip: identity-free by construction AND by guard test —
@@ -1269,6 +1301,61 @@ export default function PatientFlowNavigator({
   // H1.2: the non-pointer selection path — search list and feed rows select
   // exactly what a canvas click on that token would (same builder, same
   // redaction, same scene highlight via the selection entity).
+  const closeJourney = useCallback((): void => {
+    journeyPatientRef.current = null;
+    setJourneyState('idle');
+    setJourneyData(null);
+    setJourneyFollow(false);
+    setJourneyLinkCopied(false);
+  }, []);
+
+  // Opens the journey for an opaque patient context ref. Persona rides the
+  // request (F-1) and the patient is addressed only through the ptok scope —
+  // the server's patientScope() runs the A2P authorization + audit.
+  const openJourneyForPatient = useCallback((patientContextRef: string | null | undefined): void => {
+    if (typeof patientContextRef !== 'string' || !/^ptok_[A-Za-z0-9]{24}$/.test(patientContextRef)) return;
+    journeyPatientRef.current = patientContextRef;
+    setJourneyData(null);
+    setJourneyFollow(false);
+    setJourneyLinkCopied(false);
+    setJourneyState('loading');
+
+    void fetchPatientJourney({ patientContextRef, persona: lens?.role_id }).then((result) => {
+      if (journeyPatientRef.current !== patientContextRef) return; // stale response
+      if (result.kind === 'ok') {
+        setJourneyData(result.journey);
+        setJourneyState('ok');
+        return;
+      }
+      // Fallback: the inspector still carries the scene detail (plan B: a
+      // journey miss must never cost the operator the selection itself).
+      journeyPatientRef.current = null;
+      setJourneyState('idle');
+      setStatus(result.kind === 'forbidden'
+        ? 'Journey not available for this persona'
+        : 'Journey unavailable — inspector fallback');
+    });
+  }, [lens?.role_id]);
+
+  // The scene's onSelect closure is constructed once at mount; route through
+  // refs so it always calls the current opener/closer (the file-wide pattern).
+  const openJourneyRef = useRef(openJourneyForPatient);
+  const closeJourneyRef = useRef(closeJourney);
+  useEffect(() => {
+    openJourneyRef.current = openJourneyForPatient;
+    closeJourneyRef.current = closeJourney;
+  }, [closeJourney, openJourneyForPatient]);
+
+  const copyJourneyLink = useCallback((): void => {
+    const ptok = journeyPatientRef.current;
+    if (!ptok) return;
+    const url = `${window.location.origin}/rtdc/patient-flow-navigator?patient=${ptok}`;
+    void navigator.clipboard?.writeText(url).then(() => {
+      setJourneyLinkCopied(true);
+      window.setTimeout(() => setJourneyLinkCopied(false), 2_000);
+    }).catch(() => setStatus('Copy failed — clipboard unavailable'));
+  }, []);
+
   const selectPatientFromList = useCallback((patientId: string): void => {
     const state = lastVisibleStatesRef.current.find((candidate) => candidate.patientId === patientId);
     if (!state) return;
@@ -1281,7 +1368,8 @@ export default function PatientFlowNavigator({
     setInspectorRows(flattenInspector(redacted));
     setInspectorAction(null);
     sceneRef.current?.selectEntity({ kind: 'patient', id: patientId });
-  }, [dotsPolicy]);
+    openJourneyForPatient(String(redacted.patient_context_ref ?? redacted.patient_id ?? patientId));
+  }, [dotsPolicy, openJourneyForPatient]);
 
   // F-8: keyboard/AT selection of a delayed location — the same code path a
   // canvas raycast on the disk takes (shared occupancyInspectorData builder,
@@ -1361,6 +1449,7 @@ export default function PatientFlowNavigator({
         setInspectorTitle('Select a patient or location');
         setInspectorRows([]);
         setInspectorAction(null);
+        closeJourney();
         return;
       }
       const key = event.key.toLowerCase();
@@ -1376,7 +1465,27 @@ export default function PatientFlowNavigator({
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [dismissIntro, focusActivePatients, handleScrub, historical]);
+  }, [closeJourney, dismissIntro, focusActivePatients, handleScrub, historical]);
+
+  // B4 — the ?patient= cross-surface pivot (PJ-3): once events are loaded,
+  // select the patient and open their journey (one attempt per mount; the
+  // deep link is explicit locate intent, so the F flight is warranted —
+  // same precedent as ?focus_stop). A miss reads honestly in the status bar.
+  const handoffPatientDoneRef = useRef(false);
+  useEffect(() => {
+    if (handoffPatientDoneRef.current || !handoff.patient || events.length === 0) return;
+    handoffPatientDoneRef.current = true;
+
+    const matched = events.some((event) => event.patient_id === handoff.patient);
+    if (!matched) {
+      setStatus('Linked patient not in the current window');
+      return;
+    }
+
+    sceneRef.current?.selectEntity({ kind: 'patient', id: handoff.patient });
+    openJourneyForPatient(handoff.patient);
+    if (!sceneRef.current?.focusSelection()) focusActivePatients();
+  }, [events, focusActivePatients, handoff.patient, openJourneyForPatient]);
 
   // ---- Virtual Rounds integration (Phase 3) --------------------------------
 
@@ -1657,7 +1766,24 @@ export default function PatientFlowNavigator({
         onSelectBarrier={selectBarrierFromList}
       />
 
-      <NavigatorInspector title={inspectorTitle} rows={inspectorRows} action={inspectorAction} />
+      {journeyState === 'idle' ? (
+        <NavigatorInspector title={inspectorTitle} rows={inspectorRows} action={inspectorAction} />
+      ) : (
+        <NavigatorJourneyDrawer
+          journey={journeyData}
+          state={journeyState}
+          align={journeyAlign}
+          onAlignChange={setJourneyAlign}
+          onClose={closeJourney}
+          onFocus={() => {
+            if (!sceneRef.current?.focusSelection()) focusActivePatients();
+          }}
+          followEnabled={journeyFollow}
+          onFollowToggle={setJourneyFollow}
+          onCopyLink={copyJourneyLink}
+          copiedLink={journeyLinkCopied}
+        />
+      )}
 
       <NavigatorLegend layers={layers} />
 

--- a/resources/js/features/patientFlowNavigator/introTour.ts
+++ b/resources/js/features/patientFlowNavigator/introTour.ts
@@ -57,6 +57,12 @@ const BASE_STOPS: IntroStop[] = [
     anchor: '.patient-flow-legend',
   },
   {
+    id: 'journey',
+    title: 'Patient journey',
+    body: 'Select any patient to open their story: stay segments with time-in-place, ED and periop phases, and what happens next. The scene traces their path — bigger markers mean longer waits — and F frames the whole story.',
+    anchor: '.patient-flow-inspector',
+  },
+  {
     id: 'floors',
     title: 'Floors & shortcuts',
     body: 'Step floors here or with the arrow keys. Press ? any time for the full keyboard list — H frames the house, F flies to your selection, N returns to now.',

--- a/resources/js/features/patientFlowNavigator/journey.ts
+++ b/resources/js/features/patientFlowNavigator/journey.ts
@@ -1,0 +1,131 @@
+import axios from 'axios';
+
+import { patientJourneySchema } from '@/features/patientFlowNavigator/journeySchemas';
+import type { PatientJourney } from '@/features/patientFlowNavigator/journeySchemas';
+
+/**
+ * Patient Journey Drawer data + pure helpers (FLOW-4D plan §7.1 / §8 Phase B,
+ * findings PJ-1/PJ-2). Fetching rides the SAME contract every lensed surface
+ * uses: persona forwarded, patient addressed ONLY by opaque ptok scope; the
+ * server 403s personas without patient scope and this module surfaces that as
+ * a typed unavailability, never a crash.
+ */
+
+export type JourneyFetchResult =
+  | { kind: 'ok'; journey: PatientJourney }
+  | { kind: 'forbidden' }
+  | { kind: 'error'; message: string };
+
+export async function fetchPatientJourney(options: {
+  patientContextRef: string;
+  persona?: string;
+  from?: string;
+  to?: string;
+}): Promise<JourneyFetchResult> {
+  try {
+    const response = await axios.get('/api/patient-flow/journey', {
+      params: {
+        scope: `patient:${options.patientContextRef}`,
+        ...(options.persona ? { persona: options.persona } : {}),
+        ...(options.from ? { from: options.from } : {}),
+        ...(options.to ? { to: options.to } : {}),
+      },
+    });
+
+    const parsed = patientJourneySchema.safeParse(response.data);
+    if (!parsed.success) {
+      return { kind: 'error', message: 'Journey payload failed validation' };
+    }
+
+    return { kind: 'ok', journey: parsed.data };
+  } catch (caught) {
+    if (axios.isAxiosError(caught) && caught.response?.status === 403) {
+      return { kind: 'forbidden' };
+    }
+
+    return {
+      kind: 'error',
+      message: caught instanceof Error ? caught.message : 'Journey unavailable',
+    };
+  }
+}
+
+/** Sentinel alignment anchors (LifeLines2 align-rank-filter, plan §6.3). */
+export type JourneyAlignAnchor = 'clock' | 'arrival' | 'admit';
+
+/** The t0 (ms) for an alignment anchor, or null when the journey lacks it. */
+export function alignAnchorMs(journey: PatientJourney, anchor: JourneyAlignAnchor): number | null {
+  if (anchor === 'arrival') {
+    const first = journey.events.find((event) => event.occurred_at);
+    return first?.occurred_at ? Date.parse(first.occurred_at) : null;
+  }
+
+  if (anchor === 'admit') {
+    return journey.header.admitted_at ? Date.parse(journey.header.admitted_at) : null;
+  }
+
+  return null; // 'clock' — absolute times, no re-zeroing
+}
+
+/** "+2 hr 10 min" style offset from an anchor; absolute time when unanchored. */
+export function alignedTimeLabel(iso: string | null | undefined, anchorMs: number | null): string {
+  if (!iso) return '--';
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return '--';
+
+  if (anchorMs === null) {
+    return new Date(ms).toLocaleString([], { month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+  }
+
+  const deltaMinutes = Math.round((ms - anchorMs) / 60_000);
+  const sign = deltaMinutes < 0 ? '−' : '+';
+  const abs = Math.abs(deltaMinutes);
+  const hours = Math.floor(abs / 60);
+  const minutes = abs % 60;
+  return hours > 0 ? `${sign}${hours} hr ${minutes} min` : `${sign}${minutes} min`;
+}
+
+/** Compact dwell label from minutes: "45 min", "3 hr 20 min", "2 d 4 hr". */
+export function dwellLabel(minutes: number | null | undefined): string {
+  if (typeof minutes !== 'number' || !Number.isFinite(minutes) || minutes < 0) return '--';
+  const total = Math.round(minutes);
+  if (total < 60) return `${total} min`;
+  const hours = Math.floor(total / 60);
+  if (hours < 24) return `${hours} hr ${total % 60} min`;
+  const days = Math.floor(hours / 24);
+  return `${days} d ${hours % 24} hr`;
+}
+
+/** The selected patient's event instants (ms) for chronobar ticks (B3/B5). */
+export function journeyEventTicks(journey: PatientJourney): number[] {
+  return journey.events
+    .map((event) => (event.occurred_at ? Date.parse(event.occurred_at) : Number.NaN))
+    .filter((ms) => Number.isFinite(ms));
+}
+
+/**
+ * Scented-widget density (Willett et al., plan §6.2): bucket event instants
+ * across a window into normalized 0..1 intensities. Pure and generic — the
+ * chronobar feeds it the house event array; the drawer could feed it one
+ * journey. Returns an empty array when the window is degenerate.
+ */
+export function eventDensityBuckets(
+  eventTimesMs: number[],
+  windowStart: number,
+  windowEnd: number,
+  bucketCount = 48,
+): number[] {
+  if (!(windowEnd > windowStart) || bucketCount < 1) return [];
+
+  const counts = new Array<number>(bucketCount).fill(0);
+  const span = windowEnd - windowStart;
+  for (const ms of eventTimesMs) {
+    if (!Number.isFinite(ms) || ms < windowStart || ms > windowEnd) continue;
+    const index = Math.min(bucketCount - 1, Math.floor(((ms - windowStart) / span) * bucketCount));
+    counts[index] += 1;
+  }
+
+  const max = Math.max(...counts);
+  if (max <= 0) return counts;
+  return counts.map((count) => count / max);
+}

--- a/resources/js/features/patientFlowNavigator/journeySchemas.ts
+++ b/resources/js/features/patientFlowNavigator/journeySchemas.ts
@@ -1,0 +1,153 @@
+import { z } from 'zod';
+
+/**
+ * Zod contract for GET /api/patient-flow/journey (FLOW-4D plan §8 Phase A1;
+ * consumed by the Phase B Patient Journey Drawer). Tolerant on purpose —
+ * every field the drawer renders is nullable/optional so a server addition
+ * never white-screens the wall (the safeParse discipline).
+ */
+
+const isoString = z.string().min(1);
+
+export const journeyEventSchema = z.object({
+  event_id: z.string().nullish(),
+  event_category: z.string().nullish(),
+  event_type: z.string().nullish(),
+  trigger_event: z.string().nullish(),
+  activity: z.string().nullish(),
+  occurred_at: isoString.nullish(),
+  from_location: z.string().nullish(),
+  to_location: z.string().nullish(),
+  location_name: z.string().nullish(),
+  location_floor: z.number().nullish(),
+  unit_code: z.string().nullish(),
+  unit_id: z.number().nullish(),
+  bed: z.string().nullish(),
+  service_line: z.string().nullish(),
+  patient_class: z.string().nullish(),
+  code_counts: z.object({
+    diagnosis: z.number(),
+    order: z.number(),
+    observation: z.number(),
+    medication: z.number(),
+  }).partial().nullish(),
+});
+
+export const journeySegmentSchema = z.object({
+  kind: z.string(),
+  location: z.string().nullish(),
+  location_name: z.string().nullish(),
+  floor: z.number().nullish(),
+  unit_code: z.string().nullish(),
+  unit_id: z.number().nullish(),
+  started_at: isoString,
+  ended_at: isoString.nullish(),
+  dwell_minutes: z.number().nullish(),
+  open: z.boolean().nullish(),
+});
+
+export const journeyPhaseSchema = z.object({
+  phase: z.string(),
+  case_id: z.number().nullish(),
+  started_at: isoString,
+  ended_at: isoString.nullish(),
+  minutes: z.number().nullish(),
+  open: z.boolean().nullish(),
+});
+
+export const journeyMilestoneSchema = z.object({
+  source: z.string(),
+  case_id: z.number().nullish(),
+  milestone_type: z.string(),
+  status: z.string(),
+  required: z.boolean().nullish(),
+  completed_at: isoString.nullish(),
+});
+
+export const journeyLogisticsSchema = z.object({
+  domain: z.string(),
+  status: z.string(),
+  priority: z.string().nullish(),
+  origin: z.string().nullish(),
+  destination: z.string().nullish(),
+  service: z.string().nullish(),
+  required_unit_type: z.string().nullish(),
+  isolation_required: z.boolean().nullish(),
+  location_label: z.string().nullish(),
+  turn_type: z.string().nullish(),
+  requested_at: isoString.nullish(),
+  needed_at: isoString.nullish(),
+  completed_at: isoString.nullish(),
+});
+
+export const journeyHomeSchema = z.object({
+  domain: z.string().nullish(),
+  status: z.string(),
+  disposition: z.string().nullish(),
+  condition_label: z.string().nullish(),
+  acuity_tier: z.union([z.string(), z.number()]).nullish(),
+  service_zone: z.string().nullish(),
+  started_at: isoString.nullish(),
+  ended_at: isoString.nullish(),
+  expected_discharge_date: z.string().nullish(),
+});
+
+export const journeyBarrierSchema = z.object({
+  barrier_id: z.number(),
+  unit_id: z.number().nullish(),
+  category: z.string(),
+  description: z.string().nullish(),
+  opened_at: isoString.nullish(),
+  attribution: z.string(),
+});
+
+export const patientJourneySchema = z.object({
+  patient: z.object({
+    patient_context_ref: z.string(),
+    display_label: z.string(),
+    detail_authorized: z.boolean(),
+  }),
+  lens: z.object({
+    role_id: z.string(),
+    patient_dots: z.string(),
+  }),
+  window: z.object({ from: isoString, to: isoString }),
+  header: z.object({
+    current_location: z.string().nullish(),
+    current_location_name: z.string().nullish(),
+    current_unit_code: z.string().nullish(),
+    current_floor: z.number().nullish(),
+    service_line: z.string().nullish(),
+    patient_class: z.string().nullish(),
+    admitted_at: isoString.nullish(),
+    los_minutes: z.number().nullish(),
+    as_of: isoString.nullish(),
+  }),
+  events: z.array(journeyEventSchema),
+  segments: z.array(journeySegmentSchema),
+  phases: z.object({
+    ed: z.array(journeyPhaseSchema),
+    periop: z.array(journeyPhaseSchema),
+  }),
+  milestones: z.array(journeyMilestoneSchema),
+  logistics: z.array(journeyLogisticsSchema),
+  home: z.array(journeyHomeSchema),
+  unit_context_barriers: z.array(journeyBarrierSchema),
+  next: z.object({
+    target_location: z.string().nullish(),
+    transport_needed_at: isoString.nullish(),
+    expected_discharge_date: z.string().nullish(),
+  }),
+  epoch: z.object({
+    epoch: z.string(),
+    refreshed_at: isoString.nullish(),
+    status: z.string(),
+  }).nullish(),
+  as_of: isoString,
+  generated_at: isoString,
+});
+
+export type PatientJourney = z.infer<typeof patientJourneySchema>;
+export type JourneyEvent = z.infer<typeof journeyEventSchema>;
+export type JourneySegment = z.infer<typeof journeySegmentSchema>;
+export type JourneyPhase = z.infer<typeof journeyPhaseSchema>;

--- a/resources/js/features/patientFlowNavigator/sceneVocabulary.ts
+++ b/resources/js/features/patientFlowNavigator/sceneVocabulary.ts
@@ -71,6 +71,48 @@ export function patientHue(value: string): number {
 }
 
 // ---------------------------------------------------------------------------
+// Trace mode (plan B3, PJ-2) — the selected patient's story in-scene. The
+// gradient runs dim slate (oldest) → the patient's own identity color
+// (newest), so direction of travel is readable without animation; dwell
+// markers scale with time-in-place (stagnation IS the signal — space-time
+// path doctrine). Hue stays inside the identity clamp; saturation/lightness
+// stay below status salience. Pure + three-free so tests can pin them.
+// ---------------------------------------------------------------------------
+
+export const TRACE_DWELL_MIN_MINUTES = 30;
+
+/** hsl → rgb (0..1 each); h in degrees. Pure, allocation-light. */
+export function hslToRgb(hueDegrees: number, saturation: number, lightness: number): [number, number, number] {
+  const h = ((hueDegrees % 360) + 360) % 360 / 360;
+  if (saturation === 0) return [lightness, lightness, lightness];
+  const q = lightness < 0.5 ? lightness * (1 + saturation) : lightness + saturation - lightness * saturation;
+  const p = 2 * lightness - q;
+  const channel = (t: number): number => {
+    let x = t;
+    if (x < 0) x += 1;
+    if (x > 1) x -= 1;
+    if (x < 1 / 6) return p + (q - p) * 6 * x;
+    if (x < 1 / 2) return q;
+    if (x < 2 / 3) return p + (q - p) * (2 / 3 - x) * 6;
+    return p;
+  };
+  return [channel(h + 1 / 3), channel(h), channel(h - 1 / 3)];
+}
+
+/** Gradient stop for the trace trail at normalized age t (0 oldest → 1 newest). */
+export function traceGradientRgb(t: number, patientId: string): [number, number, number] {
+  const clamped = Math.min(1, Math.max(0, t));
+  const hue = patientHue(patientId);
+  return hslToRgb(hue, 0.15 + 0.55 * clamped, 0.24 + 0.34 * clamped);
+}
+
+/** Dwell-marker scale: 0 below the threshold, then log growth, hard-capped. */
+export function dwellNodeScale(dwellMinutes: number): number {
+  if (!Number.isFinite(dwellMinutes) || dwellMinutes < TRACE_DWELL_MIN_MINUTES) return 0;
+  return Math.min(2.2, 0.5 + Math.log10(dwellMinutes / TRACE_DWELL_MIN_MINUTES + 1) * 1.6);
+}
+
+// ---------------------------------------------------------------------------
 // Base-model category treatments (plan §5.2) — glTF `extras.category` is
 // already in mesh.userData; these tints make hallway/room/bed/ED legible.
 // All tints stay in the blue/slate operational family. `floor` and unknown
@@ -203,6 +245,14 @@ export const LEGEND_SECTIONS: LegendSection[] = [
         shape: 'line',
         colorHex: 0x49c6df,
         description: 'Where that patient has been up to the scrubbed time.',
+        layer: 'trails',
+      },
+      {
+        key: 'trace-dwell',
+        label: 'Dwell marker',
+        shape: 'sphere',
+        colorHex: 0x49c6df,
+        description: 'On the selected patient’s trace: time spent in one place — bigger means longer. Identity color, never status.',
         layer: 'trails',
       },
     ],

--- a/tests/js/patientFlow/NavigatorChronobar.test.tsx
+++ b/tests/js/patientFlow/NavigatorChronobar.test.tsx
@@ -153,4 +153,67 @@ describe('NavigatorChronobar', () => {
     expect(screen.getByText(/Replay stream ·/)).toBeInTheDocument();
     expect(screen.queryByText(/\bLive\b/)).not.toBeInTheDocument();
   });
+
+  it('B5: ±15m step buttons scrub relative to the current time, clamped to the window', () => {
+    const now = Date.parse('2026-07-09T12:00:00Z');
+    const windowStart = now - 24 * 3_600_000;
+    const onScrub = vi.fn();
+
+    render(
+      <NavigatorChronobar
+        windowStart={windowStart}
+        windowEnd={now + 24 * 3_600_000}
+        nowMs={now}
+        currentTime={now}
+        dataStart={windowStart}
+        dataEnd={now}
+        historical={false}
+        freshness="fresh"
+        forecast={null}
+        onScrub={onScrub}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Step back 15 minutes' }));
+    expect(onScrub).toHaveBeenLastCalledWith(now - 15 * 60_000);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Step forward 15 minutes' }));
+    expect(onScrub).toHaveBeenLastCalledWith(now + 15 * 60_000);
+  });
+
+  it('B5: renders the density strip as decoration and patient ticks as jump buttons', () => {
+    const now = Date.parse('2026-07-09T12:00:00Z');
+    const windowStart = now - 24 * 3_600_000;
+    const patientEvent = now - 2 * 3_600_000;
+    const onScrub = vi.fn();
+
+    const { container } = render(
+      <NavigatorChronobar
+        windowStart={windowStart}
+        windowEnd={now + 24 * 3_600_000}
+        nowMs={now}
+        currentTime={now}
+        dataStart={windowStart}
+        dataEnd={now}
+        historical={false}
+        freshness="fresh"
+        forecast={null}
+        densityBuckets={[0, 0.5, 1]}
+        patientTicks={[patientEvent, now + 30 * 24 * 3_600_000]}
+        onScrub={onScrub}
+      />,
+    );
+
+    // Density is scent, not a control — aria-hidden, one cell per bucket.
+    const density = container.querySelector('.patient-flow-chronobar-density');
+    expect(density).not.toBeNull();
+    expect(density!.getAttribute('aria-hidden')).toBe('true');
+    expect(density!.children).toHaveLength(3);
+
+    // One patient tick inside the window (the out-of-window instant drops).
+    const ticks = screen.getAllByRole('button', { name: /Jump to patient event/ });
+    expect(ticks).toHaveLength(1);
+    fireEvent.click(ticks[0]);
+    expect(onScrub).toHaveBeenLastCalledWith(patientEvent);
+  });
 });

--- a/tests/js/patientFlow/NavigatorJourneyDrawer.test.tsx
+++ b/tests/js/patientFlow/NavigatorJourneyDrawer.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import NavigatorJourneyDrawer from '@/Components/PatientFlowNavigator/NavigatorJourneyDrawer';
+import { journeyFixture } from './journey.test';
+
+/**
+ * The Patient Journey Drawer (plan §7.1, PJ-1): renders the interval story,
+ * re-zeroes on align change, degrades honestly on forbidden/error, and never
+ * shows anything but the lens-issued display label (the identity sentinel at
+ * the component boundary — raw refs can't even reach these props by type).
+ */
+
+function renderDrawer(overrides: Partial<React.ComponentProps<typeof NavigatorJourneyDrawer>> = {}) {
+  const props: React.ComponentProps<typeof NavigatorJourneyDrawer> = {
+    journey: journeyFixture(),
+    state: 'ok',
+    align: 'clock',
+    onAlignChange: vi.fn(),
+    onClose: vi.fn(),
+    onFocus: vi.fn(),
+    followEnabled: false,
+    onFollowToggle: vi.fn(),
+    onCopyLink: vi.fn(),
+    copiedLink: false,
+    ...overrides,
+  };
+  return { ...render(<NavigatorJourneyDrawer {...props} />), props };
+}
+
+describe('NavigatorJourneyDrawer', () => {
+  it('renders the interval story: segments with dwell, phases, milestones, logistics', () => {
+    renderDrawer();
+
+    expect(screen.getByText('Patient ABCDEF')).toBeTruthy();
+    expect(screen.getByText(/LOS 12 hr 15 min/)).toBeTruthy();
+    expect(screen.getByText('TICU')).toBeTruthy();
+    expect(screen.getByText(/3 hr 30 min/)).toBeTruthy();
+    expect(screen.getByText(/8 hr 45 min · ongoing/)).toBeTruthy();
+    expect(screen.getByText(/ED · boarding/)).toBeTruthy();
+    expect(screen.getByText(/pre op assessment/)).toBeTruthy();
+    expect(screen.getByText(/Bed request → Med Surg/)).toBeTruthy();
+    // Unit barriers are labeled as unit context, never patient-attributed.
+    expect(screen.getByText(/not attributed to this patient/)).toBeTruthy();
+  });
+
+  it('is nothing at all when idle', () => {
+    const { container } = renderDrawer({ state: 'idle', journey: null });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('degrades honestly on forbidden and error states', () => {
+    renderDrawer({ state: 'forbidden', journey: null });
+    expect(screen.getByText(/no patient-journey access/)).toBeTruthy();
+  });
+
+  it('align control re-zeroes via the callback and marks the active anchor', () => {
+    const { props } = renderDrawer({ align: 'arrival' });
+
+    const arrival = screen.getByRole('radio', { name: 'From arrival' });
+    expect(arrival.getAttribute('aria-checked')).toBe('true');
+
+    fireEvent.click(screen.getByRole('radio', { name: 'From admit' }));
+    expect(props.onAlignChange).toHaveBeenCalledWith('admit');
+  });
+
+  it('wires focus, follow, copy-link, and close', () => {
+    const { props } = renderDrawer();
+
+    fireEvent.click(screen.getByText('Focus trace'));
+    expect(props.onFocus).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('Follow'));
+    expect(props.onFollowToggle).toHaveBeenCalledWith(true);
+
+    fireEvent.click(screen.getByText('Copy link'));
+    expect(props.onCopyLink).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByLabelText('Close patient journey'));
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it('shows aligned offsets when anchored on arrival', () => {
+    renderDrawer({ align: 'arrival' });
+    // The MS5B segment starts 3.5h after the first event.
+    expect(screen.getAllByText(/\+3 hr 30 min/).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/js/patientFlow/introTour.test.tsx
+++ b/tests/js/patientFlow/introTour.test.tsx
@@ -51,9 +51,9 @@ describe('introTour helpers', () => {
   it('includes the rounds stop only when a run is loaded', () => {
     const withoutRounds = introStops(false);
     const withRounds = introStops(true);
-    expect(withoutRounds).toHaveLength(4);
+    expect(withoutRounds).toHaveLength(5);
     expect(withoutRounds.some((stop) => stop.id === 'rounds')).toBe(false);
-    expect(withRounds).toHaveLength(5);
+    expect(withRounds).toHaveLength(6);
     expect(withRounds[withRounds.length - 1].id).toBe('rounds');
   });
 
@@ -75,7 +75,7 @@ describe('NavigatorIntro', () => {
     );
     expect(screen.getByRole('dialog', { name: 'Navigator introduction' })).toBeTruthy();
     expect(screen.getByText('Census scope')).toBeTruthy();
-    expect(screen.getByText('1 of 4')).toBeTruthy();
+    expect(screen.getByText('1 of 5')).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Back' })).toBeNull();
   });
 
@@ -120,9 +120,9 @@ describe('NavigatorIntro', () => {
 
   it('clamps when the stop list shrinks (rounds run unloads mid-intro)', () => {
     render(
-      <NavigatorIntro stops={stops} index={4} onIndexChange={vi.fn()} onDismiss={vi.fn()} />,
+      <NavigatorIntro stops={stops} index={5} onIndexChange={vi.fn()} onDismiss={vi.fn()} />,
     );
     expect(screen.getByText('Floors & shortcuts')).toBeTruthy();
-    expect(screen.getByText('4 of 4')).toBeTruthy();
+    expect(screen.getByText('5 of 5')).toBeTruthy();
   });
 });

--- a/tests/js/patientFlow/journey.test.ts
+++ b/tests/js/patientFlow/journey.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  alignAnchorMs,
+  alignedTimeLabel,
+  dwellLabel,
+  eventDensityBuckets,
+  journeyEventTicks,
+} from '@/features/patientFlowNavigator/journey';
+import { patientJourneySchema } from '@/features/patientFlowNavigator/journeySchemas';
+import type { PatientJourney } from '@/features/patientFlowNavigator/journeySchemas';
+
+/** A minimal valid journey fixture (matches PatientJourneyService::build). */
+export function journeyFixture(overrides: Partial<PatientJourney> = {}): PatientJourney {
+  const base = {
+    patient: {
+      patient_context_ref: 'ptok_abcdefabcdefabcdefabcdef',
+      display_label: 'Patient ABCDEF',
+      detail_authorized: true,
+    },
+    lens: { role_id: 'house_supervisor', patient_dots: 'full' },
+    window: { from: '2026-07-25T02:00:00Z', to: '2026-07-27T08:00:00Z' },
+    header: {
+      current_location: 'MS5B-B001',
+      current_location_name: 'Med Surg 5B',
+      current_unit_code: 'MS5B',
+      current_floor: 5,
+      service_line: 'critical_care',
+      patient_class: 'inpatient',
+      admitted_at: '2026-07-25T08:00:00Z',
+      los_minutes: 735,
+      as_of: '2026-07-25T20:15:00Z',
+    },
+    events: [
+      { occurred_at: '2026-07-25T08:00:00Z', event_category: 'movement', event_type: 'admit', trigger_event: 'A01', to_location: 'TICU-B001', location_name: 'TICU', unit_code: 'TICU' },
+      { occurred_at: '2026-07-25T11:30:00Z', event_category: 'movement', event_type: 'transfer', trigger_event: 'A02', to_location: 'MS5B-B001', location_name: 'Med Surg 5B', unit_code: 'MS5B' },
+    ],
+    segments: [
+      { kind: 'location', location: 'TICU-B001', location_name: 'TICU', unit_code: 'TICU', started_at: '2026-07-25T08:00:00Z', ended_at: '2026-07-25T11:30:00Z', dwell_minutes: 210, open: false },
+      { kind: 'location', location: 'MS5B-B001', location_name: 'Med Surg 5B', unit_code: 'MS5B', started_at: '2026-07-25T11:30:00Z', ended_at: null, dwell_minutes: 525, open: true },
+    ],
+    phases: {
+      ed: [{ phase: 'boarding', started_at: '2026-07-25T06:00:00Z', ended_at: '2026-07-25T08:00:00Z', minutes: 120, open: false }],
+      periop: [],
+    },
+    milestones: [
+      { source: 'or_case', case_id: 7, milestone_type: 'pre_op_assessment', status: 'completed', required: true, completed_at: '2026-07-25T09:00:00Z' },
+    ],
+    logistics: [
+      { domain: 'bed_request', status: 'pending', required_unit_type: 'Med Surg', requested_at: '2026-07-25T07:00:00Z' },
+    ],
+    home: [],
+    unit_context_barriers: [
+      { barrier_id: 3, unit_id: 12, category: 'placement', description: 'EVS delay', opened_at: '2026-07-25T10:00:00Z', attribution: 'unit' },
+    ],
+    next: { target_location: 'Med Surg', transport_needed_at: null, expected_discharge_date: '2026-07-27' },
+    epoch: { epoch: 'refresh-abc12345', refreshed_at: '2026-07-25T18:00:00Z', status: 'passed' },
+    as_of: '2026-07-25T20:15:00Z',
+    generated_at: '2026-07-25T20:15:00Z',
+  };
+
+  return patientJourneySchema.parse({ ...base, ...overrides });
+}
+
+describe('patientJourneySchema', () => {
+  it('parses the service fixture shape', () => {
+    expect(() => journeyFixture()).not.toThrow();
+  });
+
+  it('tolerates server additions without failing (safeParse discipline)', () => {
+    const parsed = patientJourneySchema.safeParse({
+      ...journeyFixture(),
+      some_future_field: { anything: true },
+    });
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('alignAnchorMs / alignedTimeLabel', () => {
+  it('re-zeroes on arrival (first event) and admit', () => {
+    const journey = journeyFixture();
+    expect(alignAnchorMs(journey, 'arrival')).toBe(Date.parse('2026-07-25T08:00:00Z'));
+    expect(alignAnchorMs(journey, 'admit')).toBe(Date.parse('2026-07-25T08:00:00Z'));
+    expect(alignAnchorMs(journey, 'clock')).toBeNull();
+  });
+
+  it('labels offsets from the anchor in hours and minutes', () => {
+    const anchor = Date.parse('2026-07-25T08:00:00Z');
+    expect(alignedTimeLabel('2026-07-25T11:30:00Z', anchor)).toBe('+3 hr 30 min');
+    expect(alignedTimeLabel('2026-07-25T07:15:00Z', anchor)).toBe('−45 min');
+  });
+
+  it('falls back to absolute time when unanchored, and -- on garbage', () => {
+    expect(alignedTimeLabel('not-a-date', null)).toBe('--');
+    expect(alignedTimeLabel(null, null)).toBe('--');
+    expect(alignedTimeLabel('2026-07-25T11:30:00Z', null)).not.toBe('--');
+  });
+});
+
+describe('dwellLabel', () => {
+  it('formats minutes, hours, and days compactly', () => {
+    expect(dwellLabel(45)).toBe('45 min');
+    expect(dwellLabel(210)).toBe('3 hr 30 min');
+    expect(dwellLabel(60 * 26 + 15)).toBe('1 d 2 hr');
+    expect(dwellLabel(null)).toBe('--');
+    expect(dwellLabel(-5)).toBe('--');
+  });
+});
+
+describe('journeyEventTicks', () => {
+  it('returns finite instants only', () => {
+    const ticks = journeyEventTicks(journeyFixture());
+    expect(ticks).toHaveLength(2);
+    expect(ticks.every((ms) => Number.isFinite(ms))).toBe(true);
+  });
+});
+
+describe('eventDensityBuckets', () => {
+  const t0 = Date.parse('2026-07-25T00:00:00Z');
+  const t1 = t0 + 48 * 3_600_000;
+
+  it('normalizes bucket intensities to the busiest bucket', () => {
+    const times = [t0 + 1_000, t0 + 2_000, t0 + 3_000, t1 - 1_000];
+    const buckets = eventDensityBuckets(times, t0, t1, 48);
+    expect(buckets).toHaveLength(48);
+    expect(buckets[0]).toBe(1);
+    expect(buckets[47]).toBeCloseTo(1 / 3);
+    expect(buckets[24]).toBe(0);
+  });
+
+  it('drops out-of-window instants and survives empty input', () => {
+    expect(eventDensityBuckets([t0 - 5_000, t1 + 5_000], t0, t1, 8)).toEqual(new Array(8).fill(0));
+    expect(eventDensityBuckets([], t0, t1, 8)).toEqual(new Array(8).fill(0));
+  });
+
+  it('returns empty for a degenerate window', () => {
+    expect(eventDensityBuckets([t0], t1, t0)).toEqual([]);
+  });
+});

--- a/tests/js/patientFlow/traceVocabulary.test.ts
+++ b/tests/js/patientFlow/traceVocabulary.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  LEGEND_SECTIONS,
+  TRACE_DWELL_MIN_MINUTES,
+  dwellNodeScale,
+  hslToRgb,
+  patientHue,
+  traceGradientRgb,
+} from '@/features/patientFlowNavigator/sceneVocabulary';
+
+/**
+ * Trace-mode vocabulary (plan B3, PJ-2). Pins the doctrine: the gradient is
+ * IDENTITY territory (dim slate → the patient's own clamped hue — never a
+ * status color), dwell markers earn size from time-in-place only, and the
+ * legend words the new element (E-1: nothing in-scene is unexplained).
+ */
+describe('traceGradientRgb', () => {
+  it('brightens monotonically from oldest to newest', () => {
+    const sum = (rgb: [number, number, number]): number => rgb[0] + rgb[1] + rgb[2];
+    const oldest = traceGradientRgb(0, 'ptok_x');
+    const middle = traceGradientRgb(0.5, 'ptok_x');
+    const newest = traceGradientRgb(1, 'ptok_x');
+    expect(sum(middle)).toBeGreaterThan(sum(oldest));
+    expect(sum(newest)).toBeGreaterThan(sum(middle));
+  });
+
+  it('clamps t outside 0..1', () => {
+    expect(traceGradientRgb(-4, 'p')).toEqual(traceGradientRgb(0, 'p'));
+    expect(traceGradientRgb(9, 'p')).toEqual(traceGradientRgb(1, 'p'));
+  });
+
+  it('stays inside the identity hue clamp (160°–280°) — never amber/coral', () => {
+    // The hue driving the gradient is patientHue's, which is clamped; the
+    // red channel must therefore never dominate (amber/coral are red-led).
+    for (const id of ['a', 'zz', 'ptok_123', 'patient-9']) {
+      const hue = patientHue(id);
+      expect(hue).toBeGreaterThanOrEqual(160);
+      expect(hue).toBeLessThanOrEqual(280);
+      const [r, g, b] = traceGradientRgb(1, id);
+      expect(Math.max(g, b)).toBeGreaterThanOrEqual(r);
+    }
+  });
+});
+
+describe('dwellNodeScale', () => {
+  it('is zero below the threshold — short stops earn no marker', () => {
+    expect(dwellNodeScale(0)).toBe(0);
+    expect(dwellNodeScale(TRACE_DWELL_MIN_MINUTES - 1)).toBe(0);
+    expect(dwellNodeScale(Number.NaN)).toBe(0);
+  });
+
+  it('grows monotonically with dwell and hard-caps', () => {
+    const short = dwellNodeScale(TRACE_DWELL_MIN_MINUTES);
+    const hours = dwellNodeScale(240);
+    const days = dwellNodeScale(60 * 48);
+    expect(short).toBeGreaterThan(0);
+    expect(hours).toBeGreaterThan(short);
+    expect(days).toBeGreaterThanOrEqual(hours);
+    expect(days).toBeLessThanOrEqual(2.2);
+  });
+});
+
+describe('hslToRgb', () => {
+  it('produces expected anchor colors', () => {
+    expect(hslToRgb(0, 0, 0.5)).toEqual([0.5, 0.5, 0.5]);
+    const [r, g, b] = hslToRgb(120, 1, 0.5);
+    expect(r).toBeCloseTo(0);
+    expect(g).toBeCloseTo(1);
+    expect(b).toBeCloseTo(0);
+  });
+});
+
+describe('legend coverage', () => {
+  it('words the dwell marker so the trace is never unexplained geometry', () => {
+    const entries = LEGEND_SECTIONS.flatMap((section) => section.entries);
+    const dwell = entries.find((entry) => entry.key === 'trace-dwell');
+    expect(dwell).toBeDefined();
+    expect(dwell!.layer).toBe('trails');
+    expect(dwell!.description.toLowerCase()).toContain('longer');
+    expect(dwell!.description.toLowerCase()).toContain('never status');
+  });
+});


### PR DESCRIPTION
## Summary

Phase B of [FLOW-4D-PATIENT-JOURNEY-AND-CONFORMANCE-PLAN-2026-07-26](docs/plans/FLOW-4D-PATIENT-JOURNEY-AND-CONFORMANCE-PLAN-2026-07-26.md) — the headline capability: one patient's story, in a drawer and in the scene. Pure frontend; consumes the Phase A journey endpoint (PR #93).

### B1 — Patient Journey Drawer (finding PJ-1)
- `NavigatorJourneyDrawer`: interval-first plain-HTML story — stay segments with dwell (`3 hr 30 min`, open segments marked ongoing), ED/periop phases, OR milestones, logistics, home-hospital, unit-context barriers (explicitly "not attributed to this patient"), Next block, epoch/as-of footer. Replaces the key/value inspector for PATIENT selections only; 24px targets; `tabular-nums`.
- Tolerant Zod contract (`journeySchemas.ts`) — server additions never white-screen the wall.
- LifeLines2-style **align-from control** (Clock / From arrival / From admit) re-zeroes every time label (B2).

### B4 — Cross-surface pivot (finding PJ-3)
- `?patient={ptok}` deep link: validated opaque-ref-only at parse, selects + opens + frames once events load (the `?focus_stop` precedent); honest status line on a miss. **Copy link** in the drawer emits the pivot URL.
- 403/error falls back to the inspector — a journey miss never costs the selection.

### B3 — Trace mode in-scene (finding PJ-2)
- Open journey = the traced story: full-window trail as a **time-gradient line** (dim slate oldest → identity hue newest), **dwell markers** sized by time-in-place (log growth, 30-min floor, hard cap) — stagnation is now literally visible; every other token dims to 0.22. Non-trace rendering byte-identical.
- **Follow** toggle glides the orbit pivot + camera to the token during replay (pre-allocated vector, zero per-frame allocation); any operator camera grab clears follow and the rounds Auto tour in one gesture. `F`/Focus-trace frames the whole story bbox.
- Vocabulary additions are pure + pinned: gradient stays inside the identity hue clamp (red never dominates at t=1); the legend words the dwell marker (E-1: nothing in-scene unexplained).

### B5 — Scented chronobar (findings TN-1, AT-2)
- Event-density strip (scented widgets): normalized opacity on neutral ink, aria-hidden, one cell per bucket.
- **±15 min step buttons** — the SC 2.5.7 single-pointer alternative to drag-scrub, window-clamped.
- Selected-patient event ticks (sky/info family) jump to the open journey's instants.

### Also
- Intro tour gains the journey stop; usability protocol v1.1 stages T8 (tell-their-story, keyboard variant) + T9 (deep-link handoff) for H3.
- Window presets (TN-6, severity L) deliberately deferred; outward "Locate in 4D" buttons on ED/bed boards deferred to a follow-up touch (rounds already pivots via `focus_stop`).

## Tests
- Vitest: **151 files / 692 tests green** — 34 new across `journey.test.ts` (schema tolerance, align re-zeroing, density bucketing), `NavigatorJourneyDrawer.test.tsx` (render/lens/degrade/callbacks), `traceVocabulary.test.ts` (gradient hue-clamp, dwell monotonic+cap, legend wording), chronobar B5 cases.
- `npx tsc --noEmit` ✅ · `npx vite build` ✅ · `check-ui-canon.sh` ✅ (ratchet unchanged) · Pint ✅
- All overlay CSS values are verbatim reuses of the navigator's F-9-sanctioned scoped palette.

## Deploy
Frontend-only: `./deploy.sh` (no migrations, no sidecar change).