### PR TITLE
feat(flow4d): Phase E — wayfinding & 2D structure (canonical views, ortho, minimap, structure tree, small multiples, task modes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "Zephyrus",
             "dependencies": {
                 "@heroui/react": "^2.6.14",
                 "@iconify/icons-solar": "^1.2.3",
@@ -43,6 +42,7 @@
                 "reactflow": "^11.11.4",
                 "tailwind-merge": "^3.0.1",
                 "three": "^0.185.0",
+                "troika-three-text": "^0.52.5",
                 "zod": "^4.4.3",
                 "zustand": "^5.0.11"
             },
@@ -9040,7 +9040,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
             "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-            "dev": true,
             "dependencies": {
                 "require-from-string": "^2.0.2"
             }
@@ -12809,7 +12808,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -13623,6 +13621,36 @@
                 "tree-kill": "cli.js"
             }
         },
+        "node_modules/troika-three-text": {
+            "version": "0.52.5",
+            "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.5.tgz",
+            "integrity": "sha512-Ry3jRhic9pzcY4JduSvRRyDmVOSqEW19gT4vtK+aCiPNVcDlmkxvGG0YbFd36RTDq1wExOupXnvNF/j1oiHHDA==",
+            "license": "MIT",
+            "dependencies": {
+                "bidi-js": "^1.0.2",
+                "troika-three-utils": "^0.52.5",
+                "troika-worker-utils": "^0.52.0",
+                "webgl-sdf-generator": "1.1.1"
+            },
+            "peerDependencies": {
+                "three": ">=0.125.0"
+            }
+        },
+        "node_modules/troika-three-utils": {
+            "version": "0.52.5",
+            "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.5.tgz",
+            "integrity": "sha512-WsePbcX8RtfidRfsxK1eCZCjF81ZDzAKHH/evLs0hdV2wpoCb0vArGZHdzdOJrSS3k4zfdtbKDaBh8+phkrYnw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "three": ">=0.125.0"
+            }
+        },
+        "node_modules/troika-worker-utils": {
+            "version": "0.52.0",
+            "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+            "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+            "license": "MIT"
+        },
         "node_modules/ts-interface-checker": {
             "version": "0.1.13",
             "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -14033,6 +14061,12 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/webgl-sdf-generator": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+            "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+            "license": "MIT"
         },
         "node_modules/webidl-conversions": {
             "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
         "reactflow": "^11.11.4",
         "tailwind-merge": "^3.0.1",
         "three": "^0.185.0",
+        "troika-three-text": "^0.52.5",
         "zod": "^4.4.3",
         "zustand": "^5.0.11"
     }

--- a/resources/js/Components/PatientFlowNavigator/NavigatorChronobar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorChronobar.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo } from 'react';
 import type { ForecastAggregates } from '@/features/patientFlowNavigator/projections';
 import type { PatientFlowFreshness } from '@/features/patientFlowNavigator/types';
+import { WINDOW_PRESET_LABELS } from '@/features/patientFlowNavigator/replayTimeline';
+import type { WindowPreset } from '@/features/patientFlowNavigator/replayTimeline';
 import { formatDurationSeconds } from '@/lib/duration';
 
 interface NavigatorChronobarProps {
@@ -25,7 +27,12 @@ interface NavigatorChronobarProps {
   /** True while the stored-replay stream is connected (N-8: never "live"). */
   replaying?: boolean;
   onScrub: (timeMs: number) => void;
+  /** TN-6 window presets — the control renders only when a handler is wired. */
+  windowPreset?: WindowPreset;
+  onWindowPresetChange?: (preset: WindowPreset) => void;
 }
+
+const WINDOW_PRESET_ORDER: WindowPreset[] = ['48h', '24h', '6h', 'shift'];
 
 /** ±step affordance (SC 2.5.7 single-pointer alternative to drag-scrub). */
 const STEP_MS = 15 * 60 * 1_000;
@@ -86,6 +93,8 @@ export default function NavigatorChronobar({
   patientTicks = [],
   replaying = false,
   onScrub,
+  windowPreset = '48h',
+  onWindowPresetChange,
 }: NavigatorChronobarProps) {
   const span = Math.max(1, windowEnd - windowStart);
   const pct = (ms: number): number => Math.min(100, Math.max(0, ((ms - windowStart) / span) * 100));
@@ -143,6 +152,32 @@ export default function NavigatorChronobar({
           </button>
         </div>
       </div>
+
+      {/* TN-6: window presets — historical sources keep their extent window,
+          so the control disables rather than lying about the span. */}
+      {onWindowPresetChange && (
+        <div
+          className="patient-flow-chronobar-presets"
+          role="radiogroup"
+          aria-label="Chronobar window span"
+        >
+          {WINDOW_PRESET_ORDER.map((preset) => (
+            <label key={preset} className={windowPreset === preset ? 'active' : ''}>
+              <input
+                type="radio"
+                name="flow-window-preset"
+                checked={windowPreset === preset}
+                disabled={historical}
+                title={preset === 'shift'
+                  ? 'Window the current 07:00–19:00 shift block'
+                  : `Window ${WINDOW_PRESET_LABELS[preset]} around now`}
+                onChange={() => onWindowPresetChange(preset)}
+              />
+              {WINDOW_PRESET_LABELS[preset]}
+            </label>
+          ))}
+        </div>
+      )}
 
       {densityBuckets.length > 0 && (
         <div aria-hidden="true" className="patient-flow-chronobar-density">

--- a/resources/js/Components/PatientFlowNavigator/NavigatorMinimap.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorMinimap.tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { PatientFlowLocations } from '@/features/patientFlowNavigator/types';
+import type { OccupancyInsight } from '@/features/patientFlowNavigator/types';
+import type { CameraView } from './NavigatorScene';
+import { projectorForPoints } from '@/features/patientFlowNavigator/minimapProjection';
+
+/**
+ * Minimap / floor plate (E1): a top-down 2D schematic answering "where am I"
+ * at a glance. Location dots, delay/deviation pips (shape-coded, never color
+ * alone — CVD safe), the camera footprint (target + look direction), and the
+ * selection dot. Click a spot to fly there; the header button fits the floor.
+ *
+ * Camera + selection are POLLED from the scene (not props) so the parent never
+ * re-renders on the ~7 Hz camera stream — only this small SVG updates.
+ * Suppressed on wall/kiosk (?wall=1) by the orchestrator.
+ */
+
+interface NavigatorMinimapProps {
+  locations: PatientFlowLocations;
+  /** Current floor filter ('all' or a floor number). */
+  floor: string;
+  /** Delayed/watch occupancy insights — the delay pips. */
+  delayed: OccupancyInsight[];
+  /** Location codes with an observed pathway deviation — the deviation pips. */
+  deviationLocations: Set<string>;
+  /** Reads the live camera pose (target + position) from the scene. */
+  getCameraView: () => CameraView | null;
+  /** Reads the current selection's world position from the scene. */
+  getSelectionPoint: () => { x: number; y: number; z: number } | null;
+  /** Fly to a clicked world point. */
+  onNavigate: (point: { x: number; y: number; z: number }) => void;
+  /** Frame the whole current floor (the header button). */
+  onFitFloor: () => void;
+}
+
+const SIZE = 168;
+const POLL_MS = 160;
+
+export default function NavigatorMinimap({
+  locations,
+  floor,
+  delayed,
+  deviationLocations,
+  getCameraView,
+  getSelectionPoint,
+  onNavigate,
+  onFitFloor,
+}: NavigatorMinimapProps) {
+  const [open, setOpen] = useState(true);
+
+  // Floor-filtered location points (world XZ) + the projector over them.
+  const floorPoints = useMemo(() => {
+    return Object.values(locations)
+      .filter((loc) => loc.position_m && (floor === 'all' || String(loc.floor) === floor))
+      .map((loc) => ({
+        code: loc.location_code,
+        x: loc.position_m!.x,
+        z: loc.position_m!.z,
+        y: loc.position_m!.y ?? 0,
+      }));
+  }, [locations, floor]);
+
+  const projector = useMemo(
+    () => projectorForPoints(floorPoints.map((point) => ({ x: point.x, z: point.z }))),
+    [floorPoints],
+  );
+
+  // Poll the scene for camera + selection so the parent is never re-rendered
+  // by the camera stream. Only this component ticks.
+  const [camera, setCamera] = useState<CameraView | null>(null);
+  const [selection, setSelection] = useState<{ x: number; y: number; z: number } | null>(null);
+  const cameraKey = useRef('');
+  const selectionKey = useRef('');
+  useEffect(() => {
+    if (!open) return undefined;
+    const tick = (): void => {
+      const view = getCameraView();
+      const key = view ? `${view.target.x.toFixed(0)}|${view.target.z.toFixed(0)}|${view.position.x.toFixed(0)}|${view.position.z.toFixed(0)}` : '';
+      if (key !== cameraKey.current) { cameraKey.current = key; setCamera(view); }
+      const point = getSelectionPoint();
+      const skey = point ? `${point.x.toFixed(1)}|${point.z.toFixed(1)}` : '';
+      if (skey !== selectionKey.current) { selectionKey.current = skey; setSelection(point); }
+    };
+    tick();
+    const id = window.setInterval(tick, POLL_MS);
+    return () => window.clearInterval(id);
+  }, [open, getCameraView, getSelectionPoint]);
+
+  if (!projector || floorPoints.length === 0) return null;
+
+  const toXY = (x: number, z: number): { x: number; y: number } => {
+    const { u, v } = projector.project(x, z);
+    return { x: u * SIZE, y: v * SIZE };
+  };
+
+  const delayedByCode = new Map(delayed.map((insight) => [insight.location, insight]));
+
+  const handleClick = (event: React.MouseEvent<SVGSVGElement>): void => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const u = (event.clientX - rect.left) / rect.width;
+    const v = (event.clientY - rect.top) / rect.height;
+    const world = projector.unproject(u, v);
+    onNavigate({ x: world.x, y: 0, z: world.z });
+  };
+
+  const cameraTarget = camera ? toXY(camera.target.x, camera.target.z) : null;
+  const cameraFrom = camera ? toXY(camera.position.x, camera.position.z) : null;
+  const selectionXY = selection ? toXY(selection.x, selection.z) : null;
+
+  return (
+    <section className="patient-flow-minimap" aria-label="Floor minimap">
+      <button
+        type="button"
+        className="patient-flow-minimap-header"
+        aria-expanded={open}
+        title={open ? 'Collapse minimap' : 'Expand minimap'}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span>{floor === 'all' ? 'House' : `Floor ${floor}`}</span>
+        <span aria-hidden="true">{open ? '▾' : '▸'}</span>
+      </button>
+
+      {open && (
+        <div className="patient-flow-minimap-body">
+          <svg
+            width={SIZE}
+            height={SIZE}
+            viewBox={`0 0 ${SIZE} ${SIZE}`}
+            role="img"
+            aria-label={`Top-down map of ${floor === 'all' ? 'the house' : `floor ${floor}`}. Click to fly there.`}
+            onClick={handleClick}
+          >
+            {/* Location dots — the plate. */}
+            {floorPoints.map((point) => {
+              const { x, y } = toXY(point.x, point.z);
+              const isDeviant = deviationLocations.has(point.code);
+              const delayInsight = delayedByCode.get(point.code);
+              if (isDeviant) {
+                // Deviation pip — a square (bracket echo), never color alone.
+                return (
+                  <rect
+                    key={point.code}
+                    x={x - 3}
+                    y={y - 3}
+                    width={6}
+                    height={6}
+                    className="patient-flow-minimap-deviation"
+                  />
+                );
+              }
+              if (delayInsight && delayInsight.primaryStatus !== 'ok') {
+                // Delay pip — a triangle (echoes the scene's delayed cue).
+                return (
+                  <polygon
+                    key={point.code}
+                    points={`${x},${y - 4} ${x - 3.5},${y + 3} ${x + 3.5},${y + 3}`}
+                    className={`patient-flow-minimap-delay status-${delayInsight.primaryStatus}`}
+                  />
+                );
+              }
+              return <circle key={point.code} cx={x} cy={y} r={1.6} className="patient-flow-minimap-dot" />;
+            })}
+
+            {/* Camera footprint: look direction line + target crosshair. */}
+            {cameraTarget && cameraFrom && (
+              <line
+                x1={cameraFrom.x}
+                y1={cameraFrom.y}
+                x2={cameraTarget.x}
+                y2={cameraTarget.y}
+                className="patient-flow-minimap-look"
+              />
+            )}
+            {cameraTarget && (
+              <g className="patient-flow-minimap-camera">
+                <circle cx={cameraTarget.x} cy={cameraTarget.y} r={5} />
+                <line x1={cameraTarget.x - 7} y1={cameraTarget.y} x2={cameraTarget.x + 7} y2={cameraTarget.y} />
+                <line x1={cameraTarget.x} y1={cameraTarget.y - 7} x2={cameraTarget.x} y2={cameraTarget.y + 7} />
+              </g>
+            )}
+
+            {/* Selection dot — a ring so it reads over any pip beneath it. */}
+            {selectionXY && (
+              <circle cx={selectionXY.x} cy={selectionXY.y} r={4} className="patient-flow-minimap-selection" />
+            )}
+          </svg>
+
+          <button type="button" className="patient-flow-minimap-fit" onClick={onFitFloor}>
+            Fit floor
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { Text as TroikaText } from 'troika-three-text';
+import { buildFlightPath, flightDurationMs } from '@/features/patientFlowNavigator/cameraFlight';
 import { parseTime, positionFor } from '@/features/patientFlowNavigator/stateProjection';
 import { patientTokenInspectorData } from '@/features/patientFlowNavigator/inspector';
 import { confidenceOpacity } from '@/features/patientFlowNavigator/projections';
@@ -169,6 +171,24 @@ export class NavigatorScene {
 
   private readonly followDelta = new THREE.Vector3();
 
+  // E2: one active camera flight along the van Wijk arc. Operator input
+  // ('start') or a newer flight cancels it; pre-allocated vectors keep the
+  // per-frame step allocation-free.
+  private flight: {
+    startedAt: number;
+    duration: number;
+    panAt: (t: number) => number;
+    widthAt: (t: number) => number;
+    fromTarget: THREE.Vector3;
+    toTarget: THREE.Vector3;
+    fromDir: THREE.Vector3;
+    toDir: THREE.Vector3;
+  } | null = null;
+
+  private readonly flightScratchTarget = new THREE.Vector3();
+
+  private readonly flightScratchDir = new THREE.Vector3();
+
   private traceLineMaterial: THREE.LineBasicMaterial | null = null;
 
   // Phase C (plan §7.2): pathway-deviation glyphs. A hollow amber bracket
@@ -181,6 +201,19 @@ export class NavigatorScene {
   private pathwayDeviations = new Map<string, string>();
 
   private pathwayEnabled = false;
+
+  // E2: SDF unit-name billboards (troika-three-text). Wayfinding labels, not
+  // clickable — kept out of the raycast set. Distance-culled + LOD-scaled and
+  // billboarded each frame; hidden entirely in ortho/top overview (E3).
+  private unitLabelLayer = new THREE.Group();
+
+  private unitLabels = new Map<string, TroikaText>();
+
+  private unitLabelsEnabled = false;
+
+  private static readonly LABEL_CULL_DISTANCE = 300;
+
+  private static readonly LABEL_NEAR_DISTANCE = 70;
 
   private heatSingleMaterial: THREE.MeshStandardMaterial;
 
@@ -389,11 +422,15 @@ export class NavigatorScene {
     grid.position.y = -0.12;
     this.scene.add(grid);
 
-    this.scene.add(this.forecastLayer, this.heatLayer, this.trailLayer, this.ghostLayer, this.patientLayer, this.barrierLayer, this.roundsLayer, this.roundsRouteLayer, this.pathwayLayer);
+    this.scene.add(this.forecastLayer, this.heatLayer, this.trailLayer, this.ghostLayer, this.patientLayer, this.barrierLayer, this.roundsLayer, this.roundsRouteLayer, this.pathwayLayer, this.unitLabelLayer);
 
     // Tour Auto pauses when the OPERATOR grabs the camera; OrbitControls only
-    // dispatches 'start' for real input, never for programmatic flights.
-    this.orbit.addEventListener('start', () => this.callbacks.onUserCameraStart?.());
+    // dispatches 'start' for real input, never for programmatic flights. The
+    // operator's hand also cancels any in-progress flight (E2).
+    this.orbit.addEventListener('start', () => {
+      this.flight = null;
+      this.callbacks.onUserCameraStart?.();
+    });
 
     this.heatSingleMaterial = new THREE.MeshStandardMaterial({
       color: 0x77c06f,
@@ -1303,16 +1340,195 @@ export class NavigatorScene {
     return material;
   }
 
-  focusOn(points: Array<{ x: number; y: number; z: number }>): void {
+  // The fixed 3/4 iso direction focusOn has always framed from — preserved so
+  // a Focus flight lands on the same view it used to jump to.
+  private static readonly ISO_DIR = new THREE.Vector3(1.35, 1.05, 1.35).normalize();
+
+  private static readonly ISO_DISTANCE_SCALE = Math.hypot(1.35, 1.05, 1.35);
+
+  /**
+   * Frame a set of points. Animated by default along the van Wijk arc (E2);
+   * pass `{ instant: true }` for a hard cut (used where a flight would fight a
+   * rebuild). The destination direction stays the classic iso 3/4 framing.
+   */
+  focusOn(points: Array<{ x: number; y: number; z: number }>, options?: { instant?: boolean }): void {
     if (!points.length) return;
     const box = new THREE.Box3();
     points.forEach((point) => box.expandByPoint(new THREE.Vector3(point.x, point.y, point.z)));
     const center = box.getCenter(new THREE.Vector3());
     const size = box.getSize(new THREE.Vector3());
     const radius = Math.max(size.x, size.y, size.z, 24);
-    this.orbit.target.copy(center);
-    this.camera.position.set(center.x + radius * 1.35, center.y + radius * 1.05, center.z + radius * 1.35);
-    this.orbit.update();
+    const distance = radius * NavigatorScene.ISO_DISTANCE_SCALE;
+    this.flyTo(center, distance, NavigatorScene.ISO_DIR, options);
+  }
+
+  /**
+   * Move the camera to look at `target` from `dir` at `distance`. Animated
+   * along the van Wijk & Nuij optimal pan/zoom arc unless `instant` — long
+   * pans arc out for context, short hops stay near-linear (E2).
+   */
+  flyTo(
+    target: THREE.Vector3,
+    distance: number,
+    dir: THREE.Vector3,
+    options?: { instant?: boolean },
+  ): void {
+    const toDir = dir.clone().normalize();
+    if (options?.instant) {
+      this.flight = null;
+      this.orbit.target.copy(target);
+      this.camera.position.copy(target).addScaledVector(toDir, distance);
+      this.orbit.update();
+      return;
+    }
+
+    const fromTarget = this.orbit.target.clone();
+    const fromDir = this.flightScratchDir.subVectors(this.camera.position, this.orbit.target);
+    const fromDistance = Math.max(this.orbit.minDistance, fromDir.length());
+    fromDir.normalize();
+
+    const panDistance = fromTarget.distanceTo(target);
+    const path = buildFlightPath(panDistance, fromDistance, distance);
+    // Degenerate (already there) — no flight, just settle.
+    if (path.pathLength < 1e-4) {
+      this.flight = null;
+      this.orbit.target.copy(target);
+      this.camera.position.copy(target).addScaledVector(toDir, distance);
+      this.orbit.update();
+      return;
+    }
+
+    this.flight = {
+      startedAt: performance.now(),
+      duration: flightDurationMs(path.pathLength),
+      panAt: path.panAt,
+      widthAt: path.widthAt,
+      fromTarget,
+      toTarget: target.clone(),
+      fromDir: fromDir.clone(),
+      toDir,
+    };
+  }
+
+  /** Advance an active flight; returns true while one is running (animate). */
+  private stepFlight(): boolean {
+    const flight = this.flight;
+    if (!flight) return false;
+    const elapsed = performance.now() - flight.startedAt;
+    const t = Math.min(1, elapsed / flight.duration);
+
+    // Pan along the straight target line; smoothstep the reorientation so a
+    // direction change eases rather than tracks the (non-linear) pan param.
+    const pan = flight.panAt(t);
+    const width = flight.widthAt(t);
+    const ease = t * t * (3 - 2 * t);
+
+    this.flightScratchTarget.copy(flight.fromTarget).lerp(flight.toTarget, pan);
+    this.flightScratchDir.copy(flight.fromDir).lerp(flight.toDir, ease);
+    if (this.flightScratchDir.lengthSq() < 1e-6) this.flightScratchDir.copy(flight.toDir);
+    this.flightScratchDir.normalize();
+
+    this.orbit.target.copy(this.flightScratchTarget);
+    this.camera.position.copy(this.flightScratchTarget).addScaledVector(this.flightScratchDir, width);
+
+    if (t >= 1) this.flight = null;
+    return true;
+  }
+
+  /** True while a programmatic flight is in progress (tests / soak). */
+  isFlying(): boolean {
+    return this.flight !== null;
+  }
+
+  /**
+   * E2: place SDF unit-name billboards at unit anchors. Rebuilds the label set
+   * only when the anchor list changes (cheap: ~20 units); positioning,
+   * billboarding, LOD scale, and distance culling happen per frame in
+   * updateUnitLabels. `enabled` gates the whole layer (persona/ortho off).
+   */
+  setUnitLabels(labels: Array<{ id: string; text: string; position: { x: number; y: number; z: number } }>, enabled: boolean): void {
+    this.unitLabelsEnabled = enabled;
+    const seen = new Set<string>();
+    for (const { id, text, position } of labels) {
+      seen.add(id);
+      let label = this.unitLabels.get(id);
+      if (!label) {
+        label = new TroikaText();
+        label.font = undefined; // troika's bundled default (Roboto SDF) — no network fetch
+        label.fontSize = 4.2;
+        label.anchorX = 'center';
+        label.anchorY = 'middle';
+        label.color = 0xece7dc;
+        label.outlineWidth = 0.18;
+        label.outlineColor = 0x121514;
+        label.material.depthWrite = false;
+        label.material.transparent = true;
+        this.unitLabels.set(id, label);
+        this.unitLabelLayer.add(label);
+      }
+      if (label.text !== text) {
+        label.text = text;
+        label.sync();
+      }
+      label.userData.anchor = position;
+    }
+    // Drop labels for units no longer present.
+    for (const [id, label] of this.unitLabels.entries()) {
+      if (!seen.has(id)) {
+        this.unitLabelLayer.remove(label);
+        label.dispose();
+        this.unitLabels.delete(id);
+      }
+    }
+  }
+
+  /** Per-frame billboard + LOD + distance-cull for the unit labels (E2). */
+  private updateUnitLabels(): void {
+    if (this.unitLabels.size === 0) return;
+    const show = this.unitLabelsEnabled;
+    for (const label of this.unitLabels.values()) {
+      const anchor = label.userData.anchor as { x: number; y: number; z: number } | undefined;
+      if (!show || !anchor) {
+        label.visible = false;
+        continue;
+      }
+      label.position.set(anchor.x, anchor.y + 6.5, anchor.z);
+      const distance = this.camera.position.distanceTo(label.position);
+      if (distance > NavigatorScene.LABEL_CULL_DISTANCE) {
+        label.visible = false;
+        continue;
+      }
+      label.visible = true;
+      label.quaternion.copy(this.camera.quaternion);
+      // LOD: hold true size when close, grow slightly with distance so far
+      // labels stay legible without dominating; fade the farthest third.
+      const near = NavigatorScene.LABEL_NEAR_DISTANCE;
+      const far = NavigatorScene.LABEL_CULL_DISTANCE;
+      const scale = distance <= near ? 1 : 1 + ((distance - near) / (far - near)) * 0.9;
+      label.scale.setScalar(scale);
+      const fadeStart = far * 0.72;
+      label.material.opacity = distance <= fadeStart
+        ? 1
+        : Math.max(0, 1 - (distance - fadeStart) / (far - fadeStart));
+    }
+  }
+
+  // Straight-down direction for the Top canonical view — a hair of −z keeps
+  // OrbitControls out of the pole singularity while reading as plan-view.
+  private static readonly TOP_DIR = new THREE.Vector3(0, 1, 0.0001).normalize();
+
+  /**
+   * E2 canonical "Top" view: frame the points from directly overhead (plan
+   * view) so structure and spread read without perspective foreshortening.
+   */
+  focusTopDown(points: Array<{ x: number; y: number; z: number }>, options?: { instant?: boolean }): void {
+    if (!points.length) return;
+    const box = new THREE.Box3();
+    points.forEach((point) => box.expandByPoint(new THREE.Vector3(point.x, point.y, point.z)));
+    const center = box.getCenter(new THREE.Vector3());
+    const size = box.getSize(new THREE.Vector3());
+    const spread = Math.max(size.x, size.z, 24);
+    this.flyTo(center, spread * 1.8, NavigatorScene.TOP_DIR, options);
   }
 
   /** Fly to the current selection; false when nothing is selected (N-6 `F`). */
@@ -1341,9 +1557,16 @@ export class NavigatorScene {
   }
 
   resetCamera(): void {
+    this.flight = null;
     this.camera.position.copy(HOME_POSITION);
     this.orbit.target.copy(HOME_TARGET);
     this.orbit.update();
+  }
+
+  /** E2 canonical "House" view: fly (arc) to the default iso overview. */
+  flyToHome(options?: { instant?: boolean }): void {
+    const dir = HOME_POSITION.clone().sub(HOME_TARGET);
+    this.flyTo(HOME_TARGET.clone(), dir.length(), dir.normalize(), options);
   }
 
   /** Renderer memory/draw counters for the H4 soak hook (soakHook.ts). */
@@ -1380,6 +1603,13 @@ export class NavigatorScene {
     this.clearGroup(this.roundsRouteLayer);
     this.clearGroup(this.pathwayLayer);
     this.glyphByPatient.clear();
+    // troika Text owns its own GPU resources — dispose each, don't route
+    // through clearGroup (which only handles Mesh geometry).
+    this.unitLabels.forEach((label) => {
+      this.unitLabelLayer.remove(label);
+      label.dispose();
+    });
+    this.unitLabels.clear();
     this.roundStopMeshByUuid.clear();
     this.queueSpriteMaterials.forEach((material) => {
       material.map?.dispose();
@@ -1418,7 +1648,11 @@ export class NavigatorScene {
     if (this.disposed) return;
     const delta = Math.min(this.clock.getDelta(), 0.05);
     this.callbacks.onFrame(delta);
+    // E2: advance any active van Wijk flight before OrbitControls damps —
+    // the flight owns target+position this frame, damping then settles.
+    this.stepFlight();
     this.orbit.update();
+    this.updateUnitLabels();
     this.emitCameraText();
     this.renderer.render(this.scene, this.camera);
     this.animationId = requestAnimationFrame(this.animate);

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -223,6 +223,15 @@ export class NavigatorScene {
 
   private static readonly LABEL_NEAR_DISTANCE = 70;
 
+  // E4: GSTC flatten — the last-N-hours trail density as flat floor tiles.
+  // A transient MODE (not a persistent layer), so it never enters the layer
+  // schema/saved-views; cleared on toggle-off.
+  private trailHeatLayer = new THREE.Group();
+
+  private trailHeatGeometry = new THREE.PlaneGeometry(1, 1).rotateX(-Math.PI / 2);
+
+  private trailHeatMaterials: THREE.MeshBasicMaterial[] = [];
+
   private heatSingleMaterial: THREE.MeshStandardMaterial;
 
   private heatMultiMaterial: THREE.MeshStandardMaterial;
@@ -441,7 +450,7 @@ export class NavigatorScene {
     grid.position.y = -0.12;
     this.scene.add(grid);
 
-    this.scene.add(this.forecastLayer, this.heatLayer, this.trailLayer, this.ghostLayer, this.patientLayer, this.barrierLayer, this.roundsLayer, this.roundsRouteLayer, this.pathwayLayer, this.unitLabelLayer);
+    this.scene.add(this.forecastLayer, this.heatLayer, this.trailLayer, this.trailHeatLayer, this.ghostLayer, this.patientLayer, this.barrierLayer, this.roundsLayer, this.roundsRouteLayer, this.pathwayLayer, this.unitLabelLayer);
 
     // Tour Auto pauses when the OPERATOR grabs the camera; OrbitControls only
     // dispatches 'start' for real input, never for programmatic flights. The
@@ -864,6 +873,44 @@ export class NavigatorScene {
   /** Trace mode on/off (B3). Caller owns triggering the bucketed rebuild. */
   setTraceMode(patientId: string | null): void {
     this.tracePatientId = patientId;
+  }
+
+  /**
+   * E4 GSTC flatten: render last-N-hours trail density as flat floor tiles.
+   * `cells` carry world centers + normalized intensity; `cellW/cellD` size the
+   * tile. A transient mode — pass an empty array (or visible=false) to clear.
+   * Materials are pooled by intensity bucket so a rebuild allocates no GPU
+   * material. Density reads as a cool analysis ink, never a status color.
+   */
+  setTrailHeat(
+    cells: Array<{ x: number; y: number; z: number; intensity: number }>,
+    cellW: number,
+    cellD: number,
+    visible: boolean,
+  ): void {
+    while (this.trailHeatLayer.children.length) {
+      this.trailHeatLayer.children.pop();
+    }
+    if (!visible || cells.length === 0) return;
+    if (this.trailHeatMaterials.length === 0) {
+      // 6 opacity buckets of one cool ink — aggregate density, not status.
+      for (let bucket = 0; bucket < 6; bucket += 1) {
+        this.trailHeatMaterials.push(new THREE.MeshBasicMaterial({
+          color: 0x8fb8cc,
+          transparent: true,
+          opacity: 0.12 + (bucket / 5) * 0.6,
+          depthWrite: false,
+        }));
+      }
+    }
+    for (const cell of cells) {
+      const bucket = Math.min(5, Math.max(0, Math.round(cell.intensity * 5)));
+      const tile = new THREE.Mesh(this.trailHeatGeometry, this.trailHeatMaterials[bucket]);
+      tile.position.set(cell.x, cell.y, cell.z);
+      tile.scale.set(cellW * 0.96, 1, cellD * 0.96);
+      tile.userData = { kind: 'trail-heat' };
+      this.trailHeatLayer.add(tile);
+    }
   }
 
   /**
@@ -1738,6 +1785,9 @@ export class NavigatorScene {
     this.roundMaterials.forEach((material) => material.dispose());
     this.heatSingleMaterial.dispose();
     this.heatMultiMaterial.dispose();
+    while (this.trailHeatLayer.children.length) this.trailHeatLayer.children.pop();
+    this.trailHeatMaterials.forEach((material) => material.dispose());
+    this.trailHeatGeometry.dispose();
     this.tokenGeometry.dispose();
     this.ghostGeometry.dispose();
     this.heatGeometry.dispose();

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -562,6 +562,14 @@ export class NavigatorScene {
     return this.selectedEntity;
   }
 
+  /** World position of the current selection, or null (E1 minimap dot). */
+  getSelectionPoint(): { x: number; y: number; z: number } | null {
+    const mesh = this.selectedMesh
+      ?? (this.selectedEntity ? this.resolveEntityMesh(this.selectedEntity) : null);
+    if (!mesh) return null;
+    return { x: mesh.position.x, y: mesh.position.y, z: mesh.position.z };
+  }
+
   /** Stable entity for a hit, or null for mesh-only kinds (ghost/base). */
   private entityForMesh(mesh: THREE.Mesh): SelectionEntity | null {
     const data = mesh.userData ?? {};

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -501,6 +501,11 @@ export class NavigatorScene {
     this.clearSelectionVisual();
   }
 
+  /** The current stable selection, for view-link snapshots (E5). */
+  getSelectedEntity(): SelectionEntity | null {
+    return this.selectedEntity;
+  }
+
   /** Stable entity for a hit, or null for mesh-only kinds (ghost/base). */
   private entityForMesh(mesh: THREE.Mesh): SelectionEntity | null {
     const data = mesh.userData ?? {};

--- a/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorScene.ts
@@ -103,7 +103,15 @@ export class NavigatorScene {
 
   private scene: THREE.Scene;
 
-  private camera: THREE.PerspectiveCamera;
+  // The ACTIVE camera (raycast, flight, billboards, render all read this).
+  // E3 swaps it between the perspective iso camera and a top-down ortho one.
+  private camera: THREE.PerspectiveCamera | THREE.OrthographicCamera;
+
+  private perspectiveCamera: THREE.PerspectiveCamera;
+
+  private orthoCamera: THREE.OrthographicCamera;
+
+  private orthoEnabled = false;
 
   private orbit: OrbitControls;
 
@@ -293,10 +301,16 @@ export class NavigatorScene {
   private readonly onResize = (): void => {
     const width = this.container.clientWidth;
     const height = this.container.clientHeight;
-    this.camera.aspect = width / height;
-    this.camera.updateProjectionMatrix();
+    this.perspectiveCamera.aspect = width / height;
+    this.perspectiveCamera.updateProjectionMatrix();
+    // E3: the ortho frustum re-derives from its framed height on aspect change.
+    if (this.orthoEnabled) this.applyOrthoFrustum(this.orthoFrameHeight);
     this.renderer.setSize(width, height);
   };
+
+  // E3: the world-space vertical extent the ortho camera frames; focus/fit
+  // updates it, resize re-derives the frustum from it.
+  private orthoFrameHeight = 180;
 
   // Reused per-cast buffers — the 20 Hz hover path must not allocate.
   private raycastScratch: THREE.Object3D[] = [];
@@ -400,8 +414,13 @@ export class NavigatorScene {
     this.scene.background = new THREE.Color(0x121514);
     this.scene.fog = new THREE.Fog(0x121514, 150, 470);
 
-    this.camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 1400);
-    this.camera.position.copy(HOME_POSITION);
+    this.perspectiveCamera = new THREE.PerspectiveCamera(60, width / height, 0.1, 1400);
+    this.perspectiveCamera.position.copy(HOME_POSITION);
+    // E3 ortho camera — frustum sized on toggle; up = −z so north reads "up"
+    // in plan view. Far plane clears the fixed high vantage it flies to.
+    this.orthoCamera = new THREE.OrthographicCamera(-100, 100, 100, -100, 0.1, 2000);
+    this.orthoCamera.up.set(0, 0, -1);
+    this.camera = this.perspectiveCamera;
 
     this.orbit = new OrbitControls(this.camera, this.renderer.domElement);
     this.orbit.target.copy(HOME_TARGET);
@@ -1373,6 +1392,12 @@ export class NavigatorScene {
     dir: THREE.Vector3,
     options?: { instant?: boolean },
   ): void {
+    // E3: in plan view there is no arc — reframe the ortho camera straight
+    // down, mapping the requested framing distance to the frustum height.
+    if (this.orthoEnabled) {
+      this.frameOrtho(target.clone(), Math.max(40, distance));
+      return;
+    }
     const toDir = dir.clone().normalize();
     if (options?.instant) {
       this.flight = null;
@@ -1541,32 +1566,106 @@ export class NavigatorScene {
     return true;
   }
 
-  /** Camera pose snapshot for saved views (N-7). */
+  /** Camera pose snapshot for saved views / view links (N-7/E5). Always the
+   *  perspective pose — bookmarks and links are perspective-framed. */
   getCameraView(): CameraView {
+    const position = this.perspectiveCamera.position;
     return {
-      position: { x: this.camera.position.x, y: this.camera.position.y, z: this.camera.position.z },
+      position: { x: position.x, y: position.y, z: position.z },
       target: { x: this.orbit.target.x, y: this.orbit.target.y, z: this.orbit.target.z },
     };
   }
 
-  /** Restore a saved camera pose (N-7). */
+  /** Restore a saved camera pose (N-7). Exits ortho — bookmarks are iso. */
   setCameraView(view: CameraView): void {
-    this.camera.position.set(view.position.x, view.position.y, view.position.z);
+    if (this.orthoEnabled) this.setOrthographic(false);
+    this.perspectiveCamera.position.set(view.position.x, view.position.y, view.position.z);
     this.orbit.target.set(view.target.x, view.target.y, view.target.z);
     this.orbit.update();
   }
 
   resetCamera(): void {
     this.flight = null;
-    this.camera.position.copy(HOME_POSITION);
+    // Home is the panic key — always land in the perspective iso overview.
+    if (this.orthoEnabled) this.setOrthographic(false);
+    this.perspectiveCamera.position.copy(HOME_POSITION);
     this.orbit.target.copy(HOME_TARGET);
     this.orbit.update();
   }
 
   /** E2 canonical "House" view: fly (arc) to the default iso overview. */
   flyToHome(options?: { instant?: boolean }): void {
+    if (this.orthoEnabled) {
+      this.frameOrtho(HOME_TARGET.clone(), this.orthoFrameHeight);
+      return;
+    }
     const dir = HOME_POSITION.clone().sub(HOME_TARGET);
     this.flyTo(HOME_TARGET.clone(), dir.length(), dir.normalize(), options);
+  }
+
+  /**
+   * E3: toggle the top-down orthographic plan view. Ortho reads structure and
+   * spread without perspective foreshortening — locked straight-down, pan +
+   * zoom only. The active camera swaps beneath OrbitControls, raycast, flight,
+   * and billboards (all read `this.camera`); the perspective iso view restores
+   * on toggle-off. Returns the new state.
+   */
+  setOrthographic(enabled: boolean): boolean {
+    if (enabled === this.orthoEnabled) return this.orthoEnabled;
+    this.flight = null;
+    const target = this.orbit.target.clone();
+
+    if (enabled) {
+      // Frame the same vertical extent the perspective view currently shows.
+      const distance = this.perspectiveCamera.position.distanceTo(target);
+      const height = 2 * distance * Math.tan((this.perspectiveCamera.fov * Math.PI) / 180 / 2);
+      this.camera = this.orthoCamera;
+      this.orbit.object = this.orthoCamera;
+      this.orbit.minPolarAngle = 0;
+      this.orbit.maxPolarAngle = 0; // locked straight down (plan view)
+      this.frameOrtho(target, Math.max(40, height));
+    } else {
+      // Restore the iso perspective looking at the same target, distance
+      // recovered from the ortho frame height so the scale barely jumps.
+      const distance = this.orthoFrameHeight / (2 * Math.tan((this.perspectiveCamera.fov * Math.PI) / 180 / 2));
+      this.camera = this.perspectiveCamera;
+      this.orbit.object = this.perspectiveCamera;
+      this.orbit.minPolarAngle = 0;
+      this.orbit.maxPolarAngle = Math.PI * 0.49;
+      this.perspectiveCamera.position.copy(target).addScaledVector(NavigatorScene.ISO_DIR, distance);
+      this.orbit.target.copy(target);
+      this.orbit.update();
+    }
+
+    this.orthoEnabled = enabled;
+    return this.orthoEnabled;
+  }
+
+  isOrthographic(): boolean {
+    return this.orthoEnabled;
+  }
+
+  /** Point the ortho camera straight down at `target`, framing `height`. */
+  private frameOrtho(target: THREE.Vector3, height: number): void {
+    this.orbit.target.copy(target);
+    // A fixed high vantage — ortho scale is frustum-based, not distance-based,
+    // so any height that clears the scene works; the tiny +z avoids the pole.
+    this.orthoCamera.position.set(target.x, target.y + 800, target.z + 0.001);
+    this.applyOrthoFrustum(height);
+    this.orbit.update();
+  }
+
+  /** Size the ortho frustum to frame `height` world units at the current aspect. */
+  private applyOrthoFrustum(height: number): void {
+    this.orthoFrameHeight = height;
+    const aspect = this.container.clientWidth / Math.max(1, this.container.clientHeight);
+    const halfH = height / 2;
+    const halfW = halfH * aspect;
+    this.orthoCamera.left = -halfW;
+    this.orthoCamera.right = halfW;
+    this.orthoCamera.top = halfH;
+    this.orthoCamera.bottom = -halfH;
+    this.orthoCamera.updateProjectionMatrix();
   }
 
   /** Renderer memory/draw counters for the H4 soak hook (soakHook.ts). */

--- a/resources/js/Components/PatientFlowNavigator/NavigatorSmallMultiples.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorSmallMultiples.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import type { PatientFlowEvent, PatientFlowLocations } from '@/features/patientFlowNavigator/types';
+import { heatBounds, hourlySlices } from '@/features/patientFlowNavigator/trailHeat';
+import type { HourlySlice } from '@/features/patientFlowNavigator/trailHeat';
+
+/**
+ * Hourly small multiples (E4): six top-down density plates for the last six
+ * hours, side by side — the analysis path that replaces forced replay. A quiet
+ * hour reads quiet (patient count shown), a busy corridor reads hot. Density is
+ * opacity on ONE neutral ink (aggregate flow, never a status color). Collapsed
+ * by default; "Export" saves the strip as an SVG for a report.
+ */
+
+interface NavigatorSmallMultiplesProps {
+  tracks: Map<string, PatientFlowEvent[]>;
+  locations: PatientFlowLocations;
+  floor: string;
+  /** End of the window (wall-clock now, or the scrubbed instant). */
+  endMs: number;
+  /** E4 GSTC flatten: whether the last-6h density is drawn on the 3D floor. */
+  floorHeatOn: boolean;
+  onToggleFloorHeat: () => void;
+}
+
+const TILE = 84;
+
+function SlicePlate({ slice }: { slice: HourlySlice }) {
+  const { grid } = slice;
+  const cellW = TILE / grid.cols;
+  const cellH = TILE / grid.rows;
+  return (
+    <figure className="patient-flow-sm-plate">
+      <svg width={TILE} height={TILE} viewBox={`0 0 ${TILE} ${TILE}`} role="img" aria-label={`Flow density ${slice.label}, ${slice.patients} patients`}>
+        <rect x={0} y={0} width={TILE} height={TILE} className="patient-flow-sm-bg" />
+        {grid.cells.map((count, index) => {
+          if (count === 0 || grid.max === 0) return null;
+          const col = index % grid.cols;
+          const row = Math.floor(index / grid.cols);
+          return (
+            <rect
+              key={index}
+              x={col * cellW}
+              y={row * cellH}
+              width={cellW}
+              height={cellH}
+              className="patient-flow-sm-cell"
+              fillOpacity={0.12 + 0.88 * (count / grid.max)}
+            />
+          );
+        })}
+      </svg>
+      <figcaption>
+        <span>{slice.label}</span>
+        <small>{slice.patients} pt</small>
+      </figcaption>
+    </figure>
+  );
+}
+
+export default function NavigatorSmallMultiples({
+  tracks,
+  locations,
+  floor,
+  endMs,
+  floorHeatOn,
+  onToggleFloorHeat,
+}: NavigatorSmallMultiplesProps) {
+  const [open, setOpen] = useState(false);
+  const stripRef = useRef<HTMLDivElement>(null);
+
+  const bounds = useMemo(() => heatBounds(locations, floor), [locations, floor]);
+  const slices = useMemo(
+    () => (bounds ? hourlySlices(tracks, locations, bounds, endMs, 6, floor) : []),
+    [bounds, tracks, locations, endMs, floor],
+  );
+
+  const exportStrip = useCallback((): void => {
+    const svgs = stripRef.current?.querySelectorAll('svg');
+    if (!svgs || svgs.length === 0) return;
+    const width = TILE * svgs.length + 8 * (svgs.length - 1);
+    const parts: string[] = [];
+    svgs.forEach((svg, index) => {
+      parts.push(`<g transform="translate(${index * (TILE + 8)},0)">${svg.innerHTML}</g>`);
+    });
+    const doc = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${TILE}" viewBox="0 0 ${width} ${TILE}"><rect width="${width}" height="${TILE}" fill="#121514"/>${parts.join('')}</svg>`;
+    const blob = new Blob([doc], { type: 'image/svg+xml' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `flow-6h-${floor === 'all' ? 'house' : `floor${floor}`}.svg`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }, [floor]);
+
+  if (!bounds) return null;
+
+  return (
+    <section className="patient-flow-small-multiples" aria-label="Hourly flow density">
+      <button
+        type="button"
+        className="patient-flow-sm-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        Last 6 h <span aria-hidden="true">{open ? '▾' : '▸'}</span>
+      </button>
+
+      {open && (
+        <div className="patient-flow-sm-body">
+          <div className="patient-flow-sm-strip" ref={stripRef}>
+            {slices.map((slice) => (
+              <SlicePlate key={slice.startMs} slice={slice} />
+            ))}
+          </div>
+          <div className="patient-flow-sm-footer">
+            <span>Flow density · one hour per plate · analysis, not live</span>
+            <div className="patient-flow-sm-actions">
+              <button
+                type="button"
+                className={`patient-flow-sm-floor ${floorHeatOn ? 'active' : ''}`}
+                aria-pressed={floorHeatOn}
+                title="Flatten the last 6 hours of movement onto the 3D floor"
+                onClick={onToggleFloorHeat}
+              >
+                On floor
+              </button>
+              <button type="button" className="patient-flow-sm-export" onClick={exportStrip}>
+                Export SVG
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorStructureNav.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorStructureNav.tsx
@@ -1,0 +1,169 @@
+import React, { useCallback, useId, useMemo, useRef, useState } from 'react';
+import type { PatientFlowLocations } from '@/features/patientFlowNavigator/types';
+import {
+  buildStructureTree,
+  flattenVisible,
+} from '@/features/patientFlowNavigator/structureTree';
+import type { StructureNode } from '@/features/patientFlowNavigator/structureTree';
+
+/**
+ * Structure traversal (E3): a keyboard-walkable floor → unit → bed tree —
+ * "how do I get to X" without the pointer, and the non-pointer path to a bed
+ * selection (Data-Navigator pattern). Roving tabindex + arrow-key graph moves;
+ * Enter selects a bed (through the SAME selectEntity seam the canvas uses) or
+ * frames a floor/unit. Collapsed by default so it never crowds the wall.
+ */
+
+interface NavigatorStructureNavProps {
+  locations: PatientFlowLocations;
+  /** Select a bed by its location code — routes to the shared selectEntity path. */
+  onSelectBed: (locationCode: string) => void;
+  /** Frame a node's descendant bed positions (camera flight). */
+  onFrame: (points: Array<{ x: number; y: number; z: number }>) => void;
+}
+
+function collectPositions(node: StructureNode): Array<{ x: number; y: number; z: number }> {
+  if (node.kind === 'bed') return node.position ? [node.position] : [];
+  return node.children.flatMap(collectPositions);
+}
+
+export default function NavigatorStructureNav({
+  locations,
+  onSelectBed,
+  onFrame,
+}: NavigatorStructureNavProps) {
+  const tree = useMemo(() => buildStructureTree(locations), [locations]);
+  const [open, setOpen] = useState(false);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const rowRefs = useRef(new Map<string, HTMLButtonElement>());
+  const headingId = useId();
+
+  const rows = useMemo(() => flattenVisible(tree, expanded), [tree, expanded]);
+
+  const focusRow = useCallback((id: string | null): void => {
+    setFocusedId(id);
+    if (id) window.requestAnimationFrame(() => rowRefs.current.get(id)?.focus());
+  }, []);
+
+  const toggleExpand = useCallback((id: string): void => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const activate = useCallback((node: StructureNode): void => {
+    if (node.kind === 'bed') {
+      // Frame the bed regardless (empty beds have no occupancy entity to
+      // select); an occupied bed also selects through the shared seam.
+      if (node.position) onFrame([node.position]);
+      if (node.locationCode) onSelectBed(node.locationCode);
+      return;
+    }
+    // Floor/unit: frame it AND expand so the walk continues downward.
+    const points = collectPositions(node);
+    if (points.length) onFrame(points);
+    if (!expanded.has(node.id)) toggleExpand(node.id);
+  }, [expanded, onFrame, onSelectBed, toggleExpand]);
+
+  const onRowKeyDown = useCallback((event: React.KeyboardEvent, index: number): void => {
+    const row = rows[index];
+    if (!row) return;
+    const { node } = row;
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        if (index < rows.length - 1) focusRow(rows[index + 1].node.id);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (index > 0) focusRow(rows[index - 1].node.id);
+        break;
+      case 'ArrowRight':
+        event.preventDefault();
+        if (node.children.length > 0) {
+          if (!expanded.has(node.id)) toggleExpand(node.id);
+          else focusRow(node.children[0].id);
+        }
+        break;
+      case 'ArrowLeft':
+        event.preventDefault();
+        if (node.children.length > 0 && expanded.has(node.id)) {
+          toggleExpand(node.id);
+        } else {
+          // Ascend to the parent row (the nearest shallower row above).
+          for (let scan = index - 1; scan >= 0; scan -= 1) {
+            if (rows[scan].depth < row.depth) { focusRow(rows[scan].node.id); break; }
+          }
+        }
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        activate(node);
+        break;
+      default:
+        break;
+    }
+  }, [activate, expanded, focusRow, rows, toggleExpand]);
+
+  if (tree.length === 0) return null;
+
+  const activeId = focusedId && rows.some((row) => row.node.id === focusedId)
+    ? focusedId
+    : rows[0]?.node.id ?? null;
+
+  return (
+    <section className="patient-flow-structure-nav" aria-labelledby={headingId}>
+      <button
+        type="button"
+        className="patient-flow-structure-toggle"
+        aria-expanded={open}
+        id={headingId}
+        onClick={() => setOpen((value) => !value)}
+      >
+        Structure <span aria-hidden="true">{open ? '▾' : '▸'}</span>
+      </button>
+
+      {open && (
+        <ul role="tree" aria-label="Building structure" className="patient-flow-structure-tree">
+          {rows.map((row, index) => (
+            <li
+              key={row.node.id}
+              role="treeitem"
+              aria-level={row.depth + 1}
+              aria-expanded={row.expanded}
+              aria-selected={row.node.id === activeId}
+            >
+              <button
+                type="button"
+                ref={(element) => {
+                  if (element) rowRefs.current.set(row.node.id, element);
+                  else rowRefs.current.delete(row.node.id);
+                }}
+                tabIndex={row.node.id === activeId ? 0 : -1}
+                className={`patient-flow-structure-row kind-${row.node.kind}`}
+                style={{ paddingLeft: `${8 + row.depth * 14}px` }}
+                onKeyDown={(event) => onRowKeyDown(event, index)}
+                onFocus={() => setFocusedId(row.node.id)}
+                onClick={() => activate(row.node)}
+              >
+                {row.node.children.length > 0 && (
+                  <span className="patient-flow-structure-caret" aria-hidden="true">
+                    {row.expanded ? '▾' : '▸'}
+                  </span>
+                )}
+                <span className="patient-flow-structure-label">{row.node.label}</span>
+                {row.node.kind === 'unit' && (
+                  <span className="patient-flow-structure-count">{row.node.children.length}</span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -27,6 +27,21 @@ export interface NavigatorMetrics {
   occupiedLocations: number;
 }
 
+/**
+ * Task mode (E6, WN-6): progressive disclosure of the ballooned control
+ * surface. Monitor is the resting at-a-glance set; Investigate adds the
+ * replay/search/bookmark kit; Rounds foregrounds the walk and hides the
+ * census-analysis rollup. Default Monitor = the old layout minus the
+ * investigation-only controls.
+ */
+export type NavigatorTaskMode = 'monitor' | 'investigate' | 'rounds';
+
+const TASK_MODES: Array<{ mode: NavigatorTaskMode; label: string; title: string }> = [
+  { mode: 'monitor', label: 'Monitor', title: 'At-a-glance: status, layers, census — the resting wall' },
+  { mode: 'investigate', label: 'Investigate', title: 'Adds replay speed, find, and saved views' },
+  { mode: 'rounds', label: 'Rounds', title: 'Foregrounds the rounds walk; hides the census rollup' },
+];
+
 export interface LayerControl {
   key: keyof PatientLayerState;
   label: string;
@@ -49,6 +64,9 @@ interface NavigatorToolbarProps {
   categories: string[];
   layers: PatientLayerState;
   layerControls: LayerControl[];
+  /** E6 task mode — progressive disclosure of the control surface (WN-6). */
+  taskMode: NavigatorTaskMode;
+  onTaskModeChange: (mode: NavigatorTaskMode) => void;
   /** Census scope (B-1 family + §7.2 C3): which occupancy disks render. */
   censusScope: 'all' | 'delayed' | 'deviations';
   /** Phase C: the third radio only exists when the adherence surface is on. */
@@ -111,6 +129,8 @@ export default function NavigatorToolbar({
   categories,
   layers,
   layerControls,
+  taskMode,
+  onTaskModeChange,
   censusScope,
   showDeviationScope,
   metrics,
@@ -145,6 +165,9 @@ export default function NavigatorToolbar({
   onTourNext,
   onTourAutoToggle,
 }: NavigatorToolbarProps) {
+  // E6 progressive disclosure: which control groups this mode reveals.
+  const investigate = taskMode === 'investigate';
+  const rounds = taskMode === 'rounds';
   return (
     <aside className="patient-flow-toolbar" aria-label="Navigator controls">
       <div className="patient-flow-brand">
@@ -153,6 +176,21 @@ export default function NavigatorToolbar({
           {summary ? `${summary.patients} pts / ${summary.normalized_events} events` : 'Loading'}
           {lensTitle ? ` · ${lensTitle}` : ''}
         </span>
+      </div>
+
+      {/* E6 task mode — the one control that reshapes the rest (WN-6). */}
+      <div className="patient-flow-task-mode" role="radiogroup" aria-label="Task mode">
+        {TASK_MODES.map((entry) => (
+          <label key={entry.mode} className={taskMode === entry.mode ? 'active' : ''} title={entry.title}>
+            <input
+              type="radio"
+              name="flow-task-mode"
+              checked={taskMode === entry.mode}
+              onChange={() => onTaskModeChange(entry.mode)}
+            />
+            {entry.label}
+          </label>
+        ))}
       </div>
 
       {summary?.source && (
@@ -280,7 +318,8 @@ export default function NavigatorToolbar({
       </div>
 
       {/* N-7: three persona-keyed camera bookmarks — restore on the left,
-          save-current on the right of each chip. */}
+          save-current on the right of each chip. Investigation kit (E6). */}
+      {investigate && (
       <div className="patient-flow-views" aria-label="Saved views">
         {savedViews.map((hasView, slot) => (
           <div className="patient-flow-view-chip" key={`view-slot-${slot}`}>
@@ -313,6 +352,7 @@ export default function NavigatorToolbar({
           </div>
         ))}
       </div>
+      )}
 
       <div className="patient-flow-control-grid">
         <label htmlFor="flow-floor">Floor</label>
@@ -351,33 +391,39 @@ export default function NavigatorToolbar({
           ))}
         </select>
 
-        <label htmlFor="flow-speed">Speed</label>
-        <select id="flow-speed" value={speed} onChange={(event) => onSpeedChange(Number(event.target.value))}>
-          <option value={15}>{formatDurationMinutes(15)} / sec</option>
-          <option value={60}>{formatDurationMinutes(60)} / sec</option>
-          <option value={240}>{formatDurationMinutes(240)} / sec</option>
-          <option value={720}>{formatDurationMinutes(720)} / sec</option>
-        </select>
+        {/* Speed + Find are the investigation kit (E6) — hidden while just
+            monitoring, so the resting control column stays quiet. */}
+        {investigate && (
+          <>
+            <label htmlFor="flow-speed">Speed</label>
+            <select id="flow-speed" value={speed} onChange={(event) => onSpeedChange(Number(event.target.value))}>
+              <option value={15}>{formatDurationMinutes(15)} / sec</option>
+              <option value={60}>{formatDurationMinutes(60)} / sec</option>
+              <option value={240}>{formatDurationMinutes(240)} / sec</option>
+              <option value={720}>{formatDurationMinutes(720)} / sec</option>
+            </select>
 
-        <label htmlFor="flow-search">Find</label>
-        <input
-          id="flow-search"
-          type="search"
-          placeholder="PT, bed, service"
-          value={filters.search}
-          aria-describedby={searchMatches !== null ? 'flow-search-count' : undefined}
-          onChange={(event) => onFiltersChange({ search: event.target.value })}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault();
-              onSearchSubmit();
-            } else if (event.key === 'Escape') {
-              onFiltersChange({ search: '' });
-            }
-          }}
-        />
+            <label htmlFor="flow-search">Find</label>
+            <input
+              id="flow-search"
+              type="search"
+              placeholder="PT, bed, service"
+              value={filters.search}
+              aria-describedby={searchMatches !== null ? 'flow-search-count' : undefined}
+              onChange={(event) => onFiltersChange({ search: event.target.value })}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  onSearchSubmit();
+                } else if (event.key === 'Escape') {
+                  onFiltersChange({ search: '' });
+                }
+              }}
+            />
+          </>
+        )}
 
-        {searchMatches !== null && (
+        {investigate && searchMatches !== null && (
           <small id="flow-search-count" className="patient-flow-search-count" role="status">
             {searchMatches === 0
               ? '0 matches — check spelling or floor filter'
@@ -386,7 +432,7 @@ export default function NavigatorToolbar({
         )}
 
         {/* H1.2: selectable matches — selection without a pointer or canvas. */}
-        {searchResults.length > 0 && (
+        {investigate && searchResults.length > 0 && (
           <ul className="patient-flow-search-results" aria-label="Search matches">
             {searchResults.map((result) => (
               <li key={result.patientId}>
@@ -501,6 +547,9 @@ export default function NavigatorToolbar({
         <div><span>{ambient?.summary.eventCount ?? summary?.ambient_signals ?? 0}</span><small>Ambient</small></div>
       </div>
 
+      {/* The census-analysis rollup steps back in Rounds mode — the walk is
+          the focus there, not demand/capacity (E6). */}
+      {!rounds && (
       <section className="patient-flow-occupancy-rollup" aria-label="Occupancy timer rollup">
         <div className="patient-flow-rollup-grid">
           <div><span>{occupancy.delayed}</span><small>Delayed</small></div>
@@ -544,6 +593,7 @@ export default function NavigatorToolbar({
           </ol>
         )}
       </section>
+      )}
     </aside>
   );
 }

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -60,6 +60,8 @@ interface NavigatorToolbarProps {
   onToggleLive: () => void;
   onResetCamera: () => void;
   onFocusPatients: () => void;
+  /** E2 canonical views — Top / House / Floor / Bed, each a van Wijk arc. */
+  onCanonicalView: (view: 'top' | 'house' | 'floor' | 'bed') => void;
   /** Explicit camera flight to the narrowed census set (B-4). */
   onFocusCensusScope: () => void;
   onAskEddy: () => void;
@@ -115,6 +117,7 @@ export default function NavigatorToolbar({
   onToggleLive,
   onResetCamera,
   onFocusPatients,
+  onCanonicalView,
   onFocusCensusScope,
   onAskEddy,
   onSpeedChange,
@@ -250,6 +253,15 @@ export default function NavigatorToolbar({
             <Bot />
           </button>
         )}
+      </div>
+
+      {/* E2 canonical views — the four framings ("where am I / how do I get
+          back") as one segmented control; each flies the van Wijk arc. */}
+      <div className="patient-flow-canonical-views" role="group" aria-label="Canonical views">
+        <button type="button" title="Top-down plan view of the current floor" onClick={() => onCanonicalView('top')}>Top</button>
+        <button type="button" title="House overview (default iso view)" onClick={() => onCanonicalView('house')}>House</button>
+        <button type="button" title="Frame the current floor" onClick={() => onCanonicalView('floor')}>Floor</button>
+        <button type="button" title="Frame the current selection" onClick={() => onCanonicalView('bed')}>Bed</button>
       </div>
 
       {/* N-7: three persona-keyed camera bookmarks — restore on the left,

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bookmark, Bot, Home, Link2, Pause, Play, Radio, ScanSearch } from 'lucide-react';
+import { Bookmark, Bot, Grid3x3, Home, Link2, Pause, Play, Radio, ScanSearch } from 'lucide-react';
 import type {
   OccupancySummary,
   PatientFlowAmbient,
@@ -62,6 +62,9 @@ interface NavigatorToolbarProps {
   onFocusPatients: () => void;
   /** E2 canonical views — Top / House / Floor / Bed, each a van Wijk arc. */
   onCanonicalView: (view: 'top' | 'house' | 'floor' | 'bed') => void;
+  /** E3: whether the top-down orthographic plan view is active. */
+  orthoActive: boolean;
+  onToggleOrtho: () => void;
   /** Explicit camera flight to the narrowed census set (B-4). */
   onFocusCensusScope: () => void;
   onAskEddy: () => void;
@@ -118,6 +121,8 @@ export default function NavigatorToolbar({
   onResetCamera,
   onFocusPatients,
   onCanonicalView,
+  orthoActive,
+  onToggleOrtho,
   onFocusCensusScope,
   onAskEddy,
   onSpeedChange,
@@ -232,6 +237,16 @@ export default function NavigatorToolbar({
           onClick={onFocusPatients}
         >
           <ScanSearch />
+        </button>
+        <button
+          className={`patient-flow-icon-button ${orthoActive ? 'active' : ''}`}
+          type="button"
+          title="Top-down plan view (O) — orthographic, no perspective"
+          aria-label="Top-down plan view"
+          aria-pressed={orthoActive}
+          onClick={onToggleOrtho}
+        >
+          <Grid3x3 />
         </button>
         <button
           className="patient-flow-icon-button"

--- a/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
+++ b/resources/js/Components/PatientFlowNavigator/NavigatorToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bookmark, Bot, Home, Pause, Play, Radio, ScanSearch } from 'lucide-react';
+import { Bookmark, Bot, Home, Link2, Pause, Play, Radio, ScanSearch } from 'lucide-react';
 import type {
   OccupancySummary,
   PatientFlowAmbient,
@@ -80,6 +80,10 @@ interface NavigatorToolbarProps {
   savedViews: boolean[];
   onSaveView: (slot: number) => void;
   onApplyView: (slot: number) => void;
+  /** E5: copy the exact current view (camera/floor/layers/time/selection) as a URL. */
+  onCopyViewLink: () => void;
+  /** E5: copy a saved-view bookmark as a URL. */
+  onCopySavedViewLink: (slot: number) => void;
   /** Virtual Rounds run HUD + tour controls (R-5/R-6a); null → no run. */
   roundsHud: RoundsHudModel | null;
   tourAuto: boolean;
@@ -125,6 +129,8 @@ export default function NavigatorToolbar({
   savedViews,
   onSaveView,
   onApplyView,
+  onCopyViewLink,
+  onCopySavedViewLink,
   roundsHud,
   tourAuto,
   onTourPrev,
@@ -224,6 +230,15 @@ export default function NavigatorToolbar({
         >
           <ScanSearch />
         </button>
+        <button
+          className="patient-flow-icon-button"
+          type="button"
+          title="Copy a link to this exact view (camera, floor, layers, time, selection)"
+          aria-label="Copy view link"
+          onClick={onCopyViewLink}
+        >
+          <Link2 />
+        </button>
         {eddyEnabled && (
           <button
             className="patient-flow-icon-button"
@@ -258,6 +273,16 @@ export default function NavigatorToolbar({
             >
               <Bookmark aria-hidden="true" />
             </button>
+            {hasView && (
+              <button
+                type="button"
+                aria-label={`Copy view ${slot + 1} as a link`}
+                title={`Copy view ${slot + 1} as a shareable link`}
+                onClick={() => onCopySavedViewLink(slot)}
+              >
+                <Link2 aria-hidden="true" />
+              </button>
+            )}
           </div>
         ))}
       </div>

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -1364,8 +1364,113 @@
   color: #ffd795;
 }
 
+/* E4 small multiples — the hourly analysis strip, anchored above the minimap
+   in the bottom-left stack. Density is opacity on ONE neutral ink (aggregate
+   flow, never a status color). */
+.patient-flow-small-multiples {
+  position: absolute;
+  z-index: 3;
+  left: 16px;
+  bottom: 224px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.patient-flow-sm-toggle {
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 6px;
+  background: rgba(27, 31, 29, 0.92);
+  color: #ddd6c7;
+  font-size: 11px;
+  padding: 5px 9px;
+  cursor: pointer;
+}
+
+.patient-flow-sm-toggle:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
+}
+
+.patient-flow-sm-body {
+  margin-top: 6px;
+  padding: 8px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 6px;
+  background: rgba(27, 31, 29, 0.94);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.3);
+}
+
+.patient-flow-sm-strip {
+  display: flex;
+  gap: 8px;
+}
+
+.patient-flow-sm-plate {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.patient-flow-sm-plate svg {
+  display: block;
+  border-radius: 3px;
+}
+
+.patient-flow-sm-bg { fill: rgba(18, 21, 20, 0.7); }
+.patient-flow-sm-cell { fill: #8fb8cc; }
+
+.patient-flow-sm-plate figcaption {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 3px;
+  color: #b9b2a6;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.patient-flow-sm-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 8px;
+  color: #b9b2a6;
+  font-size: 10px;
+}
+
+.patient-flow-sm-actions {
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
+
+.patient-flow-sm-footer button {
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 5px;
+  background: rgba(27, 31, 29, 0.92);
+  color: #ddd6c7;
+  font-size: 10px;
+  padding: 3px 7px;
+  cursor: pointer;
+}
+
+.patient-flow-sm-footer button:hover {
+  background: rgba(224, 163, 63, 0.14);
+  color: #ffd795;
+}
+
+.patient-flow-sm-floor.active {
+  border-color: #e0a33f;
+  background: #3a2f1f;
+  color: #ffd795;
+}
+
 @media (max-width: 900px) {
-  .patient-flow-minimap { display: none; }
+  .patient-flow-minimap,
+  .patient-flow-small-multiples { display: none; }
   .patient-flow-structure-nav { left: 16px; }
 }
 

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -542,6 +542,52 @@
 
 /* Census scope segmented control (B-2) — a filter, deliberately styled unlike
    the layer switches so the two "barrier" concepts can't be confused. */
+/* E6 task mode — the one control that reshapes the rest (WN-6). Same radio-
+   chip idiom as the census toggle; sits at the top of the control column. */
+.patient-flow-task-mode {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  height: 30px;
+  margin-bottom: 10px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 6px;
+  overflow: hidden;
+  background: #202522;
+  font-size: 11px;
+}
+
+.patient-flow-task-mode label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  cursor: pointer;
+  user-select: none;
+  color: #b9b2a6;
+}
+
+.patient-flow-task-mode label.active {
+  background: rgba(224, 163, 63, 0.16);
+  color: #ffd795;
+}
+
+.patient-flow-task-mode input[type='radio'] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.patient-flow-task-mode label:has(input:focus-visible) {
+  outline: 2px solid #e0a33f;
+  outline-offset: -2px;
+}
+
 .patient-flow-census-toggle {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -1327,6 +1327,43 @@
 
 /* --- Saved views (N-7) ---------------------------------------------------- */
 
+/* E2 canonical views — a 4-way segmented control matching the view-chip ink;
+   quiet chrome, no status color (a framing choice is not an alarm). */
+.patient-flow-canonical-views {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  margin-bottom: 8px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 6px;
+  overflow: hidden;
+  background: #202522;
+}
+
+.patient-flow-canonical-views button {
+  border: 0;
+  border-left: 1px solid rgba(239, 234, 220, 0.14);
+  background: transparent;
+  color: #ddd6c7;
+  font-size: 11px;
+  line-height: 1;
+  padding: 6px 4px;
+  cursor: pointer;
+}
+
+.patient-flow-canonical-views button:first-child {
+  border-left: 0;
+}
+
+.patient-flow-canonical-views button:hover {
+  background: rgba(224, 163, 63, 0.14);
+  color: #ffd795;
+}
+
+.patient-flow-canonical-views button:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: -2px;
+}
+
 .patient-flow-views {
   display: grid;
   grid-template-columns: repeat(3, 1fr);

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -1252,6 +1252,99 @@
 /* --- Action list (F-8): non-pointer selection of delayed locations + barriers,
    below the feed. Same scoped overlay treatment as the other panels. --------- */
 
+/* E3 structure traversal — a collapsed disclosure at the bottom-left that
+   expands upward into a keyboard-walkable floor→unit→bed tree. Quiet chrome;
+   never a status color (structure is not an alarm). */
+.patient-flow-structure-nav {
+  position: absolute;
+  z-index: 3;
+  left: 16px;
+  bottom: 16px;
+  width: min(300px, calc(100vw - 32px));
+  display: flex;
+  flex-direction: column;
+}
+
+.patient-flow-structure-toggle {
+  align-self: flex-start;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 6px;
+  background: rgba(27, 31, 29, 0.92);
+  color: #ddd6c7;
+  font-size: 11px;
+  padding: 5px 9px;
+  cursor: pointer;
+}
+
+.patient-flow-structure-toggle:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: 2px;
+}
+
+.patient-flow-structure-tree {
+  order: -1;
+  margin: 0 0 6px;
+  padding: 6px;
+  list-style: none;
+  max-height: min(46vh, 440px);
+  overflow: auto;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 6px;
+  background: rgba(27, 31, 29, 0.94);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.3);
+}
+
+.patient-flow-structure-tree li {
+  margin: 0;
+}
+
+.patient-flow-structure-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: #ddd6c7;
+  font-size: 12px;
+  line-height: 1.3;
+  padding: 4px 6px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.patient-flow-structure-row.kind-floor {
+  color: #f3efe5;
+  font-weight: 500;
+}
+
+.patient-flow-structure-row:hover,
+.patient-flow-structure-row:focus-visible {
+  background: rgba(224, 163, 63, 0.14);
+  color: #ffd795;
+  outline: none;
+}
+
+.patient-flow-structure-caret {
+  width: 10px;
+  flex: 0 0 auto;
+  color: #b9b2a6;
+}
+
+.patient-flow-structure-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.patient-flow-structure-count {
+  flex: 0 0 auto;
+  color: #b9b2a6;
+  font-variant-numeric: tabular-nums;
+}
+
 .patient-flow-action-list {
   position: absolute;
   z-index: 3;

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -171,6 +171,58 @@
   font-variant-numeric: tabular-nums;
 }
 
+/* Window presets (TN-6): the census-toggle radio-chip idiom, sized for the
+   chronobar head. Historical sources disable rather than mislead. */
+.patient-flow-chronobar-presets {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  height: 24px;
+  margin-top: 4px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 5px;
+  overflow: hidden;
+  background: #202522;
+  font-size: 11px;
+}
+
+.patient-flow-chronobar-presets label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  cursor: pointer;
+  user-select: none;
+  color: #b9b2a6;
+  font-variant-numeric: tabular-nums;
+}
+
+.patient-flow-chronobar-presets label.active {
+  background: rgba(224, 163, 63, 0.16);
+  color: #ffd795;
+}
+
+.patient-flow-chronobar-presets label:has(input:disabled) {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.patient-flow-chronobar-presets input[type='radio'] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.patient-flow-chronobar-presets label:has(input:focus-visible) {
+  outline: 2px solid #e0a33f;
+  outline-offset: -2px;
+}
+
 /* Scented scrubber (plan B5, TN-1): a quiet event-density row above the
    track — intensity is opacity on one neutral ink, never a status color. */
 .patient-flow-chronobar-density {

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.css
@@ -1258,11 +1258,115 @@
 .patient-flow-structure-nav {
   position: absolute;
   z-index: 3;
-  left: 16px;
+  left: 200px;
   bottom: 16px;
-  width: min(300px, calc(100vw - 32px));
+  width: min(280px, calc(100vw - 216px));
   display: flex;
   flex-direction: column;
+}
+
+/* E1 minimap — the bottom-left floor plate; the structure nav sits to its
+   right. Both are desk affordances (hidden on wall/kiosk by the orchestrator). */
+.patient-flow-minimap {
+  position: absolute;
+  z-index: 3;
+  left: 16px;
+  bottom: 16px;
+  width: 176px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 6px;
+  background: rgba(27, 31, 29, 0.94);
+  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.3);
+  overflow: hidden;
+}
+
+.patient-flow-minimap-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: #ddd6c7;
+  font-size: 11px;
+  padding: 5px 8px;
+  cursor: pointer;
+}
+
+.patient-flow-minimap-header:focus-visible {
+  outline: 2px solid #e0a33f;
+  outline-offset: -2px;
+}
+
+.patient-flow-minimap-body {
+  padding: 0 4px 6px;
+}
+
+.patient-flow-minimap svg {
+  display: block;
+  width: 168px;
+  height: 168px;
+  cursor: crosshair;
+  background: rgba(18, 21, 20, 0.6);
+  border-radius: 4px;
+}
+
+.patient-flow-minimap-dot { fill: #6b6456; }
+
+/* Delay pips — triangle (shape first), amber watch / coral delayed. */
+.patient-flow-minimap-delay.status-watch { fill: #e0a33f; }
+.patient-flow-minimap-delay.status-delayed { fill: #f06755; }
+
+/* Deviation pip — a square (bracket echo), amber-capped per OQ-1. */
+.patient-flow-minimap-deviation {
+  fill: none;
+  stroke: #eaa640;
+  stroke-width: 1.4;
+}
+
+.patient-flow-minimap-look {
+  stroke: rgba(201, 162, 39, 0.5);
+  stroke-width: 1;
+  stroke-dasharray: 2 2;
+}
+
+.patient-flow-minimap-camera circle {
+  fill: none;
+  stroke: #c9a227;
+  stroke-width: 1.4;
+}
+
+.patient-flow-minimap-camera line {
+  stroke: #c9a227;
+  stroke-width: 1;
+}
+
+.patient-flow-minimap-selection {
+  fill: none;
+  stroke: #ffd795;
+  stroke-width: 2;
+}
+
+.patient-flow-minimap-fit {
+  width: 100%;
+  margin-top: 6px;
+  border: 1px solid rgba(239, 234, 220, 0.18);
+  border-radius: 5px;
+  background: rgba(27, 31, 29, 0.92);
+  color: #ddd6c7;
+  font-size: 11px;
+  padding: 4px 6px;
+  cursor: pointer;
+}
+
+.patient-flow-minimap-fit:hover {
+  background: rgba(224, 163, 63, 0.14);
+  color: #ffd795;
+}
+
+@media (max-width: 900px) {
+  .patient-flow-minimap { display: none; }
+  .patient-flow-structure-nav { left: 16px; }
 }
 
 .patient-flow-structure-toggle {

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -1495,6 +1495,32 @@ export default function PatientFlowNavigator({
     fitToFloor(floor);
   }, [fitToFloor]);
 
+  // E2 canonical views (Top / House / Floor / Bed): the four framings an
+  // operator reaches for, each a van Wijk arc. "Where am I / how do I get
+  // back" in one click. Top/Floor frame the current floor's points (or the
+  // whole house at 'all'); Bed frames the current selection.
+  const applyCanonicalView = useCallback((view: 'top' | 'house' | 'floor' | 'bed'): void => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    const floorFilter = filtersRef.current.floor;
+    const floorPoints = (): Array<{ x: number; y: number; z: number }> =>
+      Object.values(locationsRef.current)
+        .filter((loc) => loc.position_m && (floorFilter === 'all' || String(loc.floor) === floorFilter))
+        .map((loc) => ({ x: loc.position_m!.x, y: loc.position_m!.y ?? 0, z: loc.position_m!.z }));
+
+    if (view === 'house') {
+      scene.flyToHome();
+    } else if (view === 'top') {
+      scene.focusTopDown(floorPoints());
+    } else if (view === 'floor') {
+      scene.focusOn(floorPoints());
+    } else if (!scene.focusTrace()) {
+      // Bed: the selection (trace frames the whole story when a journey is
+      // open); with nothing selected, fall back to the active patients.
+      focusActivePatients();
+    }
+  }, [focusActivePatients]);
+
   // N-5: Enter in Find flies to the bbox of the matched tokens.
   const focusSearchMatches = useCallback((): void => {
     const points = lastVisibleStatesRef.current.map((state) => state.position);
@@ -1796,6 +1822,27 @@ export default function PatientFlowNavigator({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [closeJourney, dismissIntro, focusActivePatients, handleScrub, historical]);
 
+  // E2 — SDF unit-name billboards. Rebuilt only when the unit set, floor
+  // filter, or Model layer changes (not per frame); the scene owns per-frame
+  // billboarding, LOD, and distance culling. Tied to the Model layer — if you
+  // can see the building you can read its unit names; far ones fade out.
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    const floorFilter = filters.floor;
+    const labels: Array<{ id: string; text: string; position: { x: number; y: number; z: number } }> = [];
+    for (const [unitId, anchor] of placementIndex.unitAnchors) {
+      const floor = placementIndex.unitFloors.get(unitId);
+      if (floorFilter !== 'all' && String(floor) !== floorFilter) continue;
+      const unit = units.find((candidate) => candidate.unit_id === unitId);
+      const text = unit?.name
+        ?? placementIndex.unitCodeById.get(unitId)?.toUpperCase()
+        ?? `Unit ${unitId}`;
+      labels.push({ id: String(unitId), text, position: anchor });
+    }
+    scene.setUnitLabels(labels, layers.base);
+  }, [placementIndex, units, filters.floor, layers.base, sceneNonce]);
+
   // B3 — trace mode mirrors the journey drawer: open journey = traced story
   // in-scene (gradient trail + dwell markers, others dimmed). Toggling clears
   // the bucket key so the trail layer rebuilds immediately.
@@ -2083,6 +2130,7 @@ export default function PatientFlowNavigator({
         onToggleLive={() => (live ? disconnectLive() : connectLive())}
         onResetCamera={resetCamera}
         onFocusPatients={focusActivePatients}
+        onCanonicalView={applyCanonicalView}
         onFocusCensusScope={focusCensusScope}
         onSpeedChange={setSpeed}
         onFiltersChange={(patch) => setFilters((prev) => ({ ...prev, ...patch }))}

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -97,8 +97,10 @@ import NavigatorInspector from './NavigatorInspector';
 import NavigatorIntro from './NavigatorIntro';
 import NavigatorLegend from './NavigatorLegend';
 import NavigatorMinimap from './NavigatorMinimap';
+import NavigatorSmallMultiples from './NavigatorSmallMultiples';
 import NavigatorStructureNav from './NavigatorStructureNav';
 import NavigatorToolbar from './NavigatorToolbar';
+import { gridToWorldCells, densityGrid, heatBounds } from '@/features/patientFlowNavigator/trailHeat';
 import type { LayerControl, NavigatorMetrics } from './NavigatorToolbar';
 import './PatientFlowNavigator.css';
 import { formatDurationMinutes } from '@/lib/duration';
@@ -486,6 +488,8 @@ export default function PatientFlowNavigator({
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   // E3: top-down orthographic plan view (the `O` key + toolbar toggle).
   const [ortho, setOrtho] = useState(false);
+  // E4: GSTC flatten — draw the last-6h trail density on the 3D floor.
+  const [floorHeatOn, setFloorHeatOn] = useState(false);
   const [roundsRun, setRoundsRun] = useState<RunSummary | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [inspectorAction, setInspectorAction] = useState<{ label: string; href: string } | null>(null);
@@ -1887,6 +1891,30 @@ export default function PatientFlowNavigator({
     scene.setUnitLabels(labels, layers.base);
   }, [placementIndex, units, filters.floor, layers.base, sceneNonce]);
 
+  // E4 — GSTC flatten on the 3D floor: the last 6 h of movement as flat density
+  // tiles. Recomputed when toggled, the data, floor, or wall-now changes (a
+  // cheap re-bin, not per frame). Off → the layer clears.
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    if (!floorHeatOn) {
+      scene.setTrailHeat([], 0, 0, false);
+      return;
+    }
+    const bounds = heatBounds(locations, filters.floor);
+    if (!bounds) {
+      scene.setTrailHeat([], 0, 0, false);
+      return;
+    }
+    const cols = 16;
+    const rows = 16;
+    const grid = densityGrid(tracks, locations, bounds, nowMs - 6 * 3_600_000, nowMs, cols, rows, filters.floor);
+    const cells = gridToWorldCells(grid, bounds, 0.35);
+    const cellW = (bounds.maxX - bounds.minX) / cols;
+    const cellD = (bounds.maxZ - bounds.minZ) / rows;
+    scene.setTrailHeat(cells, cellW, cellD, true);
+  }, [floorHeatOn, tracks, locations, filters.floor, nowMs, sceneNonce]);
+
   // B3 — trace mode mirrors the journey drawer: open journey = traced story
   // in-scene (gradient trail + dwell markers, others dimmed). Toggling clears
   // the bucket key so the trail layer rebuilds immediately.
@@ -2231,6 +2259,19 @@ export default function PatientFlowNavigator({
           getSelectionPoint={() => sceneRef.current?.getSelectionPoint() ?? null}
           onNavigate={(point) => sceneRef.current?.focusOn([point])}
           onFitFloor={() => applyCanonicalView('floor')}
+        />
+      )}
+
+      {/* E4: the hourly small-multiples analysis card — the non-replay path to
+          "what happened this shift". Desk affordance; hidden on wall/kiosk. */}
+      {!handoff.wall && patientDotsVisible && (
+        <NavigatorSmallMultiples
+          tracks={tracks}
+          locations={locations}
+          floor={filters.floor}
+          endMs={nowMs}
+          floorHeatOn={floorHeatOn}
+          onToggleFloorHeat={() => setFloorHeatOn((value) => !value)}
         />
       )}
 

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -96,6 +96,7 @@ import NavigatorFloorRail from './NavigatorFloorRail';
 import NavigatorInspector from './NavigatorInspector';
 import NavigatorIntro from './NavigatorIntro';
 import NavigatorLegend from './NavigatorLegend';
+import NavigatorStructureNav from './NavigatorStructureNav';
 import NavigatorToolbar from './NavigatorToolbar';
 import type { LayerControl, NavigatorMetrics } from './NavigatorToolbar';
 import './PatientFlowNavigator.css';
@@ -475,6 +476,8 @@ export default function PatientFlowNavigator({
   const [searchMatches, setSearchMatches] = useState<number | null>(null);
   const [searchResults, setSearchResults] = useState<Array<{ patientId: string; label: string }>>([]);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  // E3: top-down orthographic plan view (the `O` key + toolbar toggle).
+  const [ortho, setOrtho] = useState(false);
   const [roundsRun, setRoundsRun] = useState<RunSummary | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [inspectorAction, setInspectorAction] = useState<{ label: string; href: string } | null>(null);
@@ -1807,6 +1810,7 @@ export default function PatientFlowNavigator({
       }
       const key = event.key.toLowerCase();
       if (key === 'h') {
+        setOrtho(false);
         sceneRef.current?.resetCamera();
       } else if (key === 'f') {
         // focusTrace frames the whole traced story when a journey is open
@@ -1814,6 +1818,10 @@ export default function PatientFlowNavigator({
         if (!sceneRef.current?.focusTrace()) focusActivePatients();
       } else if (key === 'n') {
         if (!historical) handleScrub(nowMsRef.current);
+      } else if (key === 'o') {
+        // E3: toggle the top-down orthographic plan view.
+        const scene = sceneRef.current;
+        if (scene) setOrtho(scene.setOrthographic(!scene.isOrthographic()));
       } else if (event.key === '?') {
         setShortcutsOpen((value) => !value);
       }
@@ -1821,6 +1829,13 @@ export default function PatientFlowNavigator({
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [closeJourney, dismissIntro, focusActivePatients, handleScrub, historical]);
+
+  // E3: keep the ortho toggle in sync when Home/canonical views exit plan view
+  // (resetCamera drops ortho; the toolbar toggle must reflect that).
+  const toggleOrtho = useCallback((): void => {
+    const scene = sceneRef.current;
+    if (scene) setOrtho(scene.setOrthographic(!scene.isOrthographic()));
+  }, []);
 
   // E2 — SDF unit-name billboards. Rebuilt only when the unit set, floor
   // filter, or Model layer changes (not per frame); the scene owns per-frame
@@ -2128,9 +2143,11 @@ export default function PatientFlowNavigator({
           setPlaying((value) => !value);
         }}
         onToggleLive={() => (live ? disconnectLive() : connectLive())}
-        onResetCamera={resetCamera}
+        onResetCamera={() => { setOrtho(false); resetCamera(); }}
         onFocusPatients={focusActivePatients}
         onCanonicalView={applyCanonicalView}
+        orthoActive={ortho}
+        onToggleOrtho={toggleOrtho}
         onFocusCensusScope={focusCensusScope}
         onSpeedChange={setSpeed}
         onFiltersChange={(patch) => setFilters((prev) => ({ ...prev, ...patch }))}
@@ -2165,6 +2182,12 @@ export default function PatientFlowNavigator({
         barriers={layers.barriers ? barriers : []}
         onSelectLocation={selectLocationFromList}
         onSelectBarrier={selectBarrierFromList}
+      />
+
+      <NavigatorStructureNav
+        locations={locations}
+        onSelectBed={selectLocationFromList}
+        onFrame={(points) => sceneRef.current?.focusOn(points)}
       />
 
       {journeyState === 'idle' ? (
@@ -2210,6 +2233,7 @@ export default function PatientFlowNavigator({
             <div><dt>H</dt><dd>Home view</dd></div>
             <div><dt>F</dt><dd>Focus selection (or active patients)</dd></div>
             <div><dt>N</dt><dd>Jump to now</dd></div>
+            <div><dt>O</dt><dd>Top-down plan view (orthographic)</dd></div>
             <div><dt>↑ ↓</dt><dd>Step floors (floor rail focused)</dd></div>
             <div><dt>← → ↑ ↓</dt><dd>Pan the camera (click the scene first)</dd></div>
             <div><dt>Enter</dt><dd>In Find: fly to matches</dd></div>

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -31,7 +31,11 @@ import {
   prepareReplay,
   recentReplayEvents,
   replayStatus,
+  windowForPreset,
 } from '@/features/patientFlowNavigator/replayTimeline';
+import type { WindowPreset } from '@/features/patientFlowNavigator/replayTimeline';
+import { buildViewSearch, parseViewState } from '@/features/patientFlowNavigator/viewState';
+import type { NavigatorViewSnapshot, ParsedViewState } from '@/features/patientFlowNavigator/viewState';
 import {
   ENTITY_PROJECTION_KINDS,
   aggregatesAt,
@@ -136,7 +140,7 @@ const EMPTY_OCCUPANCY_SUMMARY: OccupancySummary = {
   topBarriers: [],
 };
 
-export interface HandoffParams {
+export interface HandoffParams extends ParsedViewState {
   floor: string | null;
   unitRef: string | null;
   t: number | null;
@@ -148,9 +152,25 @@ export interface HandoffParams {
   patient: string | null;
 }
 
-/** Mobile→web A3 handoff: ?persona=&scope=&t=&focus_stop=&patient= (persona is resolved server-side). Exported for tests. */
+/**
+ * Mobile→web A3 handoff + E5 view-state params:
+ * ?persona=&scope=&t=&focus_stop=&patient=&cam=&layers=&census=&win=&sel=&wall=
+ * (persona is resolved server-side). Exported for tests.
+ */
 export function parseHandoff(): HandoffParams {
-  const empty: HandoffParams = { floor: null, unitRef: null, t: null, focusStop: null, patient: null };
+  const empty: HandoffParams = {
+    floor: null,
+    unitRef: null,
+    t: null,
+    focusStop: null,
+    patient: null,
+    camera: null,
+    layers: null,
+    censusScope: null,
+    windowPreset: null,
+    selection: null,
+    wall: false,
+  };
   if (typeof window === 'undefined') return empty;
   const params = new URLSearchParams(window.location.search);
 
@@ -173,7 +193,14 @@ export function parseHandoff(): HandoffParams {
   const rawPatient = params.get('patient');
   const patient = rawPatient && /^ptok_[A-Za-z0-9]{24}$/.test(rawPatient) ? rawPatient : null;
 
-  return { floor, unitRef, t, focusStop: params.get('focus_stop'), patient };
+  return {
+    floor,
+    unitRef,
+    t,
+    focusStop: params.get('focus_stop'),
+    patient,
+    ...parseViewState(window.location.search),
+  };
 }
 
 function defaultLayersForLens(lens: FlowLens | null | undefined): PatientLayerState {
@@ -324,7 +351,14 @@ export default function PatientFlowNavigator({
     category: initialCategory,
     search: '',
   });
-  const layersRef = useRef<PatientLayerState>(defaultLayersForLens(lens));
+  // E5: a shared view link may carry an explicit layer set and census scope;
+  // both stay clamped by the same gates as the interactive controls (a URL
+  // can request, never grant — the lens and flags still decide what renders).
+  const initialLayers = useMemo<PatientLayerState>(
+    () => (handoff.layers ? { ...defaultLayersForLens(lens), ...handoff.layers } : defaultLayersForLens(lens)),
+    [handoff.layers, lens],
+  );
+  const layersRef = useRef<PatientLayerState>(initialLayers);
   const censusScopeRef = useRef<NavigatorCensusScope>('all');
   // Phase C scene flags: ptok → worded chip state, refreshed on the
   // conformance poll; version feeds the heavy-layer bucket key.
@@ -353,6 +387,10 @@ export default function PatientFlowNavigator({
   const scopeAppliedRef = useRef(false);
   const inspectorInitializedRef = useRef(false);
   const occupancyRequestRef = useRef(0);
+  // E5: one-shot guards for linked camera pose and aggregate selection —
+  // an epoch rebootstrap must not re-yank the operator back to the link.
+  const handoffCameraDoneRef = useRef(false);
+  const handoffSelectionDoneRef = useRef(false);
 
   const [summary, setSummary] = useState<PatientFlowSummary | null>(null);
   const [ambient, setAmbient] = useState<PatientFlowAmbient | null>(null);
@@ -363,7 +401,16 @@ export default function PatientFlowNavigator({
   const [roundStops, setRoundStops] = useState<RoundStop[]>([]);
   const [filters, setFilters] = useState<PatientFlowFilters>(filtersRef.current);
   const [layers, setLayers] = useState<PatientLayerState>(layersRef.current);
-  const [censusScope, setCensusScope] = useState<NavigatorCensusScope>('all');
+  // E5: honor a linked census scope; the deviations scope only exists when
+  // the adherence surface composes for this page/persona.
+  const [censusScope, setCensusScope] = useState<NavigatorCensusScope>(() => {
+    if (handoff.censusScope === 'deviations') return conformanceEnabled ? 'deviations' : 'all';
+    return handoff.censusScope ?? 'all';
+  });
+  // TN-6: chronobar window preset — 48h default; historical sources keep
+  // their data-extent window regardless.
+  const [windowPreset, setWindowPreset] = useState<WindowPreset>(handoff.windowPreset ?? '48h');
+  const windowPresetRef = useRef(windowPreset);
   const [currentTime, setCurrentTime] = useState(currentTimeRef.current);
   const [speed, setSpeed] = useState(60);
   const [playing, setPlaying] = useState(false);
@@ -846,7 +893,7 @@ export default function PatientFlowNavigator({
     if (historical || playingRef.current || liveRef.current) return;
     if (!followNowRef.current) return;
     if (Math.abs(currentTimeRef.current - nowMs) >= 90_000) return;
-    setTimeWindow({ start: nowMs - LIVE_WINDOW_HALF_MS, end: nowMs + LIVE_WINDOW_HALF_MS });
+    setTimeWindow(windowForPreset(windowPresetRef.current, nowMs));
     currentTimeRef.current = nowMs;
     setCurrentTime(nowMs);
   }, [historical, nowMs]);
@@ -906,6 +953,18 @@ export default function PatientFlowNavigator({
     currentTimeRef.current = timeMs;
     setCurrentTime(timeMs);
   }, []);
+
+  // TN-6: switching presets resizes the window around now and clamps the
+  // scrub position into it. The default 48h path is identical to before.
+  const applyWindowPreset = useCallback((preset: WindowPreset): void => {
+    windowPresetRef.current = preset;
+    setWindowPreset(preset);
+    if (historicalRef.current) return;
+    const next = windowForPreset(preset, nowMsRef.current);
+    setTimeWindow(next);
+    const clamped = Math.min(next.end, Math.max(next.start, currentTimeRef.current));
+    if (clamped !== currentTimeRef.current) applyTime(clamped);
+  }, [applyTime]);
 
   // N-3: the camera readout speaks place, not xyz — the nearest unit centroid
   // to the orbit target names what the operator is looking at. Raw coordinates
@@ -988,7 +1047,11 @@ export default function PatientFlowNavigator({
         setLocations(locationData);
         setEvents(sortedEvents);
         setFeed(recentReplayEvents(sortedEvents));
-        setTimeWindow({ start: timeline.windowStart, end: timeline.windowEnd });
+        // TN-6: a narrowed preset survives bootstrap (deep links, epoch
+        // rebootstraps); historical sources always keep the extent window.
+        setTimeWindow(timeline.historical || windowPresetRef.current === '48h'
+          ? { start: timeline.windowStart, end: timeline.windowEnd }
+          : windowForPreset(windowPresetRef.current, anchorMs));
         applyTime(timeline.currentTime);
         setError(null);
         setRebuildNotice(null);
@@ -1300,6 +1363,12 @@ export default function PatientFlowNavigator({
       // no-oped; bumping the nonce re-runs them against the live scene.
       // (Exposed by the ?patient= deep link on a slow first load.)
       setSceneNonce((nonce) => nonce + 1);
+      // E5: a linked camera pose restores exactly once, before the model
+      // finishes loading — the link IS the operator's framing.
+      if (handoff.camera && !handoffCameraDoneRef.current) {
+        handoffCameraDoneRef.current = true;
+        scene.setCameraView(handoff.camera);
+      }
       scene.setHoverEnabled(!(playingRef.current && speedRef.current > 60));
       lastBucketKeyRef.current = '';
       lastRoundsKeyRef.current = '';
@@ -1324,7 +1393,7 @@ export default function PatientFlowNavigator({
       sceneRef.current = null;
       scene?.dispose();
     };
-  }, [summary?.model_url, dotsPolicy, handleCameraMove, refreshScene]);
+  }, [summary?.model_url, dotsPolicy, handleCameraMove, refreshScene, handoff.camera]);
 
   // ---- playback / live -----------------------------------------------------
   const disconnectLive = useCallback((): void => {
@@ -1544,6 +1613,56 @@ export default function PatientFlowNavigator({
     }).catch(() => setStatus('Copy failed — clipboard unavailable'));
   }, []);
 
+  // E5: snapshot the exact current view as a shareable URL. Selection rides
+  // the strongest existing param for its kind (patient=ptok / focus_stop=
+  // uuid / sel=aggregate) — never a new way to address a person.
+  const buildCurrentViewUrl = useCallback((): string => {
+    const scene = sceneRef.current;
+    const entity = scene?.getSelectedEntity() ?? null;
+    const snapshot: NavigatorViewSnapshot = {
+      camera: scene ? scene.getCameraView() : null,
+      floor: filtersRef.current.floor,
+      layers: { ...layersRef.current },
+      censusScope: censusScopeRef.current,
+      timeMs: followNowRef.current ? null : currentTimeRef.current,
+      windowPreset: windowPresetRef.current,
+      selection: entity && (entity.kind === 'occupancy' || entity.kind === 'barrier')
+        ? { kind: entity.kind, id: entity.id }
+        : null,
+      patient: entity?.kind === 'patient' && /^ptok_[A-Za-z0-9]{24}$/.test(entity.id) ? entity.id : null,
+      focusStop: entity?.kind === 'round-stop' ? entity.id : null,
+    };
+    return `${window.location.origin}/rtdc/patient-flow-navigator${buildViewSearch(snapshot)}`;
+  }, []);
+
+  const copyViewLink = useCallback((): void => {
+    void navigator.clipboard?.writeText(buildCurrentViewUrl())
+      .then(() => setToastMessage('View link copied'))
+      .catch(() => setStatus('Copy failed — clipboard unavailable'));
+  }, [buildCurrentViewUrl]);
+
+  // E5: a saved-view bookmark shares as a link too — camera/floor/layers only
+  // (a bookmark has no time or selection of its own).
+  const copySavedViewLink = useCallback((slot: number): void => {
+    const view = views[slot];
+    if (!view) return;
+    const snapshot: NavigatorViewSnapshot = {
+      camera: view.camera,
+      floor: view.floor,
+      layers: { ...layersRef.current, ...view.layers },
+      censusScope: 'all',
+      timeMs: null,
+      windowPreset: '48h',
+      selection: null,
+      patient: null,
+      focusStop: null,
+    };
+    const url = `${window.location.origin}/rtdc/patient-flow-navigator${buildViewSearch(snapshot)}`;
+    void navigator.clipboard?.writeText(url)
+      .then(() => setToastMessage(`View ${slot + 1} link copied`))
+      .catch(() => setStatus('Copy failed — clipboard unavailable'));
+  }, [views]);
+
   const selectPatientFromList = useCallback((patientId: string): void => {
     const state = lastVisibleStatesRef.current.find((candidate) => candidate.patientId === patientId);
     if (!state) return;
@@ -1592,6 +1711,26 @@ export default function PatientFlowNavigator({
     setInspectorAction(null);
     sceneRef.current?.selectEntity({ kind: 'barrier', id: String(barrier.barrier_id) });
   }, []);
+
+  // E5: restore a linked aggregate selection once its dataset is present —
+  // the same list-selection code paths a keyboard user takes (H1.2/F-8).
+  useEffect(() => {
+    if (handoffSelectionDoneRef.current || !handoff.selection) return;
+    const { kind, id } = handoff.selection;
+    if (kind === 'occupancy') {
+      if (!lastOccupancyInsightsRef.current.some((insight) => insight.location === id)) return;
+      handoffSelectionDoneRef.current = true;
+      selectLocationFromList(id);
+    } else {
+      const barrierId = Number(id);
+      if (!Number.isFinite(barrierId) || !barriers.some((barrier) => barrier.barrier_id === barrierId)) return;
+      handoffSelectionDoneRef.current = true;
+      selectBarrierFromList(barrierId);
+    }
+    // The link is explicit locate intent (the ?patient=/?focus_stop
+    // precedent) — but a linked camera pose outranks the flight.
+    if (!handoff.camera) sceneRef.current?.focusSelection();
+  }, [handoff.selection, handoff.camera, metrics, barriers, sceneNonce, selectBarrierFromList, selectLocationFromList]);
 
   // N-7: three persona-keyed camera/floor/layers bookmarks. The updater
   // stays pure — persistence happens outside setState.
@@ -1919,6 +2058,8 @@ export default function PatientFlowNavigator({
             patientTicks={chronobarPatientTicks}
             replaying={live}
             onScrub={handleScrub}
+            windowPreset={windowPreset}
+            onWindowPresetChange={applyWindowPreset}
           />
         )}
         playing={playing}
@@ -1956,6 +2097,8 @@ export default function PatientFlowNavigator({
         savedViews={views.map((view) => view !== null)}
         onSaveView={saveView}
         onApplyView={applyView}
+        onCopyViewLink={copyViewLink}
+        onCopySavedViewLink={copySavedViewLink}
         roundsHud={roundsHud}
         tourAuto={tourAuto}
         onTourPrev={() => tourStep(-1)}

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -96,6 +96,7 @@ import NavigatorFloorRail from './NavigatorFloorRail';
 import NavigatorInspector from './NavigatorInspector';
 import NavigatorIntro from './NavigatorIntro';
 import NavigatorLegend from './NavigatorLegend';
+import NavigatorMinimap from './NavigatorMinimap';
 import NavigatorStructureNav from './NavigatorStructureNav';
 import NavigatorToolbar from './NavigatorToolbar';
 import type { LayerControl, NavigatorMetrics } from './NavigatorToolbar';
@@ -421,6 +422,13 @@ export default function PatientFlowNavigator({
   // Raw xyz debug readout is title-attribute-only — written via ref so a
   // camera emit never re-renders the tree when the place label is unchanged.
   const cameraSpanRef = useRef<HTMLSpanElement | null>(null);
+  // E1: latest camera pose for the minimap — a ref (not state) so the ~7 Hz
+  // camera stream never re-renders the orchestrator; the minimap polls it.
+  const cameraViewRef = useRef<CameraView | null>(null);
+  // E1: floor location codes with an observed deviation, for the minimap pips.
+  // Guarded setState from refreshScene (change-keyed) so the hot path is cheap.
+  const [deviantLocationCodes, setDeviantLocationCodes] = useState<string[]>([]);
+  const deviantLocationKeyRef = useRef('');
   const [metrics, setMetrics] = useState<NavigatorMetrics>({ active: 0, events: 0, occupiedLocations: 0 });
   // F-8 non-pointer parity: the delayed/watch locations currently drawn in the
   // scene, exposed as a keyboard-selectable list (NavigatorActionList).
@@ -552,6 +560,9 @@ export default function PatientFlowNavigator({
   const introStopList = useMemo(() => introStops(roundsActive), [roundsActive]);
 
   const tracks = useMemo(() => rebuildTracks(events), [events]);
+
+  // E1: deviant floor-location codes as a Set for the minimap pips.
+  const deviationLocationSet = useMemo(() => new Set(deviantLocationCodes), [deviantLocationCodes]);
 
   // S-1: advance wall-clock now every 60s. The ref updates in the same tick so
   // any repaint that fires before the effects run already sees the fresh value.
@@ -718,6 +729,23 @@ export default function PatientFlowNavigator({
     lastOccupancyInsightsRef.current = occupancyInsights;
     // Only the visible disks are selectable in the scene; the list mirrors them.
     setActionableInsights(visibleOccupancyInsights.filter((insight) => insight.primaryStatus !== 'ok'));
+    // E1 minimap deviation pips: the location codes of currently-visible
+    // flagged patients. Change-keyed so the hot path only re-renders the
+    // minimap when the set actually shifts. Empty (and free) while dark.
+    if (deviationsRef.current.size > 0) {
+      const codes = [...new Set(states
+        .filter((state) => deviationsRef.current.has(state.patientId))
+        .map((state) => state.event.to_location)
+        .filter((code): code is string => Boolean(code)))].sort();
+      const key = codes.join('|');
+      if (key !== deviantLocationKeyRef.current) {
+        deviantLocationKeyRef.current = key;
+        setDeviantLocationCodes(codes);
+      }
+    } else if (deviantLocationKeyRef.current !== '') {
+      deviantLocationKeyRef.current = '';
+      setDeviantLocationCodes([]);
+    }
     scene.setPathwayDeviations(deviationsRef.current, layersRef.current.pathway);
     scene.updateTokens(
       states,
@@ -973,6 +1001,7 @@ export default function PatientFlowNavigator({
   // to the orbit target names what the operator is looking at. Raw coordinates
   // survive in the status-bar title attribute for debugging.
   const handleCameraMove = useCallback((view: CameraView): void => {
+    cameraViewRef.current = view;
     if (cameraSpanRef.current) {
       cameraSpanRef.current.title =
         `camera x ${Math.round(view.position.x)} y ${Math.round(view.position.y)} z ${Math.round(view.position.z)}`
@@ -2189,6 +2218,21 @@ export default function PatientFlowNavigator({
         onSelectBed={selectLocationFromList}
         onFrame={(points) => sceneRef.current?.focusOn(points)}
       />
+
+      {/* E1: the minimap answers "where am I" — suppressed on wall/kiosk
+          (?wall=1), where the whole screen is the instrument. */}
+      {!handoff.wall && (
+        <NavigatorMinimap
+          locations={locations}
+          floor={filters.floor}
+          delayed={actionableInsights}
+          deviationLocations={deviationLocationSet}
+          getCameraView={() => cameraViewRef.current}
+          getSelectionPoint={() => sceneRef.current?.getSelectionPoint() ?? null}
+          onNavigate={(point) => sceneRef.current?.focusOn([point])}
+          onFitFloor={() => applyCanonicalView('floor')}
+        />
+      )}
 
       {journeyState === 'idle' ? (
         <NavigatorInspector title={inspectorTitle} rows={inspectorRows} action={inspectorAction} />

--- a/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
+++ b/resources/js/Components/PatientFlowNavigator/PatientFlowNavigator.tsx
@@ -101,7 +101,7 @@ import NavigatorSmallMultiples from './NavigatorSmallMultiples';
 import NavigatorStructureNav from './NavigatorStructureNav';
 import NavigatorToolbar from './NavigatorToolbar';
 import { gridToWorldCells, densityGrid, heatBounds } from '@/features/patientFlowNavigator/trailHeat';
-import type { LayerControl, NavigatorMetrics } from './NavigatorToolbar';
+import type { LayerControl, NavigatorMetrics, NavigatorTaskMode } from './NavigatorToolbar';
 import './PatientFlowNavigator.css';
 import { formatDurationMinutes } from '@/lib/duration';
 
@@ -490,6 +490,9 @@ export default function PatientFlowNavigator({
   const [ortho, setOrtho] = useState(false);
   // E4: GSTC flatten — draw the last-6h trail density on the 3D floor.
   const [floorHeatOn, setFloorHeatOn] = useState(false);
+  // E6: task mode — progressive disclosure of the toolbar (WN-6). Default
+  // Monitor is the resting at-a-glance layout minus the investigation kit.
+  const [taskMode, setTaskMode] = useState<NavigatorTaskMode>('monitor');
   const [roundsRun, setRoundsRun] = useState<RunSummary | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [inspectorAction, setInspectorAction] = useState<{ label: string; href: string } | null>(null);
@@ -2190,6 +2193,8 @@ export default function PatientFlowNavigator({
         categories={categories}
         layers={layers}
         layerControls={layerControls}
+        taskMode={taskMode}
+        onTaskModeChange={setTaskMode}
         censusScope={censusScope}
         showDeviationScope={conformanceEnabled}
         metrics={metrics}
@@ -2263,8 +2268,9 @@ export default function PatientFlowNavigator({
       )}
 
       {/* E4: the hourly small-multiples analysis card — the non-replay path to
-          "what happened this shift". Desk affordance; hidden on wall/kiosk. */}
-      {!handoff.wall && patientDotsVisible && (
+          "what happened this shift". Desk affordance; hidden on wall/kiosk and
+          revealed only in Investigate mode (E6 progressive disclosure). */}
+      {!handoff.wall && patientDotsVisible && taskMode === 'investigate' && (
         <NavigatorSmallMultiples
           tracks={tracks}
           locations={locations}

--- a/resources/js/features/patientFlowNavigator/cameraFlight.ts
+++ b/resources/js/features/patientFlowNavigator/cameraFlight.ts
@@ -1,0 +1,73 @@
+// Camera flight path (E2): van Wijk & Nuij's "Smooth and efficient zooming
+// and panning" (InfoVis 2003), operationalized for the orbit camera — the
+// orbit TARGET is the pan position, camera DISTANCE is the zoom width. Long
+// pans rise above both endpoints (zoom out → pan → zoom in) so the operator
+// keeps context; short hops stay near-linear. Pure math, pinned by
+// cameraFlight.test.ts; NavigatorScene consumes it frame-by-frame.
+
+export interface FlightPath {
+  /** Total path length in van Wijk's (u, w) space — duration scales on this. */
+  pathLength: number;
+  /** Pan progress 0..1 along the straight target line at normalized time t. */
+  panAt: (t: number) => number;
+  /** Camera distance (zoom width) at normalized time t. */
+  widthAt: (t: number) => number;
+}
+
+/** van Wijk's ρ — trade-off between panning and zooming; 1.42 is his ρ*. */
+export const FLIGHT_RHO = 1.42;
+
+/** ms per unit of path length; clamped so no flight is jarring or glacial. */
+export const FLIGHT_MS_PER_UNIT = 420;
+export const FLIGHT_MIN_MS = 320;
+export const FLIGHT_MAX_MS = 2_200;
+
+export function flightDurationMs(pathLength: number): number {
+  return Math.min(FLIGHT_MAX_MS, Math.max(FLIGHT_MIN_MS, pathLength * FLIGHT_MS_PER_UNIT));
+}
+
+const EPSILON = 1e-6;
+
+/**
+ * Build the optimal pan/zoom path from (pan 0, width w0) to (pan panDistance,
+ * width w1). Widths must be positive; a degenerate pan collapses to the pure
+ * exponential zoom van Wijk gives for u0 = u1.
+ */
+export function buildFlightPath(panDistance: number, w0: number, w1: number, rho = FLIGHT_RHO): FlightPath {
+  const startWidth = Math.max(EPSILON, w0);
+  const endWidth = Math.max(EPSILON, w1);
+  const distance = Math.max(0, panDistance);
+
+  if (distance < EPSILON) {
+    // Pure zoom: w(s) = w0 · e^(±ρs), S = |ln(w1/w0)| / ρ.
+    const pathLength = Math.abs(Math.log(endWidth / startWidth)) / rho;
+    const direction = endWidth >= startWidth ? 1 : -1;
+    return {
+      pathLength,
+      panAt: () => 1,
+      widthAt: (t) => startWidth * Math.exp(direction * rho * (t * pathLength)),
+    };
+  }
+
+  // b_i and r_i per van Wijk & Nuij §3 (asinh form keeps precision).
+  const rhoSq = rho * rho;
+  const b = (i: 0 | 1): number => {
+    const wi = i === 0 ? startWidth : endWidth;
+    const sign = i === 0 ? 1 : -1;
+    return (endWidth * endWidth - startWidth * startWidth + sign * (rhoSq * rhoSq * distance * distance))
+      / (2 * wi * rhoSq * distance);
+  };
+  const r = (bi: number): number => Math.log(-bi + Math.sqrt(bi * bi + 1));
+  const r0 = r(b(0));
+  const r1 = r(b(1));
+  const pathLength = (r1 - r0) / rho;
+
+  const u = (s: number): number => (startWidth / rhoSq) * (Math.cosh(r0) * Math.tanh(rho * s + r0) - Math.sinh(r0));
+  const w = (s: number): number => (startWidth * Math.cosh(r0)) / Math.cosh(rho * s + r0);
+
+  return {
+    pathLength,
+    panAt: (t) => Math.min(1, Math.max(0, u(t * pathLength) / distance)),
+    widthAt: (t) => w(t * pathLength),
+  };
+}

--- a/resources/js/features/patientFlowNavigator/minimapProjection.ts
+++ b/resources/js/features/patientFlowNavigator/minimapProjection.ts
@@ -1,0 +1,70 @@
+// Minimap projection (E1): a top-down 2D schematic of the current floor. Maps
+// world XZ (plan view) to a unit square and back, so the minimap can place
+// dots/pips/the camera footprint and turn a click back into a world point to
+// fly to. Pure + padded bounds; pinned by minimapProjection.test.ts.
+
+export interface Bounds2D {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+}
+
+export interface MinimapProjector {
+  bounds: Bounds2D;
+  /** World (x,z) → normalized minimap coords in [0,1] (v grows with +z / south). */
+  project: (x: number, z: number) => { u: number; v: number };
+  /** Normalized [0,1] minimap coords → world (x, z). */
+  unproject: (u: number, v: number) => { x: number; z: number };
+}
+
+const MIN_SPAN = 1;
+
+/** Padded XZ bounds over a point set; `pad` is a fraction of the larger span. */
+export function computeBounds(
+  points: Array<{ x: number; z: number }>,
+  pad = 0.08,
+): Bounds2D | null {
+  if (points.length === 0) return null;
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minZ = Infinity;
+  let maxZ = -Infinity;
+  for (const point of points) {
+    minX = Math.min(minX, point.x);
+    maxX = Math.max(maxX, point.x);
+    minZ = Math.min(minZ, point.z);
+    maxZ = Math.max(maxZ, point.z);
+  }
+  const spanX = Math.max(MIN_SPAN, maxX - minX);
+  const spanZ = Math.max(MIN_SPAN, maxZ - minZ);
+  const padX = spanX * pad;
+  const padZ = spanZ * pad;
+  return { minX: minX - padX, maxX: maxX + padX, minZ: minZ - padZ, maxZ: maxZ + padZ };
+}
+
+/** Build a projector for the given bounds (or a point set via computeBounds). */
+export function buildProjector(bounds: Bounds2D): MinimapProjector {
+  const spanX = Math.max(MIN_SPAN, bounds.maxX - bounds.minX);
+  const spanZ = Math.max(MIN_SPAN, bounds.maxZ - bounds.minZ);
+  return {
+    bounds,
+    project: (x, z) => ({
+      u: (x - bounds.minX) / spanX,
+      v: (z - bounds.minZ) / spanZ,
+    }),
+    unproject: (u, v) => ({
+      x: bounds.minX + u * spanX,
+      z: bounds.minZ + v * spanZ,
+    }),
+  };
+}
+
+/** Convenience: projector straight from a point set, or null if empty. */
+export function projectorForPoints(
+  points: Array<{ x: number; z: number }>,
+  pad?: number,
+): MinimapProjector | null {
+  const bounds = computeBounds(points, pad);
+  return bounds ? buildProjector(bounds) : null;
+}

--- a/resources/js/features/patientFlowNavigator/replayTimeline.ts
+++ b/resources/js/features/patientFlowNavigator/replayTimeline.ts
@@ -8,6 +8,50 @@ import { parseTime } from './stateProjection';
 export const LIVE_WINDOW_HALF_MS = 24 * 60 * 60 * 1000;
 const MINIMUM_HISTORICAL_WINDOW_MS = 2 * 60 * 60 * 1000;
 
+/**
+ * Chronobar window presets (TN-6): the 48h review/projection window is the
+ * default; 24h/6h narrow it symmetrically around now so recent activity is
+ * not compressed into a sliver; `shift` anchors to the current 07:00/19:00
+ * shift block (local clock, matching the chronobar's shift detents).
+ */
+export type WindowPreset = '48h' | '24h' | '6h' | 'shift';
+
+export const WINDOW_PRESET_LABELS: Record<WindowPreset, string> = {
+  '48h': '48 h',
+  '24h': '24 h',
+  '6h': '6 h',
+  shift: 'Shift',
+};
+
+const PRESET_HALF_MS: Record<Exclude<WindowPreset, 'shift'>, number> = {
+  '48h': LIVE_WINDOW_HALF_MS,
+  '24h': 12 * 60 * 60 * 1000,
+  '6h': 3 * 60 * 60 * 1000,
+};
+
+/** Start of the shift block containing `nowMs` (07:00–19:00 / 19:00–07:00 local). */
+function shiftStart(nowMs: number): number {
+  const cursor = new Date(nowMs);
+  cursor.setMinutes(0, 0, 0);
+  // Walk back at most 12 hours to the latest 07:00/19:00 boundary at or
+  // before now — the same boundaries the chronobar renders as detents.
+  for (let step = 0; step <= 12; step += 1) {
+    if (cursor.getHours() === 7 || cursor.getHours() === 19) return cursor.getTime();
+    cursor.setHours(cursor.getHours() - 1);
+  }
+  return cursor.getTime();
+}
+
+/** The live window for a preset. Historical sources keep their data-extent window instead. */
+export function windowForPreset(preset: WindowPreset, nowMs: number): { start: number; end: number } {
+  if (preset === 'shift') {
+    const start = shiftStart(nowMs);
+    return { start, end: start + 12 * 60 * 60 * 1000 };
+  }
+  const half = PRESET_HALF_MS[preset];
+  return { start: nowMs - half, end: nowMs + half };
+}
+
 export interface ReplayTimeline {
   windowStart: number;
   windowEnd: number;

--- a/resources/js/features/patientFlowNavigator/structureTree.ts
+++ b/resources/js/features/patientFlowNavigator/structureTree.ts
@@ -1,0 +1,138 @@
+// Structure traversal (E3): a floor → unit → bed hierarchy over the navigator's
+// locations, for Data-Navigator-style keyboard walking of the building without
+// the pointer. Pure model — buildStructureTree + flattenVisible are unit-tested;
+// NavigatorStructureNav renders the flattened rows with roving arrow-key focus
+// and selects through the SAME selectEntity seam a canvas click uses.
+import type { PatientFlowLocation, PatientFlowLocations } from './types';
+
+export type StructureKind = 'floor' | 'unit' | 'bed';
+
+export interface StructureNode {
+  /** Stable id — `floor:{n}` / `unit:{floor}:{code}` / `bed:{locationCode}`. */
+  id: string;
+  kind: StructureKind;
+  label: string;
+  /** For a bed: the location code (selects the occupancy entity). */
+  locationCode: string | null;
+  /** Anchor to frame this node's points; null for beds without geometry. */
+  position: { x: number; y: number; z: number } | null;
+  /** Floor number this node belongs to, for the camera-frame fallback. */
+  floor: number | null;
+  children: StructureNode[];
+}
+
+export interface FlatRow {
+  node: StructureNode;
+  depth: number;
+  /** Undefined for beds (leaves); true/false for expandable rows. */
+  expanded?: boolean;
+}
+
+function positionOf(loc: PatientFlowLocation): { x: number; y: number; z: number } | null {
+  return loc.position_m ? { x: loc.position_m.x, y: loc.position_m.y ?? 0, z: loc.position_m.z } : null;
+}
+
+function averagePosition(
+  positions: Array<{ x: number; y: number; z: number }>,
+): { x: number; y: number; z: number } | null {
+  if (positions.length === 0) return null;
+  const sum = positions.reduce(
+    (acc, point) => ({ x: acc.x + point.x, y: acc.y + point.y, z: acc.z + point.z }),
+    { x: 0, y: 0, z: 0 },
+  );
+  return { x: sum.x / positions.length, y: sum.y / positions.length, z: sum.z / positions.length };
+}
+
+/**
+ * Build the floor → unit → bed tree from the navigator's locations. Beds sort
+ * by name; units by code; floors ascending. Locations without a floor or a
+ * bed-like category (rooms/beds/ED spaces) are grouped under their unit; pure
+ * infra (elevators, corridors) is excluded — it is not a wayfinding target.
+ */
+export function buildStructureTree(locations: PatientFlowLocations): StructureNode[] {
+  const EXCLUDED = new Set(['elevator', 'corridor', 'floor']);
+  const byFloor = new Map<number, Map<string, PatientFlowLocation[]>>();
+
+  for (const loc of Object.values(locations)) {
+    if (loc.floor === null || loc.floor === undefined) continue;
+    if (EXCLUDED.has(loc.category)) continue;
+    const unitCode = (loc.unit_code ?? 'Unassigned').toUpperCase();
+    let units = byFloor.get(loc.floor);
+    if (!units) {
+      units = new Map();
+      byFloor.set(loc.floor, units);
+    }
+    const beds = units.get(unitCode) ?? [];
+    beds.push(loc);
+    units.set(unitCode, beds);
+  }
+
+  return [...byFloor.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([floor, units]) => {
+      const unitNodes: StructureNode[] = [...units.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([unitCode, beds]) => {
+          const bedNodes: StructureNode[] = beds
+            .slice()
+            .sort((a, b) => (a.name ?? a.location_code).localeCompare(b.name ?? b.location_code))
+            .map((loc) => ({
+              id: `bed:${loc.location_code}`,
+              kind: 'bed' as const,
+              label: loc.name ?? loc.location_code,
+              locationCode: loc.location_code,
+              position: positionOf(loc),
+              floor,
+              children: [],
+            }));
+          const unitPos = averagePosition(
+            bedNodes.map((bed) => bed.position).filter((p): p is NonNullable<typeof p> => p !== null),
+          );
+          return {
+            id: `unit:${floor}:${unitCode}`,
+            kind: 'unit' as const,
+            label: unitCode === 'UNASSIGNED' ? 'Unassigned' : unitCode,
+            locationCode: null,
+            position: unitPos,
+            floor,
+            children: bedNodes,
+          };
+        });
+      const floorPos = averagePosition(
+        unitNodes.map((unit) => unit.position).filter((p): p is NonNullable<typeof p> => p !== null),
+      );
+      return {
+        id: `floor:${floor}`,
+        kind: 'floor' as const,
+        label: `Floor ${floor}`,
+        locationCode: null,
+        position: floorPos,
+        floor,
+        children: unitNodes,
+      };
+    });
+}
+
+/** Flatten the tree to the currently-visible rows given the expanded set. */
+export function flattenVisible(nodes: StructureNode[], expanded: Set<string>): FlatRow[] {
+  const rows: FlatRow[] = [];
+  const walk = (list: StructureNode[], depth: number): void => {
+    for (const node of list) {
+      const isLeaf = node.children.length === 0;
+      rows.push({ node, depth, expanded: isLeaf ? undefined : expanded.has(node.id) });
+      if (!isLeaf && expanded.has(node.id)) walk(node.children, depth + 1);
+    }
+  };
+  walk(nodes, 0);
+  return rows;
+}
+
+/** The parent id of a node id, or null for a floor (root). */
+export function parentIdOf(id: string): string | null {
+  if (id.startsWith('bed:')) return null; // resolved by scan (a bed's unit id isn't derivable from its code)
+  if (id.startsWith('unit:')) {
+    const [, floor] = id.split(':');
+    return `floor:${floor}`;
+  }
+  return null;
+}

--- a/resources/js/features/patientFlowNavigator/trailHeat.ts
+++ b/resources/js/features/patientFlowNavigator/trailHeat.ts
@@ -1,0 +1,164 @@
+// Trail heat + small multiples (E4): the analysis path that replaces forced
+// replay. Instead of scrubbing time, flatten movement over a window into a
+// density grid (GSTC flatten), and slice the last N hours into small multiples
+// so a shift's flow reads at a glance. Pure + pinned by trailHeat.test.ts.
+import type { PatientFlowEvent, PatientFlowLocations } from './types';
+import { parseTime, positionFor } from './stateProjection';
+
+export interface HeatBounds {
+  minX: number;
+  maxX: number;
+  minZ: number;
+  maxZ: number;
+}
+
+export interface DensityGrid {
+  cols: number;
+  rows: number;
+  /** Row-major counts, length cols*rows. */
+  cells: number[];
+  /** The single busiest cell count, for normalization. */
+  max: number;
+}
+
+export interface HourlySlice {
+  startMs: number;
+  endMs: number;
+  label: string;
+  grid: DensityGrid;
+  /** Distinct patients present in this hour. */
+  patients: number;
+}
+
+/** Padded XZ bounds over the floor's placed locations (the grid's frame). */
+export function heatBounds(locations: PatientFlowLocations, floor: string): HeatBounds | null {
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minZ = Infinity;
+  let maxZ = -Infinity;
+  let any = false;
+  for (const loc of Object.values(locations)) {
+    if (!loc.position_m) continue;
+    if (floor !== 'all' && String(loc.floor) !== floor) continue;
+    any = true;
+    minX = Math.min(minX, loc.position_m.x);
+    maxX = Math.max(maxX, loc.position_m.x);
+    minZ = Math.min(minZ, loc.position_m.z);
+    maxZ = Math.max(maxZ, loc.position_m.z);
+  }
+  if (!any) return null;
+  const padX = Math.max(1, (maxX - minX) * 0.06);
+  const padZ = Math.max(1, (maxZ - minZ) * 0.06);
+  return { minX: minX - padX, maxX: maxX + padX, minZ: minZ - padZ, maxZ: maxZ + padZ };
+}
+
+/**
+ * Bin the presence points (resolved event locations) in [startMs, endMs] into
+ * a cols×rows density grid over `bounds`. Each in-window event on a matching
+ * floor adds one to its cell — where flow concentrated, without replay.
+ */
+export function densityGrid(
+  tracks: Map<string, PatientFlowEvent[]>,
+  locations: PatientFlowLocations,
+  bounds: HeatBounds,
+  startMs: number,
+  endMs: number,
+  cols = 12,
+  rows = 12,
+  floor = 'all',
+): DensityGrid {
+  const cells = new Array<number>(cols * rows).fill(0);
+  const spanX = Math.max(1e-6, bounds.maxX - bounds.minX);
+  const spanZ = Math.max(1e-6, bounds.maxZ - bounds.minZ);
+  let max = 0;
+
+  for (const track of tracks.values()) {
+    for (const event of track) {
+      const at = parseTime(event.occurred_at);
+      if (at < startMs || at > endMs) continue;
+      if (floor !== 'all' && event.location_floor != null && String(event.location_floor) !== floor) continue;
+      const position = positionFor(locations, event.to_location);
+      if (!position) continue;
+      const u = (position.x - bounds.minX) / spanX;
+      const v = (position.z - bounds.minZ) / spanZ;
+      if (u < 0 || u > 1 || v < 0 || v > 1) continue;
+      const col = Math.min(cols - 1, Math.floor(u * cols));
+      const row = Math.min(rows - 1, Math.floor(v * rows));
+      const index = row * cols + col;
+      cells[index] += 1;
+      if (cells[index] > max) max = cells[index];
+    }
+  }
+
+  return { cols, rows, cells, max };
+}
+
+function pad2(value: number): string {
+  return value < 10 ? `0${value}` : String(value);
+}
+
+function hourLabel(startMs: number): string {
+  const date = new Date(startMs);
+  return `${pad2(date.getHours())}:00`;
+}
+
+/**
+ * Slice [endMs − hours·h, endMs] into `hours` hourly density grids (oldest
+ * first) — the small-multiples strip. Each slice also counts distinct patients
+ * present, so a quiet hour reads as quiet, not just empty.
+ */
+export function hourlySlices(
+  tracks: Map<string, PatientFlowEvent[]>,
+  locations: PatientFlowLocations,
+  bounds: HeatBounds,
+  endMs: number,
+  hours = 6,
+  floor = 'all',
+  cols = 12,
+  rows = 12,
+): HourlySlice[] {
+  const hourMs = 3_600_000;
+  const slices: HourlySlice[] = [];
+  for (let index = hours - 1; index >= 0; index -= 1) {
+    const sliceEnd = endMs - index * hourMs;
+    const sliceStart = sliceEnd - hourMs;
+    const grid = densityGrid(tracks, locations, bounds, sliceStart, sliceEnd, cols, rows, floor);
+    const patients = new Set<string>();
+    for (const [patientId, track] of tracks.entries()) {
+      if (track.some((event) => {
+        const at = parseTime(event.occurred_at);
+        return at >= sliceStart && at <= sliceEnd
+          && (floor === 'all' || event.location_floor == null || String(event.location_floor) === floor);
+      })) {
+        patients.add(patientId);
+      }
+    }
+    slices.push({ startMs: sliceStart, endMs: sliceEnd, label: hourLabel(sliceStart), grid, patients: patients.size });
+  }
+  return slices;
+}
+
+/** Flatten a density grid into scene heat cells (world-centered tiles). */
+export function gridToWorldCells(
+  grid: DensityGrid,
+  bounds: HeatBounds,
+  y = 0.4,
+): Array<{ x: number; y: number; z: number; intensity: number }> {
+  if (grid.max === 0) return [];
+  const cellW = (bounds.maxX - bounds.minX) / grid.cols;
+  const cellD = (bounds.maxZ - bounds.minZ) / grid.rows;
+  const out: Array<{ x: number; y: number; z: number; intensity: number }> = [];
+  for (let row = 0; row < grid.rows; row += 1) {
+    for (let col = 0; col < grid.cols; col += 1) {
+      const count = grid.cells[row * grid.cols + col];
+      if (count === 0) continue;
+      out.push({
+        x: bounds.minX + (col + 0.5) * cellW,
+        y,
+        z: bounds.minZ + (row + 0.5) * cellD,
+        intensity: count / grid.max,
+      });
+    }
+  }
+  return out;
+}

--- a/resources/js/features/patientFlowNavigator/viewState.ts
+++ b/resources/js/features/patientFlowNavigator/viewState.ts
@@ -1,0 +1,162 @@
+// URL view state (plan §Phase E, E5): serialize/parse the operator's exact
+// view — camera, floor, layers, time, selection, census scope, window preset —
+// so any view is shareable as a link. Pure module, round-trip pinned by
+// viewState.test.ts (seeded property sweep).
+//
+// Identity rule: a patient selection travels ONLY as the existing opaque
+// `patient=ptok_…` param and a round stop as `focus_stop=` — this module
+// never invents a second way to address a person. `sel=` carries the two
+// aggregate kinds (occupancy location, barrier id) exclusively.
+import type { PatientLayerState } from './types';
+import type { WindowPreset } from './replayTimeline';
+
+export interface ViewCamera {
+  position: { x: number; y: number; z: number };
+  target: { x: number; y: number; z: number };
+}
+
+export type AggregateSelectionKind = 'occupancy' | 'barrier';
+
+export interface AggregateSelection {
+  kind: AggregateSelectionKind;
+  id: string;
+}
+
+/** Everything the copy-view-link path snapshots. Null/default fields are omitted from the URL. */
+export interface NavigatorViewSnapshot {
+  camera: ViewCamera | null;
+  /** Floor filter; 'all' is the default and omitted. */
+  floor: string;
+  /** Full layer state; null omits the param (recipient keeps lens defaults). */
+  layers: PatientLayerState | null;
+  censusScope: 'all' | 'delayed' | 'deviations';
+  /** Scrubbed instant; null = following now (recipient opens at their now). */
+  timeMs: number | null;
+  windowPreset: WindowPreset;
+  /** Aggregate selection (occupancy/barrier). Patients/round stops use their own params. */
+  selection: AggregateSelection | null;
+  /** Opaque patient pivot (ptok) — reuses the Phase B `patient=` contract. */
+  patient: string | null;
+  /** Round-stop pivot — reuses the R-1 `focus_stop=` contract. */
+  focusStop: string | null;
+}
+
+/** Parsed view-state additions layered onto the legacy handoff params. */
+export interface ParsedViewState {
+  camera: ViewCamera | null;
+  layers: PatientLayerState | null;
+  censusScope: 'delayed' | 'deviations' | null;
+  windowPreset: WindowPreset | null;
+  selection: AggregateSelection | null;
+  /** Wall/kiosk chrome suppression (E1): hides desk-only widgets like the minimap. */
+  wall: boolean;
+}
+
+export const LAYER_KEYS: ReadonlyArray<keyof PatientLayerState> = [
+  'base', 'tokens', 'trails', 'heat', 'ghosts', 'barriers', 'rounds', 'pathway',
+];
+
+const WINDOW_PRESETS: ReadonlyArray<WindowPreset> = ['48h', '24h', '6h', 'shift'];
+
+const CAMERA_COORD_LIMIT = 100_000;
+
+function roundCoord(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function validCoord(value: number): boolean {
+  return Number.isFinite(value) && Math.abs(value) <= CAMERA_COORD_LIMIT;
+}
+
+/** `cam=px,py,pz,tx,ty,tz` — 1-decimal fixed so links stay short and stable. */
+export function serializeCamera(camera: ViewCamera): string {
+  const parts = [
+    camera.position.x, camera.position.y, camera.position.z,
+    camera.target.x, camera.target.y, camera.target.z,
+  ];
+  return parts.map((part) => String(roundCoord(part))).join(',');
+}
+
+export function parseCamera(raw: string | null): ViewCamera | null {
+  if (!raw) return null;
+  const parts = raw.split(',').map(Number);
+  if (parts.length !== 6 || !parts.every(validCoord)) return null;
+  return {
+    position: { x: parts[0], y: parts[1], z: parts[2] },
+    target: { x: parts[3], y: parts[4], z: parts[5] },
+  };
+}
+
+/** `layers=base,tokens,heat` — listed keys on, unlisted off; unknown keys dropped. */
+export function serializeLayers(layers: PatientLayerState): string {
+  return LAYER_KEYS.filter((key) => layers[key]).join(',');
+}
+
+export function parseLayers(raw: string | null): PatientLayerState | null {
+  if (raw === null) return null;
+  const requested = new Set(raw.split(',').filter(Boolean));
+  const known = new Set<string>(LAYER_KEYS);
+  for (const key of requested) {
+    if (!known.has(key)) requested.delete(key);
+  }
+  const state = {} as PatientLayerState;
+  for (const key of LAYER_KEYS) state[key] = requested.has(key);
+  return state;
+}
+
+function parseSelection(raw: string | null): AggregateSelection | null {
+  if (!raw) return null;
+  const splitAt = raw.indexOf(':');
+  if (splitAt <= 0) return null;
+  const kind = raw.slice(0, splitAt);
+  const id = raw.slice(splitAt + 1);
+  if (!id) return null;
+  if (kind !== 'occupancy' && kind !== 'barrier') return null;
+  return { kind, id };
+}
+
+/**
+ * Build the shareable search string for a snapshot. Defaults are omitted so a
+ * home-view link is just the page URL; param names extend the existing
+ * mobile→web handoff grammar (`scope`/`t`/`patient`/`focus_stop`) unchanged.
+ */
+export function buildViewSearch(snapshot: NavigatorViewSnapshot): string {
+  const params = new URLSearchParams();
+  if (snapshot.floor !== 'all' && /^\d+$/.test(snapshot.floor)) {
+    params.set('scope', `floor:${snapshot.floor}`);
+  }
+  if (snapshot.timeMs !== null && Number.isFinite(snapshot.timeMs)) {
+    params.set('t', new Date(snapshot.timeMs).toISOString());
+  }
+  if (snapshot.camera) params.set('cam', serializeCamera(snapshot.camera));
+  if (snapshot.layers) params.set('layers', serializeLayers(snapshot.layers));
+  if (snapshot.censusScope !== 'all') params.set('census', snapshot.censusScope);
+  if (snapshot.windowPreset !== '48h') params.set('win', snapshot.windowPreset);
+  if (snapshot.selection) params.set('sel', `${snapshot.selection.kind}:${snapshot.selection.id}`);
+  if (snapshot.patient) params.set('patient', snapshot.patient);
+  if (snapshot.focusStop) params.set('focus_stop', snapshot.focusStop);
+  const search = params.toString();
+  return search ? `?${search}` : '';
+}
+
+/** Parse the E5 additions from a search string. Garbage degrades to nulls, never throws. */
+export function parseViewState(search: string): ParsedViewState {
+  const params = new URLSearchParams(search);
+
+  const rawCensus = params.get('census');
+  const censusScope = rawCensus === 'delayed' || rawCensus === 'deviations' ? rawCensus : null;
+
+  const rawPreset = params.get('win');
+  const windowPreset = WINDOW_PRESETS.includes(rawPreset as WindowPreset)
+    ? (rawPreset as WindowPreset)
+    : null;
+
+  return {
+    camera: parseCamera(params.get('cam')),
+    layers: parseLayers(params.get('layers')),
+    censusScope,
+    windowPreset,
+    selection: parseSelection(params.get('sel')),
+    wall: params.get('wall') === '1',
+  };
+}

--- a/resources/js/types/troika-three-text.d.ts
+++ b/resources/js/types/troika-three-text.d.ts
@@ -1,0 +1,20 @@
+// Minimal ambient types for `troika-three-text` (ships none, no @types exists).
+// Covers only the SDF-billboard surface the 4D Navigator's unit labels use
+// (E2). Kept local so NavigatorScene.ts stays strict-typed without an `any`.
+declare module 'troika-three-text' {
+  import type { Mesh, Material, Color } from 'three';
+
+  export class Text extends Mesh {
+    text: string;
+    font: string | undefined;
+    fontSize: number;
+    color: number | string | Color;
+    anchorX: number | 'left' | 'center' | 'right' | string;
+    anchorY: number | 'top' | 'top-baseline' | 'middle' | 'bottom-baseline' | 'bottom' | string;
+    outlineWidth: number | string;
+    outlineColor: number | string | Color;
+    material: Material & { transparent: boolean; depthWrite: boolean; opacity: number };
+    sync(callback?: () => void): void;
+    dispose(): void;
+  }
+}

--- a/tests/js/patientFlow/NavigatorMinimap.test.tsx
+++ b/tests/js/patientFlow/NavigatorMinimap.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import NavigatorMinimap from '@/Components/PatientFlowNavigator/NavigatorMinimap';
+import type { PatientFlowLocation, PatientFlowLocations, OccupancyInsight } from '@/features/patientFlowNavigator/types';
+import type { CameraView } from '@/Components/PatientFlowNavigator/NavigatorScene';
+
+/** E1 — the minimap places the plate + pips and turns a click into a fly-to. */
+
+function loc(code: string, floor: number, x: number, z: number): PatientFlowLocation {
+  return {
+    facility_space_id: 1,
+    location_code: code,
+    source_location_code: code,
+    name: code,
+    category: 'bed',
+    floor,
+    unit_code: 'U',
+    position_m: { x, y: 0, z },
+  } as PatientFlowLocation;
+}
+
+const LOCATIONS: PatientFlowLocations = {
+  a: loc('L1', 3, 0, 0),
+  b: loc('L2', 3, 100, 0),
+  c: loc('L3', 3, 100, 50),
+  d: loc('L4', 2, 0, 0), // other floor — excluded when floor=3
+};
+
+function delayed(location: string, status: OccupancyInsight['primaryStatus']): OccupancyInsight {
+  return {
+    location,
+    locationName: location,
+    primaryStatus: status,
+    position: { x: 100, y: 0, z: 0 },
+    stayMinutes: 120,
+    blockers: [],
+    timers: [],
+  } as unknown as OccupancyInsight;
+}
+
+const CAMERA: CameraView = {
+  position: { x: 50, y: 100, z: 120 },
+  target: { x: 50, y: 0, z: 25 },
+};
+
+function setup(overrides: Partial<React.ComponentProps<typeof NavigatorMinimap>> = {}) {
+  const onNavigate = vi.fn();
+  const onFitFloor = vi.fn();
+  const utils = render(
+    <NavigatorMinimap
+      locations={LOCATIONS}
+      floor="3"
+      delayed={[delayed('L2', 'delayed')]}
+      deviationLocations={new Set(['L3'])}
+      getCameraView={() => CAMERA}
+      getSelectionPoint={() => null}
+      onNavigate={onNavigate}
+      onFitFloor={onFitFloor}
+      {...overrides}
+    />,
+  );
+  return { onNavigate, onFitFloor, ...utils };
+}
+
+describe('NavigatorMinimap (E1)', () => {
+  it('renders the plate for the current floor and labels itself', () => {
+    setup();
+    expect(screen.getByRole('img', { name: /floor 3/i })).toBeInTheDocument();
+    const header = screen.getByRole('button', { name: /Floor 3/ });
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    expect(header).toHaveAttribute('title', 'Collapse minimap');
+  });
+
+  it('draws a delay triangle and a deviation square (shape, not color alone)', () => {
+    const { container } = setup();
+    expect(container.querySelector('.patient-flow-minimap-delay')).toBeInTheDocument();
+    expect(container.querySelector('.patient-flow-minimap-deviation')).toBeInTheDocument();
+  });
+
+  it('turns a map click into a world fly-to', () => {
+    const { onNavigate, container } = setup();
+    const svg = container.querySelector('svg')!;
+    // jsdom getBoundingClientRect is 0×0; the handler still fires with u=v=NaN→
+    // clamp-free, but we only assert it routed a navigation intent.
+    vi.spyOn(svg, 'getBoundingClientRect').mockReturnValue({
+      left: 0, top: 0, width: 168, height: 168, right: 168, bottom: 168, x: 0, y: 0, toJSON: () => ({}),
+    } as DOMRect);
+    fireEvent.click(svg, { clientX: 84, clientY: 84 });
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+    const point = onNavigate.mock.calls[0][0];
+    expect(point).toHaveProperty('x');
+    expect(point).toHaveProperty('z');
+  });
+
+  it('fits the floor from the header button', () => {
+    const { onFitFloor } = setup();
+    fireEvent.click(screen.getByRole('button', { name: 'Fit floor' }));
+    expect(onFitFloor).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when the floor has no placed locations', () => {
+    const { container } = render(
+      <NavigatorMinimap
+        locations={{}}
+        floor="9"
+        delayed={[]}
+        deviationLocations={new Set()}
+        getCameraView={() => null}
+        getSelectionPoint={() => null}
+        onNavigate={vi.fn()}
+        onFitFloor={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tests/js/patientFlow/NavigatorSmallMultiples.test.tsx
+++ b/tests/js/patientFlow/NavigatorSmallMultiples.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import NavigatorSmallMultiples from '@/Components/PatientFlowNavigator/NavigatorSmallMultiples';
+import type { PatientFlowEvent, PatientFlowLocation, PatientFlowLocations } from '@/features/patientFlowNavigator/types';
+
+/** E4 — the hourly small-multiples analysis card. */
+
+function loc(code: string, x: number, z: number): PatientFlowLocation {
+  return {
+    facility_space_id: 1,
+    location_code: code,
+    source_location_code: code,
+    name: code,
+    category: 'bed',
+    floor: 3,
+    unit_code: 'U',
+    position_m: { x, y: 0, z },
+  } as PatientFlowLocation;
+}
+
+const LOCATIONS: PatientFlowLocations = { A: loc('A', 0, 0), B: loc('B', 100, 100) };
+const END = Date.parse('2026-07-27T12:00:00Z');
+
+function ev(patientId: string, to: string, at: number): PatientFlowEvent {
+  return {
+    event_id: `${patientId}-${at}`,
+    event_category: 'movement',
+    event_type: 'move',
+    patient_id: patientId,
+    patient_display_id: patientId,
+    encounter_id: `enc-${patientId}`,
+    occurred_at: new Date(at).toISOString(),
+    to_location: to,
+    location_floor: 3,
+  } as PatientFlowEvent;
+}
+
+const TRACKS = new Map<string, PatientFlowEvent[]>([
+  ['p1', [ev('p1', 'A', END - 30 * 60_000)]],
+]);
+
+function setup(overrides: Partial<React.ComponentProps<typeof NavigatorSmallMultiples>> = {}) {
+  const onToggleFloorHeat = vi.fn();
+  const utils = render(
+    <NavigatorSmallMultiples
+      tracks={TRACKS}
+      locations={LOCATIONS}
+      floor="3"
+      endMs={END}
+      floorHeatOn={false}
+      onToggleFloorHeat={onToggleFloorHeat}
+      {...overrides}
+    />,
+  );
+  return { onToggleFloorHeat, ...utils };
+}
+
+describe('NavigatorSmallMultiples (E4)', () => {
+  it('is collapsed by default and reveals six hourly plates on toggle', () => {
+    setup();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Last 6 h/ }));
+    expect(screen.getAllByRole('img')).toHaveLength(6);
+  });
+
+  it('labels each plate as analysis, never live', () => {
+    setup();
+    fireEvent.click(screen.getByRole('button', { name: /Last 6 h/ }));
+    expect(screen.getByText(/analysis, not live/)).toBeInTheDocument();
+  });
+
+  it('routes the on-floor flatten toggle and reflects its pressed state', () => {
+    const { onToggleFloorHeat } = setup({ floorHeatOn: true });
+    fireEvent.click(screen.getByRole('button', { name: /Last 6 h/ }));
+    const toggle = screen.getByRole('button', { name: 'On floor' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(toggle);
+    expect(onToggleFloorHeat).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when the floor has no placed locations', () => {
+    const { container } = render(
+      <NavigatorSmallMultiples
+        tracks={TRACKS}
+        locations={{}}
+        floor="9"
+        endMs={END}
+        floorHeatOn={false}
+        onToggleFloorHeat={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tests/js/patientFlow/NavigatorStructureNav.test.tsx
+++ b/tests/js/patientFlow/NavigatorStructureNav.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import NavigatorStructureNav from '@/Components/PatientFlowNavigator/NavigatorStructureNav';
+import type { PatientFlowLocation, PatientFlowLocations } from '@/features/patientFlowNavigator/types';
+
+/** E3 — the keyboard-walkable structure tree over the action-list seam. */
+
+function loc(code: string, name: string, unit: string, x: number): PatientFlowLocation {
+  return {
+    facility_space_id: 1,
+    location_code: code,
+    source_location_code: code,
+    name,
+    category: 'bed',
+    floor: 3,
+    unit_code: unit,
+    position_m: { x, y: 0, z: 0 },
+  } as PatientFlowLocation;
+}
+
+const LOCATIONS: PatientFlowLocations = {
+  a: loc('3-5E-01', 'Bed 01', '5E', 10),
+  b: loc('3-5E-02', 'Bed 02', '5E', 12),
+};
+
+function setup(overrides: Partial<React.ComponentProps<typeof NavigatorStructureNav>> = {}) {
+  const onSelectBed = vi.fn();
+  const onFrame = vi.fn();
+  render(
+    <NavigatorStructureNav
+      locations={LOCATIONS}
+      onSelectBed={onSelectBed}
+      onFrame={onFrame}
+      {...overrides}
+    />,
+  );
+  return { onSelectBed, onFrame };
+}
+
+describe('NavigatorStructureNav (E3)', () => {
+  it('is collapsed by default and reveals the tree on toggle', () => {
+    setup();
+    expect(screen.queryByRole('tree')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Structure/ }));
+    expect(screen.getByRole('tree', { name: 'Building structure' })).toBeInTheDocument();
+  });
+
+  it('expands a floor with ArrowRight, then descends to the unit', () => {
+    setup();
+    fireEvent.click(screen.getByRole('button', { name: /Structure/ }));
+
+    const floor = screen.getByRole('treeitem', { name: /Floor 3/ });
+    expect(floor).toHaveAttribute('aria-expanded', 'false');
+
+    const floorButton = screen.getByRole('button', { name: /Floor 3/ });
+    fireEvent.keyDown(floorButton, { key: 'ArrowRight' });
+    // Floor now expanded — the 5E unit row appears.
+    expect(screen.getByRole('button', { name: /5E/ })).toBeInTheDocument();
+  });
+
+  it('selects a bed through the shared seam and frames it', () => {
+    const { onSelectBed, onFrame } = setup();
+    fireEvent.click(screen.getByRole('button', { name: /Structure/ }));
+    // Expand floor then unit by activating them.
+    fireEvent.click(screen.getByRole('button', { name: /Floor 3/ }));
+    fireEvent.click(screen.getByRole('button', { name: /5E/ }));
+
+    fireEvent.click(screen.getByRole('button', { name: /Bed 01/ }));
+    expect(onSelectBed).toHaveBeenCalledWith('3-5E-01');
+    expect(onFrame).toHaveBeenCalled();
+  });
+
+  it('collapses an expanded floor with ArrowLeft', () => {
+    setup();
+    fireEvent.click(screen.getByRole('button', { name: /Structure/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Floor 3/ })); // expands + frames
+    expect(screen.getByRole('button', { name: /5E/ })).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByRole('button', { name: /Floor 3/ }), { key: 'ArrowLeft' });
+    expect(screen.queryByRole('button', { name: /5E/ })).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no locations', () => {
+    const { container } = render(
+      <NavigatorStructureNav locations={{}} onSelectBed={vi.fn()} onFrame={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/tests/js/patientFlow/NavigatorToolbar.test.tsx
+++ b/tests/js/patientFlow/NavigatorToolbar.test.tsx
@@ -53,6 +53,8 @@ function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorT
     onSelectSearchResult: vi.fn(),
     onSaveView: vi.fn(),
     onApplyView: vi.fn(),
+    onCopyViewLink: vi.fn(),
+    onCopySavedViewLink: vi.fn(),
     onTourPrev: vi.fn(),
     onTourNext: vi.fn(),
     onTourAutoToggle: vi.fn(),
@@ -237,6 +239,23 @@ describe('NavigatorToolbar saved views (N-7)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Save current view to slot 3' }));
     expect(handlers.onSaveView).toHaveBeenCalledWith(2);
+  });
+});
+
+describe('NavigatorToolbar view links (E5)', () => {
+  it('copies the current view from the always-available toolbar action', () => {
+    const handlers = renderToolbar();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy view link' }));
+    expect(handlers.onCopyViewLink).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers copy-as-link only on filled saved-view slots', () => {
+    const handlers = renderToolbar({ savedViews: [true, false, false] });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy view 1 as a link' }));
+    expect(handlers.onCopySavedViewLink).toHaveBeenCalledWith(0);
+    expect(screen.queryByRole('button', { name: 'Copy view 2 as a link' })).not.toBeInTheDocument();
   });
 });
 

--- a/tests/js/patientFlow/NavigatorToolbar.test.tsx
+++ b/tests/js/patientFlow/NavigatorToolbar.test.tsx
@@ -42,6 +42,7 @@ function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorT
     onToggleLive: vi.fn(),
     onResetCamera: vi.fn(),
     onFocusPatients: vi.fn(),
+    onCanonicalView: vi.fn(),
     onFocusCensusScope: vi.fn(),
     onAskEddy: vi.fn(),
     onSpeedChange: vi.fn(),
@@ -239,6 +240,20 @@ describe('NavigatorToolbar saved views (N-7)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Save current view to slot 3' }));
     expect(handlers.onSaveView).toHaveBeenCalledWith(2);
+  });
+});
+
+describe('NavigatorToolbar canonical views (E2)', () => {
+  it('offers Top / House / Floor / Bed, each routing to the framing', () => {
+    const handlers = renderToolbar();
+
+    const group = screen.getByRole('group', { name: 'Canonical views' });
+    expect(group).toBeInTheDocument();
+
+    for (const [label, view] of [['Top', 'top'], ['House', 'house'], ['Floor', 'floor'], ['Bed', 'bed']] as const) {
+      fireEvent.click(screen.getByRole('button', { name: label }));
+      expect(handlers.onCanonicalView).toHaveBeenCalledWith(view);
+    }
   });
 });
 

--- a/tests/js/patientFlow/NavigatorToolbar.test.tsx
+++ b/tests/js/patientFlow/NavigatorToolbar.test.tsx
@@ -57,6 +57,7 @@ function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorT
     onApplyView: vi.fn(),
     onCopyViewLink: vi.fn(),
     onCopySavedViewLink: vi.fn(),
+    onTaskModeChange: vi.fn(),
     onTourPrev: vi.fn(),
     onTourNext: vi.fn(),
     onTourAutoToggle: vi.fn(),
@@ -77,6 +78,7 @@ function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorT
       categories={[]}
       layers={{ base: true, tokens: true, trails: true, heat: true, ghosts: true, barriers: true, rounds: true, pathway: false }}
       layerControls={layerControls}
+      taskMode="investigate"
       censusScope="all"
       showDeviationScope={false}
       metrics={{ active: 12, events: 40, occupiedLocations: 9 }}
@@ -242,6 +244,38 @@ describe('NavigatorToolbar saved views (N-7)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Save current view to slot 3' }));
     expect(handlers.onSaveView).toHaveBeenCalledWith(2);
+  });
+});
+
+describe('NavigatorToolbar task modes (E6)', () => {
+  it('offers Monitor / Investigate / Rounds and routes the change', () => {
+    const handlers = renderToolbar({ taskMode: 'monitor' });
+
+    const group = screen.getByRole('radiogroup', { name: 'Task mode' });
+    expect(group).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('radio', { name: 'Investigate' }));
+    expect(handlers.onTaskModeChange).toHaveBeenCalledWith('investigate');
+  });
+
+  it('Monitor hides the investigation kit — Find, Speed, and saved views', () => {
+    renderToolbar({ taskMode: 'monitor' });
+    expect(screen.queryByLabelText('Find')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Speed')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'View 1' })).not.toBeInTheDocument();
+    // Core monitoring controls remain.
+    expect(screen.getByLabelText('Floor')).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup', { name: 'Census scope' })).toBeInTheDocument();
+  });
+
+  it('Investigate reveals the investigation kit', () => {
+    renderToolbar({ taskMode: 'investigate' });
+    expect(screen.getByLabelText('Find')).toBeInTheDocument();
+    expect(screen.getByLabelText('Speed')).toBeInTheDocument();
+  });
+
+  it('Rounds hides the occupancy rollup so the walk is the focus', () => {
+    renderToolbar({ taskMode: 'rounds' });
+    expect(screen.queryByLabelText('Occupancy timer rollup')).not.toBeInTheDocument();
   });
 });
 

--- a/tests/js/patientFlow/NavigatorToolbar.test.tsx
+++ b/tests/js/patientFlow/NavigatorToolbar.test.tsx
@@ -43,6 +43,7 @@ function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorT
     onResetCamera: vi.fn(),
     onFocusPatients: vi.fn(),
     onCanonicalView: vi.fn(),
+    onToggleOrtho: vi.fn(),
     onFocusCensusScope: vi.fn(),
     onAskEddy: vi.fn(),
     onSpeedChange: vi.fn(),
@@ -81,6 +82,7 @@ function renderToolbar(overrides: Partial<React.ComponentProps<typeof NavigatorT
       metrics={{ active: 12, events: 40, occupiedLocations: 9 }}
       occupancy={occupancy}
       eddyEnabled={false}
+      orthoActive={false}
       searchMatches={null}
       searchResults={[]}
       savedViews={[false, false, false]}
@@ -254,6 +256,21 @@ describe('NavigatorToolbar canonical views (E2)', () => {
       fireEvent.click(screen.getByRole('button', { name: label }));
       expect(handlers.onCanonicalView).toHaveBeenCalledWith(view);
     }
+  });
+});
+
+describe('NavigatorToolbar ortho toggle (E3)', () => {
+  it('exposes the plan-view toggle as a pressable, reflecting active state', () => {
+    const handlers = renderToolbar({ orthoActive: false });
+    const toggle = screen.getByRole('button', { name: 'Top-down plan view' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+    fireEvent.click(toggle);
+    expect(handlers.onToggleOrtho).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks the toggle pressed while plan view is active', () => {
+    renderToolbar({ orthoActive: true });
+    expect(screen.getByRole('button', { name: 'Top-down plan view' })).toHaveAttribute('aria-pressed', 'true');
   });
 });
 

--- a/tests/js/patientFlow/cameraFlight.test.ts
+++ b/tests/js/patientFlow/cameraFlight.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFlightPath,
+  flightDurationMs,
+  FLIGHT_MAX_MS,
+  FLIGHT_MIN_MS,
+} from '@/features/patientFlowNavigator/cameraFlight';
+
+/** E2 — the van Wijk arc: verified properties, not just "it moves". */
+
+describe('buildFlightPath (van Wijk & Nuij)', () => {
+  it('starts and ends exactly at the endpoint widths and pan bounds', () => {
+    const path = buildFlightPath(200, 40, 90);
+    expect(path.panAt(0)).toBeCloseTo(0, 5);
+    expect(path.panAt(1)).toBeCloseTo(1, 5);
+    expect(path.widthAt(0)).toBeCloseTo(40, 4);
+    expect(path.widthAt(1)).toBeCloseTo(90, 4);
+  });
+
+  it('pans monotonically', () => {
+    const path = buildFlightPath(300, 60, 60);
+    let previous = -1;
+    for (let step = 0; step <= 20; step += 1) {
+      const pan = path.panAt(step / 20);
+      expect(pan).toBeGreaterThanOrEqual(previous);
+      previous = pan;
+    }
+  });
+
+  it('rises above both endpoint widths on a long pan — the context arc', () => {
+    const path = buildFlightPath(600, 30, 30);
+    let peak = 0;
+    for (let step = 0; step <= 40; step += 1) {
+      peak = Math.max(peak, path.widthAt(step / 40));
+    }
+    expect(peak).toBeGreaterThan(30 * 1.5);
+    expect(path.widthAt(0)).toBeCloseTo(30, 4);
+    expect(path.widthAt(1)).toBeCloseTo(30, 4);
+  });
+
+  it('keeps a short hop close to the endpoint widths (no gratuitous zoom-out)', () => {
+    const path = buildFlightPath(8, 50, 50);
+    let peak = 0;
+    for (let step = 0; step <= 20; step += 1) {
+      peak = Math.max(peak, path.widthAt(step / 20));
+    }
+    expect(peak).toBeLessThan(50 * 1.2);
+  });
+
+  it('degenerates to a pure exponential zoom when the pan distance is zero', () => {
+    const zoomIn = buildFlightPath(0, 100, 25);
+    expect(zoomIn.pathLength).toBeGreaterThan(0);
+    expect(zoomIn.widthAt(0)).toBeCloseTo(100, 4);
+    expect(zoomIn.widthAt(1)).toBeCloseTo(25, 3);
+    expect(zoomIn.widthAt(0.5)).toBeCloseTo(50, 3); // geometric midpoint
+    expect(zoomIn.panAt(0.5)).toBe(1);
+  });
+
+  it('handles a zero-length flight without NaNs', () => {
+    const still = buildFlightPath(0, 60, 60);
+    expect(still.pathLength).toBe(0);
+    expect(still.widthAt(1)).toBeCloseTo(60, 5);
+  });
+});
+
+describe('flightDurationMs', () => {
+  it('clamps into the [min, max] band', () => {
+    expect(flightDurationMs(0)).toBe(FLIGHT_MIN_MS);
+    expect(flightDurationMs(1_000)).toBe(FLIGHT_MAX_MS);
+  });
+
+  it('scales with path length between the clamps', () => {
+    expect(flightDurationMs(2)).toBeGreaterThan(flightDurationMs(1));
+  });
+});

--- a/tests/js/patientFlow/handoff.test.ts
+++ b/tests/js/patientFlow/handoff.test.ts
@@ -24,4 +24,28 @@ describe('parseHandoff', () => {
     expect(handoff.focusStop).toBeNull();
     expect(handoff.unitRef).toBe('5e');
   });
+
+  it('reads the E5 view-state params alongside the legacy grammar', () => {
+    setSearch('?scope=floor:2&cam=10,20,30,0,5,0&layers=base,heat&census=delayed&win=6h&sel=occupancy:ED-04&wall=1');
+    const handoff = parseHandoff();
+    expect(handoff.floor).toBe('2');
+    expect(handoff.camera).toEqual({ position: { x: 10, y: 20, z: 30 }, target: { x: 0, y: 5, z: 0 } });
+    expect(handoff.layers?.base).toBe(true);
+    expect(handoff.layers?.heat).toBe(true);
+    expect(handoff.layers?.tokens).toBe(false);
+    expect(handoff.censusScope).toBe('delayed');
+    expect(handoff.windowPreset).toBe('6h');
+    expect(handoff.selection).toEqual({ kind: 'occupancy', id: 'ED-04' });
+    expect(handoff.wall).toBe(true);
+  });
+
+  it('degrades garbage view-state params to nulls', () => {
+    setSearch('?cam=bogus&census=nope&win=90h&sel=patient:raw-mrn-123');
+    const handoff = parseHandoff();
+    expect(handoff.camera).toBeNull();
+    expect(handoff.censusScope).toBeNull();
+    expect(handoff.windowPreset).toBeNull();
+    // `sel=` refuses person kinds — a patient travels only as an opaque ptok.
+    expect(handoff.selection).toBeNull();
+  });
 });

--- a/tests/js/patientFlow/minimapProjection.test.ts
+++ b/tests/js/patientFlow/minimapProjection.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProjector,
+  computeBounds,
+  projectorForPoints,
+} from '@/features/patientFlowNavigator/minimapProjection';
+
+/** E1 — the minimap projection round-trips world XZ ↔ minimap [0,1]. */
+
+describe('computeBounds', () => {
+  it('pads the extent by a fraction of the larger span', () => {
+    const bounds = computeBounds([{ x: 0, z: 0 }, { x: 100, z: 40 }], 0.1);
+    expect(bounds).not.toBeNull();
+    // spanX 100 → padX 10; spanZ 40 → padZ 4.
+    expect(bounds!.minX).toBeCloseTo(-10);
+    expect(bounds!.maxX).toBeCloseTo(110);
+    expect(bounds!.minZ).toBeCloseTo(-4);
+    expect(bounds!.maxZ).toBeCloseTo(44);
+  });
+
+  it('returns null for no points', () => {
+    expect(computeBounds([])).toBeNull();
+  });
+
+  it('never collapses a zero span to a divide-by-zero', () => {
+    const bounds = computeBounds([{ x: 5, z: 5 }], 0);
+    const projector = buildProjector(bounds!);
+    expect(Number.isFinite(projector.project(5, 5).u)).toBe(true);
+  });
+});
+
+describe('buildProjector round-trip', () => {
+  it('project ∘ unproject is identity across the plate', () => {
+    const projector = buildProjector({ minX: -20, maxX: 80, minZ: 10, maxZ: 60 });
+    for (const [x, z] of [[-20, 10], [80, 60], [30, 35], [0, 20]] as Array<[number, number]>) {
+      const { u, v } = projector.project(x, z);
+      const back = projector.unproject(u, v);
+      expect(back.x).toBeCloseTo(x, 6);
+      expect(back.z).toBeCloseTo(z, 6);
+    }
+  });
+
+  it('maps the bounds corners to the unit square', () => {
+    const projector = buildProjector({ minX: 0, maxX: 100, minZ: 0, maxZ: 50 });
+    expect(projector.project(0, 0)).toEqual({ u: 0, v: 0 });
+    expect(projector.project(100, 50)).toEqual({ u: 1, v: 1 });
+    expect(projector.project(50, 25)).toEqual({ u: 0.5, v: 0.5 });
+  });
+});
+
+describe('projectorForPoints', () => {
+  it('is null for an empty set, a projector otherwise', () => {
+    expect(projectorForPoints([])).toBeNull();
+    expect(projectorForPoints([{ x: 1, z: 2 }])).not.toBeNull();
+  });
+});

--- a/tests/js/patientFlow/structureTree.test.ts
+++ b/tests/js/patientFlow/structureTree.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildStructureTree,
+  flattenVisible,
+  parentIdOf,
+} from '@/features/patientFlowNavigator/structureTree';
+import type { PatientFlowLocation, PatientFlowLocations } from '@/features/patientFlowNavigator/types';
+
+/** E3 — the floor→unit→bed structure model, keyboard-walked. */
+
+function loc(overrides: Partial<PatientFlowLocation> & { location_code: string }): PatientFlowLocation {
+  return {
+    facility_space_id: 1,
+    source_location_code: overrides.location_code,
+    name: overrides.location_code,
+    category: 'bed',
+    floor: 3,
+    unit_code: '5E',
+    position_m: { x: 0, y: 0, z: 0 },
+    ...overrides,
+  } as PatientFlowLocation;
+}
+
+const LOCATIONS: PatientFlowLocations = {
+  '3-5E-01': loc({ location_code: '3-5E-01', name: 'Bed 01', floor: 3, unit_code: '5e', position_m: { x: 10, y: 0, z: 10 } }),
+  '3-5E-02': loc({ location_code: '3-5E-02', name: 'Bed 02', floor: 3, unit_code: '5e', position_m: { x: 12, y: 0, z: 10 } }),
+  '3-ICU-01': loc({ location_code: '3-ICU-01', name: 'ICU A', floor: 3, unit_code: 'icu', position_m: { x: 20, y: 0, z: 20 } }),
+  '2-ED-01': loc({ location_code: '2-ED-01', name: 'ED 1', floor: 2, unit_code: 'ed', category: 'ed', position_m: { x: 5, y: 0, z: 5 } }),
+  'lift-1': loc({ location_code: 'lift-1', name: 'Elevator', floor: 2, unit_code: null, category: 'elevator' }),
+  'nofloor': loc({ location_code: 'nofloor', name: 'Limbo', floor: null, unit_code: 'x' }),
+};
+
+describe('buildStructureTree', () => {
+  it('groups floor → unit → bed, floors ascending and units alphabetized', () => {
+    const tree = buildStructureTree(LOCATIONS);
+    expect(tree.map((floor) => floor.label)).toEqual(['Floor 2', 'Floor 3']);
+
+    const floor3 = tree.find((node) => node.id === 'floor:3')!;
+    expect(floor3.children.map((unit) => unit.label)).toEqual(['5E', 'ICU']);
+
+    const unit5e = floor3.children.find((unit) => unit.label === '5E')!;
+    expect(unit5e.children.map((bed) => bed.label)).toEqual(['Bed 01', 'Bed 02']);
+    expect(unit5e.children[0].locationCode).toBe('3-5E-01');
+  });
+
+  it('excludes infrastructure (elevators) and floorless locations', () => {
+    const tree = buildStructureTree(LOCATIONS);
+    const codes = tree.flatMap((f) => f.children.flatMap((u) => u.children.map((b) => b.locationCode)));
+    expect(codes).not.toContain('lift-1');
+    expect(codes).not.toContain('nofloor');
+  });
+
+  it('derives unit and floor anchor positions from descendant beds', () => {
+    const tree = buildStructureTree(LOCATIONS);
+    const unit5e = tree.find((f) => f.id === 'floor:3')!.children.find((u) => u.label === '5E')!;
+    expect(unit5e.position).toEqual({ x: 11, y: 0, z: 10 }); // centroid of beds 01/02
+    const floor3 = tree.find((f) => f.id === 'floor:3')!;
+    expect(floor3.position).not.toBeNull();
+  });
+
+  it('returns an empty tree for empty locations', () => {
+    expect(buildStructureTree({})).toEqual([]);
+  });
+});
+
+describe('flattenVisible', () => {
+  it('shows only roots when nothing is expanded', () => {
+    const tree = buildStructureTree(LOCATIONS);
+    const rows = flattenVisible(tree, new Set());
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.depth === 0)).toBe(true);
+    expect(rows[0].expanded).toBe(false); // floors are expandable
+  });
+
+  it('reveals a floor\'s units when expanded, beds when the unit is too', () => {
+    const tree = buildStructureTree(LOCATIONS);
+    const rows = flattenVisible(tree, new Set(['floor:3', 'unit:3:5E']));
+    const labels = rows.map((row) => row.node.label);
+    expect(labels).toContain('5E');
+    expect(labels).toContain('Bed 01');
+    // Floor 2 stays collapsed — its ED bed is not shown.
+    expect(labels).not.toContain('ED 1');
+    // Beds are leaves — no expanded flag.
+    const bed = rows.find((row) => row.node.label === 'Bed 01')!;
+    expect(bed.expanded).toBeUndefined();
+    expect(bed.depth).toBe(2);
+  });
+});
+
+describe('parentIdOf', () => {
+  it('maps a unit to its floor and a floor to null', () => {
+    expect(parentIdOf('unit:3:5E')).toBe('floor:3');
+    expect(parentIdOf('floor:3')).toBeNull();
+  });
+});

--- a/tests/js/patientFlow/trailHeat.test.ts
+++ b/tests/js/patientFlow/trailHeat.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import {
+  densityGrid,
+  gridToWorldCells,
+  heatBounds,
+  hourlySlices,
+} from '@/features/patientFlowNavigator/trailHeat';
+import type { PatientFlowEvent, PatientFlowLocation, PatientFlowLocations } from '@/features/patientFlowNavigator/types';
+
+/** E4 — the flatten/analysis model: density grids + hourly slices. */
+
+function loc(code: string, floor: number, x: number, z: number): PatientFlowLocation {
+  return {
+    facility_space_id: 1,
+    location_code: code,
+    source_location_code: code,
+    name: code,
+    category: 'bed',
+    floor,
+    unit_code: 'U',
+    position_m: { x, y: 0, z },
+  } as PatientFlowLocation;
+}
+
+const LOCATIONS: PatientFlowLocations = {
+  'A': loc('A', 3, 0, 0),
+  'B': loc('B', 3, 100, 0),
+  'C': loc('C', 3, 100, 100),
+  'D': loc('D', 2, 0, 0),
+};
+
+const T0 = Date.parse('2026-07-27T12:00:00Z');
+
+function ev(patientId: string, to: string, at: number, floor = 3): PatientFlowEvent {
+  return {
+    event_id: `${patientId}-${at}`,
+    event_category: 'movement',
+    event_type: 'move',
+    patient_id: patientId,
+    patient_display_id: patientId,
+    encounter_id: `enc-${patientId}`,
+    occurred_at: new Date(at).toISOString(),
+    to_location: to,
+    location_floor: floor,
+  } as PatientFlowEvent;
+}
+
+function tracksFrom(events: PatientFlowEvent[]): Map<string, PatientFlowEvent[]> {
+  const map = new Map<string, PatientFlowEvent[]>();
+  for (const event of events) {
+    const list = map.get(event.patient_id) ?? [];
+    list.push(event);
+    map.set(event.patient_id, list);
+  }
+  return map;
+}
+
+describe('heatBounds', () => {
+  it('frames only the requested floor with padding', () => {
+    const bounds = heatBounds(LOCATIONS, '3');
+    expect(bounds).not.toBeNull();
+    expect(bounds!.minX).toBeLessThan(0);
+    expect(bounds!.maxX).toBeGreaterThan(100);
+  });
+
+  it('is null when no placed location matches the floor', () => {
+    expect(heatBounds(LOCATIONS, '9')).toBeNull();
+  });
+});
+
+describe('densityGrid', () => {
+  it('bins in-window events into cells and tracks the max', () => {
+    const tracks = tracksFrom([
+      ev('p1', 'A', T0 + 1000),
+      ev('p2', 'A', T0 + 2000),
+      ev('p3', 'B', T0 + 3000),
+    ]);
+    const bounds = heatBounds(LOCATIONS, '3')!;
+    const grid = densityGrid(tracks, LOCATIONS, bounds, T0, T0 + 10_000, 8, 8, '3');
+    const total = grid.cells.reduce((sum, count) => sum + count, 0);
+    expect(total).toBe(3);
+    expect(grid.max).toBe(2); // two events landed on A's cell
+  });
+
+  it('excludes events outside the time window', () => {
+    const tracks = tracksFrom([ev('p1', 'A', T0 - 10_000), ev('p2', 'A', T0 + 1000)]);
+    const bounds = heatBounds(LOCATIONS, '3')!;
+    const grid = densityGrid(tracks, LOCATIONS, bounds, T0, T0 + 10_000, 8, 8, '3');
+    expect(grid.cells.reduce((sum, count) => sum + count, 0)).toBe(1);
+  });
+
+  it('excludes other-floor events when a floor is set', () => {
+    const tracks = tracksFrom([ev('p1', 'D', T0 + 1000, 2), ev('p2', 'A', T0 + 1000, 3)]);
+    const bounds = heatBounds(LOCATIONS, '3')!;
+    const grid = densityGrid(tracks, LOCATIONS, bounds, T0, T0 + 10_000, 8, 8, '3');
+    expect(grid.cells.reduce((sum, count) => sum + count, 0)).toBe(1);
+  });
+});
+
+describe('hourlySlices', () => {
+  it('produces `hours` slices, oldest first, each labeled and patient-counted', () => {
+    const end = T0;
+    const tracks = tracksFrom([
+      ev('p1', 'A', end - 30 * 60_000), // 30 min ago → newest slice
+      ev('p2', 'B', end - 90 * 60_000), // 90 min ago → second-newest
+    ]);
+    const bounds = heatBounds(LOCATIONS, '3')!;
+    const slices = hourlySlices(tracks, LOCATIONS, bounds, end, 6, '3');
+    expect(slices).toHaveLength(6);
+    // Oldest first, latest last.
+    expect(slices[0].startMs).toBeLessThan(slices[5].startMs);
+    // The last slice (0–1h ago) holds p1; the second-to-last (1–2h ago) holds p2.
+    expect(slices[5].patients).toBe(1);
+    expect(slices[4].patients).toBe(1);
+    expect(slices[0].patients).toBe(0);
+  });
+});
+
+describe('gridToWorldCells', () => {
+  it('emits only non-empty cells with normalized intensity and world centers', () => {
+    const bounds = { minX: 0, maxX: 100, minZ: 0, maxZ: 100 };
+    const grid = { cols: 2, rows: 2, cells: [0, 4, 0, 2], max: 4 };
+    const cells = gridToWorldCells(grid, bounds, 0.5);
+    expect(cells).toHaveLength(2);
+    const hottest = cells.find((cell) => cell.intensity === 1)!;
+    expect(hottest.x).toBeCloseTo(75); // col 1 center of a 2-col grid over 0..100
+    expect(hottest.z).toBeCloseTo(25); // row 0 center
+    expect(cells.every((cell) => cell.y === 0.5)).toBe(true);
+  });
+
+  it('is empty when the grid has no density', () => {
+    expect(gridToWorldCells({ cols: 2, rows: 2, cells: [0, 0, 0, 0], max: 0 }, { minX: 0, maxX: 1, minZ: 0, maxZ: 1 })).toEqual([]);
+  });
+});

--- a/tests/js/patientFlow/viewState.test.ts
+++ b/tests/js/patientFlow/viewState.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildViewSearch,
+  LAYER_KEYS,
+  parseCamera,
+  parseLayers,
+  parseViewState,
+  serializeCamera,
+} from '@/features/patientFlowNavigator/viewState';
+import type { NavigatorViewSnapshot, ViewCamera } from '@/features/patientFlowNavigator/viewState';
+import { windowForPreset, WINDOW_PRESET_LABELS } from '@/features/patientFlowNavigator/replayTimeline';
+import type { WindowPreset } from '@/features/patientFlowNavigator/replayTimeline';
+import type { PatientLayerState } from '@/features/patientFlowNavigator/types';
+
+/** E5 — any exact view is shareable as a URL; parse(serialize(x)) === x. */
+
+const BASE_SNAPSHOT: NavigatorViewSnapshot = {
+  camera: null,
+  floor: 'all',
+  layers: null,
+  censusScope: 'all',
+  timeMs: null,
+  windowPreset: '48h',
+  selection: null,
+  patient: null,
+  focusStop: null,
+};
+
+function layersFrom(enabled: Array<keyof PatientLayerState>): PatientLayerState {
+  const state = {} as PatientLayerState;
+  for (const key of LAYER_KEYS) state[key] = enabled.includes(key);
+  return state;
+}
+
+/** Deterministic LCG so the property sweep is reproducible in CI. */
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 2 ** 32;
+  };
+}
+
+describe('viewState camera round-trip', () => {
+  it('serializes to 1-decimal fixed and parses back', () => {
+    const camera: ViewCamera = {
+      position: { x: 88.04, y: 104.16, z: -161.95 },
+      target: { x: 0, y: 48, z: 0.25 },
+    };
+    const raw = serializeCamera(camera);
+    expect(raw).toBe('88,104.2,-161.9,0,48,0.3');
+    expect(parseCamera(raw)).toEqual({
+      position: { x: 88, y: 104.2, z: -161.9 },
+      target: { x: 0, y: 48, z: 0.3 },
+    });
+  });
+
+  it('rejects malformed, short, and out-of-range payloads', () => {
+    expect(parseCamera(null)).toBeNull();
+    expect(parseCamera('')).toBeNull();
+    expect(parseCamera('1,2,3')).toBeNull();
+    expect(parseCamera('1,2,3,4,5,abc')).toBeNull();
+    expect(parseCamera('1,2,3,4,5,9999999')).toBeNull();
+  });
+});
+
+describe('viewState layers round-trip', () => {
+  it('lists enabled keys and treats unlisted as off', () => {
+    const layers = layersFrom(['base', 'heat', 'pathway']);
+    const parsed = parseLayers('base,heat,pathway');
+    expect(parsed).toEqual(layers);
+  });
+
+  it('drops unknown keys instead of failing', () => {
+    const parsed = parseLayers('base,glitter,heat');
+    expect(parsed).toEqual(layersFrom(['base', 'heat']));
+  });
+
+  it('null means the param was absent (lens defaults win)', () => {
+    expect(parseLayers(null)).toBeNull();
+  });
+});
+
+describe('buildViewSearch defaults', () => {
+  it('emits an empty string for the default view', () => {
+    expect(buildViewSearch(BASE_SNAPSHOT)).toBe('');
+  });
+
+  it('reuses the legacy param grammar for floor, time, patient, and stop', () => {
+    const search = buildViewSearch({
+      ...BASE_SNAPSHOT,
+      floor: '3',
+      timeMs: Date.parse('2026-07-27T12:00:00Z'),
+      patient: 'ptok_AAAAAAAAAAAAAAAAAAAAAAAA',
+      focusStop: 'stop-uuid-1',
+    });
+    const params = new URLSearchParams(search);
+    expect(params.get('scope')).toBe('floor:3');
+    expect(params.get('t')).toBe('2026-07-27T12:00:00.000Z');
+    expect(params.get('patient')).toBe('ptok_AAAAAAAAAAAAAAAAAAAAAAAA');
+    expect(params.get('focus_stop')).toBe('stop-uuid-1');
+  });
+
+  it('never emits a raw identifier param kind for patients', () => {
+    // The only person-addressing params are the opaque ptok and stop uuid.
+    const search = buildViewSearch({
+      ...BASE_SNAPSHOT,
+      selection: { kind: 'occupancy', id: 'ED-BED-04' },
+      patient: 'ptok_AAAAAAAAAAAAAAAAAAAAAAAA',
+    });
+    expect(search).not.toContain('mrn');
+    expect(search).not.toContain('encounter');
+    expect(new URLSearchParams(search).get('sel')).toBe('occupancy:ED-BED-04');
+  });
+});
+
+describe('viewState property round-trip (seeded sweep)', () => {
+  it('parse(serialize(snapshot)) preserves every field across 200 random views', () => {
+    const random = seededRandom(0x5eed);
+    const scopes = ['all', 'delayed', 'deviations'] as const;
+    const presets: WindowPreset[] = ['48h', '24h', '6h', 'shift'];
+
+    for (let round = 0; round < 200; round += 1) {
+      const coord = (): number => Math.round((random() * 800 - 400) * 10) / 10;
+      const camera: ViewCamera | null = random() < 0.8
+        ? {
+            position: { x: coord(), y: coord(), z: coord() },
+            target: { x: coord(), y: coord(), z: coord() },
+          }
+        : null;
+      const layers = random() < 0.7
+        ? layersFrom(LAYER_KEYS.filter(() => random() < 0.5))
+        : null;
+      const snapshot: NavigatorViewSnapshot = {
+        camera,
+        floor: random() < 0.5 ? String(1 + Math.floor(random() * 9)) : 'all',
+        layers,
+        censusScope: scopes[Math.floor(random() * scopes.length)],
+        timeMs: random() < 0.5 ? Date.parse('2026-07-27T00:00:00Z') + Math.floor(random() * 86_400_000) : null,
+        windowPreset: presets[Math.floor(random() * presets.length)],
+        selection: random() < 0.4
+          ? { kind: random() < 0.5 ? 'occupancy' : 'barrier', id: `id-${Math.floor(random() * 999)}` }
+          : null,
+        patient: null,
+        focusStop: null,
+      };
+
+      const search = buildViewSearch(snapshot);
+      const parsed = parseViewState(search);
+      const params = new URLSearchParams(search);
+
+      expect(parsed.camera).toEqual(snapshot.camera);
+      expect(parsed.layers).toEqual(snapshot.layers);
+      expect(parsed.censusScope).toEqual(snapshot.censusScope === 'all' ? null : snapshot.censusScope);
+      expect(parsed.windowPreset).toEqual(snapshot.windowPreset === '48h' ? null : snapshot.windowPreset);
+      expect(parsed.selection).toEqual(snapshot.selection);
+      expect(params.get('scope')).toEqual(snapshot.floor === 'all' ? null : `floor:${snapshot.floor}`);
+      expect(params.get('t')).toEqual(snapshot.timeMs === null ? null : new Date(snapshot.timeMs).toISOString());
+    }
+  });
+
+  it('parses garbage to nulls, never throwing', () => {
+    const parsed = parseViewState('?cam=zzz&layers=&census=everything&win=90h&sel=:&wall=2');
+    expect(parsed.camera).toBeNull();
+    expect(parsed.layers).toEqual(parseLayers(''));
+    expect(parsed.censusScope).toBeNull();
+    expect(parsed.windowPreset).toBeNull();
+    expect(parsed.selection).toBeNull();
+    expect(parsed.wall).toBe(false);
+  });
+
+  it('reads wall=1 as the kiosk chrome-suppression flag', () => {
+    expect(parseViewState('?wall=1').wall).toBe(true);
+  });
+});
+
+describe('windowForPreset (TN-6)', () => {
+  const noon = Date.parse('2026-07-27T16:00:00Z'); // 12:00 EDT — inside the day shift
+
+  it('offers symmetric halves for 48h/24h/6h', () => {
+    for (const [preset, half] of [['48h', 24], ['24h', 12], ['6h', 3]] as Array<[WindowPreset, number]>) {
+      const { start, end } = windowForPreset(preset, noon);
+      expect(noon - start).toBe(half * 3_600_000);
+      expect(end - noon).toBe(half * 3_600_000);
+    }
+  });
+
+  it('anchors the shift preset to the enclosing 07:00/19:00 block', () => {
+    const { start, end } = windowForPreset('shift', noon);
+    expect(end - start).toBe(12 * 3_600_000);
+    expect(start).toBeLessThanOrEqual(noon);
+    expect(end).toBeGreaterThanOrEqual(noon);
+    const startHour = new Date(start).getHours();
+    expect([7, 19]).toContain(startHour);
+  });
+
+  it('labels every preset for the chronobar control', () => {
+    for (const preset of ['48h', '24h', '6h', 'shift'] as WindowPreset[]) {
+      expect(WINDOW_PRESET_LABELS[preset]).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Phase E — Wayfinding & 2D structure (FLOW-4D plan)

Sixth-of-seven phase of the 4D Navigator journey/conformance plan. All work is navigator-side (dark-only wall instrument, F-9); no backend, no schema, no flag changes. Builds on Phases A/B/C (journey drawer, per-case conformance, adherence surface) already on prod.

### What landed
- **E5 — URL view state + copy view link.** `viewState.ts` serializes camera/floor/layers/time/census/window/selection to URL params (round-trip pinned by a seeded 200-view property sweep). `parseHandoff` extended back-compatibly; a link can *request* but the lens/flags still decide what renders. Copy-view-link in the toolbar + copy-as-link on saved-view slots. A patient travels only as the opaque `ptok`; `sel=` carries aggregate kinds only.
- **TN-6 — chronobar window presets** (48h/24h/6h/Shift); historical sources keep their extent window; bootstrap + live-follow are preset-aware.
- **E2 — van Wijk flight arc + canonical views + SDF labels.** `cameraFlight.ts` (van Wijk & Nuij optimal pan/zoom, ρ*=1.42; 8 property tests). `focusOn`/`focusSelection`/`focusRoundStop` now fly the arc; Top/House/Floor/Bed canonical framings; operator input cancels a flight. SDF unit-name billboards via `troika-three-text` (local ambient .d.ts) — per-frame billboard + LOD + distance cull, tied to the Model layer.
- **E3 — top-down orthographic mode (`O`) + structure traversal.** Perspective/ortho camera swap beneath OrbitControls (raycast/flight/billboards all read the active camera); ortho is locked plan view, pan+zoom, frustum from the framed extent; Home/bookmarks/links restore the iso perspective. `structureTree.ts` (pure floor→unit→bed) + `NavigatorStructureNav` (WAI-ARIA tree, roving tabindex, arrow-key graph) selecting through the shared `selectEntity` seam.
- **E1 — minimap floor plate.** `minimapProjection.ts` (pure world-XZ ↔ minimap round-trip) + `NavigatorMinimap` SVG plate — location dots, delay pips (triangle), deviation pips (square/bracket, amber-capped), camera footprint, selection ring; click flies to the point. CVD-safe (shape, not color alone). Polls camera/selection from the scene so the ~7 Hz camera stream never re-renders the orchestrator. Suppressed on `?wall=1`.
- **E4 — trail-heat flatten + hourly small multiples.** `trailHeat.ts` (density grids + hourly slices, pure). `NavigatorSmallMultiples` — six top-down hourly density plates (the analysis path replacing forced replay) + SVG export; an "On floor" toggle flattens the last 6 h onto the 3D floor via a transient scene layer. Density is opacity on one cool ink, never a status color.
- **E6 — task modes (WN-6).** Monitor / Investigate / Rounds progressive disclosure of the ballooned toolbar. Monitor (default) = the resting layout minus the investigation kit; Investigate adds Speed/Find/saved views + the small-multiples card; Rounds foregrounds the walk and steps back the census rollup.

### Deferred (plan-consistent)
- Outward "Locate in 4D" buttons on ED/bed boards (plan B4): those rows carry no opaque `ptok` client-side; a patient-level deep link needs backend ptok minting + re-identification review — scoped separately. Rounds already pivots via `focus_stop`.

### Test plan
- [x] `tsc --noEmit` clean
- [x] `vite build` clean (troika bundles into the lazy NavigatorScene chunk)
- [x] Full vitest: **781 passed** (patientFlow: 216, incl. new viewState/cameraFlight/structureTree/minimapProjection/trailHeat + component suites)
- [x] `scripts/check-ui-canon.sh` passed (raw-palette ratchet ≤ 76)
- [ ] Rendered-scene browser coverage of flight/ortho/minimap — lands in Phase F (F5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
