### PR TITLE
fix(flow4d): Phase D post-review hardening

### DIFF
--- a/app/Services/CarePathways/PathwayInstanceReadService.php
+++ b/app/Services/CarePathways/PathwayInstanceReadService.php
@@ -69,11 +69,13 @@ final class PathwayInstanceReadService
             return null;
         }
 
+        // Explicit column list: this table also carries an encrypted source
+        // identity column we never touch — never pull it into memory.
         $instance = DB::table('patient_experience.pathway_instances')
             ->where('access_grant_id', $accessGrantId)
             ->orderByDesc('instantiated_at')
             ->orderByDesc('pathway_instance_id')
-            ->first();
+            ->first(['pathway_instance_id', 'pathway_version_id', 'recorded_at']);
 
         if ($instance === null) {
             return null;

--- a/app/Services/CarePathways/ReferenceModelCompiler.php
+++ b/app/Services/CarePathways/ReferenceModelCompiler.php
@@ -181,13 +181,16 @@ final class ReferenceModelCompiler
      */
     private function orderMilestones(iterable $milestones): array
     {
+        // Keyed by stable_key so a duplicate (compileVersion relies on the DB
+        // unique constraint, but compile() is public) can't produce duplicate
+        // activities — first occurrence wins, deterministically.
         $rows = [];
         foreach ($milestones as $m) {
             $key = trim((string) ($m['stable_key'] ?? ''));
-            if ($key === '') {
+            if ($key === '' || isset($rows[$key])) {
                 continue;
             }
-            $rows[] = [
+            $rows[$key] = [
                 'stable_key' => $key,
                 'title' => trim((string) ($m['title'] ?? '')),
                 'phase' => isset($m['phase']) && $m['phase'] !== '' ? (string) $m['phase'] : null,
@@ -195,6 +198,7 @@ final class ReferenceModelCompiler
                 'timing' => $this->timing($m['expected_range'] ?? []),
             ];
         }
+        $rows = array_values($rows);
 
         usort($rows, static function (array $a, array $b): int {
             $sa = $a['sequence'] ?? PHP_INT_MAX;

--- a/app/Services/PatientFlow/PatientJourneyService.php
+++ b/app/Services/PatientFlow/PatientJourneyService.php
@@ -13,6 +13,7 @@ use App\Services\CarePathways\PathwayInstanceReadService;
 use App\Services\Flow\FlowLensService;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
@@ -163,26 +164,29 @@ class PatientJourneyService
         }
 
         $admittedAt = $encounter->admitted_at ? CarbonImmutable::parse((string) $encounter->admitted_at) : null;
-        $losDays = $admittedAt !== null ? intdiv(max(0, $admittedAt->diffInMinutes($now, false)), 1440) : 0;
+        // Carbon 3 returns a float from diffInMinutes; cast to int BEFORE intdiv
+        // (an implicit float→int is E_DEPRECATED in PHP 8.1+ and a TypeError in 9).
+        $losMinutes = $admittedAt !== null ? (int) max(0.0, $admittedAt->diffInMinutes($now, false)) : 0;
 
-        return $this->pathwayDemo->syntheticProgress($losDays, $now);
+        return $this->pathwayDemo->syntheticProgress(intdiv($losMinutes, 1440), $now);
     }
 
     /**
      * The demo attaches to exactly one patient — the longest-stay active
      * inpatient (earliest admit) — so the synthetic pathway shows meaningful
      * progress and never appears on every patient. Only consulted when the demo
-     * flag is on.
+     * flag is on. The designated patient changes at most once per demo refresh,
+     * so the lookup is cached briefly to keep it off every journey request.
      */
     private function isDesignatedDemoEncounter(Encounter $encounter): bool
     {
-        $designatedId = Encounter::query()
+        $designatedId = Cache::remember('flow4d.demo.designated_encounter_id', 60, static fn () => Encounter::query()
             ->where('status', 'active')
             ->where('is_deleted', false)
             ->whereNotNull('admitted_at')
             ->orderBy('admitted_at')
             ->orderBy('encounter_id')
-            ->value('encounter_id');
+            ->value('encounter_id'));
 
         return $designatedId !== null && (int) $designatedId === (int) $encounter->getKey();
     }

--- a/docs/DEVLOG-flow4d-pathway-bridge-2026-07-27.md
+++ b/docs/DEVLOG-flow4d-pathway-bridge-2026-07-27.md
@@ -81,6 +81,29 @@ in the journey drawer for one designated demo patient. Deploy is a normal
 `./deploy.sh --frontend` (no migration, no `--db`); do it only on the usual cadence
 with [SU] awareness, since it surfaces the demo overlay on the investor env.
 
+## Post-review hardening (PR #117, follow-up)
+
+An independent code review after merge (no CRITICAL/HIGH; PHI-opaqueness, dark-serving
+inertness, and append-only reads all confirmed) surfaced four hardening items, fixed
+in a follow-up:
+
+1. **`intdiv(float)` in the LOS calc** — Carbon 3's `diffInMinutes()` returns a float;
+   the raw `intdiv(max(0, $diff), 1440)` logged an `E_DEPRECATED` (implicit lossy
+   float→int) on every demo journey-open and would `TypeError` under PHP 9. Now casts
+   to int first. Regression test uses a fractional-second admit + an `E_DEPRECATED`
+   trap (PHPUnit here isn't configured to fail on deprecations).
+2. **`isDesignatedDemoEncounter` per-request scan** — the `ORDER BY admitted_at LIMIT 1`
+   ran on every journey request while the demo flag is on (no supporting index).
+   Cached 60 s (the designated patient changes at most once per demo refresh).
+3. **Minimal columns** on the `pathway_instances` read — the table also carries an
+   encrypted source-identity column; the read now selects only the 3 columns it uses.
+4. **Duplicate-`stable_key` guard** in the public `compile()` (compileVersion relies on
+   the DB unique constraint; `compile()` is public) — first occurrence wins.
+
+Left as documented limitations (not bugs): the narrow client stale-payload window on a
+just-flipped flag (dark feature only), and stage-level progress (v1 is milestone-level;
+the plan's "stage/milestone" phrasing narrows to milestones here).
+
 ## Deferred (with serving; not scheduled)
 
 - The `PlanDefinition` projection output on the compiler (D3).

--- a/tests/Feature/CarePathways/PathwayInstanceReadServiceTest.php
+++ b/tests/Feature/CarePathways/PathwayInstanceReadServiceTest.php
@@ -112,6 +112,14 @@ final class PathwayInstanceReadServiceTest extends TestCase
         $this->assertNull($service->progressForEncounterId(987654));
     }
 
+    public function test_a_null_encounter_id_short_circuits_even_with_the_gate_on(): void
+    {
+        // The journey spine calls progressForEncounterId($encounter?->getKey());
+        // a patient with no active encounter passes null — must return null
+        // without touching the DB, gate on or off.
+        $this->assertNull(app(PathwayInstanceReadService::class)->progressForEncounterId(null));
+    }
+
     public function test_reads_never_mutate_the_append_only_status_history(): void
     {
         $before = DB::table('patient_experience.pathway_milestone_status_events')->count();

--- a/tests/Feature/PatientFlow/PatientJourneyEndpointTest.php
+++ b/tests/Feature/PatientFlow/PatientJourneyEndpointTest.php
@@ -11,6 +11,7 @@ use App\Services\PatientFlow\FlowEventNormalizer;
 use App\Services\PatientFlow\FlowEventRepository;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
 
 /**
@@ -164,6 +165,47 @@ class PatientJourneyEndpointTest extends TestCase
         $this->assertNotEmpty($response->json('pathway_progress.milestones'));
         // The synthetic pathway carries no real patient identity.
         $this->assertStringNotContainsString($patientRef, $response->getContent());
+    }
+
+    public function test_demo_los_calc_handles_fractional_timestamps_without_a_precision_deprecation(): void
+    {
+        // Regression: Carbon 3 diffInMinutes returns a float; a raw intdiv(float)
+        // both loses precision (E_DEPRECATED) and breaks under PHP 9. Admit at a
+        // NON-whole-minute offset so the minute delta is fractional.
+        config(['care-pathways.demo.enabled' => true, 'care-pathways.assignment_enabled' => false]);
+        Cache::flush(); // designated-encounter lookup is cached; keep this test deterministic
+
+        $patientRef = $this->seedJourneyEvents();
+        Encounter::create([
+            'patient_ref' => $patientRef,
+            'admitted_at' => CarbonImmutable::now()->subDays(2)->subHours(5)->subSeconds(19),
+            'status' => 'active',
+            'is_deleted' => false,
+        ]);
+        $contextRef = app(MobilePatientContextService::class)->contextRefFor($patientRef);
+
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $message) use (&$deprecations): bool {
+            if ($errno === E_DEPRECATED && str_contains($message, 'loses precision')) {
+                $deprecations[] = $message;
+            }
+
+            return false;
+        });
+        try {
+            $response = $this->actingAs($this->admin())
+                ->getJson("/api/patient-flow/journey?persona=house_supervisor&scope=patient:{$contextRef}")
+                ->assertOk();
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $deprecations, 'LOS calc must not trigger an implicit float→int deprecation');
+        // LOS ≈ 2.2 days → intdiv to day 2: milestones through day 1 complete,
+        // the day-2 milestone current.
+        $summary = $response->json('pathway_progress.summary');
+        $this->assertSame(3, $summary['completed']);
+        $this->assertSame('hf_gdmt', $summary['current_stable_key']);
     }
 
     public function test_journey_requires_a_patient_scope(): void

--- a/tests/Unit/CarePathways/ReferenceModelCompilerTest.php
+++ b/tests/Unit/CarePathways/ReferenceModelCompilerTest.php
@@ -154,4 +154,22 @@ final class ReferenceModelCompilerTest extends TestCase
         $this->assertSame([], $model['timing_targets']);
         $this->assertArrayHasKey('m1_missing', $model['deviation_labels']);
     }
+
+    public function test_duplicate_stable_keys_are_deduplicated_first_occurrence_wins(): void
+    {
+        // compile() is public; the DB unique constraint only protects
+        // compileVersion(). A duplicate key must not double an activity.
+        $model = (new ReferenceModelCompiler)->compile(
+            ['pathway_key' => 'x', 'label' => 'X', 'semantic_version' => '1.0.0'],
+            [
+                ['stable_key' => 'm1', 'title' => 'First', 'sequence' => 1, 'expected_range' => ['day_offset_max' => 1]],
+                ['stable_key' => 'm1', 'title' => 'Duplicate', 'sequence' => 1, 'expected_range' => ['day_offset_max' => 9]],
+                ['stable_key' => 'm2', 'title' => 'Second', 'sequence' => 2, 'expected_range' => []],
+            ],
+        );
+
+        $this->assertSame(['m1', 'm2'], $model['activities']);
+        // First occurrence wins — the '_late' ceiling is day 1, not 9.
+        $this->assertSame('First beyond day 1', $model['deviation_labels']['m1_late']);
+    }
 }


### PR DESCRIPTION
## Summary

Post-merge hardening of [Phase D (#115)](https://github.com/sudoshi/Zephyrus/pull/115) after an independent code review. The review found **no CRITICAL/HIGH** issues and confirmed PHI-opaqueness, dark-serving inertness, and append-only read discipline all hold. These four items are the actionable follow-ups; the feature still ships dark and this PR changes no prod flags.

1. **`intdiv(float)` in the LOS calc** (`PatientJourneyService`) — Carbon 3's `diffInMinutes()` returns a `float`; the raw `intdiv(max(0, $diff), 1440)` logged an `E_DEPRECATED` (implicit lossy float→int) on **every demo journey-open** and would `TypeError` under PHP 9. Now casts to `int` first.
2. **`isDesignatedDemoEncounter` per-request scan** (`PatientJourneyService`) — the `ORDER BY admitted_at LIMIT 1` ran on every journey request while the demo flag is on, with no supporting index. Cached 60 s (the designated patient changes at most once per demo refresh).
3. **Minimal columns** (`PathwayInstanceReadService`) — the `pathway_instances` read now selects only the 3 columns it uses; the table also carries an encrypted source-identity column that should never be pulled into memory.
4. **Duplicate-`stable_key` guard** (`ReferenceModelCompiler`) — `compileVersion()` relies on the DB unique constraint, but the public `compile()` did not; a duplicate key could double an activity. First occurrence now wins.

Documented as limitations (not bugs), unchanged: the narrow client stale-payload window on a just-flipped flag (dark feature only), and stage-level progress (v1 is milestone-level).

## Test plan

- [x] 3 new regression tests: fractional-timestamp LOS with an `E_DEPRECATED` trap (PHPUnit here isn't configured to fail on deprecations, so the trap is explicit), `progressForEncounterId(null)` short-circuit, duplicate-`stable_key` dedup.
- [x] Full CarePathways + PatientFlow suites: **116 green**. Pint clean.
- [x] No frontend change; no migration; no prod flags touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)